### PR TITLE
fix: Migrate from tempdir to tempfile crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_bytes = "0.11.8"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 serde_repr = "0.1.16"
-tempdir = "0.3"
+tempfile = "3.8"
 tokio = { version = "1", features = ["macros"] }
 typed-builder = "^0.18"
 url = "2"

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -60,5 +60,5 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempdir = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/iceberg/src/io.rs
+++ b/crates/iceberg/src/io.rs
@@ -393,7 +393,7 @@ mod tests {
     use futures::io::AllowStdIo;
     use futures::{AsyncReadExt, AsyncWriteExt};
 
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use super::{FileIO, FileIOBuilder};
 
@@ -415,7 +415,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_input_file() {
-        let tmp_dir = TempDir::new("test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
 
         let file_name = "a.txt";
         let content = "Iceberg loves rust.";
@@ -436,7 +436,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_local_file() {
-        let tmp_dir = TempDir::new("test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
 
         let file_name = "a.txt";
         let content = "Iceberg loves rust.";
@@ -452,7 +452,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_non_exist_file() {
-        let tmp_dir = TempDir::new("test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
 
         let file_name = "a.txt";
         let full_path = format!("{}/{}", tmp_dir.path().to_str().unwrap(), file_name);
@@ -464,7 +464,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_output_file() {
-        let tmp_dir = TempDir::new("test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
 
         let file_name = "a.txt";
         let content = "Iceberg loves rust.";

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -918,7 +918,7 @@ pub(super) mod _serde {
 mod test {
     use std::{fs, sync::Arc};
 
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use crate::{
         io::FileIOBuilder,
@@ -1091,7 +1091,7 @@ mod test {
             }]
         };
 
-        let temp_dir = TempDir::new("manifest_list_v1").unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("manifest_list_v1.avro");
         let io = FileIOBuilder::new_fs_io().build().unwrap();
         let output_file = io.new_output(path.to_str().unwrap()).unwrap();
@@ -1140,7 +1140,7 @@ mod test {
             }]
         };
 
-        let temp_dir = TempDir::new("manifest_list_v2").unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("manifest_list_v2.avro");
         let io = FileIOBuilder::new_fs_io().build().unwrap();
         let output_file = io.new_output(path.to_str().unwrap()).unwrap();


### PR DESCRIPTION
tempdir is obsolete and relies on remove_dir_all 0.5.3 which has a security vulnerability. Migrate to using tempfile crate instead. References:
- [RUSTSEC-2018-0017](https://rustsec.org/advisories/RUSTSEC-2018-0017)
- [RUSTSEC-2013-0018](https://rustsec.org/advisories/RUSTSEC-2023-0018)