### PR TITLE
fix: Update github configuration to avoid conflicting merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,8 +34,14 @@ github:
     rebase: false
   protected_branches:
     main:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+
       required_pull_request_reviews:
         required_approving_review_count: 1
+
+      required_linear_history: true
   features:
     wiki: false
     issues: true


### PR DESCRIPTION
Recently we see conflicting merge, and we add this check in github setting to avoid it.