### PR TITLE
minor: Provide Debug impl for pub structs #73

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -117,6 +117,7 @@ impl RestCatalogConfig {
     }
 }
 
+#[derive(Debug)]
 struct HttpClient(Client);
 
 impl HttpClient {
@@ -178,6 +179,7 @@ impl HttpClient {
 }
 
 /// Rest catalog implementation.
+#[derive(Debug)]
 pub struct RestCatalog {
     config: RestCatalogConfig,
     client: HttpClient,

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -29,7 +29,7 @@ use std::ops::Deref;
 
 /// The catalog API for Iceberg Rust.
 #[async_trait]
-pub trait Catalog {
+pub trait Catalog: std::fmt::Debug {
     /// List namespaces from table.
     async fn list_namespaces(&self, parent: Option<&NamespaceIdent>)
         -> Result<Vec<NamespaceIdent>>;
@@ -215,6 +215,7 @@ impl TableIdent {
 }
 
 /// TableCreation represents the creation of a table in the catalog.
+#[derive(Debug)]
 pub struct TableCreation {
     /// The name of the table.
     pub name: String,
@@ -231,6 +232,7 @@ pub struct TableCreation {
 }
 
 /// TableCommit represents the commit of a table in the catalog.
+#[derive(Debug)]
 pub struct TableCommit {
     /// The table ident.
     pub ident: TableIdent,
@@ -243,6 +245,7 @@ pub struct TableCommit {
 }
 
 /// TableRequirement represents a requirement for a table in the catalog.
+#[derive(Debug)]
 pub enum TableRequirement {
     /// The table must not already exist; used for create transactions
     NotExist,
@@ -273,6 +276,7 @@ pub enum TableRequirement {
 /// TableUpdate represents an update to a table in the catalog.
 ///
 /// TODO: we should fill with UpgradeFormatVersionUpdate, AddSchemaUpdate and so on.
+#[derive(Debug)]
 pub enum TableUpdate {}
 
 #[cfg(test)]

--- a/crates/iceberg/src/io.rs
+++ b/crates/iceberg/src/io.rs
@@ -91,6 +91,7 @@ pub struct FileIO {
 }
 
 /// Builder for [`FileIO`].
+#[derive(Debug)]
 pub struct FileIOBuilder {
     /// This is used to infer scheme of operator.
     ///

--- a/crates/iceberg/src/rest.rs
+++ b/crates/iceberg/src/rest.rs
@@ -17,6 +17,7 @@
 
 //! This module provide rest catalog implementation.
 
+#[derive(Debug)]
 pub struct RestCatalog {
     url: String,
 }

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -83,6 +83,16 @@ pub struct ManifestListWriter {
     avro_writer: Writer<'static, Vec<u8>>,
 }
 
+impl std::fmt::Debug for ManifestListWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ManifestListWriter")
+            .field("format_version", &self.format_version)
+            .field("output_file", &self.output_file)
+            .field("avro_writer", &self.avro_writer.schema())
+            .finish_non_exhaustive()
+    }
+}
+
 impl ManifestListWriter {
     /// Construct a v1 [`ManifestListWriter`] that writes to a provided [`OutputFile`].
     pub fn v1(output_file: OutputFile, snapshot_id: i64, parent_snapshot_id: i64) -> Self {

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -54,6 +54,7 @@ pub struct Schema {
 }
 
 /// Schema builder.
+#[derive(Debug)]
 pub struct SchemaBuilder {
     schema_id: i32,
     fields: Vec<NestedFieldRef>,

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -23,7 +23,7 @@ use crate::TableIdent;
 use typed_builder::TypedBuilder;
 
 /// Table represents a table in the catalog.
-#[derive(TypedBuilder)]
+#[derive(TypedBuilder, Debug)]
 pub struct Table {
     file_io: FileIO,
     #[builder(default, setter(strip_option))]

--- a/crates/iceberg/src/transform/bucket.rs
+++ b/crates/iceberg/src/transform/bucket.rs
@@ -22,6 +22,7 @@ use arrow_schema::{DataType, TimeUnit};
 
 use super::TransformFunction;
 
+#[derive(Debug)]
 pub struct Bucket {
     mod_n: u32,
 }

--- a/crates/iceberg/src/transform/identity.rs
+++ b/crates/iceberg/src/transform/identity.rs
@@ -21,6 +21,7 @@ use arrow_array::ArrayRef;
 use super::TransformFunction;
 
 /// Return identity array.
+#[derive(Debug)]
 pub struct Identity {}
 
 impl TransformFunction for Identity {

--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -38,6 +38,7 @@ const DAY_PER_SECOND: f64 = 1.0_f64 / 24.0_f64 / 3600.0_f64;
 const UNIX_EPOCH_YEAR: i32 = 1970;
 
 /// Extract a date or timestamp year, as years from 1970
+#[derive(Debug)]
 pub struct Year;
 
 impl TransformFunction for Year {
@@ -55,6 +56,7 @@ impl TransformFunction for Year {
 }
 
 /// Extract a date or timestamp month, as months from 1970-01-01
+#[derive(Debug)]
 pub struct Month;
 
 impl TransformFunction for Month {
@@ -81,6 +83,7 @@ impl TransformFunction for Month {
 }
 
 /// Extract a date or timestamp day, as days from 1970-01-01
+#[derive(Debug)]
 pub struct Day;
 
 impl TransformFunction for Day {
@@ -115,6 +118,7 @@ impl TransformFunction for Day {
 }
 
 /// Extract a timestamp hour, as hours from 1970-01-01 00:00:00
+#[derive(Debug)]
 pub struct Hour;
 
 impl TransformFunction for Hour {

--- a/crates/iceberg/src/transform/truncate.rs
+++ b/crates/iceberg/src/transform/truncate.rs
@@ -24,6 +24,7 @@ use crate::Error;
 
 use super::TransformFunction;
 
+#[derive(Debug)]
 pub struct Truncate {
     width: u32,
 }

--- a/crates/iceberg/src/transform/void.rs
+++ b/crates/iceberg/src/transform/void.rs
@@ -20,6 +20,7 @@ use arrow_array::{new_null_array, ArrayRef};
 
 use super::TransformFunction;
 
+#[derive(Debug)]
 pub struct Void {}
 
 impl TransformFunction for Void {


### PR DESCRIPTION
Fixes #73 by:

* auto-deriving Debug in cases where all fields are formattable
* providing a manual implementation for cases where fields are not themselves formattable
  * Sole case is `ManifestListWriter`'s `avro_writer`, in which case the schema of the writer is the only value printed