### PR TITLE
Metadata integration tests

### DIFF
--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -77,7 +77,7 @@ pub struct Snapshot {
     /// A string map that summarizes the snapshot changes, including operation.
     summary: Summary,
     /// ID of the table’s current schema when the snapshot was created.
-    #[builder(setter(strip_option))]
+    #[builder(setter(strip_option), default = "None")]
     schema_id: Option<i64>,
 }
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1339,4 +1339,18 @@ mod tests {
             "data did not match any variant of untagged enum TableMetadataEnum"
         )
     }
+
+    #[test]
+    fn test_table_metadata_v2_missing_schemas() {
+        let metadata =
+            fs::read_to_string("testdata/table_metadata/TableMetadataV2MissingSchemas.json")
+                .unwrap();
+
+        let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
+
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "data did not match any variant of untagged enum TableMetadataEnum"
+        )
+    }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1310,4 +1310,18 @@ mod tests {
             "data did not match any variant of untagged enum TableMetadataEnum"
         )
     }
+
+    #[test]
+    fn test_table_metadata_v2_missing_partition_specs() {
+        let metadata =
+            fs::read_to_string("testdata/table_metadata/TableMetadataV2MissingPartitionSpecs.json")
+                .unwrap();
+
+        let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
+
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "data did not match any variant of untagged enum TableMetadataEnum"
+        )
+    }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1324,4 +1324,19 @@ mod tests {
             "data did not match any variant of untagged enum TableMetadataEnum"
         )
     }
+
+    #[test]
+    fn test_table_metadata_v2_missing_last_partition_id() {
+        let metadata = fs::read_to_string(
+            "testdata/table_metadata/TableMetadataV2MissingLastPartitionId.json",
+        )
+        .unwrap();
+
+        let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
+
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "data did not match any variant of untagged enum TableMetadataEnum"
+        )
+    }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1353,4 +1353,18 @@ mod tests {
             "data did not match any variant of untagged enum TableMetadataEnum"
         )
     }
+
+    #[test]
+    fn test_table_metadata_v2_unsupported_version() {
+        let metadata =
+            fs::read_to_string("testdata/table_metadata/TableMetadataUnsupportedVersion.json")
+                .unwrap();
+
+        let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
+
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "data did not match any variant of untagged enum TableMetadataEnum"
+        )
+    }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -681,6 +681,8 @@ mod tests {
         SnapshotRetention, SortDirection, SortField, SortOrder, Summary, Transform, Type,
     };
 
+    use crate::error::{Error, ErrorKind};
+
     use super::{FormatVersion, MetadataLog, SnapshotLog};
 
     fn check_table_metadata_serde(json: &str, expected_type: TableMetadata) {
@@ -1282,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_table_metadata_v2_schema_not_found() {
         let metadata =
             fs::read_to_string("testdata/table_metadata/TableMetadataV2CurrentSchemaNotFound.json")
@@ -1290,6 +1291,9 @@ mod tests {
 
         let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
 
-        desered.unwrap();
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "DataInvalid => No schema exists with the current schema id."
+        )
     }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -368,7 +368,7 @@ pub(super) mod _serde {
                 } else {
                     Err(self::Error::new(
                         ErrorKind::DataInvalid,
-                        &format!(
+                        format!(
                             "No schema exists with the current schema id {}.",
                             value.current_schema_id
                         ),

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -368,7 +368,10 @@ pub(super) mod _serde {
                 } else {
                     Err(self::Error::new(
                         ErrorKind::DataInvalid,
-                        "No schema exists with the current schema id.",
+                        &format!(
+                            "No schema exists with the current schema id {}.",
+                            value.current_schema_id
+                        ),
                     ))
                 }?,
                 schemas,
@@ -1290,7 +1293,7 @@ mod tests {
 
         assert_eq!(
             desered.unwrap_err().to_string(),
-            "DataInvalid => No schema exists with the current schema id."
+            "DataInvalid => No schema exists with the current schema id 2."
         )
     }
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1296,4 +1296,18 @@ mod tests {
             "DataInvalid => No schema exists with the current schema id."
         )
     }
+
+    #[test]
+    fn test_table_metadata_v2_missing_sort_order() {
+        let metadata =
+            fs::read_to_string("testdata/table_metadata/TableMetadataV2MissingSortOrder.json")
+                .unwrap();
+
+        let desered: Result<TableMetadata, serde_json::Error> = serde_json::from_str(&metadata);
+
+        assert_eq!(
+            desered.unwrap_err().to_string(),
+            "data did not match any variant of untagged enum TableMetadataEnum"
+        )
+    }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -354,8 +354,7 @@ pub(super) mod _serde {
                     .schemas
                     .into_iter()
                     .map(|schema| Ok((schema.schema_id, Arc::new(schema.try_into()?))))
-                    .collect::<Result<Vec<_>, Error>>()?
-                    .into_iter(),
+                    .collect::<Result<Vec<_>, Error>>()?,
             );
             Ok(TableMetadata {
                 format_version: FormatVersion::V2,
@@ -680,8 +679,6 @@ mod tests {
         PartitionField, PartitionSpec, PrimitiveType, Schema, Snapshot, SnapshotReference,
         SnapshotRetention, SortDirection, SortField, SortOrder, Summary, Transform, Type,
     };
-
-    use crate::error::{Error, ErrorKind};
 
     use super::{FormatVersion, MetadataLog, SnapshotLog};
 

--- a/crates/iceberg/testdata/table_metadata/TableMetadataUnsupportedVersion.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataUnsupportedVersion.json
@@ -1,0 +1,36 @@
+{
+  "format-version": 3,
+  "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+  "location": "s3://bucket/test/location",
+  "last-updated-ms": 1602638573874,
+  "last-sequence-number": 0,
+  "last-column-id": 3,
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  },
+  "partition-spec": [],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV1Valid.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV1Valid.json
@@ -1,0 +1,42 @@
+{
+  "format-version": 1,
+  "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
+  "location": "s3://bucket/test/location",
+  "last-updated-ms": 1602638573874,
+  "last-column-id": 3,
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  },
+  "partition-spec": [
+    {
+      "name": "x",
+      "transform": "identity",
+      "source-id": 1,
+      "field-id": 1000
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2CurrentSchemaNotFound.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2CurrentSchemaNotFound.json
@@ -22,10 +22,6 @@
     {
       "type": "struct",
       "schema-id": 1,
-      "identifier-field-ids": [
-        1,
-        2
-      ],
       "fields": [
         {
           "id": 1,
@@ -85,38 +81,8 @@
     }
   ],
   "properties": {},
-  "current-snapshot-id": 3055729675574597004,
-  "snapshots": [
-    {
-      "snapshot-id": 3051729675574597004,
-      "timestamp-ms": 1515100955770,
-      "sequence-number": 0,
-      "summary": {
-        "operation": "append"
-      },
-      "manifest-list": "s3://a/b/1.avro"
-    },
-    {
-      "snapshot-id": 3055729675574597004,
-      "parent-snapshot-id": 3051729675574597004,
-      "timestamp-ms": 1555100955770,
-      "sequence-number": 1,
-      "summary": {
-        "operation": "append"
-      },
-      "manifest-list": "s3://a/b/2.avro",
-      "schema-id": 1
-    }
-  ],
-  "snapshot-log": [
-    {
-      "snapshot-id": 3051729675574597004,
-      "timestamp-ms": 1515100955770
-    },
-    {
-      "snapshot-id": 3055729675574597004,
-      "timestamp-ms": 1555100955770
-    }
-  ],
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
   "metadata-log": []
 }

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2CurrentSchemaNotFound.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2CurrentSchemaNotFound.json
@@ -1,0 +1,122 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 2,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "type": "struct",
+      "schema-id": 1,
+      "identifier-field-ids": [
+        1,
+        2
+      ],
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": 3055729675574597004,
+  "snapshots": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770,
+      "sequence-number": 0,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/1.avro"
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "parent-snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1555100955770,
+      "sequence-number": 1,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/2.avro",
+      "schema-id": 1
+    }
+  ],
+  "snapshot-log": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "timestamp-ms": 1555100955770
+    }
+  ],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingLastPartitionId.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingLastPartitionId.json
@@ -1,0 +1,73 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [{
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  }],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingPartitionSpecs.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingPartitionSpecs.json
@@ -1,0 +1,67 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [{
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  }],
+  "partition-spec": [
+    {
+      "name": "x",
+      "transform": "identity",
+      "source-id": 1,
+      "field-id": 1000
+    }
+  ],
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingSchemas.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingSchemas.json
@@ -1,0 +1,71 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  },
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingSortOrder.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2MissingSortOrder.json
@@ -1,0 +1,54 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [{
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [
+      {
+        "id": 1,
+        "name": "x",
+        "required": true,
+        "type": "long"
+      },
+      {
+        "id": 2,
+        "name": "y",
+        "required": true,
+        "type": "long",
+        "doc": "comment"
+      },
+      {
+        "id": 3,
+        "name": "z",
+        "required": true,
+        "type": "long"
+      }
+    ]
+  }],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "properties": {},
+  "current-snapshot-id": -1,
+  "snapshots": [],
+  "snapshot-log": [],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2Valid.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2Valid.json
@@ -1,0 +1,122 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 1,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "type": "struct",
+      "schema-id": 1,
+      "identifier-field-ids": [
+        1,
+        2
+      ],
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {},
+  "current-snapshot-id": 3055729675574597004,
+  "snapshots": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770,
+      "sequence-number": 0,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/1.avro"
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "parent-snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1555100955770,
+      "sequence-number": 1,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "s3://a/b/2.avro",
+      "schema-id": 1
+    }
+  ],
+  "snapshot-log": [
+    {
+      "snapshot-id": 3051729675574597004,
+      "timestamp-ms": 1515100955770
+    },
+    {
+      "snapshot-id": 3055729675574597004,
+      "timestamp-ms": 1555100955770
+    }
+  ],
+  "metadata-log": []
+}

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV2ValidMinimal.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV2ValidMinimal.json
@@ -1,0 +1,71 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds integration tests for reading the table metadata from files. Some of the tests are designed to fail. With the current design of the serialization/deserialization the error doesn't specify which field is missing. So I couldn't do a precise check for certain tests.