### PR TITLE
feat: Allow Schema Serialization/deserialization

### DIFF
--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -626,6 +626,7 @@ pub(super) mod _serde {
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
     #[serde(untagged)]
+    /// Enum for Schema serialization/deserializaion
     pub(super) enum SchemaEnum {
         V2(SchemaV2),
         V1(SchemaV1),
@@ -654,6 +655,7 @@ pub(super) mod _serde {
         pub fields: StructType,
     }
 
+    /// Helper to serialize/deserializa Schema
     impl TryFrom<SchemaEnum> for Schema {
         type Error = Error;
         fn try_from(value: SchemaEnum) -> Result<Self> {
@@ -714,7 +716,6 @@ pub(super) mod _serde {
     impl From<Schema> for SchemaV1 {
         fn from(value: Schema) -> Self {
             SchemaV1 {
-                // r#type: TypeEnum::Struct,
                 schema_id: Some(value.schema_id),
                 identifier_field_ids: if value.identifier_field_ids.is_empty() {
                     None
@@ -765,7 +766,6 @@ mod tests {
             .unwrap();
 
         check_schema_serde(record, schema);
-
     }
 
     #[test]

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -750,7 +750,7 @@ mod tests {
     #[test]
     fn test_serde_with_schema_id() {
         let (schema, record) = table_schema_simple();
-        
+
         let x: SchemaV2 = serde_json::from_str(record).unwrap();
         check_schema_serde(record, schema, SchemaEnum::V2(x));
     }
@@ -759,7 +759,7 @@ mod tests {
     fn test_serde_without_schema_id() {
         let (mut schema, record) = table_schema_simple();
         // we remove the ""schema-id": 1," string from example
-        let new_record = record.replace("\"schema-id\":1,","");
+        let new_record = record.replace("\"schema-id\":1,", "");
         // By default schema_id field is set to DEFAULT_SCHEMA_ID when no value is set in json
         schema.schema_id = DEFAULT_SCHEMA_ID;
 
@@ -861,7 +861,7 @@ mod tests {
             ],
             "identifier-field-ids":[2]
         }"#;
-        (schema,record)
+        (schema, record)
     }
 
     fn table_schema_nested() -> Schema {

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -668,11 +668,7 @@ pub(super) mod _serde {
 
     impl From<Schema> for SchemaEnum {
         fn from(value: Schema) -> Self {
-            if value.schema_id == 0 {
-                SchemaEnum::V1(value.into())
-            } else {
-                SchemaEnum::V2(value.into())
-            }
+            SchemaEnum::V2(value.into())
         }
     }
 


### PR DESCRIPTION
This change allow Schema Serialzation/Deserialization based on the `into `and `try_from` parameters for serde from a new enum regrouping SchemaV1 and SchemaV2 struct. I added also some helper for conversion between the enum and Schema struct.

The functionality is tested with a new test inside the test section