### PR TITLE
feat: Bump version 0.2.0 to prepare for release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 members = ["crates/catalog/*", "crates/examples", "crates/iceberg", "crates/test_utils"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://rust.iceberg.apache.org/"
 

--- a/crates/catalog/hms/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/hms/DEPENDENCIES.rust.tsv
@@ -13,7 +13,9 @@ arrow-array@49.0.0		X
 arrow-buffer@49.0.0		X											
 arrow-data@49.0.0		X											
 arrow-schema@49.0.0		X											
+async-broadcast@0.6.0		X							X				
 async-compat@0.2.3		X							X				
+async-recursion@1.0.5		X							X				
 async-trait@0.1.75		X							X				
 autocfg@1.1.0		X							X				
 backon@0.4.1		X											
@@ -31,6 +33,7 @@ bytes@1.5.0									X
 cc@1.0.83		X							X				
 cfg-if@1.0.0		X							X				
 chrono@0.4.31		X							X				
+concurrent-queue@2.4.0		X							X				
 const-oid@0.9.6		X							X				
 const-random@0.1.17		X							X				
 const-random-macro@0.1.16		X							X				
@@ -39,6 +42,7 @@ core-foundation-sys@0.8.6		X							X
 core2@0.4.0		X							X				
 cpufeatures@0.2.11		X							X				
 crc32fast@1.3.2		X							X				
+crossbeam-utils@0.8.19		X							X				
 crunchy@0.2.2									X				
 crypto-common@0.1.6		X							X				
 darling@0.14.4									X				
@@ -48,8 +52,10 @@ darling_core@0.20.3									X
 darling_macro@0.14.4									X				
 darling_macro@0.20.3									X				
 dary_heap@0.3.6		X							X				
+dashmap@5.5.3									X				
 der@0.7.8		X							X				
 deranged@0.3.10		X							X				
+derivative@2.2.0		X							X				
 derive_builder@0.13.0		X							X				
 derive_builder_core@0.13.0		X							X				
 derive_builder_macro@0.13.0		X							X				
@@ -58,8 +64,11 @@ dlv-list@0.5.2		X							X
 either@1.9.0		X							X				
 encoding_rs@0.8.33		X			X				X				
 equivalent@1.0.1		X							X				
+event-listener@3.1.0		X							X				
+event-listener-strategy@0.1.0		X							X				
 fastrand@1.9.0		X							X				
 fastrand@2.0.1		X							X				
+faststr@0.2.16		X							X				
 flagset@0.4.4		X											
 fnv@1.0.7		X							X				
 foreign-types@0.3.2		X							X				
@@ -75,6 +84,7 @@ futures-macro@0.3.30		X							X
 futures-sink@0.3.30		X							X				
 futures-task@0.3.30		X							X				
 futures-util@0.3.30		X							X				
+fxhash@0.2.1		X							X				
 generic-array@0.14.7									X				
 getrandom@0.2.11		X							X				
 gimli@0.28.1		X							X				
@@ -83,9 +93,8 @@ half@2.3.1		X							X
 hashbrown@0.13.2		X							X				
 hashbrown@0.14.3		X							X				
 heck@0.4.1		X							X				
-hermit-abi@0.3.3		X							X				
 hex@0.4.3		X							X				
-hive_metastore@0.0.1		X											
+hive_metastore@0.0.2		X											
 hmac@0.12.1		X							X				
 home@0.5.9		X							X				
 http@0.2.11		X							X				
@@ -103,7 +112,7 @@ ident_case@1.0.1		X							X
 idna@0.5.0		X							X				
 indexmap@2.1.0		X							X				
 instant@0.1.12					X								
-integer-encoding@3.0.4									X				
+integer-encoding@4.0.0									X				
 ipnet@2.9.0		X							X				
 itertools@0.12.0		X							X				
 itoa@1.0.10		X							X				
@@ -114,16 +123,24 @@ libc@0.2.151		X							X
 libflate@2.0.0									X				
 libflate_lz77@2.0.0									X				
 libm@0.2.8		X							X				
+linked-hash-map@0.5.6		X							X				
+linkedbytes@0.1.8		X							X				
 linux-raw-sys@0.4.12		X	X						X				
 lock_api@0.4.11		X							X				
 log@0.4.20		X							X				
 md-5@0.10.6		X							X				
 memchr@2.6.4									X			X	
+memoffset@0.9.0									X				
+metainfo@0.7.9		X							X				
 mime@0.3.17		X							X				
 miniz_oxide@0.7.1		X							X				X
 mio@0.8.10									X				
+motore@0.4.0		X							X				
+motore-macros@0.4.0		X							X				
+mur3@0.1.0									X				
 murmur3@0.5.2		X							X				
 native-tls@0.2.11		X							X				
+nix@0.27.1									X				
 num@0.4.1		X							X				
 num-bigint@0.4.4		X							X				
 num-bigint-dig@0.8.4		X							X				
@@ -132,7 +149,8 @@ num-integer@0.1.45		X							X
 num-iter@0.1.43		X							X				
 num-rational@0.4.1		X							X				
 num-traits@0.2.17		X							X				
-num_cpus@1.16.0		X							X				
+num_enum@0.7.2		X			X				X				
+num_enum_derive@0.7.2		X			X				X				
 object@0.32.2		X							X				
 once_cell@1.19.0		X							X				
 opendal@0.44.0		X											
@@ -140,14 +158,16 @@ openssl@0.10.62		X
 openssl-macros@0.1.1		X							X				
 openssl-probe@0.1.5		X							X				
 openssl-sys@0.9.98									X				
-ordered-float@3.9.2									X				
 ordered-float@4.2.0									X				
 ordered-multimap@0.7.1									X				
+parking@2.2.0		X							X				
 parking_lot@0.12.1		X							X				
 parking_lot_core@0.9.9		X							X				
+paste@1.0.14		X							X				
 pem@3.0.3									X				
 pem-rfc7468@0.7.0		X							X				
 percent-encoding@2.3.1		X							X				
+pilota@0.10.0		X							X				
 pin-project@1.1.3		X							X				
 pin-project-internal@1.1.3		X							X				
 pin-project-lite@0.2.13		X							X				
@@ -157,6 +177,7 @@ pkcs8@0.10.2		X							X
 pkg-config@0.3.28		X							X				
 powerfmt@0.2.0		X							X				
 ppv-lite86@0.2.17		X							X				
+proc-macro-crate@2.0.1		X							X				
 proc-macro2@1.0.71		X							X				
 quad-rand@0.2.1									X				
 quick-xml@0.30.0									X				
@@ -176,6 +197,7 @@ rsa@0.9.6		X							X
 rust-ini@0.20.0									X				
 rust_decimal@1.33.1									X				
 rustc-demangle@0.1.23		X							X				
+rustc-hash@1.1.0		X							X				
 rustix@0.38.28		X	X						X				
 rustls@0.21.10		X						X	X				
 rustls-native-certs@0.6.3		X						X	X				
@@ -198,7 +220,9 @@ serde_with@3.4.0		X							X
 serde_with_macros@3.4.0		X							X				
 sha1@0.10.6		X							X				
 sha2@0.10.8		X							X				
+signal-hook-registry@1.4.1		X							X				
 signature@2.2.0		X							X				
+simdutf8@0.1.4		X							X				
 simple_asn1@0.6.2								X					
 slab@0.4.9									X				
 smallvec@1.11.2		X							X				
@@ -216,10 +240,8 @@ system-configuration@0.5.1		X							X
 system-configuration-sys@0.5.0		X							X				
 tap@1.0.1									X				
 tempfile@3.8.1		X							X				
-tent-thrift@0.18.1		X											
 thiserror@1.0.52		X							X				
 thiserror-impl@1.0.52		X							X				
-threadpool@1.8.1		X							X				
 time@0.3.31		X							X				
 time-core@0.1.2		X							X				
 time-macros@0.2.16		X							X				
@@ -230,9 +252,15 @@ tokio@1.35.1									X
 tokio-macros@2.2.0									X				
 tokio-native-tls@0.3.1									X				
 tokio-rustls@0.24.1		X							X				
+tokio-stream@0.1.14									X				
 tokio-util@0.7.10									X				
+toml_datetime@0.6.3		X							X				
+toml_edit@0.20.2		X							X				
+tower@0.4.13									X				
+tower-layer@0.3.2									X				
 tower-service@0.3.2									X				
 tracing@0.1.40									X				
+tracing-attributes@0.1.27									X				
 tracing-core@0.1.32									X				
 try-lock@0.2.5									X				
 typed-builder@0.16.2		X							X				
@@ -249,6 +277,8 @@ urlencoding@2.1.3									X
 uuid@1.6.1		X							X				
 vcpkg@0.2.15		X							X				
 version_check@0.9.4		X							X				
+volo@0.9.0		X							X				
+volo-thrift@0.9.2		X							X				
 want@0.3.1									X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X				
 wasm-bindgen@0.2.89		X							X				
@@ -278,6 +308,7 @@ windows_x86_64_gnullvm@0.48.5		X							X
 windows_x86_64_gnullvm@0.52.0		X							X				
 windows_x86_64_msvc@0.48.5		X							X				
 windows_x86_64_msvc@0.52.0		X							X				
+winnow@0.5.30									X				
 winreg@0.50.0									X				
 wyz@0.5.1									X				
 zerocopy@0.7.32		X		X					X				

--- a/crates/catalog/hms/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/hms/DEPENDENCIES.rust.tsv
@@ -1,290 +1,284 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.21.0		X						X				
-adler@1.0.2	X	X						X				
-adler32@1.2.0												X
-ahash@0.7.6		X						X				
-ahash@0.8.3		X						X				
-android-tzdata@0.1.1		X						X				
-android_system_properties@0.1.5		X						X				
-anyhow@1.0.72		X						X				
-apache-avro@0.16.0		X										
-arrayvec@0.7.4		X						X				
-arrow-arith@47.0.0		X										
-arrow-array@47.0.0		X										
-arrow-buffer@47.0.0		X										
-arrow-data@47.0.0		X										
-arrow-schema@47.0.0		X										
-async-compat@0.2.1		X						X				
-async-trait@0.1.73		X						X				
-autocfg@1.1.0		X						X				
-backon@0.4.1		X										
-backtrace@0.3.69		X						X				
-base64@0.21.4		X						X				
-base64ct@1.6.0		X						X				
-bimap@0.6.3		X						X				
-bitflags@1.3.2		X						X				
-bitflags@2.4.1		X						X				
-bitvec@1.0.1								X				
-block-buffer@0.10.4		X						X				
-bumpalo@3.13.0		X						X				
-byteorder@1.4.3								X			X	
-bytes@1.4.0								X				
-cc@1.0.83		X						X				
-cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
-const-random@0.1.15		X						X				
-const-random-macro@0.1.15		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-core2@0.4.0		X						X				
-cpufeatures@0.2.9		X						X				
-crc32fast@1.3.2		X						X				
-crunchy@0.2.2								X				
-crypto-common@0.1.6		X						X				
-darling@0.14.4								X				
-darling@0.20.3								X				
-darling_core@0.14.4								X				
-darling_core@0.20.3								X				
-darling_macro@0.14.4								X				
-darling_macro@0.20.3								X				
-dary_heap@0.3.6		X						X				
-der@0.7.8		X						X				
-deranged@0.3.8		X						X				
-derive_builder@0.12.0		X						X				
-derive_builder_core@0.12.0		X						X				
-derive_builder_macro@0.12.0		X						X				
-digest@0.10.7		X						X				
-dlv-list@0.5.1		X						X				
-either@1.9.0		X						X				
-encoding_rs@0.8.33		X		X				X				
-fastrand@1.9.0		X						X				
-fastrand@2.0.1		X						X				
-flagset@0.4.4		X										
-fnv@1.0.7		X						X				
-foreign-types@0.3.2		X						X				
-foreign-types-shared@0.1.1		X						X				
-form_urlencoded@1.2.0		X						X				
-funty@2.0.0								X				
-futures@0.3.28		X						X				
-futures-channel@0.3.28		X						X				
-futures-core@0.3.28		X						X				
-futures-executor@0.3.28		X						X				
-futures-io@0.3.28		X						X				
-futures-macro@0.3.28		X						X				
-futures-sink@0.3.28		X						X				
-futures-task@0.3.28		X						X				
-futures-util@0.3.28		X						X				
-generic-array@0.14.7								X				
-getrandom@0.2.10		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.21								X				
-half@2.3.1		X						X				
-hashbrown@0.12.3		X						X				
-hashbrown@0.13.2		X						X				
-hashbrown@0.14.1		X						X				
-heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
-hex@0.4.3		X						X				
-hive_metastore@0.0.1		X										
-hmac@0.12.1		X						X				
-home@0.5.5		X						X				
-http@0.2.9		X						X				
-http-body@0.4.5								X				
-httparse@1.8.0		X						X				
-httpdate@1.0.3		X						X				
-hyper@0.14.27								X				
-hyper-rustls@0.24.1		X					X	X				
-hyper-tls@0.5.0		X						X				
-iana-time-zone@0.1.57		X						X				
-iana-time-zone-haiku@0.1.2		X						X				
-iceberg@0.1.0		X										
-iceberg-catalog-hms@0.1.0		X										
-ident_case@1.0.1		X						X				
-idna@0.4.0		X						X				
-indexmap@1.9.3		X						X				
-instant@0.1.12				X								
-integer-encoding@3.0.4								X				
-ipnet@2.8.0		X						X				
-itertools@0.12.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.64		X						X				
-jsonwebtoken@9.2.0								X				
-lazy_static@1.4.0		X						X				
-libc@0.2.150		X						X				
-libflate@2.0.0								X				
-libflate_lz77@2.0.0								X				
-libm@0.2.7		X						X				
-linux-raw-sys@0.4.12		X	X					X				
-lock_api@0.4.10		X						X				
-log@0.4.20		X						X				
-md-5@0.10.5		X						X				
-memchr@2.5.0								X			X	
-mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
-mio@0.8.8								X				
-murmur3@0.5.2		X						X				
-native-tls@0.2.11		X						X				
-num@0.4.1		X						X				
-num-bigint@0.4.4		X						X				
-num-bigint-dig@0.8.4		X						X				
-num-complex@0.4.4		X						X				
-num-integer@0.1.45		X						X				
-num-iter@0.1.43		X						X				
-num-rational@0.4.1		X						X				
-num-traits@0.2.16		X						X				
-num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
-once_cell@1.18.0		X						X				
-opendal@0.44.0		X										
-openssl@0.10.60		X										
-openssl-macros@0.1.1		X						X				
-openssl-probe@0.1.5		X						X				
-openssl-sys@0.9.96								X				
-ordered-float@3.9.2								X				
-ordered-float@4.1.1								X				
-ordered-multimap@0.7.1								X				
-parking_lot@0.12.1		X						X				
-parking_lot_core@0.9.8		X						X				
-pem@3.0.3								X				
-pem-rfc7468@0.7.0		X						X				
-percent-encoding@2.3.0		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
-pin-project-lite@0.2.13		X						X				
-pin-utils@0.1.0		X						X				
-pkcs1@0.7.5		X						X				
-pkcs8@0.10.2		X						X				
-pkg-config@0.3.27		X						X				
-ppv-lite86@0.2.17		X						X				
-proc-macro-hack@0.5.20+deprecated		X						X				
-proc-macro2@1.0.66		X						X				
-quad-rand@0.2.1								X				
-quick-xml@0.30.0								X				
-quick-xml@0.31.0								X				
-quote@1.0.32		X						X				
-radium@0.7.0								X				
-rand@0.8.5		X						X				
-rand_chacha@0.3.1		X						X				
-rand_core@0.6.4		X						X				
-redox_syscall@0.3.5								X				
-redox_syscall@0.4.1								X				
-regex-lite@0.1.5		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.20		X						X				
-ring@0.16.20									X			
-ring@0.17.7									X			
-rle-decode-fast@1.0.3		X						X				
-rsa@0.9.2		X						X				
-rust-ini@0.20.0								X				
-rust_decimal@1.32.0								X				
-rustc-demangle@0.1.23		X						X				
-rustix@0.38.26		X	X					X				
-rustls@0.21.7		X					X	X				
-rustls-native-certs@0.6.3		X					X	X				
-rustls-pemfile@1.0.3		X					X	X				
-rustls-webpki@0.101.5							X					
-rustversion@1.0.14		X						X				
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
-scopeguard@1.2.0		X						X				
-sct@0.7.0		X					X	X				
-security-framework@2.9.2		X						X				
-security-framework-sys@2.9.1		X						X				
-serde@1.0.189		X						X				
-serde_bytes@0.11.12		X						X				
-serde_derive@1.0.189		X						X				
-serde_json@1.0.107		X						X				
-serde_repr@0.1.16		X						X				
-serde_urlencoded@0.7.1		X						X				
-serde_with@3.4.0		X						X				
-serde_with_macros@3.4.0		X						X				
-sha1@0.10.5		X						X				
-sha2@0.10.7		X						X				
-signal-hook-registry@1.4.1		X						X				
-signature@2.1.0		X						X				
-simple_asn1@0.6.2							X					
-slab@0.4.9								X				
-smallvec@1.11.0		X						X				
-socket2@0.4.9		X						X				
-socket2@0.5.4		X						X				
-spin@0.5.2								X				
-spin@0.9.8								X				
-spki@0.7.2		X						X				
-strsim@0.10.0								X				
-strum@0.25.0								X				
-strum_macros@0.25.3								X				
-subtle@2.5.0				X								
-syn@1.0.109		X						X				
-syn@2.0.32		X						X				
-tap@1.0.1								X				
-tempfile@3.8.1		X						X				
-tent-thrift@0.18.1		X										
-thiserror@1.0.49		X						X				
-thiserror-impl@1.0.49		X						X				
-threadpool@1.8.1		X						X				
-time@0.3.25		X						X				
-time-core@0.1.1		X						X				
-time-macros@0.2.11		X						X				
-tiny-keccak@2.0.2						X						
-tinyvec@1.6.0		X						X				X
-tinyvec_macros@0.1.1		X						X				X
-tokio@1.32.0								X				
-tokio-macros@2.1.0								X				
-tokio-native-tls@0.3.1								X				
-tokio-rustls@0.24.1		X						X				
-tokio-util@0.7.8								X				
-tower-service@0.3.2								X				
-tracing@0.1.37								X				
-tracing-core@0.1.31								X				
-try-lock@0.2.4								X				
-typed-builder@0.16.2		X						X				
-typed-builder@0.18.0		X						X				
-typed-builder-macro@0.16.2		X						X				
-typed-builder-macro@0.18.0		X						X				
-typenum@1.16.0		X						X				
-unicode-bidi@0.3.13		X						X				
-unicode-ident@1.0.11		X						X		X		
-unicode-normalization@0.1.22		X						X				
-untrusted@0.7.1							X					
-untrusted@0.9.0							X					
-url@2.4.1		X						X				
-urlencoding@2.1.3								X				
-uuid@1.6.1		X						X				
-vcpkg@0.2.15		X						X				
-version_check@0.9.4		X						X				
-want@0.3.1								X				
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.87		X						X				
-wasm-bindgen-backend@0.2.87		X						X				
-wasm-bindgen-futures@0.4.37		X						X				
-wasm-bindgen-macro@0.2.87		X						X				
-wasm-bindgen-macro-support@0.2.87		X						X				
-wasm-bindgen-shared@0.2.87		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.64		X						X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows@0.48.0		X						X				
-windows-sys@0.48.0		X						X				
-windows-sys@0.52.0		X						X				
-windows-targets@0.48.1		X						X				
-windows-targets@0.52.0		X						X				
-windows_aarch64_gnullvm@0.48.0		X						X				
-windows_aarch64_gnullvm@0.52.0		X						X				
-windows_aarch64_msvc@0.48.0		X						X				
-windows_aarch64_msvc@0.52.0		X						X				
-windows_i686_gnu@0.48.0		X						X				
-windows_i686_gnu@0.52.0		X						X				
-windows_i686_msvc@0.48.0		X						X				
-windows_i686_msvc@0.52.0		X						X				
-windows_x86_64_gnu@0.48.0		X						X				
-windows_x86_64_gnu@0.52.0		X						X				
-windows_x86_64_gnullvm@0.48.0		X						X				
-windows_x86_64_gnullvm@0.52.0		X						X				
-windows_x86_64_msvc@0.48.0		X						X				
-windows_x86_64_msvc@0.52.0		X						X				
-winreg@0.50.0								X				
-wyz@0.5.1								X				
-zeroize@1.6.0		X						X				
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X							X				
+adler@1.0.2	X	X							X				
+adler32@1.2.0													X
+ahash@0.8.6		X							X				
+android-tzdata@0.1.1		X							X				
+android_system_properties@0.1.5		X							X				
+anyhow@1.0.77		X							X				
+apache-avro@0.16.0		X											
+arrayvec@0.7.4		X							X				
+arrow-arith@49.0.0		X											
+arrow-array@49.0.0		X											
+arrow-buffer@49.0.0		X											
+arrow-data@49.0.0		X											
+arrow-schema@49.0.0		X											
+async-compat@0.2.3		X							X				
+async-trait@0.1.75		X							X				
+autocfg@1.1.0		X							X				
+backon@0.4.1		X											
+backtrace@0.3.69		X							X				
+base64@0.21.5		X							X				
+base64ct@1.6.0		X							X				
+bimap@0.6.3		X							X				
+bitflags@1.3.2		X							X				
+bitflags@2.4.1		X							X				
+bitvec@1.0.1									X				
+block-buffer@0.10.4		X							X				
+bumpalo@3.14.0		X							X				
+byteorder@1.5.0									X			X	
+bytes@1.5.0									X				
+cc@1.0.83		X							X				
+cfg-if@1.0.0		X							X				
+chrono@0.4.31		X							X				
+const-oid@0.9.6		X							X				
+const-random@0.1.17		X							X				
+const-random-macro@0.1.16		X							X				
+core-foundation@0.9.4		X							X				
+core-foundation-sys@0.8.6		X							X				
+core2@0.4.0		X							X				
+cpufeatures@0.2.11		X							X				
+crc32fast@1.3.2		X							X				
+crunchy@0.2.2									X				
+crypto-common@0.1.6		X							X				
+darling@0.14.4									X				
+darling@0.20.3									X				
+darling_core@0.14.4									X				
+darling_core@0.20.3									X				
+darling_macro@0.14.4									X				
+darling_macro@0.20.3									X				
+dary_heap@0.3.6		X							X				
+der@0.7.8		X							X				
+deranged@0.3.10		X							X				
+derive_builder@0.13.0		X							X				
+derive_builder_core@0.13.0		X							X				
+derive_builder_macro@0.13.0		X							X				
+digest@0.10.7		X							X				
+dlv-list@0.5.2		X							X				
+either@1.9.0		X							X				
+encoding_rs@0.8.33		X			X				X				
+equivalent@1.0.1		X							X				
+fastrand@1.9.0		X							X				
+fastrand@2.0.1		X							X				
+flagset@0.4.4		X											
+fnv@1.0.7		X							X				
+foreign-types@0.3.2		X							X				
+foreign-types-shared@0.1.1		X							X				
+form_urlencoded@1.2.1		X							X				
+funty@2.0.0									X				
+futures@0.3.30		X							X				
+futures-channel@0.3.30		X							X				
+futures-core@0.3.30		X							X				
+futures-executor@0.3.30		X							X				
+futures-io@0.3.30		X							X				
+futures-macro@0.3.30		X							X				
+futures-sink@0.3.30		X							X				
+futures-task@0.3.30		X							X				
+futures-util@0.3.30		X							X				
+generic-array@0.14.7									X				
+getrandom@0.2.11		X							X				
+gimli@0.28.1		X							X				
+h2@0.3.22									X				
+half@2.3.1		X							X				
+hashbrown@0.13.2		X							X				
+hashbrown@0.14.3		X							X				
+heck@0.4.1		X							X				
+hermit-abi@0.3.3		X							X				
+hex@0.4.3		X							X				
+hive_metastore@0.0.1		X											
+hmac@0.12.1		X							X				
+home@0.5.9		X							X				
+http@0.2.11		X							X				
+http-body@0.4.6									X				
+httparse@1.8.0		X							X				
+httpdate@1.0.3		X							X				
+hyper@0.14.28									X				
+hyper-rustls@0.24.2		X						X	X				
+hyper-tls@0.5.0		X							X				
+iana-time-zone@0.1.58		X							X				
+iana-time-zone-haiku@0.1.2		X							X				
+iceberg@0.2.0		X											
+iceberg-catalog-hms@0.2.0		X											
+ident_case@1.0.1		X							X				
+idna@0.5.0		X							X				
+indexmap@2.1.0		X							X				
+instant@0.1.12					X								
+integer-encoding@3.0.4									X				
+ipnet@2.9.0		X							X				
+itertools@0.12.0		X							X				
+itoa@1.0.10		X							X				
+js-sys@0.3.66		X							X				
+jsonwebtoken@9.2.0									X				
+lazy_static@1.4.0		X							X				
+libc@0.2.151		X							X				
+libflate@2.0.0									X				
+libflate_lz77@2.0.0									X				
+libm@0.2.8		X							X				
+linux-raw-sys@0.4.12		X	X						X				
+lock_api@0.4.11		X							X				
+log@0.4.20		X							X				
+md-5@0.10.6		X							X				
+memchr@2.6.4									X			X	
+mime@0.3.17		X							X				
+miniz_oxide@0.7.1		X							X				X
+mio@0.8.10									X				
+murmur3@0.5.2		X							X				
+native-tls@0.2.11		X							X				
+num@0.4.1		X							X				
+num-bigint@0.4.4		X							X				
+num-bigint-dig@0.8.4		X							X				
+num-complex@0.4.4		X							X				
+num-integer@0.1.45		X							X				
+num-iter@0.1.43		X							X				
+num-rational@0.4.1		X							X				
+num-traits@0.2.17		X							X				
+num_cpus@1.16.0		X							X				
+object@0.32.2		X							X				
+once_cell@1.19.0		X							X				
+opendal@0.44.0		X											
+openssl@0.10.62		X											
+openssl-macros@0.1.1		X							X				
+openssl-probe@0.1.5		X							X				
+openssl-sys@0.9.98									X				
+ordered-float@3.9.2									X				
+ordered-float@4.2.0									X				
+ordered-multimap@0.7.1									X				
+parking_lot@0.12.1		X							X				
+parking_lot_core@0.9.9		X							X				
+pem@3.0.3									X				
+pem-rfc7468@0.7.0		X							X				
+percent-encoding@2.3.1		X							X				
+pin-project@1.1.3		X							X				
+pin-project-internal@1.1.3		X							X				
+pin-project-lite@0.2.13		X							X				
+pin-utils@0.1.0		X							X				
+pkcs1@0.7.5		X							X				
+pkcs8@0.10.2		X							X				
+pkg-config@0.3.28		X							X				
+powerfmt@0.2.0		X							X				
+ppv-lite86@0.2.17		X							X				
+proc-macro2@1.0.71		X							X				
+quad-rand@0.2.1									X				
+quick-xml@0.30.0									X				
+quick-xml@0.31.0									X				
+quote@1.0.33		X							X				
+radium@0.7.0									X				
+rand@0.8.5		X							X				
+rand_chacha@0.3.1		X							X				
+rand_core@0.6.4		X							X				
+redox_syscall@0.4.1									X				
+regex-lite@0.1.5		X							X				
+reqsign@0.14.6		X											
+reqwest@0.11.23		X							X				
+ring@0.17.7										X			
+rle-decode-fast@1.0.3		X							X				
+rsa@0.9.6		X							X				
+rust-ini@0.20.0									X				
+rust_decimal@1.33.1									X				
+rustc-demangle@0.1.23		X							X				
+rustix@0.38.28		X	X						X				
+rustls@0.21.10		X						X	X				
+rustls-native-certs@0.6.3		X						X	X				
+rustls-pemfile@1.0.4		X						X	X				
+rustls-webpki@0.101.7								X					
+rustversion@1.0.14		X							X				
+ryu@1.0.16		X				X							
+schannel@0.1.22									X				
+scopeguard@1.2.0		X							X				
+sct@0.7.1		X						X	X				
+security-framework@2.9.2		X							X				
+security-framework-sys@2.9.1		X							X				
+serde@1.0.193		X							X				
+serde_bytes@0.11.13		X							X				
+serde_derive@1.0.193		X							X				
+serde_json@1.0.108		X							X				
+serde_repr@0.1.17		X							X				
+serde_urlencoded@0.7.1		X							X				
+serde_with@3.4.0		X							X				
+serde_with_macros@3.4.0		X							X				
+sha1@0.10.6		X							X				
+sha2@0.10.8		X							X				
+signature@2.2.0		X							X				
+simple_asn1@0.6.2								X					
+slab@0.4.9									X				
+smallvec@1.11.2		X							X				
+socket2@0.5.5		X							X				
+spin@0.5.2									X				
+spin@0.9.8									X				
+spki@0.7.3		X							X				
+strsim@0.10.0									X				
+strum@0.25.0									X				
+strum_macros@0.25.3									X				
+subtle@2.5.0					X								
+syn@1.0.109		X							X				
+syn@2.0.43		X							X				
+system-configuration@0.5.1		X							X				
+system-configuration-sys@0.5.0		X							X				
+tap@1.0.1									X				
+tempfile@3.8.1		X							X				
+tent-thrift@0.18.1		X											
+thiserror@1.0.52		X							X				
+thiserror-impl@1.0.52		X							X				
+threadpool@1.8.1		X							X				
+time@0.3.31		X							X				
+time-core@0.1.2		X							X				
+time-macros@0.2.16		X							X				
+tiny-keccak@2.0.2							X						
+tinyvec@1.6.0		X							X				X
+tinyvec_macros@0.1.1		X							X				X
+tokio@1.35.1									X				
+tokio-macros@2.2.0									X				
+tokio-native-tls@0.3.1									X				
+tokio-rustls@0.24.1		X							X				
+tokio-util@0.7.10									X				
+tower-service@0.3.2									X				
+tracing@0.1.40									X				
+tracing-core@0.1.32									X				
+try-lock@0.2.5									X				
+typed-builder@0.16.2		X							X				
+typed-builder@0.18.0		X							X				
+typed-builder-macro@0.16.2		X							X				
+typed-builder-macro@0.18.0		X							X				
+typenum@1.17.0		X							X				
+unicode-bidi@0.3.14		X							X				
+unicode-ident@1.0.12		X							X		X		
+unicode-normalization@0.1.22		X							X				
+untrusted@0.9.0								X					
+url@2.5.0		X							X				
+urlencoding@2.1.3									X				
+uuid@1.6.1		X							X				
+vcpkg@0.2.15		X							X				
+version_check@0.9.4		X							X				
+want@0.3.1									X				
+wasi@0.11.0+wasi-snapshot-preview1		X	X						X				
+wasm-bindgen@0.2.89		X							X				
+wasm-bindgen-backend@0.2.89		X							X				
+wasm-bindgen-futures@0.4.39		X							X				
+wasm-bindgen-macro@0.2.89		X							X				
+wasm-bindgen-macro-support@0.2.89		X							X				
+wasm-bindgen-shared@0.2.89		X							X				
+wasm-streams@0.3.0		X							X				
+web-sys@0.3.66		X							X				
+windows-core@0.51.1		X							X				
+windows-sys@0.48.0		X							X				
+windows-sys@0.52.0		X							X				
+windows-targets@0.48.5		X							X				
+windows-targets@0.52.0		X							X				
+windows_aarch64_gnullvm@0.48.5		X							X				
+windows_aarch64_gnullvm@0.52.0		X							X				
+windows_aarch64_msvc@0.48.5		X							X				
+windows_aarch64_msvc@0.52.0		X							X				
+windows_i686_gnu@0.48.5		X							X				
+windows_i686_gnu@0.52.0		X							X				
+windows_i686_msvc@0.48.5		X							X				
+windows_i686_msvc@0.52.0		X							X				
+windows_x86_64_gnu@0.48.5		X							X				
+windows_x86_64_gnu@0.52.0		X							X				
+windows_x86_64_gnullvm@0.48.5		X							X				
+windows_x86_64_gnullvm@0.52.0		X							X				
+windows_x86_64_msvc@0.48.5		X							X				
+windows_x86_64_msvc@0.52.0		X							X				
+winreg@0.50.0									X				
+wyz@0.5.1									X				
+zerocopy@0.7.32		X		X					X				
+zeroize@1.7.0		X							X				

--- a/crates/catalog/rest/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/rest/DEPENDENCIES.rust.tsv
@@ -1,295 +1,295 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.21.0		X						X				
-adler@1.0.2	X	X						X				
-adler32@1.2.0												X
-ahash@0.7.6		X						X				
-ahash@0.8.3		X						X				
-aho-corasick@1.1.2								X			X	
-android-tzdata@0.1.1		X						X				
-android_system_properties@0.1.5		X						X				
-anyhow@1.0.72		X						X				
-apache-avro@0.16.0		X										
-arrayvec@0.7.4		X						X				
-arrow-arith@47.0.0		X										
-arrow-array@47.0.0		X										
-arrow-buffer@47.0.0		X										
-arrow-data@47.0.0		X										
-arrow-schema@47.0.0		X										
-async-compat@0.2.1		X						X				
-async-trait@0.1.73		X						X				
-autocfg@1.1.0		X						X				
-backon@0.4.1		X										
-backtrace@0.3.69		X						X				
-base64@0.21.4		X						X				
-base64ct@1.6.0		X						X				
-bimap@0.6.3		X						X				
-bitflags@1.3.2		X						X				
-bitflags@2.4.1		X						X				
-bitvec@1.0.1								X				
-block-buffer@0.10.4		X						X				
-bumpalo@3.13.0		X						X				
-byteorder@1.4.3								X			X	
-bytes@1.4.0								X				
-cc@1.0.83		X						X				
-cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
-const-random@0.1.15		X						X				
-const-random-macro@0.1.15		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-core2@0.4.0		X						X				
-cpufeatures@0.2.9		X						X				
-crc32fast@1.3.2		X						X				
-crunchy@0.2.2								X				
-crypto-common@0.1.6		X						X				
-darling@0.14.4								X				
-darling@0.20.3								X				
-darling_core@0.14.4								X				
-darling_core@0.20.3								X				
-darling_macro@0.14.4								X				
-darling_macro@0.20.3								X				
-dary_heap@0.3.6		X						X				
-der@0.7.8		X						X				
-deranged@0.3.8		X						X				
-derive_builder@0.12.0		X						X				
-derive_builder_core@0.12.0		X						X				
-derive_builder_macro@0.12.0		X						X				
-digest@0.10.7		X						X				
-dlv-list@0.5.1		X						X				
-either@1.9.0		X						X				
-encoding_rs@0.8.33		X		X				X				
-env_logger@0.10.1		X						X				
-fastrand@1.9.0		X						X				
-fastrand@2.0.1		X						X				
-flagset@0.4.4		X										
-fnv@1.0.7		X						X				
-foreign-types@0.3.2		X						X				
-foreign-types-shared@0.1.1		X						X				
-form_urlencoded@1.2.0		X						X				
-funty@2.0.0								X				
-futures@0.3.28		X						X				
-futures-channel@0.3.28		X						X				
-futures-core@0.3.28		X						X				
-futures-executor@0.3.28		X						X				
-futures-io@0.3.28		X						X				
-futures-macro@0.3.28		X						X				
-futures-sink@0.3.28		X						X				
-futures-task@0.3.28		X						X				
-futures-util@0.3.28		X						X				
-generic-array@0.14.7								X				
-getrandom@0.2.10		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.21								X				
-half@2.3.1		X						X				
-hashbrown@0.12.3		X						X				
-hashbrown@0.13.2		X						X				
-hashbrown@0.14.1		X						X				
-heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
-hex@0.4.3		X						X				
-hmac@0.12.1		X						X				
-home@0.5.5		X						X				
-http@0.2.9		X						X				
-http-body@0.4.5								X				
-httparse@1.8.0		X						X				
-httpdate@1.0.3		X						X				
-humantime@2.1.0		X						X				
-hyper@0.14.27								X				
-hyper-rustls@0.24.1		X					X	X				
-hyper-tls@0.5.0		X						X				
-iana-time-zone@0.1.57		X						X				
-iana-time-zone-haiku@0.1.2		X						X				
-iceberg@0.1.0		X										
-iceberg-catalog-rest@0.1.0		X										
-iceberg_test_utils@0.1.0		X										
-ident_case@1.0.1		X						X				
-idna@0.4.0		X						X				
-indexmap@1.9.3		X						X				
-instant@0.1.12				X								
-ipnet@2.8.0		X						X				
-is-terminal@0.4.9								X				
-itertools@0.12.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.64		X						X				
-jsonwebtoken@9.2.0								X				
-lazy_static@1.4.0		X						X				
-libc@0.2.150		X						X				
-libflate@2.0.0								X				
-libflate_lz77@2.0.0								X				
-libm@0.2.7		X						X				
-linux-raw-sys@0.4.12		X	X					X				
-lock_api@0.4.10		X						X				
-log@0.4.20		X						X				
-md-5@0.10.5		X						X				
-memchr@2.5.0								X			X	
-mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
-mio@0.8.8								X				
-murmur3@0.5.2		X						X				
-native-tls@0.2.11		X						X				
-num@0.4.1		X						X				
-num-bigint@0.4.4		X						X				
-num-bigint-dig@0.8.4		X						X				
-num-complex@0.4.4		X						X				
-num-integer@0.1.45		X						X				
-num-iter@0.1.43		X						X				
-num-rational@0.4.1		X						X				
-num-traits@0.2.16		X						X				
-num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
-once_cell@1.18.0		X						X				
-opendal@0.44.0		X										
-openssl@0.10.60		X										
-openssl-macros@0.1.1		X						X				
-openssl-probe@0.1.5		X						X				
-openssl-sys@0.9.96								X				
-ordered-float@4.1.1								X				
-ordered-multimap@0.7.1								X				
-parking_lot@0.12.1		X						X				
-parking_lot_core@0.9.8		X						X				
-pem@3.0.3								X				
-pem-rfc7468@0.7.0		X						X				
-percent-encoding@2.3.0		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
-pin-project-lite@0.2.13		X						X				
-pin-utils@0.1.0		X						X				
-pkcs1@0.7.5		X						X				
-pkcs8@0.10.2		X						X				
-pkg-config@0.3.27		X						X				
-ppv-lite86@0.2.17		X						X				
-proc-macro-hack@0.5.20+deprecated		X						X				
-proc-macro2@1.0.66		X						X				
-quad-rand@0.2.1								X				
-quick-xml@0.30.0								X				
-quick-xml@0.31.0								X				
-quote@1.0.32		X						X				
-radium@0.7.0								X				
-rand@0.8.5		X						X				
-rand_chacha@0.3.1		X						X				
-rand_core@0.6.4		X						X				
-redox_syscall@0.3.5								X				
-redox_syscall@0.4.1								X				
-regex@1.9.4		X						X				
-regex-automata@0.3.7		X						X				
-regex-lite@0.1.5		X						X				
-regex-syntax@0.7.5		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.20		X						X				
-ring@0.16.20									X			
-ring@0.17.7									X			
-rle-decode-fast@1.0.3		X						X				
-rsa@0.9.2		X						X				
-rust-ini@0.20.0								X				
-rust_decimal@1.32.0								X				
-rustc-demangle@0.1.23		X						X				
-rustix@0.38.26		X	X					X				
-rustls@0.21.7		X					X	X				
-rustls-native-certs@0.6.3		X					X	X				
-rustls-pemfile@1.0.3		X					X	X				
-rustls-webpki@0.101.5							X					
-rustversion@1.0.14		X						X				
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
-scopeguard@1.2.0		X						X				
-sct@0.7.0		X					X	X				
-security-framework@2.9.2		X						X				
-security-framework-sys@2.9.1		X						X				
-serde@1.0.189		X						X				
-serde_bytes@0.11.12		X						X				
-serde_derive@1.0.189		X						X				
-serde_json@1.0.107		X						X				
-serde_repr@0.1.16		X						X				
-serde_urlencoded@0.7.1		X						X				
-serde_with@3.4.0		X						X				
-serde_with_macros@3.4.0		X						X				
-sha1@0.10.5		X						X				
-sha2@0.10.7		X						X				
-signal-hook-registry@1.4.1		X						X				
-signature@2.1.0		X						X				
-simple_asn1@0.6.2							X					
-slab@0.4.9								X				
-smallvec@1.11.0		X						X				
-socket2@0.4.9		X						X				
-socket2@0.5.4		X						X				
-spin@0.5.2								X				
-spin@0.9.8								X				
-spki@0.7.2		X						X				
-strsim@0.10.0								X				
-strum@0.25.0								X				
-strum_macros@0.25.3								X				
-subtle@2.5.0				X								
-syn@1.0.109		X						X				
-syn@2.0.32		X						X				
-tap@1.0.1								X				
-tempfile@3.8.1		X						X				
-termcolor@1.4.0								X			X	
-thiserror@1.0.49		X						X				
-thiserror-impl@1.0.49		X						X				
-time@0.3.25		X						X				
-time-core@0.1.1		X						X				
-time-macros@0.2.11		X						X				
-tiny-keccak@2.0.2						X						
-tinyvec@1.6.0		X						X				X
-tinyvec_macros@0.1.1		X						X				X
-tokio@1.32.0								X				
-tokio-macros@2.1.0								X				
-tokio-native-tls@0.3.1								X				
-tokio-rustls@0.24.1		X						X				
-tokio-util@0.7.8								X				
-tower-service@0.3.2								X				
-tracing@0.1.37								X				
-tracing-core@0.1.31								X				
-try-lock@0.2.4								X				
-typed-builder@0.16.2		X						X				
-typed-builder@0.18.0		X						X				
-typed-builder-macro@0.16.2		X						X				
-typed-builder-macro@0.18.0		X						X				
-typenum@1.16.0		X						X				
-unicode-bidi@0.3.13		X						X				
-unicode-ident@1.0.11		X						X		X		
-unicode-normalization@0.1.22		X						X				
-untrusted@0.7.1							X					
-untrusted@0.9.0							X					
-url@2.4.1		X						X				
-urlencoding@2.1.3								X				
-uuid@1.6.1		X						X				
-vcpkg@0.2.15		X						X				
-version_check@0.9.4		X						X				
-want@0.3.1								X				
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.87		X						X				
-wasm-bindgen-backend@0.2.87		X						X				
-wasm-bindgen-futures@0.4.37		X						X				
-wasm-bindgen-macro@0.2.87		X						X				
-wasm-bindgen-macro-support@0.2.87		X						X				
-wasm-bindgen-shared@0.2.87		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.64		X						X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-util@0.1.6								X			X	
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows@0.48.0		X						X				
-windows-sys@0.48.0		X						X				
-windows-sys@0.52.0		X						X				
-windows-targets@0.48.1		X						X				
-windows-targets@0.52.0		X						X				
-windows_aarch64_gnullvm@0.48.0		X						X				
-windows_aarch64_gnullvm@0.52.0		X						X				
-windows_aarch64_msvc@0.48.0		X						X				
-windows_aarch64_msvc@0.52.0		X						X				
-windows_i686_gnu@0.48.0		X						X				
-windows_i686_gnu@0.52.0		X						X				
-windows_i686_msvc@0.48.0		X						X				
-windows_i686_msvc@0.52.0		X						X				
-windows_x86_64_gnu@0.48.0		X						X				
-windows_x86_64_gnu@0.52.0		X						X				
-windows_x86_64_gnullvm@0.48.0		X						X				
-windows_x86_64_gnullvm@0.52.0		X						X				
-windows_x86_64_msvc@0.48.0		X						X				
-windows_x86_64_msvc@0.52.0		X						X				
-winreg@0.50.0								X				
-wyz@0.5.1								X				
-zeroize@1.6.0		X						X				
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X							X				
+adler@1.0.2	X	X							X				
+adler32@1.2.0													X
+ahash@0.8.6		X							X				
+aho-corasick@1.1.2									X			X	
+android-tzdata@0.1.1		X							X				
+android_system_properties@0.1.5		X							X				
+anstream@0.6.11		X							X				
+anstyle@1.0.4		X							X				
+anstyle-parse@0.2.3		X							X				
+anstyle-query@1.0.2		X							X				
+anstyle-wincon@3.0.2		X							X				
+anyhow@1.0.77		X							X				
+apache-avro@0.16.0		X											
+arrayvec@0.7.4		X							X				
+arrow-arith@49.0.0		X											
+arrow-array@49.0.0		X											
+arrow-buffer@49.0.0		X											
+arrow-data@49.0.0		X											
+arrow-schema@49.0.0		X											
+async-compat@0.2.3		X							X				
+async-trait@0.1.75		X							X				
+autocfg@1.1.0		X							X				
+backon@0.4.1		X											
+backtrace@0.3.69		X							X				
+base64@0.21.5		X							X				
+base64ct@1.6.0		X							X				
+bimap@0.6.3		X							X				
+bitflags@1.3.2		X							X				
+bitflags@2.4.1		X							X				
+bitvec@1.0.1									X				
+block-buffer@0.10.4		X							X				
+bumpalo@3.14.0		X							X				
+byteorder@1.5.0									X			X	
+bytes@1.5.0									X				
+cc@1.0.83		X							X				
+cfg-if@1.0.0		X							X				
+chrono@0.4.31		X							X				
+colorchoice@1.0.0		X							X				
+const-oid@0.9.6		X							X				
+const-random@0.1.17		X							X				
+const-random-macro@0.1.16		X							X				
+core-foundation@0.9.4		X							X				
+core-foundation-sys@0.8.6		X							X				
+core2@0.4.0		X							X				
+cpufeatures@0.2.11		X							X				
+crc32fast@1.3.2		X							X				
+crunchy@0.2.2									X				
+crypto-common@0.1.6		X							X				
+darling@0.14.4									X				
+darling@0.20.3									X				
+darling_core@0.14.4									X				
+darling_core@0.20.3									X				
+darling_macro@0.14.4									X				
+darling_macro@0.20.3									X				
+dary_heap@0.3.6		X							X				
+der@0.7.8		X							X				
+deranged@0.3.10		X							X				
+derive_builder@0.13.0		X							X				
+derive_builder_core@0.13.0		X							X				
+derive_builder_macro@0.13.0		X							X				
+digest@0.10.7		X							X				
+dlv-list@0.5.2		X							X				
+either@1.9.0		X							X				
+encoding_rs@0.8.33		X			X				X				
+env_filter@0.1.0		X							X				
+env_logger@0.11.0		X							X				
+equivalent@1.0.1		X							X				
+fastrand@1.9.0		X							X				
+fastrand@2.0.1		X							X				
+flagset@0.4.4		X											
+fnv@1.0.7		X							X				
+foreign-types@0.3.2		X							X				
+foreign-types-shared@0.1.1		X							X				
+form_urlencoded@1.2.1		X							X				
+funty@2.0.0									X				
+futures@0.3.30		X							X				
+futures-channel@0.3.30		X							X				
+futures-core@0.3.30		X							X				
+futures-executor@0.3.30		X							X				
+futures-io@0.3.30		X							X				
+futures-macro@0.3.30		X							X				
+futures-sink@0.3.30		X							X				
+futures-task@0.3.30		X							X				
+futures-util@0.3.30		X							X				
+generic-array@0.14.7									X				
+getrandom@0.2.11		X							X				
+gimli@0.28.1		X							X				
+h2@0.3.22									X				
+half@2.3.1		X							X				
+hashbrown@0.13.2		X							X				
+hashbrown@0.14.3		X							X				
+heck@0.4.1		X							X				
+hermit-abi@0.3.3		X							X				
+hex@0.4.3		X							X				
+hmac@0.12.1		X							X				
+home@0.5.9		X							X				
+http@0.2.11		X							X				
+http-body@0.4.6									X				
+httparse@1.8.0		X							X				
+httpdate@1.0.3		X							X				
+humantime@2.1.0		X							X				
+hyper@0.14.28									X				
+hyper-rustls@0.24.2		X						X	X				
+hyper-tls@0.5.0		X							X				
+iana-time-zone@0.1.58		X							X				
+iana-time-zone-haiku@0.1.2		X							X				
+iceberg@0.2.0		X											
+iceberg-catalog-rest@0.2.0		X											
+iceberg_test_utils@0.2.0		X											
+ident_case@1.0.1		X							X				
+idna@0.5.0		X							X				
+indexmap@2.1.0		X							X				
+instant@0.1.12					X								
+ipnet@2.9.0		X							X				
+itertools@0.12.0		X							X				
+itoa@1.0.10		X							X				
+js-sys@0.3.66		X							X				
+jsonwebtoken@9.2.0									X				
+lazy_static@1.4.0		X							X				
+libc@0.2.151		X							X				
+libflate@2.0.0									X				
+libflate_lz77@2.0.0									X				
+libm@0.2.8		X							X				
+linux-raw-sys@0.4.12		X	X						X				
+lock_api@0.4.11		X							X				
+log@0.4.20		X							X				
+md-5@0.10.6		X							X				
+memchr@2.6.4									X			X	
+mime@0.3.17		X							X				
+miniz_oxide@0.7.1		X							X				X
+mio@0.8.10									X				
+murmur3@0.5.2		X							X				
+native-tls@0.2.11		X							X				
+num@0.4.1		X							X				
+num-bigint@0.4.4		X							X				
+num-bigint-dig@0.8.4		X							X				
+num-complex@0.4.4		X							X				
+num-integer@0.1.45		X							X				
+num-iter@0.1.43		X							X				
+num-rational@0.4.1		X							X				
+num-traits@0.2.17		X							X				
+num_cpus@1.16.0		X							X				
+object@0.32.2		X							X				
+once_cell@1.19.0		X							X				
+opendal@0.44.0		X											
+openssl@0.10.62		X											
+openssl-macros@0.1.1		X							X				
+openssl-probe@0.1.5		X							X				
+openssl-sys@0.9.98									X				
+ordered-float@4.2.0									X				
+ordered-multimap@0.7.1									X				
+parking_lot@0.12.1		X							X				
+parking_lot_core@0.9.9		X							X				
+pem@3.0.3									X				
+pem-rfc7468@0.7.0		X							X				
+percent-encoding@2.3.1		X							X				
+pin-project@1.1.3		X							X				
+pin-project-internal@1.1.3		X							X				
+pin-project-lite@0.2.13		X							X				
+pin-utils@0.1.0		X							X				
+pkcs1@0.7.5		X							X				
+pkcs8@0.10.2		X							X				
+pkg-config@0.3.28		X							X				
+powerfmt@0.2.0		X							X				
+ppv-lite86@0.2.17		X							X				
+proc-macro2@1.0.71		X							X				
+quad-rand@0.2.1									X				
+quick-xml@0.30.0									X				
+quick-xml@0.31.0									X				
+quote@1.0.33		X							X				
+radium@0.7.0									X				
+rand@0.8.5		X							X				
+rand_chacha@0.3.1		X							X				
+rand_core@0.6.4		X							X				
+redox_syscall@0.4.1									X				
+regex@1.10.2		X							X				
+regex-automata@0.4.3		X							X				
+regex-lite@0.1.5		X							X				
+regex-syntax@0.8.2		X							X				
+reqsign@0.14.6		X											
+reqwest@0.11.23		X							X				
+ring@0.17.7										X			
+rle-decode-fast@1.0.3		X							X				
+rsa@0.9.6		X							X				
+rust-ini@0.20.0									X				
+rust_decimal@1.33.1									X				
+rustc-demangle@0.1.23		X							X				
+rustix@0.38.28		X	X						X				
+rustls@0.21.10		X						X	X				
+rustls-native-certs@0.6.3		X						X	X				
+rustls-pemfile@1.0.4		X						X	X				
+rustls-webpki@0.101.7								X					
+rustversion@1.0.14		X							X				
+ryu@1.0.16		X				X							
+schannel@0.1.22									X				
+scopeguard@1.2.0		X							X				
+sct@0.7.1		X						X	X				
+security-framework@2.9.2		X							X				
+security-framework-sys@2.9.1		X							X				
+serde@1.0.193		X							X				
+serde_bytes@0.11.13		X							X				
+serde_derive@1.0.193		X							X				
+serde_json@1.0.108		X							X				
+serde_repr@0.1.17		X							X				
+serde_urlencoded@0.7.1		X							X				
+serde_with@3.4.0		X							X				
+serde_with_macros@3.4.0		X							X				
+sha1@0.10.6		X							X				
+sha2@0.10.8		X							X				
+signal-hook-registry@1.4.1		X							X				
+signature@2.2.0		X							X				
+simple_asn1@0.6.2								X					
+slab@0.4.9									X				
+smallvec@1.11.2		X							X				
+socket2@0.5.5		X							X				
+spin@0.5.2									X				
+spin@0.9.8									X				
+spki@0.7.3		X							X				
+strsim@0.10.0									X				
+strum@0.25.0									X				
+strum_macros@0.25.3									X				
+subtle@2.5.0					X								
+syn@1.0.109		X							X				
+syn@2.0.43		X							X				
+system-configuration@0.5.1		X							X				
+system-configuration-sys@0.5.0		X							X				
+tap@1.0.1									X				
+tempfile@3.8.1		X							X				
+thiserror@1.0.52		X							X				
+thiserror-impl@1.0.52		X							X				
+time@0.3.31		X							X				
+time-core@0.1.2		X							X				
+time-macros@0.2.16		X							X				
+tiny-keccak@2.0.2							X						
+tinyvec@1.6.0		X							X				X
+tinyvec_macros@0.1.1		X							X				X
+tokio@1.35.1									X				
+tokio-macros@2.2.0									X				
+tokio-native-tls@0.3.1									X				
+tokio-rustls@0.24.1		X							X				
+tokio-util@0.7.10									X				
+tower-service@0.3.2									X				
+tracing@0.1.40									X				
+tracing-core@0.1.32									X				
+try-lock@0.2.5									X				
+typed-builder@0.16.2		X							X				
+typed-builder@0.18.0		X							X				
+typed-builder-macro@0.16.2		X							X				
+typed-builder-macro@0.18.0		X							X				
+typenum@1.17.0		X							X				
+unicode-bidi@0.3.14		X							X				
+unicode-ident@1.0.12		X							X		X		
+unicode-normalization@0.1.22		X							X				
+untrusted@0.9.0								X					
+url@2.5.0		X							X				
+urlencoding@2.1.3									X				
+utf8parse@0.2.1		X							X				
+uuid@1.6.1		X							X				
+vcpkg@0.2.15		X							X				
+version_check@0.9.4		X							X				
+want@0.3.1									X				
+wasi@0.11.0+wasi-snapshot-preview1		X	X						X				
+wasm-bindgen@0.2.89		X							X				
+wasm-bindgen-backend@0.2.89		X							X				
+wasm-bindgen-futures@0.4.39		X							X				
+wasm-bindgen-macro@0.2.89		X							X				
+wasm-bindgen-macro-support@0.2.89		X							X				
+wasm-bindgen-shared@0.2.89		X							X				
+wasm-streams@0.3.0		X							X				
+web-sys@0.3.66		X							X				
+windows-core@0.51.1		X							X				
+windows-sys@0.48.0		X							X				
+windows-sys@0.52.0		X							X				
+windows-targets@0.48.5		X							X				
+windows-targets@0.52.0		X							X				
+windows_aarch64_gnullvm@0.48.5		X							X				
+windows_aarch64_gnullvm@0.52.0		X							X				
+windows_aarch64_msvc@0.48.5		X							X				
+windows_aarch64_msvc@0.52.0		X							X				
+windows_i686_gnu@0.48.5		X							X				
+windows_i686_gnu@0.52.0		X							X				
+windows_i686_msvc@0.48.5		X							X				
+windows_i686_msvc@0.52.0		X							X				
+windows_x86_64_gnu@0.48.5		X							X				
+windows_x86_64_gnu@0.52.0		X							X				
+windows_x86_64_gnullvm@0.48.5		X							X				
+windows_x86_64_gnullvm@0.52.0		X							X				
+windows_x86_64_msvc@0.48.5		X							X				
+windows_x86_64_msvc@0.52.0		X							X				
+winreg@0.50.0									X				
+wyz@0.5.1									X				
+zerocopy@0.7.32		X		X					X				
+zeroize@1.7.0		X							X				

--- a/crates/iceberg/DEPENDENCIES.rust.tsv
+++ b/crates/iceberg/DEPENDENCIES.rust.tsv
@@ -1,284 +1,276 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.21.0		X						X				
-adler@1.0.2	X	X						X				
-adler32@1.2.0												X
-ahash@0.7.6		X						X				
-ahash@0.8.3		X						X				
-android-tzdata@0.1.1		X						X				
-android_system_properties@0.1.5		X						X				
-anyhow@1.0.72		X						X				
-apache-avro@0.16.0		X										
-arrayvec@0.7.4		X						X				
-arrow-arith@47.0.0		X										
-arrow-array@47.0.0		X										
-arrow-buffer@47.0.0		X										
-arrow-data@47.0.0		X										
-arrow-schema@47.0.0		X										
-async-compat@0.2.1		X						X				
-async-trait@0.1.73		X						X				
-autocfg@1.1.0		X						X				
-backon@0.4.1		X										
-backtrace@0.3.69		X						X				
-base64@0.21.4		X						X				
-base64ct@1.6.0		X						X				
-bimap@0.6.3		X						X				
-bitflags@1.3.2		X						X				
-bitflags@2.4.1		X						X				
-bitvec@1.0.1								X				
-block-buffer@0.10.4		X						X				
-bumpalo@3.13.0		X						X				
-byteorder@1.4.3								X			X	
-bytes@1.4.0								X				
-cc@1.0.83		X						X				
-cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
-const-random@0.1.15		X						X				
-const-random-macro@0.1.15		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-core2@0.4.0		X						X				
-cpufeatures@0.2.9		X						X				
-crc32fast@1.3.2		X						X				
-crunchy@0.2.2								X				
-crypto-common@0.1.6		X						X				
-darling@0.14.4								X				
-darling@0.20.3								X				
-darling_core@0.14.4								X				
-darling_core@0.20.3								X				
-darling_macro@0.14.4								X				
-darling_macro@0.20.3								X				
-dary_heap@0.3.6		X						X				
-der@0.7.8		X						X				
-deranged@0.3.8		X						X				
-derive_builder@0.12.0		X						X				
-derive_builder_core@0.12.0		X						X				
-derive_builder_macro@0.12.0		X						X				
-digest@0.10.7		X						X				
-dlv-list@0.5.1		X						X				
-either@1.9.0		X						X				
-encoding_rs@0.8.33		X		X				X				
-fastrand@1.9.0		X						X				
-fastrand@2.0.1		X						X				
-flagset@0.4.4		X										
-fnv@1.0.7		X						X				
-foreign-types@0.3.2		X						X				
-foreign-types-shared@0.1.1		X						X				
-form_urlencoded@1.2.0		X						X				
-funty@2.0.0								X				
-futures@0.3.28		X						X				
-futures-channel@0.3.28		X						X				
-futures-core@0.3.28		X						X				
-futures-executor@0.3.28		X						X				
-futures-io@0.3.28		X						X				
-futures-macro@0.3.28		X						X				
-futures-sink@0.3.28		X						X				
-futures-task@0.3.28		X						X				
-futures-util@0.3.28		X						X				
-generic-array@0.14.7								X				
-getrandom@0.2.10		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.21								X				
-half@2.3.1		X						X				
-hashbrown@0.12.3		X						X				
-hashbrown@0.13.2		X						X				
-hashbrown@0.14.1		X						X				
-heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
-hex@0.4.3		X						X				
-hmac@0.12.1		X						X				
-home@0.5.5		X						X				
-http@0.2.9		X						X				
-http-body@0.4.5								X				
-httparse@1.8.0		X						X				
-httpdate@1.0.3		X						X				
-hyper@0.14.27								X				
-hyper-rustls@0.24.1		X					X	X				
-hyper-tls@0.5.0		X						X				
-iana-time-zone@0.1.57		X						X				
-iana-time-zone-haiku@0.1.2		X						X				
-iceberg@0.1.0		X										
-ident_case@1.0.1		X						X				
-idna@0.4.0		X						X				
-indexmap@1.9.3		X						X				
-instant@0.1.12				X								
-ipnet@2.8.0		X						X				
-itertools@0.12.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.64		X						X				
-jsonwebtoken@9.2.0								X				
-lazy_static@1.4.0		X						X				
-libc@0.2.150		X						X				
-libflate@2.0.0								X				
-libflate_lz77@2.0.0								X				
-libm@0.2.7		X						X				
-linux-raw-sys@0.4.12		X	X					X				
-lock_api@0.4.10		X						X				
-log@0.4.20		X						X				
-md-5@0.10.5		X						X				
-memchr@2.5.0								X			X	
-mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
-mio@0.8.8								X				
-murmur3@0.5.2		X						X				
-native-tls@0.2.11		X						X				
-num@0.4.1		X						X				
-num-bigint@0.4.4		X						X				
-num-bigint-dig@0.8.4		X						X				
-num-complex@0.4.4		X						X				
-num-integer@0.1.45		X						X				
-num-iter@0.1.43		X						X				
-num-rational@0.4.1		X						X				
-num-traits@0.2.16		X						X				
-num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
-once_cell@1.18.0		X						X				
-opendal@0.44.0		X										
-openssl@0.10.60		X										
-openssl-macros@0.1.1		X						X				
-openssl-probe@0.1.5		X						X				
-openssl-sys@0.9.96								X				
-ordered-float@4.1.1								X				
-ordered-multimap@0.7.1								X				
-parking_lot@0.12.1		X						X				
-parking_lot_core@0.9.8		X						X				
-pem@3.0.3								X				
-pem-rfc7468@0.7.0		X						X				
-percent-encoding@2.3.0		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
-pin-project-lite@0.2.13		X						X				
-pin-utils@0.1.0		X						X				
-pkcs1@0.7.5		X						X				
-pkcs8@0.10.2		X						X				
-pkg-config@0.3.27		X						X				
-ppv-lite86@0.2.17		X						X				
-proc-macro-hack@0.5.20+deprecated		X						X				
-proc-macro2@1.0.66		X						X				
-quad-rand@0.2.1								X				
-quick-xml@0.30.0								X				
-quick-xml@0.31.0								X				
-quote@1.0.32		X						X				
-radium@0.7.0								X				
-rand@0.8.5		X						X				
-rand_chacha@0.3.1		X						X				
-rand_core@0.6.4		X						X				
-redox_syscall@0.3.5								X				
-redox_syscall@0.4.1								X				
-regex-lite@0.1.5		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.20		X						X				
-ring@0.16.20									X			
-ring@0.17.7									X			
-rle-decode-fast@1.0.3		X						X				
-rsa@0.9.2		X						X				
-rust-ini@0.20.0								X				
-rust_decimal@1.32.0								X				
-rustc-demangle@0.1.23		X						X				
-rustix@0.38.26		X	X					X				
-rustls@0.21.7		X					X	X				
-rustls-native-certs@0.6.3		X					X	X				
-rustls-pemfile@1.0.3		X					X	X				
-rustls-webpki@0.101.5							X					
-rustversion@1.0.14		X						X				
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
-scopeguard@1.2.0		X						X				
-sct@0.7.0		X					X	X				
-security-framework@2.9.2		X						X				
-security-framework-sys@2.9.1		X						X				
-serde@1.0.189		X						X				
-serde_bytes@0.11.12		X						X				
-serde_derive@1.0.189		X						X				
-serde_json@1.0.107		X						X				
-serde_repr@0.1.16		X						X				
-serde_urlencoded@0.7.1		X						X				
-serde_with@3.4.0		X						X				
-serde_with_macros@3.4.0		X						X				
-sha1@0.10.5		X						X				
-sha2@0.10.7		X						X				
-signal-hook-registry@1.4.1		X						X				
-signature@2.1.0		X						X				
-simple_asn1@0.6.2							X					
-slab@0.4.9								X				
-smallvec@1.11.0		X						X				
-socket2@0.4.9		X						X				
-socket2@0.5.4		X						X				
-spin@0.5.2								X				
-spin@0.9.8								X				
-spki@0.7.2		X						X				
-strsim@0.10.0								X				
-strum@0.25.0								X				
-strum_macros@0.25.3								X				
-subtle@2.5.0				X								
-syn@1.0.109		X						X				
-syn@2.0.32		X						X				
-tap@1.0.1								X				
-tempfile@3.8.1		X						X				
-thiserror@1.0.49		X						X				
-thiserror-impl@1.0.49		X						X				
-time@0.3.25		X						X				
-time-core@0.1.1		X						X				
-time-macros@0.2.11		X						X				
-tiny-keccak@2.0.2						X						
-tinyvec@1.6.0		X						X				X
-tinyvec_macros@0.1.1		X						X				X
-tokio@1.32.0								X				
-tokio-macros@2.1.0								X				
-tokio-native-tls@0.3.1								X				
-tokio-rustls@0.24.1		X						X				
-tokio-util@0.7.8								X				
-tower-service@0.3.2								X				
-tracing@0.1.37								X				
-tracing-core@0.1.31								X				
-try-lock@0.2.4								X				
-typed-builder@0.16.2		X						X				
-typed-builder@0.18.0		X						X				
-typed-builder-macro@0.16.2		X						X				
-typed-builder-macro@0.18.0		X						X				
-typenum@1.16.0		X						X				
-unicode-bidi@0.3.13		X						X				
-unicode-ident@1.0.11		X						X		X		
-unicode-normalization@0.1.22		X						X				
-untrusted@0.7.1							X					
-untrusted@0.9.0							X					
-url@2.4.1		X						X				
-urlencoding@2.1.3								X				
-uuid@1.6.1		X						X				
-vcpkg@0.2.15		X						X				
-version_check@0.9.4		X						X				
-want@0.3.1								X				
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.87		X						X				
-wasm-bindgen-backend@0.2.87		X						X				
-wasm-bindgen-futures@0.4.37		X						X				
-wasm-bindgen-macro@0.2.87		X						X				
-wasm-bindgen-macro-support@0.2.87		X						X				
-wasm-bindgen-shared@0.2.87		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.64		X						X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows@0.48.0		X						X				
-windows-sys@0.48.0		X						X				
-windows-sys@0.52.0		X						X				
-windows-targets@0.48.1		X						X				
-windows-targets@0.52.0		X						X				
-windows_aarch64_gnullvm@0.48.0		X						X				
-windows_aarch64_gnullvm@0.52.0		X						X				
-windows_aarch64_msvc@0.48.0		X						X				
-windows_aarch64_msvc@0.52.0		X						X				
-windows_i686_gnu@0.48.0		X						X				
-windows_i686_gnu@0.52.0		X						X				
-windows_i686_msvc@0.48.0		X						X				
-windows_i686_msvc@0.52.0		X						X				
-windows_x86_64_gnu@0.48.0		X						X				
-windows_x86_64_gnu@0.52.0		X						X				
-windows_x86_64_gnullvm@0.48.0		X						X				
-windows_x86_64_gnullvm@0.52.0		X						X				
-windows_x86_64_msvc@0.48.0		X						X				
-windows_x86_64_msvc@0.52.0		X						X				
-winreg@0.50.0								X				
-wyz@0.5.1								X				
-zeroize@1.6.0		X						X				
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X							X				
+adler@1.0.2	X	X							X				
+adler32@1.2.0													X
+ahash@0.8.6		X							X				
+android-tzdata@0.1.1		X							X				
+android_system_properties@0.1.5		X							X				
+anyhow@1.0.77		X							X				
+apache-avro@0.16.0		X											
+arrayvec@0.7.4		X							X				
+arrow-arith@49.0.0		X											
+arrow-array@49.0.0		X											
+arrow-buffer@49.0.0		X											
+arrow-data@49.0.0		X											
+arrow-schema@49.0.0		X											
+async-compat@0.2.3		X							X				
+async-trait@0.1.75		X							X				
+autocfg@1.1.0		X							X				
+backon@0.4.1		X											
+backtrace@0.3.69		X							X				
+base64@0.21.5		X							X				
+base64ct@1.6.0		X							X				
+bimap@0.6.3		X							X				
+bitflags@1.3.2		X							X				
+bitflags@2.4.1		X							X				
+bitvec@1.0.1									X				
+block-buffer@0.10.4		X							X				
+bumpalo@3.14.0		X							X				
+byteorder@1.5.0									X			X	
+bytes@1.5.0									X				
+cc@1.0.83		X							X				
+cfg-if@1.0.0		X							X				
+chrono@0.4.31		X							X				
+const-oid@0.9.6		X							X				
+const-random@0.1.17		X							X				
+const-random-macro@0.1.16		X							X				
+core-foundation@0.9.4		X							X				
+core-foundation-sys@0.8.6		X							X				
+core2@0.4.0		X							X				
+cpufeatures@0.2.11		X							X				
+crc32fast@1.3.2		X							X				
+crunchy@0.2.2									X				
+crypto-common@0.1.6		X							X				
+darling@0.14.4									X				
+darling@0.20.3									X				
+darling_core@0.14.4									X				
+darling_core@0.20.3									X				
+darling_macro@0.14.4									X				
+darling_macro@0.20.3									X				
+dary_heap@0.3.6		X							X				
+der@0.7.8		X							X				
+deranged@0.3.10		X							X				
+derive_builder@0.13.0		X							X				
+derive_builder_core@0.13.0		X							X				
+derive_builder_macro@0.13.0		X							X				
+digest@0.10.7		X							X				
+dlv-list@0.5.2		X							X				
+either@1.9.0		X							X				
+encoding_rs@0.8.33		X			X				X				
+equivalent@1.0.1		X							X				
+fastrand@1.9.0		X							X				
+fastrand@2.0.1		X							X				
+flagset@0.4.4		X											
+fnv@1.0.7		X							X				
+foreign-types@0.3.2		X							X				
+foreign-types-shared@0.1.1		X							X				
+form_urlencoded@1.2.1		X							X				
+funty@2.0.0									X				
+futures@0.3.30		X							X				
+futures-channel@0.3.30		X							X				
+futures-core@0.3.30		X							X				
+futures-executor@0.3.30		X							X				
+futures-io@0.3.30		X							X				
+futures-macro@0.3.30		X							X				
+futures-sink@0.3.30		X							X				
+futures-task@0.3.30		X							X				
+futures-util@0.3.30		X							X				
+generic-array@0.14.7									X				
+getrandom@0.2.11		X							X				
+gimli@0.28.1		X							X				
+h2@0.3.22									X				
+half@2.3.1		X							X				
+hashbrown@0.13.2		X							X				
+hashbrown@0.14.3		X							X				
+heck@0.4.1		X							X				
+hex@0.4.3		X							X				
+hmac@0.12.1		X							X				
+home@0.5.9		X							X				
+http@0.2.11		X							X				
+http-body@0.4.6									X				
+httparse@1.8.0		X							X				
+httpdate@1.0.3		X							X				
+hyper@0.14.28									X				
+hyper-rustls@0.24.2		X						X	X				
+hyper-tls@0.5.0		X							X				
+iana-time-zone@0.1.58		X							X				
+iana-time-zone-haiku@0.1.2		X							X				
+iceberg@0.2.0		X											
+ident_case@1.0.1		X							X				
+idna@0.5.0		X							X				
+indexmap@2.1.0		X							X				
+instant@0.1.12					X								
+ipnet@2.9.0		X							X				
+itertools@0.12.0		X							X				
+itoa@1.0.10		X							X				
+js-sys@0.3.66		X							X				
+jsonwebtoken@9.2.0									X				
+lazy_static@1.4.0		X							X				
+libc@0.2.151		X							X				
+libflate@2.0.0									X				
+libflate_lz77@2.0.0									X				
+libm@0.2.8		X							X				
+linux-raw-sys@0.4.12		X	X						X				
+lock_api@0.4.11		X							X				
+log@0.4.20		X							X				
+md-5@0.10.6		X							X				
+memchr@2.6.4									X			X	
+mime@0.3.17		X							X				
+miniz_oxide@0.7.1		X							X				X
+mio@0.8.10									X				
+murmur3@0.5.2		X							X				
+native-tls@0.2.11		X							X				
+num@0.4.1		X							X				
+num-bigint@0.4.4		X							X				
+num-bigint-dig@0.8.4		X							X				
+num-complex@0.4.4		X							X				
+num-integer@0.1.45		X							X				
+num-iter@0.1.43		X							X				
+num-rational@0.4.1		X							X				
+num-traits@0.2.17		X							X				
+object@0.32.2		X							X				
+once_cell@1.19.0		X							X				
+opendal@0.44.0		X											
+openssl@0.10.62		X											
+openssl-macros@0.1.1		X							X				
+openssl-probe@0.1.5		X							X				
+openssl-sys@0.9.98									X				
+ordered-float@4.2.0									X				
+ordered-multimap@0.7.1									X				
+parking_lot@0.12.1		X							X				
+parking_lot_core@0.9.9		X							X				
+pem@3.0.3									X				
+pem-rfc7468@0.7.0		X							X				
+percent-encoding@2.3.1		X							X				
+pin-project@1.1.3		X							X				
+pin-project-internal@1.1.3		X							X				
+pin-project-lite@0.2.13		X							X				
+pin-utils@0.1.0		X							X				
+pkcs1@0.7.5		X							X				
+pkcs8@0.10.2		X							X				
+pkg-config@0.3.28		X							X				
+powerfmt@0.2.0		X							X				
+ppv-lite86@0.2.17		X							X				
+proc-macro2@1.0.71		X							X				
+quad-rand@0.2.1									X				
+quick-xml@0.30.0									X				
+quick-xml@0.31.0									X				
+quote@1.0.33		X							X				
+radium@0.7.0									X				
+rand@0.8.5		X							X				
+rand_chacha@0.3.1		X							X				
+rand_core@0.6.4		X							X				
+redox_syscall@0.4.1									X				
+regex-lite@0.1.5		X							X				
+reqsign@0.14.6		X											
+reqwest@0.11.23		X							X				
+ring@0.17.7										X			
+rle-decode-fast@1.0.3		X							X				
+rsa@0.9.6		X							X				
+rust-ini@0.20.0									X				
+rust_decimal@1.33.1									X				
+rustc-demangle@0.1.23		X							X				
+rustix@0.38.28		X	X						X				
+rustls@0.21.10		X						X	X				
+rustls-native-certs@0.6.3		X						X	X				
+rustls-pemfile@1.0.4		X						X	X				
+rustls-webpki@0.101.7								X					
+rustversion@1.0.14		X							X				
+ryu@1.0.16		X				X							
+schannel@0.1.22									X				
+scopeguard@1.2.0		X							X				
+sct@0.7.1		X						X	X				
+security-framework@2.9.2		X							X				
+security-framework-sys@2.9.1		X							X				
+serde@1.0.193		X							X				
+serde_bytes@0.11.13		X							X				
+serde_derive@1.0.193		X							X				
+serde_json@1.0.108		X							X				
+serde_repr@0.1.17		X							X				
+serde_urlencoded@0.7.1		X							X				
+serde_with@3.4.0		X							X				
+serde_with_macros@3.4.0		X							X				
+sha1@0.10.6		X							X				
+sha2@0.10.8		X							X				
+signature@2.2.0		X							X				
+simple_asn1@0.6.2								X					
+slab@0.4.9									X				
+smallvec@1.11.2		X							X				
+socket2@0.5.5		X							X				
+spin@0.5.2									X				
+spin@0.9.8									X				
+spki@0.7.3		X							X				
+strsim@0.10.0									X				
+strum@0.25.0									X				
+strum_macros@0.25.3									X				
+subtle@2.5.0					X								
+syn@1.0.109		X							X				
+syn@2.0.43		X							X				
+system-configuration@0.5.1		X							X				
+system-configuration-sys@0.5.0		X							X				
+tap@1.0.1									X				
+tempfile@3.8.1		X							X				
+thiserror@1.0.52		X							X				
+thiserror-impl@1.0.52		X							X				
+time@0.3.31		X							X				
+time-core@0.1.2		X							X				
+time-macros@0.2.16		X							X				
+tiny-keccak@2.0.2							X						
+tinyvec@1.6.0		X							X				X
+tinyvec_macros@0.1.1		X							X				X
+tokio@1.35.1									X				
+tokio-macros@2.2.0									X				
+tokio-native-tls@0.3.1									X				
+tokio-rustls@0.24.1		X							X				
+tokio-util@0.7.10									X				
+tower-service@0.3.2									X				
+tracing@0.1.40									X				
+tracing-core@0.1.32									X				
+try-lock@0.2.5									X				
+typed-builder@0.16.2		X							X				
+typed-builder@0.18.0		X							X				
+typed-builder-macro@0.16.2		X							X				
+typed-builder-macro@0.18.0		X							X				
+typenum@1.17.0		X							X				
+unicode-bidi@0.3.14		X							X				
+unicode-ident@1.0.12		X							X		X		
+unicode-normalization@0.1.22		X							X				
+untrusted@0.9.0								X					
+url@2.5.0		X							X				
+urlencoding@2.1.3									X				
+uuid@1.6.1		X							X				
+vcpkg@0.2.15		X							X				
+version_check@0.9.4		X							X				
+want@0.3.1									X				
+wasi@0.11.0+wasi-snapshot-preview1		X	X						X				
+wasm-bindgen@0.2.89		X							X				
+wasm-bindgen-backend@0.2.89		X							X				
+wasm-bindgen-futures@0.4.39		X							X				
+wasm-bindgen-macro@0.2.89		X							X				
+wasm-bindgen-macro-support@0.2.89		X							X				
+wasm-bindgen-shared@0.2.89		X							X				
+wasm-streams@0.3.0		X							X				
+web-sys@0.3.66		X							X				
+windows-core@0.51.1		X							X				
+windows-sys@0.48.0		X							X				
+windows-sys@0.52.0		X							X				
+windows-targets@0.48.5		X							X				
+windows-targets@0.52.0		X							X				
+windows_aarch64_gnullvm@0.48.5		X							X				
+windows_aarch64_gnullvm@0.52.0		X							X				
+windows_aarch64_msvc@0.48.5		X							X				
+windows_aarch64_msvc@0.52.0		X							X				
+windows_i686_gnu@0.48.5		X							X				
+windows_i686_gnu@0.52.0		X							X				
+windows_i686_msvc@0.48.5		X							X				
+windows_i686_msvc@0.52.0		X							X				
+windows_x86_64_gnu@0.48.5		X							X				
+windows_x86_64_gnu@0.52.0		X							X				
+windows_x86_64_gnullvm@0.48.5		X							X				
+windows_x86_64_gnullvm@0.52.0		X							X				
+windows_x86_64_msvc@0.48.5		X							X				
+windows_x86_64_msvc@0.52.0		X							X				
+winreg@0.50.0									X				
+wyz@0.5.1									X				
+zerocopy@0.7.32		X		X					X				
+zeroize@1.7.0		X							X				


### PR DESCRIPTION
We have reached consensus to run the first release: `0.2.0`, see [the discussion](https://lists.apache.org/thread/8sj66kf02qd0qtyyrj4gox3yozjk3vtd) in mail list. 

This is the first step of #180 :

1. Bump version to 0.2.0
2. Update dependencies.