### PR TITLE
Remove `publish:` section from `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -59,7 +59,3 @@ notifications:
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
     jira_options: link label link label
-
-publish:
-  whoami: gh-pages
-  hostname: rust.iceberg.apache.org


### PR DESCRIPTION
We don't specify this in `iceberg-python` either.

I got this in my inbox:

![image](https://github.com/apache/iceberg-rust/assets/1134248/d68c332f-4958-47a1-b1bf-b394d1d94108)

The hostname is only used for non-`.apache.org` domains