### PR TITLE
chore: Upgrade toolchain to 1.75.0

### DIFF
--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -167,7 +167,7 @@ impl ManifestWriter {
             let entry = self
                 .field_summary
                 .remove(&field.source_id)
-                .unwrap_or(FieldSummary::default());
+                .unwrap_or_default();
             partition_summary.push(entry);
         }
         partition_summary

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "1.72.1"
+channel = "1.75.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Upgrade to latest stable toolchain.

This will enable nice things such as #139 , hive metastore client.