### PR TITLE
Add UnboundSortOrder

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -555,7 +555,7 @@ mod _serde {
 
     use serde_derive::{Deserialize, Serialize};
 
-    use iceberg::spec::{Schema, SortOrder, TableMetadata, UnboundPartitionSpec};
+    use iceberg::spec::{Schema, TableMetadata, UnboundPartitionSpec, UnboundSortOrder};
     use iceberg::{Error, ErrorKind, Namespace, TableIdent, TableRequirement, TableUpdate};
 
     pub(super) const OK: u16 = 200u16;
@@ -695,7 +695,7 @@ mod _serde {
         pub(super) location: Option<String>,
         pub(super) schema: Schema,
         pub(super) partition_spec: Option<UnboundPartitionSpec>,
-        pub(super) write_order: Option<SortOrder>,
+        pub(super) write_order: Option<UnboundSortOrder>,
         pub(super) stage_create: Option<bool>,
         pub(super) properties: Option<HashMap<String, String>>,
     }
@@ -721,8 +721,8 @@ mod tests {
     use iceberg::spec::ManifestListLocation::ManifestListFile;
     use iceberg::spec::{
         FormatVersion, NestedField, NullOrder, Operation, PrimitiveType, Schema, Snapshot,
-        SnapshotLog, SortDirection, SortField, SortOrder, Summary, Transform, Type,
-        UnboundPartitionField, UnboundPartitionSpec,
+        SnapshotLog, SortDirection, SortOrder, Summary, Transform, Type, UnboundPartitionField,
+        UnboundPartitionSpec, UnboundSortField, UnboundSortOrder,
     };
     use iceberg::transaction::Transaction;
     use mockito::{Mock, Server, ServerGuard};
@@ -1277,9 +1277,10 @@ mod tests {
                     .unwrap(),
             )
             .sort_order(
-                SortOrder::builder()
+                UnboundSortOrder::builder()
+                    .with_order_id(1)
                     .with_sort_field(
-                        SortField::builder()
+                        UnboundSortField::builder()
                             .source_id(2)
                             .transform(Transform::Identity)
                             .direction(SortDirection::Ascending)

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -555,7 +555,7 @@ mod _serde {
 
     use serde_derive::{Deserialize, Serialize};
 
-    use iceberg::spec::{Schema, TableMetadata, UnboundPartitionSpec, UnboundSortOrder};
+    use iceberg::spec::{Schema, SortOrder, TableMetadata, UnboundPartitionSpec};
     use iceberg::{Error, ErrorKind, Namespace, TableIdent, TableRequirement, TableUpdate};
 
     pub(super) const OK: u16 = 200u16;
@@ -695,7 +695,7 @@ mod _serde {
         pub(super) location: Option<String>,
         pub(super) schema: Schema,
         pub(super) partition_spec: Option<UnboundPartitionSpec>,
-        pub(super) write_order: Option<UnboundSortOrder>,
+        pub(super) write_order: Option<SortOrder>,
         pub(super) stage_create: Option<bool>,
         pub(super) properties: Option<HashMap<String, String>>,
     }
@@ -721,8 +721,8 @@ mod tests {
     use iceberg::spec::ManifestListLocation::ManifestListFile;
     use iceberg::spec::{
         FormatVersion, NestedField, NullOrder, Operation, PrimitiveType, Schema, Snapshot,
-        SnapshotLog, SortDirection, SortOrder, Summary, Transform, Type, UnboundPartitionField,
-        UnboundPartitionSpec, UnboundSortField, UnboundSortOrder,
+        SnapshotLog, SortDirection, SortField, SortOrder, Summary, Transform, Type,
+        UnboundPartitionField, UnboundPartitionSpec,
     };
     use iceberg::transaction::Transaction;
     use mockito::{Mock, Server, ServerGuard};
@@ -1277,17 +1277,16 @@ mod tests {
                     .unwrap(),
             )
             .sort_order(
-                UnboundSortOrder::builder()
-                    .with_order_id(1)
+                SortOrder::builder()
                     .with_sort_field(
-                        UnboundSortField::builder()
+                        SortField::builder()
                             .source_id(2)
                             .transform(Transform::Identity)
                             .direction(SortDirection::Ascending)
                             .null_order(NullOrder::First)
                             .build(),
                     )
-                    .build()
+                    .build_unbound()
                     .unwrap(),
             )
             .build();

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -21,7 +21,7 @@ use serde_derive::{Deserialize, Serialize};
 use urlencoding::encode;
 
 use crate::spec::{
-    FormatVersion, Schema, Snapshot, SnapshotReference, SortOrder, UnboundPartitionSpec,
+    FormatVersion, Schema, Snapshot, SnapshotReference, UnboundPartitionSpec, UnboundSortOrder,
 };
 use crate::table::Table;
 use crate::{Error, ErrorKind, Result};
@@ -231,7 +231,7 @@ pub struct TableCreation {
     pub partition_spec: Option<UnboundPartitionSpec>,
     /// The sort order of the table.
     #[builder(default, setter(strip_option))]
-    pub sort_order: Option<SortOrder>,
+    pub sort_order: Option<UnboundSortOrder>,
     /// The properties of the table.
     #[builder(default)]
     pub properties: HashMap<String, String>,
@@ -375,7 +375,7 @@ pub enum TableUpdate {
     #[serde(rename_all = "kebab-case")]
     AddSortOrder {
         /// Sort order to add.
-        sort_order: SortOrder,
+        sort_order: UnboundSortOrder,
     },
     /// Set table's default sort order
     #[serde(rename_all = "kebab-case")]
@@ -432,8 +432,8 @@ mod tests {
     use crate::spec::ManifestListLocation::ManifestListFile;
     use crate::spec::{
         FormatVersion, NestedField, NullOrder, Operation, PrimitiveType, Schema, Snapshot,
-        SnapshotReference, SnapshotRetention, SortDirection, SortField, SortOrder, Summary,
-        Transform, Type, UnboundPartitionField, UnboundPartitionSpec,
+        SnapshotReference, SnapshotRetention, SortDirection, Summary, Transform, Type,
+        UnboundPartitionField, UnboundPartitionSpec, UnboundSortField, UnboundSortOrder,
     };
     use crate::{NamespaceIdent, TableIdent, TableRequirement, TableUpdate};
     use serde::de::DeserializeOwned;
@@ -848,10 +848,10 @@ mod tests {
         "#;
 
         let update = TableUpdate::AddSortOrder {
-            sort_order: SortOrder::builder()
+            sort_order: UnboundSortOrder::builder()
                 .with_order_id(1)
                 .with_sort_field(
-                    SortField::builder()
+                    UnboundSortField::builder()
                         .source_id(2)
                         .direction(SortDirection::Ascending)
                         .null_order(NullOrder::First)
@@ -859,7 +859,7 @@ mod tests {
                         .build(),
                 )
                 .with_sort_field(
-                    SortField::builder()
+                    UnboundSortField::builder()
                         .source_id(3)
                         .direction(SortDirection::Descending)
                         .null_order(NullOrder::Last)

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -17,19 +17,18 @@
 
 //! Catalog API for Apache Iceberg
 
-use serde_derive::{Deserialize, Serialize};
-use urlencoding::encode;
-
 use crate::spec::{
-    FormatVersion, Schema, Snapshot, SnapshotReference, UnboundPartitionSpec, UnboundSortOrder,
+    FormatVersion, Schema, Snapshot, SnapshotReference, SortOrder, UnboundPartitionSpec,
 };
 use crate::table::Table;
 use crate::{Error, ErrorKind, Result};
 use async_trait::async_trait;
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::mem::take;
 use std::ops::Deref;
 use typed_builder::TypedBuilder;
+use urlencoding::encode;
 use uuid::Uuid;
 
 /// The catalog API for Iceberg Rust.
@@ -231,7 +230,7 @@ pub struct TableCreation {
     pub partition_spec: Option<UnboundPartitionSpec>,
     /// The sort order of the table.
     #[builder(default, setter(strip_option))]
-    pub sort_order: Option<UnboundSortOrder>,
+    pub sort_order: Option<SortOrder>,
     /// The properties of the table.
     #[builder(default)]
     pub properties: HashMap<String, String>,
@@ -375,7 +374,7 @@ pub enum TableUpdate {
     #[serde(rename_all = "kebab-case")]
     AddSortOrder {
         /// Sort order to add.
-        sort_order: UnboundSortOrder,
+        sort_order: SortOrder,
     },
     /// Set table's default sort order
     #[serde(rename_all = "kebab-case")]
@@ -432,8 +431,8 @@ mod tests {
     use crate::spec::ManifestListLocation::ManifestListFile;
     use crate::spec::{
         FormatVersion, NestedField, NullOrder, Operation, PrimitiveType, Schema, Snapshot,
-        SnapshotReference, SnapshotRetention, SortDirection, Summary, Transform, Type,
-        UnboundPartitionField, UnboundPartitionSpec, UnboundSortField, UnboundSortOrder,
+        SnapshotReference, SnapshotRetention, SortDirection, SortField, SortOrder, Summary,
+        Transform, Type, UnboundPartitionField, UnboundPartitionSpec,
     };
     use crate::{NamespaceIdent, TableIdent, TableRequirement, TableUpdate};
     use serde::de::DeserializeOwned;
@@ -848,10 +847,10 @@ mod tests {
         "#;
 
         let update = TableUpdate::AddSortOrder {
-            sort_order: UnboundSortOrder::builder()
+            sort_order: SortOrder::builder()
                 .with_order_id(1)
                 .with_sort_field(
-                    UnboundSortField::builder()
+                    SortField::builder()
                         .source_id(2)
                         .direction(SortDirection::Ascending)
                         .null_order(NullOrder::First)
@@ -859,14 +858,14 @@ mod tests {
                         .build(),
                 )
                 .with_sort_field(
-                    UnboundSortField::builder()
+                    SortField::builder()
                         .source_id(3)
                         .direction(SortDirection::Descending)
                         .null_order(NullOrder::Last)
                         .transform(Transform::Bucket(4))
                         .build(),
                 )
-                .build()
+                .build_unbound()
                 .unwrap(),
         };
 

--- a/crates/iceberg/src/spec/sort.rs
+++ b/crates/iceberg/src/spec/sort.rs
@@ -19,13 +19,15 @@
  * Sorting
 */
 use crate::error::Result;
+use crate::spec::Schema;
 use crate::{Error, ErrorKind};
-use itertools::Itertools;
+use core::fmt;
 use serde::{Deserialize, Serialize};
+use std::fmt::Formatter;
 use std::sync::Arc;
 use typed_builder::TypedBuilder;
 
-use super::{schema::SchemaRef, transform::Transform};
+use super::transform::Transform;
 
 /// Reference to [`SortOrder`].
 pub type SortOrderRef = Arc<SortOrder>;
@@ -40,6 +42,15 @@ pub enum SortDirection {
     Descending,
 }
 
+impl fmt::Display for SortDirection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            SortDirection::Ascending => write!(f, "ascending"),
+            SortDirection::Descending => write!(f, "descending"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Copy, Clone)]
 /// Describes the order of null values when sorted.
 pub enum NullOrder {
@@ -49,6 +60,15 @@ pub enum NullOrder {
     #[serde(rename = "nulls-last")]
     /// Nulls are stored last
     Last,
+}
+
+impl fmt::Display for NullOrder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            NullOrder::First => write!(f, "first"),
+            NullOrder::Last => write!(f, "last"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TypedBuilder)]
@@ -65,9 +85,20 @@ pub struct SortField {
     pub null_order: NullOrder,
 }
 
+impl fmt::Display for SortField {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SortField {{ source_id: {}, transform: {}, direction: {}, null_order: {} }}",
+            self.source_id, self.transform, self.direction, self.null_order
+        )
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Builder, Default)]
 #[serde(rename_all = "kebab-case")]
 #[builder(setter(prefix = "with"))]
+#[builder(build_fn(skip))]
 /// A sort order is defined by a sort order id and a list of sort fields.
 /// The order of the sort fields within the list defines the order in which the sort is applied to the data.
 pub struct SortOrder {
@@ -85,89 +116,28 @@ impl SortOrder {
         SortOrderBuilder::default()
     }
 
+    /// Create an unbound unsorted order
+    pub fn unsorted_order() -> SortOrder {
+        SortOrder {
+            order_id: 0,
+            fields: Vec::new(),
+        }
+    }
+
     /// Returns true if the sort order is unsorted.
     ///
     /// A [`SortOrder`] is unsorted if it has no sort fields.
     pub fn is_unsorted(&self) -> bool {
         self.fields.is_empty()
     }
-
-    /// Converts to an unbound sort order
-    pub fn to_unbound(&self) -> UnboundSortOrder {
-        UnboundSortOrder::builder()
-            .with_order_id(self.order_id)
-            .with_fields(
-                self.fields
-                    .iter()
-                    .map(|x| UnboundSortField {
-                        source_id: x.source_id,
-                        transform: x.transform,
-                        direction: x.direction,
-                        null_order: x.null_order,
-                    })
-                    .collect_vec(),
-            )
-            .build()
-            .unwrap()
-    }
 }
 
-/// Reference to [`UnboundSortOrder`].
-pub type UnboundSortOrderRef = Arc<UnboundSortOrder>;
-
-/// Entry for every column that is to be sorted
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, TypedBuilder)]
-#[serde(rename_all = "kebab-case")]
-pub struct UnboundSortField {
-    /// A source column id from the table’s schema
-    pub source_id: i32,
-    /// A transform that is used to produce values to be sorted on from the source column.
-    pub transform: Transform,
-    /// A sort direction, that can only be either asc or desc
-    pub direction: SortDirection,
-    /// A null order that describes the order of null values when sorted.
-    pub null_order: NullOrder,
-}
-
-/// Unbound sort order can be later bound to a schema.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Builder, Default)]
-#[serde(rename_all = "kebab-case")]
-#[builder(setter(prefix = "with"))]
-#[builder(build_fn(skip))]
-pub struct UnboundSortOrder {
-    /// Identifier for the SortOrder, order_id `0` is no sort order.
-    pub order_id: i64,
-    /// Details of the sort
-    #[builder(setter(each(name = "with_sort_field")))]
-    pub fields: Vec<UnboundSortField>,
-}
-
-impl UnboundSortOrder {
-    /// Create unbound sort order builder
-    pub fn builder() -> UnboundSortOrderBuilder {
-        UnboundSortOrderBuilder::default()
-    }
-
-    /// Create an unbound unsorted order
-    fn unsorted_order() -> UnboundSortOrder {
-        UnboundSortOrder {
-            order_id: 0,
-            fields: Vec::new(),
-        }
-    }
-
-    /// Bind unbound partition spec to a schema
-    pub fn bind(&self, _schema: SchemaRef) -> Result<SortOrder> {
-        todo!()
-    }
-}
-
-impl UnboundSortOrderBuilder {
+impl SortOrderBuilder {
     /// Creates a new unbound sort order.
-    pub fn build(&self) -> Result<UnboundSortOrder> {
-        let fields = self.fields.clone().unwrap_or(Vec::new());
+    pub fn build_unbound(&self) -> Result<SortOrder> {
+        let fields = self.fields.clone().unwrap_or_default();
         return match (self.order_id, fields.as_slice()) {
-            (Some(0) | None, []) => Ok(UnboundSortOrder::unsorted_order()),
+            (Some(0) | None, []) => Ok(SortOrder::unsorted_order()),
             (_, []) => Err(Error::new(
                 ErrorKind::Unexpected,
                 "Unsorted order ID must be 0",
@@ -176,17 +146,61 @@ impl UnboundSortOrderBuilder {
                 ErrorKind::Unexpected,
                 "Sort order ID 0 is reserved for unsorted order",
             )),
-            (_, [..]) => Ok(UnboundSortOrder {
-                order_id: self.order_id.unwrap_or(1),
+            (maybe_order_id, [..]) => Ok(SortOrder {
+                order_id: maybe_order_id.unwrap_or(1),
                 fields: fields.to_vec(),
             }),
         };
+    }
+
+    /// Creates a new bound sort order.
+    pub fn build(&self, schema: Schema) -> Result<SortOrder> {
+        let unbound_sort_order = self.build_unbound()?;
+        SortOrderBuilder::check_compatibility(unbound_sort_order, schema)
+    }
+
+    /// Returns the given sort order if it is compatible with the given schema
+    fn check_compatibility(sort_order: SortOrder, schema: Schema) -> Result<SortOrder> {
+        let sort_fields = &sort_order.fields;
+        for sort_field in sort_fields {
+            match schema.field_by_id(sort_field.source_id) {
+                None => {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        format!("Cannot find source column for sort field: {sort_field}"),
+                    ))
+                }
+                Some(source_field) => {
+                    let source_type = source_field.field_type.as_ref();
+
+                    if !source_type.is_primitive() {
+                        return Err(Error::new(
+                            ErrorKind::Unexpected,
+                            format!("Cannot sort by non-primitive source field: {source_type}"),
+                        ));
+                    }
+
+                    let field_transform = sort_field.transform;
+                    if field_transform.result_type(source_type).is_err() {
+                        return Err(Error::new(
+                            ErrorKind::Unexpected,
+                            format!(
+                                "Invalid source type {source_type} for transform {field_transform}"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(sort_order)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::spec::{ListType, NestedField, PrimitiveType, Type};
 
     #[test]
     fn test_sort_field() {
@@ -238,33 +252,224 @@ mod tests {
     }
 
     #[test]
-    fn test_unbound_sort_order() {
-        let spec = r#"
-        {
-        "order-id": 1,
-        "fields": [ {
-            "transform": "identity",
-            "source-id": 2,
-            "direction": "asc",
-            "null-order": "nulls-first"
-         }, {
-            "transform": "bucket[4]",
-            "source-id": 3,
-            "direction": "desc",
-            "null-order": "nulls-last"
-         } ]
-        }
-        "#;
+    fn test_build_unbound_should_return_err_if_unsorted_order_does_not_have_an_order_id_of_zero() {
+        assert_eq!(
+            SortOrder::builder()
+                .with_order_id(1)
+                .build_unbound()
+                .expect_err("Expected an Err value")
+                .message(),
+            "Unsorted order ID must be 0"
+        )
+    }
 
-        let order: UnboundSortOrder = serde_json::from_str(spec).unwrap();
-        assert_eq!(Transform::Identity, order.fields[0].transform);
-        assert_eq!(2, order.fields[0].source_id);
-        assert_eq!(SortDirection::Ascending, order.fields[0].direction);
-        assert_eq!(NullOrder::First, order.fields[0].null_order);
+    #[test]
+    fn test_build_unbound_should_return_err_if_order_id_equals_zero_is_used_for_anything_other_than_unsorted_order(
+    ) {
+        assert_eq!(
+            SortOrder::builder()
+                .with_order_id(0)
+                .with_sort_field(
+                    SortField::builder()
+                        .source_id(2)
+                        .direction(SortDirection::Ascending)
+                        .null_order(NullOrder::First)
+                        .transform(Transform::Identity)
+                        .build()
+                )
+                .build_unbound()
+                .expect_err("Expected an Err value")
+                .message(),
+            "Sort order ID 0 is reserved for unsorted order"
+        )
+    }
 
-        assert_eq!(Transform::Bucket(4), order.fields[1].transform);
-        assert_eq!(3, order.fields[1].source_id);
-        assert_eq!(SortDirection::Descending, order.fields[1].direction);
-        assert_eq!(NullOrder::Last, order.fields[1].null_order);
+    #[test]
+    fn test_build_unbound_should_return_unsorted_sort_order() {
+        assert_eq!(
+            SortOrder::builder()
+                .with_order_id(0)
+                .build_unbound()
+                .expect("Expected an Ok value"),
+            SortOrder::unsorted_order()
+        )
+    }
+
+    #[test]
+    fn test_build_unbound_should_return_sort_order_with_given_order_id_and_sort_fields() {
+        let sort_field = SortField::builder()
+            .source_id(2)
+            .direction(SortDirection::Ascending)
+            .null_order(NullOrder::First)
+            .transform(Transform::Identity)
+            .build();
+
+        assert_eq!(
+            SortOrder::builder()
+                .with_order_id(2)
+                .with_sort_field(sort_field.clone())
+                .build_unbound()
+                .expect("Expected an Ok value"),
+            SortOrder {
+                order_id: 2,
+                fields: vec![sort_field]
+            }
+        )
+    }
+
+    #[test]
+    fn test_build_unbound_should_return_sort_order_with_given_sort_fields_and_defaults_to_1_if_missing_an_order_id(
+    ) {
+        let sort_field = SortField::builder()
+            .source_id(2)
+            .direction(SortDirection::Ascending)
+            .null_order(NullOrder::First)
+            .transform(Transform::Identity)
+            .build();
+
+        assert_eq!(
+            SortOrder::builder()
+                .with_sort_field(sort_field.clone())
+                .build_unbound()
+                .expect("Expected an Ok value"),
+            SortOrder {
+                order_id: 1,
+                fields: vec![sort_field]
+            }
+        )
+    }
+
+    #[test]
+    fn test_build_should_return_err_if_sort_order_field_is_not_present_in_schema() {
+        let schema = Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![NestedField::required(
+                1,
+                "foo",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .into()])
+            .build()
+            .unwrap();
+
+        let sort_order_builder_result = SortOrder::builder()
+            .with_sort_field(
+                SortField::builder()
+                    .source_id(2)
+                    .direction(SortDirection::Ascending)
+                    .null_order(NullOrder::First)
+                    .transform(Transform::Identity)
+                    .build(),
+            )
+            .build(schema);
+
+        assert_eq!(
+            sort_order_builder_result
+                .expect_err("Expected an Err value")
+                .message(),
+            "Cannot find source column for sort field: SortField { source_id: 2, transform: identity, direction: ascending, null_order: first }"
+        )
+    }
+
+    #[test]
+    fn test_build_should_return_err_if_source_field_is_not_a_primitive_type() {
+        let schema = Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![NestedField::required(
+                1,
+                "foo",
+                Type::List(ListType {
+                    element_field: NestedField::list_element(
+                        2,
+                        Type::Primitive(PrimitiveType::String),
+                        true,
+                    )
+                    .into(),
+                }),
+            )
+            .into()])
+            .build()
+            .unwrap();
+
+        let sort_order_builder_result = SortOrder::builder()
+            .with_sort_field(
+                SortField::builder()
+                    .source_id(1)
+                    .direction(SortDirection::Ascending)
+                    .null_order(NullOrder::First)
+                    .transform(Transform::Identity)
+                    .build(),
+            )
+            .build(schema);
+
+        assert_eq!(
+            sort_order_builder_result
+                .expect_err("Expected an Err value")
+                .message(),
+            "Cannot sort by non-primitive source field: list"
+        )
+    }
+
+    #[test]
+    fn test_build_should_return_err_if_source_field_type_is_not_supported_by_transform() {
+        let schema = Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![NestedField::required(
+                1,
+                "foo",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .into()])
+            .build()
+            .unwrap();
+
+        let sort_order_builder_result = SortOrder::builder()
+            .with_sort_field(
+                SortField::builder()
+                    .source_id(1)
+                    .direction(SortDirection::Ascending)
+                    .null_order(NullOrder::First)
+                    .transform(Transform::Year)
+                    .build(),
+            )
+            .build(schema);
+
+        assert_eq!(
+            sort_order_builder_result
+                .expect_err("Expected an Err value")
+                .message(),
+            "Invalid source type int for transform year"
+        )
+    }
+
+    #[test]
+    fn test_build_should_return_valid_sort_order() {
+        let schema = Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+            ])
+            .build()
+            .unwrap();
+
+        let sort_field = SortField::builder()
+            .source_id(2)
+            .direction(SortDirection::Ascending)
+            .null_order(NullOrder::First)
+            .transform(Transform::Identity)
+            .build();
+
+        let sort_order_builder_result = SortOrder::builder()
+            .with_sort_field(sort_field.clone())
+            .build(schema);
+
+        assert_eq!(
+            sort_order_builder_result.expect("Expected an Ok value"),
+            SortOrder {
+                order_id: 1,
+                fields: vec![sort_field],
+            }
+        )
     }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1072,7 +1072,10 @@ mod tests {
             .build()
             .unwrap();
 
-        let sort_order = SortOrder::builder().with_order_id(0).build().unwrap();
+        let sort_order = SortOrder::builder()
+            .with_order_id(0)
+            .build_unbound()
+            .unwrap();
 
         let snapshot = Snapshot::builder()
             .with_snapshot_id(638933773299822130)
@@ -1196,7 +1199,7 @@ mod tests {
                 direction: SortDirection::Descending,
                 null_order: NullOrder::Last,
             })
-            .build()
+            .build_unbound()
             .unwrap();
 
         let snapshot1 = Snapshot::builder()
@@ -1325,7 +1328,7 @@ mod tests {
                 direction: SortDirection::Descending,
                 null_order: NullOrder::Last,
             })
-            .build()
+            .build_unbound()
             .unwrap();
 
         let expected = TableMetadata {

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -18,9 +18,7 @@
 //! This module contains transaction api.
 
 use crate::error::Result;
-use crate::spec::{
-    FormatVersion, NullOrder, SortDirection, Transform, UnboundSortField, UnboundSortOrder,
-};
+use crate::spec::{FormatVersion, NullOrder, SortDirection, SortField, SortOrder, Transform};
 use crate::table::Table;
 use crate::TableUpdate::UpgradeFormatVersion;
 use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
@@ -126,7 +124,7 @@ impl<'a> Transaction<'a> {
 /// Transaction action for replacing sort order.
 pub struct ReplaceSortOrderAction<'a> {
     tx: Transaction<'a>,
-    sort_fields: Vec<UnboundSortField>,
+    sort_fields: Vec<SortField>,
 }
 
 impl<'a> ReplaceSortOrderAction<'a> {
@@ -142,9 +140,9 @@ impl<'a> ReplaceSortOrderAction<'a> {
 
     /// Finished building the action and apply it to the transaction.
     pub fn apply(mut self) -> Result<Transaction<'a>> {
-        let unbound_sort_order = UnboundSortOrder::builder()
+        let unbound_sort_order = SortOrder::builder()
             .with_fields(self.sort_fields)
-            .build()?;
+            .build_unbound()?;
 
         let updates = vec![
             TableUpdate::AddSortOrder {
@@ -192,7 +190,7 @@ impl<'a> ReplaceSortOrderAction<'a> {
                 )
             })?;
 
-        let sort_field = UnboundSortField::builder()
+        let sort_field = SortField::builder()
             .source_id(field_id)
             .transform(Transform::Identity)
             .direction(sort_direction)


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-rust/issues/99

Useful links: 
- [PR to add UnboundSortOrder to Java impl](https://github.com/apache/iceberg/pull/4360)
- [Similar ticket to add UnboundPartitionSpec to Rust impl](https://github.com/apache/iceberg-rust/issues/98)