### PR TITLE
feat: init file writer interface

### DIFF
--- a/crates/iceberg/src/writer/file_writer/mod.rs
+++ b/crates/iceberg/src/writer/file_writer/mod.rs
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module contains the writer for data file format supported by iceberg: parquet, orc.
+
+use super::{CurrentFileStatus, DefaultOutput};
+use crate::Result;
+use arrow_array::RecordBatch;
+
+/// File writer builder trait.
+pub trait FileWriterBuilder<O = DefaultOutput>: Send + Clone + 'static {
+    /// The associated file writer type.
+    type R: FileWriter<O>;
+    /// Build file writer.
+    fn build(self) -> impl std::future::Future<Output = Result<Self::R>> + Send;
+}
+
+/// File writer focus on writing record batch to different physical file format.(Such as parquet. orc)
+pub trait FileWriter<O = DefaultOutput>: Send + 'static + CurrentFileStatus {
+    /// Write record batch to file.
+    fn write(&mut self, batch: &RecordBatch) -> impl std::future::Future<Output = Result<()>> + Send;
+    /// Close file writer.
+    fn close(self) -> impl std::future::Future<Output = Result<O>> + Send;
+}

--- a/crates/iceberg/src/writer/file_writer/mod.rs
+++ b/crates/iceberg/src/writer/file_writer/mod.rs
@@ -20,19 +20,20 @@
 use super::{CurrentFileStatus, DefaultOutput};
 use crate::Result;
 use arrow_array::RecordBatch;
+use futures::Future;
 
 /// File writer builder trait.
 pub trait FileWriterBuilder<O = DefaultOutput>: Send + Clone + 'static {
     /// The associated file writer type.
     type R: FileWriter<O>;
     /// Build file writer.
-    fn build(self) -> impl std::future::Future<Output = Result<Self::R>> + Send;
+    fn build(self) -> impl Future<Output = Result<Self::R>> + Send;
 }
 
 /// File writer focus on writing record batch to different physical file format.(Such as parquet. orc)
-pub trait FileWriter<O = DefaultOutput>: Send + 'static + CurrentFileStatus {
+pub trait FileWriter<O = DefaultOutput>: Send + CurrentFileStatus + 'static {
     /// Write record batch to file.
-    fn write(&mut self, batch: &RecordBatch) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn write(&mut self, batch: &RecordBatch) -> impl Future<Output = Result<()>> + Send;
     /// Close file writer.
-    fn close(self) -> impl std::future::Future<Output = Result<O>> + Send;
+    fn close(self) -> impl Future<Output = Result<O>> + Send;
 }

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -15,41 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Native Rust implementation of Apache Iceberg
+//! The iceberg writer module.
 
-#![deny(missing_docs)]
+use crate::spec::DataFileBuilder;
 
-#[macro_use]
-extern crate derive_builder;
+pub mod file_writer;
 
-mod error;
-pub use error::Error;
-pub use error::ErrorKind;
-pub use error::Result;
+type DefaultOutput = Vec<DataFileBuilder>;
 
-mod catalog;
-
-pub use catalog::Catalog;
-pub use catalog::Namespace;
-pub use catalog::NamespaceIdent;
-pub use catalog::TableCommit;
-pub use catalog::TableCreation;
-pub use catalog::TableIdent;
-pub use catalog::TableRequirement;
-pub use catalog::TableUpdate;
-
-#[allow(dead_code)]
-pub mod table;
-
-mod avro;
-pub mod io;
-pub mod spec;
-
-mod scan;
-
-#[allow(dead_code)]
-pub mod expr;
-pub mod transaction;
-pub mod transform;
-
-pub mod writer;
+/// The current file status of iceberg writer. It implement for the writer which write a single
+/// file.
+pub trait CurrentFileStatus {
+    /// Get the current file path.
+    fn current_file_path(&self) -> String;
+    /// Get the current file row number.
+    fn current_row_num(&self) -> usize;
+    /// Get the current file written size.
+    fn current_written_size(&self) -> usize;
+}


### PR DESCRIPTION
related issue: https://github.com/apache/iceberg-rust/issues/34
It's the part of  #135.

The file writer interface is about the writer for data file format, e.g. parquet, orc.