### PR TITLE
Fix compile failures

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -1278,7 +1278,10 @@ mod tests {
             uuid!("bf289591-dcc0-4234-ad4f-5c3eed811a29"),
             table.metadata().uuid()
         );
-        assert_eq!(1657810967051, table.metadata().last_updated_ms());
+        assert_eq!(
+            1657810967051,
+            table.metadata().last_updated_ms().timestamp_millis()
+        );
         assert_eq!(
             vec![&Arc::new(
                 Schema::builder()
@@ -1450,7 +1453,10 @@ mod tests {
             uuid!("bf289591-dcc0-4234-ad4f-5c3eed811a29"),
             table.metadata().uuid()
         );
-        assert_eq!(1657810967051, table.metadata().last_updated_ms());
+        assert_eq!(
+            1657810967051,
+            table.metadata().last_updated_ms().timestamp_millis()
+        );
         assert_eq!(
             vec![&Arc::new(
                 Schema::builder()


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-rust/issues/104

I think something was merged in after https://github.com/apache/iceberg-rust/pull/94 without rebasing on top of `main` resulting in some compile failures (type check errors). 

Not a big deal, easily fixed. 