### PR TITLE
Fix: avro schema names for manifest and manifest_list

### DIFF
--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -662,7 +662,7 @@ mod _const_schema {
             )),
         ];
         let schema = Schema::builder().with_fields(fields).build().unwrap();
-        schema_to_avro_schema("manifest", &schema)
+        schema_to_avro_schema("manifest_entry", &schema)
     }
 
     pub(super) fn manifest_schema_v1(partition_type: StructType) -> Result<AvroSchema, Error> {
@@ -696,7 +696,7 @@ mod _const_schema {
             )),
         ];
         let schema = Schema::builder().with_fields(fields).build().unwrap();
-        schema_to_avro_schema("manifest", &schema)
+        schema_to_avro_schema("manifest_entry", &schema)
     }
 }
 

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -495,10 +495,10 @@ mod _const_schema {
     };
 
     pub(super) static MANIFEST_LIST_AVRO_SCHEMA_V1: Lazy<AvroSchema> =
-        Lazy::new(|| schema_to_avro_schema("manifest_list", &V1_SCHEMA).unwrap());
+        Lazy::new(|| schema_to_avro_schema("manifest_file", &V1_SCHEMA).unwrap());
 
     pub(super) static MANIFEST_LIST_AVRO_SCHEMA_V2: Lazy<AvroSchema> =
-        Lazy::new(|| schema_to_avro_schema("manifest_list", &V2_SCHEMA).unwrap());
+        Lazy::new(|| schema_to_avro_schema("manifest_file", &V2_SCHEMA).unwrap());
 }
 
 /// Entry in a manifest list.


### PR DESCRIPTION
Closes #179

Once writing works it's probably best to make an integration test that tries to read the manifests.