### PR TITLE
feat: Make thrift transport configurable

### DIFF
--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -31,11 +31,12 @@ use typed_builder::TypedBuilder;
 
 /// Which variant of the thrift transport to communicate with HMS
 /// See: <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md#framed-vs-unframed-transport>
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum HmsThriftTransport {
     /// Use the framed transport
     Framed,
     /// Use the buffered transport (default)
+    #[default]
     Buffered,
 }
 


### PR DESCRIPTION
Adds an enum `HmsThriftTransport` to the `HmsCatalogConfig` to allow setting the thrift transport type #188 

Corresponds to the metastore setting `hive.metastore.thrift.framed.transport.enabled` [on the metastore server side](https://issues.apache.org/jira/browse/HIVE-2767).