### PR TITLE
feat: Add lookup tables to StructType

### DIFF
--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -257,7 +257,7 @@ impl<'de> Deserialize<'de> for StructType {
 }
 
 impl StructType {
-    ///
+    /// Creates a struct type with the given fields.
     pub fn new(fields: Vec<StructField>) -> Self {
         let id_lookup = BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
         let name_lookup =

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -258,7 +258,7 @@ impl<'de> Deserialize<'de> for StructType {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["type", "fields"];
+        const FIELDS: &[&str] = &["type", "fields"];
         deserializer.deserialize_struct("struct", FIELDS, StructTypeVisitor)
     }
 }

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -256,7 +256,7 @@ impl StructType {
         Self { fields, id_lookup }
     }
     /// Get structfield with certain id
-    pub fn get(&self, id: i32) -> Option<&StructField> {
+    pub fn field_by_id(&self, id: i32) -> Option<&StructField> {
         self.fields.get(*self.id_lookup.get(&id)?)
     }
 }

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -18,11 +18,7 @@
 /*!
  * Data Types
 */
-use std::{
-    collections::BTreeMap,
-    fmt,
-    ops::Index,
-};
+use std::{collections::BTreeMap, fmt, ops::Index};
 
 use serde::{
     de::{self, Error, IntoDeserializer, MapAccess, Visitor},

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -201,10 +201,7 @@ pub struct StructType {
     fields: Vec<StructField>,
     /// Lookup for index by field id
     #[serde(skip_serializing)]
-    id_lookup: BTreeMap<i32, usize>,
-    /// Lookup for index by field name
-    #[serde(skip_serializing)]
-    name_lookup: HashMap<String, usize>,
+    id_lookup: BTreeMap<i32, usize>
 }
 
 impl<'de> Deserialize<'de> for StructType {
@@ -260,21 +257,14 @@ impl StructType {
     /// Creates a struct type with the given fields.
     pub fn new(fields: Vec<StructField>) -> Self {
         let id_lookup = BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
-        let name_lookup =
-            HashMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.name.clone(), i)));
         Self {
             fields,
-            id_lookup,
-            name_lookup,
+            id_lookup
         }
     }
     /// Get structfield with certain id
     pub fn get(&self, id: i32) -> Option<&StructField> {
         self.fields.get(*self.id_lookup.get(&id)?)
-    }
-    /// Get structfield with certain name
-    pub fn get_by_name(&self, name: &str) -> Option<&StructField> {
-        self.fields.get(*self.name_lookup.get(name)?)
     }
 }
 

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -410,7 +410,6 @@ mod tests {
                     write_default: None,
                 }],
                 id_lookup: BTreeMap::from([(1, 0)]),
-                name_lookup: HashMap::from([("id".to_string(), 0)]),
             }),
         )
     }
@@ -444,7 +443,6 @@ mod tests {
                     write_default: None,
                 }],
                 id_lookup: BTreeMap::from([(1, 0)]),
-                name_lookup: HashMap::from([("id".to_string(), 0)]),
             }),
         )
     }
@@ -496,7 +494,6 @@ mod tests {
                     },
                 ],
                 id_lookup: BTreeMap::from([(1, 0), (2, 1)]),
-                name_lookup: HashMap::from([("id".to_string(), 0), ("data".to_string(), 1)]),
             }),
         )
     }

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -246,15 +246,8 @@ impl<'de> Deserialize<'de> for StructType {
                 }
                 let fields: Vec<StructField> =
                     fields.ok_or_else(|| de::Error::missing_field("fields"))?;
-                let id_lookup =
-                    BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
-                let name_lookup =
-                    HashMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.name.clone(), i)));
-                Ok(StructType {
-                    fields,
-                    id_lookup,
-                    name_lookup,
-                })
+
+                Ok(StructType::new(fields))
             }
         }
 
@@ -264,6 +257,17 @@ impl<'de> Deserialize<'de> for StructType {
 }
 
 impl StructType {
+    ///
+    pub fn new(fields: Vec<StructField>) -> Self {
+        let id_lookup = BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
+        let name_lookup =
+            HashMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.name.clone(), i)));
+        Self {
+            fields,
+            id_lookup,
+            name_lookup,
+        }
+    }
     /// Get structfield with certain id
     pub fn get(&self, id: i32) -> Option<&StructField> {
         self.fields.get(*self.id_lookup.get(&id)?)

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -19,7 +19,7 @@
  * Data Types
 */
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fmt,
     ops::Index,
 };
@@ -201,7 +201,7 @@ pub struct StructType {
     fields: Vec<StructField>,
     /// Lookup for index by field id
     #[serde(skip_serializing)]
-    id_lookup: BTreeMap<i32, usize>
+    id_lookup: BTreeMap<i32, usize>,
 }
 
 impl<'de> Deserialize<'de> for StructType {
@@ -257,10 +257,7 @@ impl StructType {
     /// Creates a struct type with the given fields.
     pub fn new(fields: Vec<StructField>) -> Self {
         let id_lookup = BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
-        Self {
-            fields,
-            id_lookup
-        }
+        Self { fields, id_lookup }
     }
     /// Get structfield with certain id
     pub fn get(&self, id: i32) -> Option<&StructField> {

--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -18,10 +18,10 @@
 /*!
  * Data Types
 */
-use std::{fmt, ops::Index};
+use std::{collections::BTreeMap, fmt, ops::Index};
 
 use serde::{
-    de::{Error, IntoDeserializer},
+    de::{self, Error, IntoDeserializer, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
@@ -190,17 +190,70 @@ impl fmt::Display for PrimitiveType {
 }
 
 /// DataType for a specific struct
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename = "struct", tag = "type")]
 pub struct StructType {
     /// Struct fields
     fields: Vec<StructField>,
+    /// Lookup for index by field id
+    #[serde(skip_serializing)]
+    id_lookup: BTreeMap<i32, usize>,
+}
+
+impl<'de> Deserialize<'de> for StructType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Type,
+            Fields,
+        }
+
+        struct StructTypeVisitor;
+
+        impl<'de> Visitor<'de> for StructTypeVisitor {
+            type Value = StructType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<StructType, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut fields = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Type => (),
+                        Field::Fields => {
+                            if fields.is_some() {
+                                return Err(de::Error::duplicate_field("fields"));
+                            }
+                            fields = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let fields: Vec<StructField> =
+                    fields.ok_or_else(|| de::Error::missing_field("fields"))?;
+                let id_lookup =
+                    BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
+                Ok(StructType { fields, id_lookup })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["type", "fields"];
+        deserializer.deserialize_struct("struct", FIELDS, StructTypeVisitor)
+    }
 }
 
 impl StructType {
     /// Get structfield with certain id
-    pub fn get(&self, id: usize) -> Option<&StructField> {
-        self.fields.iter().find(|field| field.id as usize == id)
+    pub fn get(&self, id: i32) -> Option<&StructField> {
+        self.fields.get(*self.id_lookup.get(&id)?)
     }
     /// Get structfield with certain name
     pub fn get_name(&self, name: &str) -> Option<&StructField> {
@@ -349,6 +402,7 @@ mod tests {
                     initial_default: None,
                     write_default: None,
                 }],
+                id_lookup: BTreeMap::from([(1, 0)]),
             }),
         )
     }
@@ -381,6 +435,7 @@ mod tests {
                     initial_default: None,
                     write_default: None,
                 }],
+                id_lookup: BTreeMap::from([(1, 0)]),
             }),
         )
     }
@@ -431,6 +486,7 @@ mod tests {
                         write_default: None,
                     },
                 ],
+                id_lookup: BTreeMap::from([(1, 0), (2, 1)]),
             }),
         )
     }


### PR DESCRIPTION
This PR adds lookup tables for field ids and field names to the StructType. This speeds up the field access for structs with a lot of fields.