### PR TITLE
chore: Use HashMap instead of BTreeMap for storing fields by id in StructType

### DIFF
--- a/src/spec/datatypes.rs
+++ b/src/spec/datatypes.rs
@@ -18,7 +18,7 @@
 /*!
  * Data Types
 */
-use std::{collections::BTreeMap, fmt, ops::Index};
+use std::{collections::HashMap, fmt, ops::Index};
 
 use serde::{
     de::{self, Error, IntoDeserializer, MapAccess, Visitor},
@@ -197,7 +197,7 @@ pub struct StructType {
     fields: Vec<StructField>,
     /// Lookup for index by field id
     #[serde(skip_serializing)]
-    id_lookup: BTreeMap<i32, usize>,
+    id_lookup: HashMap<i32, usize>,
 }
 
 impl<'de> Deserialize<'de> for StructType {
@@ -252,7 +252,7 @@ impl<'de> Deserialize<'de> for StructType {
 impl StructType {
     /// Creates a struct type with the given fields.
     pub fn new(fields: Vec<StructField>) -> Self {
-        let id_lookup = BTreeMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
+        let id_lookup = HashMap::from_iter(fields.iter().enumerate().map(|(i, x)| (x.id, i)));
         Self { fields, id_lookup }
     }
     /// Get structfield with certain id
@@ -402,7 +402,7 @@ mod tests {
                     initial_default: None,
                     write_default: None,
                 }],
-                id_lookup: BTreeMap::from([(1, 0)]),
+                id_lookup: HashMap::from([(1, 0)]),
             }),
         )
     }
@@ -435,7 +435,7 @@ mod tests {
                     initial_default: None,
                     write_default: None,
                 }],
-                id_lookup: BTreeMap::from([(1, 0)]),
+                id_lookup: HashMap::from([(1, 0)]),
             }),
         )
     }
@@ -486,7 +486,7 @@ mod tests {
                         write_default: None,
                     },
                 ],
-                id_lookup: BTreeMap::from([(1, 0), (2, 1)]),
+                id_lookup: HashMap::from([(1, 0), (2, 1)]),
             }),
         )
     }


### PR DESCRIPTION
This change updates the id_lookup table in `StructType` to be a HashMap implementation instead of BTreeMap. Since there won't be a need to do min/max or any kind of ordering, a `BTreeMap` shouldn't be necessary, and lookups for a field based on id can just be done in O(1).

cc: @JanKaul @Xuanwo @Fokko 