### PR TITLE
feat: support ser/deser of value 

### DIFF
--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -261,10 +261,7 @@ pub(crate) fn avro_decimal_schema(precision: usize, scale: usize) -> Result<Avro
     Ok(AvroSchema::Decimal(DecimalSchema {
         precision,
         scale,
-        inner: Box::new(avro_fixed_schema(
-            Type::decimal_required_bytes(precision as u32)? as usize,
-            None,
-        )?),
+        inner: Box::new(AvroSchema::Bytes),
     }))
 }
 
@@ -471,7 +468,7 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
                         )
                     })?;
                     match logical_type {
-                        "uuid" => Type::Primitive(PrimitiveType::Uuid),
+                        UUID_LOGICAL_TYPE => Type::Primitive(PrimitiveType::Uuid),
                         ty => {
                             return Err(Error::new(
                                 ErrorKind::FeatureUnsupported,

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -154,7 +154,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
             // not string type.
             let key_field = {
                 let mut field = AvroRecordField {
-                    name: map.key_field.name.clone(),
+                    name: "key".into(),
                     doc: None,
                     aliases: None,
                     default: None,
@@ -172,7 +172,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
 
             let value_field = {
                 let mut field = AvroRecordField {
-                    name: map.key_field.name.clone(),
+                    name: "value".to_string(),
                     doc: None,
                     aliases: None,
                     default: None,
@@ -188,16 +188,23 @@ impl SchemaVisitor for SchemaToAvroSchema {
                 field
             };
 
+            let fields = vec![key_field, value_field];
+            let lookup = fields
+                .iter()
+                .enumerate()
+                .map(|f| (f.1.name.clone(), f.0))
+                .collect();
+
             let item_avro_schema = AvroSchema::Record(RecordSchema {
                 name: Name::from(format!("k{}_v{}", map.key_field.id, map.value_field.id).as_str()),
                 aliases: None,
                 doc: None,
-                fields: vec![key_field, value_field],
-                lookup: Default::default(),
+                fields,
+                lookup,
                 attributes: Default::default(),
             });
 
-            Ok(Either::Left(item_avro_schema))
+            Ok(Either::Left(AvroSchema::Array(item_avro_schema.into())))
         }
     }
 

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -34,7 +34,7 @@ use serde_json::{Number, Value};
 const FILED_ID_PROP: &str = "field-id";
 const UUID_BYTES: usize = 16;
 const UUID_LOGICAL_TYPE: &str = "uuid";
-// # TODO
+// # TODO: https://github.com/apache/iceberg-rust/issues/86
 // This const may better to maintain in avro-rs.
 const LOGICAL_TYPE: &str = "logicalType";
 

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -1476,7 +1476,7 @@ mod _serde {
                     Type::Primitive(PrimitiveType::String) => Ok(Some(Literal::string(v))),
                     _ => Err(invalid_err("string")),
                 },
-                // # TODO
+                // # TODO:https://github.com/apache/iceberg-rust/issues/86
                 // rust avro don't support deserialize any bytes representation now.
                 RawLiteralEnum::Bytes(_) => Err(invalid_err_with_reason(
                     "bytes",
@@ -2227,7 +2227,7 @@ mod tests {
         );
     }
 
-    // # TODO
+    // # TODO:https://github.com/apache/iceberg-rust/issues/86
     // rust avro don't support deserialize any bytes representation now:
     // - binary
     // - decimal
@@ -2250,7 +2250,7 @@ mod tests {
         check_serialzie_avro(literal, &ty, expect_value);
     }
 
-    // # TODO
+    // # TODO:https://github.com/apache/iceberg-rust/issues/86
     // rust avro can't support to convert any byte-like type to fixed in avro now.
     // - uuid ser/de
     // - fixed ser/de

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -1678,7 +1678,7 @@ mod tests {
         }
     }
 
-    fn check_serialzie_avro(literal: Literal, ty: &Type, expect_value: Value) {
+    fn check_serialize_avro(literal: Literal, ty: &Type, expect_value: Value) {
         let expect_value = Value::Record(vec![("col".to_string(), expect_value)]);
 
         let fields = vec![NestedField::required(1, "col", ty.clone()).into()];
@@ -2236,7 +2236,7 @@ mod tests {
         let literal = Literal::Primitive(PrimitiveLiteral::Binary(vec![1, 2, 3, 4, 5]));
         let ty = Type::Primitive(PrimitiveType::Binary);
         let expect_value = Value::Bytes(vec![1, 2, 3, 4, 5]);
-        check_serialzie_avro(literal, &ty, expect_value);
+        check_serialize_avro(literal, &ty, expect_value);
     }
 
     #[test]
@@ -2247,7 +2247,7 @@ mod tests {
             scale: 8,
         });
         let expect_value = Value::Decimal(apache_avro::Decimal::from(12345_i128.to_be_bytes()));
-        check_serialzie_avro(literal, &ty, expect_value);
+        check_serialize_avro(literal, &ty, expect_value);
     }
 
     // # TODO:https://github.com/apache/iceberg-rust/issues/86

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -1027,7 +1027,7 @@ mod serde {
 
     #[derive(SerializeDerive, DeserializeDerive)]
     #[serde(transparent)]
-    /// Raw literal representation used for serde. The seriailize way is used for avro serializer.
+    /// Raw literal representation used for serde. The serialize way is used for Avro serializer.
     pub struct RawLiteral(RawLiteralEnum);
 
     impl RawLiteral {


### PR DESCRIPTION
This PR:
1. modify to store i128 for Value::Decimal
It make more easy to process Value::Decimal and avoid type consisent problem if we use Decimal.
2. support support ser/deser of value 
3. add related test and fix some wrong in schema 