### PR TITLE
fix: fix parse partitions in manifest_list

### DIFF
--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -1104,8 +1104,8 @@ mod _serde {
             Ok(ManifestEntry {
                 status: self.status.try_into()?,
                 snapshot_id: Some(self.snapshot_id),
-                sequence_number: None,
-                file_sequence_number: None,
+                sequence_number: Some(0),
+                file_sequence_number: Some(0),
                 data_file: self.data_file.try_into(partition_type, schema)?,
             })
         }
@@ -1620,8 +1620,8 @@ mod tests {
             entries: vec![ManifestEntry {
                 status: ManifestStatus::Added,
                 snapshot_id: Some(0),
-                sequence_number: None,
-                file_sequence_number: None,
+                sequence_number: Some(0),
+                file_sequence_number: Some(0),
                 data_file: DataFile {
                     content: DataContentType::Data,
                     file_path: "s3://testbucket/iceberg_data/iceberg_ctl/iceberg_db/iceberg_tbl/data/00000-7-45268d71-54eb-476c-b42c-942d880c04a1-00001.parquet".to_string(),
@@ -1690,8 +1690,8 @@ mod tests {
                 ManifestEntry {
                     status: ManifestStatus::Added,
                     snapshot_id: Some(0),
-                    sequence_number: None,
-                    file_sequence_number: None,
+                    sequence_number: Some(0),
+                    file_sequence_number: Some(0),
                     data_file: DataFile {
                         content: DataContentType::Data,
                         file_path: "s3://testbucket/prod/db/sample/data/category=x/00010-1-d5c93668-1e52-41ac-92a6-bba590cbf249-00001.parquet".to_string(),

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -694,7 +694,15 @@ pub(super) mod _serde {
                     .into_iter()
                     .map(|v| {
                         let partition_spec_id = v.partition_spec_id;
+                        let manifest_path = v.manifest_path.clone();
                         v.try_into(partition_types.get(&partition_spec_id))
+                            .map_err(|err| {
+                                err.with_context("manifest file path", manifest_path)
+                                    .with_context(
+                                        "partition spec id",
+                                        partition_spec_id.to_string(),
+                                    )
+                            })
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             })
@@ -728,7 +736,15 @@ pub(super) mod _serde {
                     .into_iter()
                     .map(|v| {
                         let partition_spec_id = v.partition_spec_id;
+                        let manifest_path = v.manifest_path.clone();
                         v.try_into(partition_types.get(&partition_spec_id))
+                            .map_err(|err| {
+                                err.with_context("manifest file path", manifest_path)
+                                    .with_context(
+                                        "partition spec id",
+                                        partition_spec_id.to_string(),
+                                    )
+                            })
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             })


### PR DESCRIPTION
This PR:
1. fix #121 and modify unit test to test this case.
2. fix #119, add init default when reading v1 manifest
3. add test case for writing back v1 manifest/manifest-list as v2 
   - for manifest list, we can directly write back a manifest list as v2.
   - for manifest, we can call `upgrade_version` and then write it back as v2.