### PR TITLE
refactor: remove unwraps

### DIFF
--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -540,7 +540,10 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
 pub(crate) fn avro_schema_to_schema(avro_schema: &AvroSchema) -> Result<Schema> {
     if let AvroSchema::Record(_) = avro_schema {
         let mut converter = AvroSchemaToSchema { next_id: 0 };
-        let typ = visit(avro_schema, &mut converter)?.expect("Iceberg schema should not be none.");
+        let typ = visit(avro_schema, &mut converter)?.ok_or(Error::new(
+            ErrorKind::Unexpected,
+            "Iceberg schema should not be none.",
+        ))?;
         if let Type::Struct(s) = typ {
             Schema::builder()
                 .with_fields(s.fields().iter().cloned())

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -442,7 +442,7 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
 
     fn array(&mut self, array: &AvroSchema, item: Option<Type>) -> Result<Self::T> {
         if let AvroSchema::Array(item_schema) = array {
-            let element_field: std::sync::Arc<NestedField> = NestedField::list_element(
+            let element_field = NestedField::list_element(
                 self.next_field_id(),
                 item.ok_or(Error::new(ErrorKind::Unexpected, "item should not be None"))?,
                 !is_avro_optional(item_schema),

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -695,7 +695,7 @@ mod _const_schema {
                 ])),
             )),
         ];
-        let schema = Schema::builder().with_fields(fields).build().unwrap();
+        let schema = Schema::builder().with_fields(fields).build()?;
         schema_to_avro_schema("manifest_entry", &schema)
     }
 }

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -169,10 +169,9 @@ impl SchemaBuilder {
 
             let mut cur_field_id = identifier_field_id;
             while let Some(parent) = id_to_parent.get(&cur_field_id) {
-                let parent_field = id_to_field.get(parent).ok_or(Error::new(
-                    ErrorKind::FeatureUnsupported,
-                    "Field id should not disappear.",
-                ))?;
+                let parent_field = id_to_field
+                    .get(parent)
+                    .expect("Field id should not disappear.");
                 ensure_data_valid!(
                     parent_field.field_type.is_struct(),
                     "Cannot add field {} as an identifier field: must not be nested in {:?}",

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -169,9 +169,10 @@ impl SchemaBuilder {
 
             let mut cur_field_id = identifier_field_id;
             while let Some(parent) = id_to_parent.get(&cur_field_id) {
-                let parent_field = id_to_field
-                    .get(parent)
-                    .expect("Field id should not disappear.");
+                let parent_field = id_to_field.get(parent).ok_or(Error::new(
+                    ErrorKind::FeatureUnsupported,
+                    "Field id should not disappear.",
+                ))?;
                 ensure_data_valid!(
                     parent_field.field_type.is_struct(),
                     "Cannot add field {} as an identifier field: must not be nested in {:?}",

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -136,7 +136,7 @@ impl SchemaBuilder {
         id_to_field: &HashMap<i32, NestedFieldRef>,
         identifier_field_ids: impl Iterator<Item = i32>,
     ) -> Result<()> {
-        let id_to_parent = index_parents(r#struct);
+        let id_to_parent = index_parents(r#struct)?;
         for identifier_field_id in identifier_field_ids {
             let field = id_to_field.get(&identifier_field_id).ok_or_else(|| {
                 Error::new(
@@ -406,7 +406,7 @@ pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>
 }
 
 /// Creates a field id to parent field id map.
-pub fn index_parents(r#struct: &StructType) -> HashMap<i32, i32> {
+pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
     struct IndexByParent {
         parents: Vec<i32>,
         result: HashMap<i32, i32>,
@@ -487,8 +487,8 @@ pub fn index_parents(r#struct: &StructType) -> HashMap<i32, i32> {
         parents: vec![],
         result: HashMap::new(),
     };
-    visit_struct(r#struct, &mut index).unwrap();
-    index.result
+    visit_struct(r#struct, &mut index)?;
+    Ok(index.result)
 }
 
 #[derive(Default)]
@@ -973,9 +973,9 @@ mod tests {
     fn test_schema_display() {
         let expected_str = r#"
 table {
-  1: foo: optional string 
-  2: bar: required int 
-  3: baz: optional boolean 
+  1: foo: optional string
+  2: bar: required int
+  3: baz: optional boolean
 }
 "#;
 

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -972,13 +972,13 @@ mod tests {
 
     #[test]
     fn test_schema_display() {
-        let expected_str = r#"
+        let expected_str = "
 table {
-  1: foo: optional string
-  2: bar: required int
-  3: baz: optional boolean
+  1: foo: optional string\x20
+  2: bar: required int\x20
+  3: baz: optional boolean\x20
 }
-"#;
+";
 
         assert_eq!(expected_str, format!("\n{}", table_schema_simple().0));
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -210,8 +210,10 @@ impl TableMetadata {
     /// Get current snapshot
     #[inline]
     pub fn current_snapshot(&self) -> Option<&SnapshotRef> {
-        self.current_snapshot_id
-            .and_then(|s| self.snapshot_by_id(s))
+        self.current_snapshot_id.map(|s| {
+            self.snapshot_by_id(s)
+                .expect("Current snapshot id has been set, but doesn't exist in metadata")
+        })
     }
 
     /// Return all sort orders.

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -25,8 +25,6 @@ use std::fmt::{Display, Formatter};
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
-use crate::{Error, ErrorKind};
-
 use super::{
     snapshot::{Snapshot, SnapshotReference, SnapshotRetention},
     PartitionSpecRef, SchemaId, SchemaRef, SnapshotRef, SortOrderRef,
@@ -213,8 +211,7 @@ impl TableMetadata {
     #[inline]
     pub fn current_snapshot(&self) -> Option<&SnapshotRef> {
         self.current_snapshot_id
-            .map(|s| self.snapshot_by_id(s))
-            .flatten()
+            .and_then(|s| self.snapshot_by_id(s))
     }
 
     /// Return all sort orders.

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -25,6 +25,8 @@ use std::fmt::{Display, Formatter};
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
+use crate::{Error, ErrorKind};
+
 use super::{
     snapshot::{Snapshot, SnapshotReference, SnapshotRetention},
     PartitionSpecRef, SchemaId, SchemaRef, SnapshotRef, SortOrderRef,
@@ -210,10 +212,9 @@ impl TableMetadata {
     /// Get current snapshot
     #[inline]
     pub fn current_snapshot(&self) -> Option<&SnapshotRef> {
-        self.current_snapshot_id.map(|s| {
-            self.snapshot_by_id(s)
-                .expect("Current snapshot id has been set, but doesn't exist in metadata")
-        })
+        self.current_snapshot_id
+            .map(|s| self.snapshot_by_id(s))
+            .flatten()
     }
 
     /// Return all sort orders.

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -160,7 +160,10 @@ impl<'a> ReplaceSortOrderAction<'a> {
                     .table
                     .metadata()
                     .default_sort_order()
-                    .expect("default sort order impossible to be None")
+                    .ok_or(Error::new(
+                        ErrorKind::Unexpected,
+                        "default sort order impossible to be none",
+                    ))?
                     .order_id,
             },
         ];


### PR DESCRIPTION
Remove `unwrap` and `expect`.
It looks like some `expect` are expected.
For example
```rust
pub fn current_snapshot(&self) -> Option<&SnapshotRef> {
        self.current_snapshot_id.map(|s| {
            self.snapshot_by_id(s)
                .expect("Current snapshot id has been set, but doesn't exist in metadata")
        })
    }
```
Also, it looks like we want this panic to happen.
```rust
    pub fn default_sort_order(&self) -> Option<&SortOrderRef> {
        if self.default_sort_order_id == DEFAULT_SORT_ORDER_ID {
            self.sort_orders.get(&DEFAULT_SORT_ORDER_ID)
        } else {
            Some(
                self.sort_orders
                    .get(&self.default_sort_order_id)
                    .expect("Default order id has been set, but not found in table metadata!"),
            )
        }
    }
```
I tried to remove this `expect` in this PR and there will not be an error message.
Do we expect panic here?