### PR TITLE
feat: add builder to TableMetadata interface

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -52,7 +52,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 serde_repr = "0.1.16"
 url = "2"
-uuid = "1.4.1"
+uuid = { version = "1.4.1", features = ["v4"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -21,6 +21,8 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use derive_builder::UninitializedFieldError;
+
 /// Result that is a wrapper of `Result<T, iceberg::Error>`
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -189,6 +191,14 @@ impl Debug for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source.as_ref().map(|v| v.as_ref())
+    }
+}
+
+// We define a from implementation from builder Error to Iceberg Error
+impl From<UninitializedFieldError> for Error {
+    fn from(ufe: UninitializedFieldError) -> Error {
+        Error::new(ErrorKind::DataInvalid, "Some fields of table metadata not inited")
+        .with_source(ufe)
     }
 }
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -22,7 +22,6 @@ The main struct here is [TableMetadataV2] which defines the data for a table.
 
 use std::{collections::HashMap, sync::Arc, time::UNIX_EPOCH};
 
-use derive_builder::UninitializedFieldError;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use uuid::Uuid;
@@ -133,13 +132,6 @@ pub struct TableMetadata {
     /// even if the refs map is null.
     #[builder(default = "Self::default_ref()", setter(custom))]
     refs: HashMap<String, SnapshotReference>,
-}
-
-// We define a from implementation from builder Error to Iceberg Error
-impl From<UninitializedFieldError> for Error {
-    fn from(ufe: UninitializedFieldError) -> Error {
-        Error::new(ErrorKind::DataInvalid, ufe.to_string())
-    }
 }
 
 impl TableMetadataBuilder {


### PR DESCRIPTION
related issue : https://github.com/apache/iceberg-rust/issues/52

Add a builder for TableMetadata interface
- fields not mandatory have default values
- Formatversion defaults to V2