### PR TITLE
chore: Add licenses for markdown files

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,6 +23,5 @@ header:
   paths-ignore:
     - 'LICENSE'
     - 'NOTICE'
-    - '**/*.md'
 
   comment: on-failure

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
 # Native Rust implementation of Apache Iceberg


### PR DESCRIPTION
Fix https://github.com/apache/iceberg-rust/issues/10