### PR TITLE
refactor: rm async_trait and add trait_variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/catalog/*", "crates/examples", "crates/iceberg", "crates/test_utils"]
+members = [
+    "crates/catalog/*",
+    "crates/examples",
+    "crates/iceberg",
+    "crates/test_utils",
+]
 
 [workspace.package]
 version = "0.1.0"
@@ -33,7 +38,6 @@ apache-avro = "0.16"
 arrow-arith = { version = ">=46" }
 arrow-array = { version = ">=46" }
 arrow-schema = { version = ">=46" }
-async-trait = "0.1"
 bimap = "0.6"
 bitvec = "1.0.1"
 chrono = "0.4"

--- a/crates/catalog/hms/Cargo.toml
+++ b/crates/catalog/hms/Cargo.toml
@@ -28,7 +28,6 @@ license = { workspace = true }
 keywords = ["iceberg", "hive", "catalog"]
 
 [dependencies]
-async-trait = { workspace = true }
 hive_metastore = "0.0.1"
 iceberg = { workspace = true }
 # the thrift upstream suffered from no regular rust release.

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use super::utils::*;
-use async_trait::async_trait;
 use hive_metastore::{TThriftHiveMetastoreSyncClient, ThriftHiveMetastoreSyncClient};
 use iceberg::table::Table;
 use iceberg::{Catalog, Namespace, NamespaceIdent, Result, TableCommit, TableCreation, TableIdent};
@@ -89,7 +88,6 @@ impl HmsCatalog {
 }
 
 /// Refer to <https://github.com/apache/iceberg/blob/main/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java> for implementation details.
-#[async_trait]
 impl Catalog for HmsCatalog {
     /// HMS doesn't support nested namespaces.
     ///

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -28,8 +28,6 @@ license = { workspace = true }
 keywords = ["iceberg", "rest", "catalog"]
 
 [dependencies]
-# async-trait = { workspace = true }
-async-trait = { workspace = true }
 chrono = { workspace = true }
 iceberg = { workspace = true }
 log = "0.4.20"

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -19,7 +19,6 @@
 
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use reqwest::header::{self, HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Request, Response, StatusCode};
 use serde::de::DeserializeOwned;
@@ -215,7 +214,6 @@ pub struct RestCatalog {
     client: HttpClient,
 }
 
-#[async_trait]
 impl Catalog for RestCatalog {
     /// List namespaces from table.
     async fn list_namespaces(
@@ -1558,7 +1556,7 @@ mod tests {
         "type": "NoSuchTableException",
         "code": 404
     }
-}      
+}
             "#,
             )
             .create_async()

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -33,7 +33,6 @@ apache-avro = { workspace = true }
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
-async-trait = { workspace = true }
 bimap = { workspace = true }
 bitvec = { workspace = true }
 chrono = { workspace = true }
@@ -55,6 +54,7 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = { workspace = true }
 serde_with = { workspace = true }
+trait-variant = "0.1.1"
 typed-builder = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -25,7 +25,6 @@ use crate::spec::{
 };
 use crate::table::Table;
 use crate::{Error, ErrorKind, Result};
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::mem::take;
 use std::ops::Deref;
@@ -33,8 +32,9 @@ use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 /// The catalog API for Iceberg Rust.
-#[async_trait]
-pub trait Catalog: std::fmt::Debug {
+/// see https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html
+#[trait_variant::make(Catalog: Send)]
+pub trait LocalCatalog: std::fmt::Debug {
     /// List namespaces from table.
     async fn list_namespaces(&self, parent: Option<&NamespaceIdent>)
         -> Result<Vec<NamespaceIdent>>;
@@ -505,7 +505,7 @@ mod tests {
 {
     "type": "assert-ref-snapshot-id",
     "ref": "snapshot-name",
-    "snapshot-id": null 
+    "snapshot-id": null
 }
         "#,
             TableRequirement::RefSnapshotIdMatch {
@@ -625,7 +625,7 @@ mod tests {
 {
     "action": "assign-uuid",
     "uuid": "2cc52516-5e73-41f2-b139-545d41a4e151"
-}        
+}
         "#,
             TableUpdate::AssignUuid {
                 uuid: uuid!("2cc52516-5e73-41f2-b139-545d41a4e151"),
@@ -640,7 +640,7 @@ mod tests {
 {
     "action": "upgrade-format-version",
     "format-version": 2
-}        
+}
         "#,
             TableUpdate::UpgradeFormatVersion {
                 format_version: FormatVersion::V2,
@@ -932,7 +932,7 @@ mod tests {
         1,
         2
     ]
-}  
+}
         "#;
 
         let update = TableUpdate::RemoveSnapshots {
@@ -990,7 +990,7 @@ mod tests {
     "min-snapshots-to-keep": 2,
     "max-snapshot-age-ms": 3,
     "max-ref-age-ms": 4
-}        
+}
         "#;
 
         let update = TableUpdate::SetSnapshotRef {
@@ -1017,7 +1017,7 @@ mod tests {
         "prop1": "v1",
         "prop2": "v2"
     }
-}        
+}
         "#;
 
         let update = TableUpdate::SetProperties {
@@ -1041,7 +1041,7 @@ mod tests {
         "prop1",
         "prop2"
     ]
-}        
+}
         "#;
 
         let update = TableUpdate::RemoveProperties {


### PR DESCRIPTION
Close #139 
Use `trait_variant::make` to support async fn in pub traits. It creates 2 traits ---- `LocalCatalog` for single thread and `Catalog` with `Send` for multithreaded runtime.