### PR TITLE
chore: Upgrade uuid manually and remove pinned version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,4 @@ tokio = { version = "1", features = ["macros"] }
 typed-builder = "^0.18"
 url = "2"
 urlencoding = "2"
-# We pin uuid's version to 1.5.0 because this bug: https://github.com/uuid-rs/uuid/issues/720
-uuid = "~1.5.0"
+uuid = "1.6.1"


### PR DESCRIPTION
`uuid` has fixed recently fixed the bug in `1.6.0`, and dependabot failed to remove the `~` prefix, so I upgrade it by hand.