### PR TITLE
feat: complete the basic file scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ arrow-schema = { version = ">=46" }
 async-trait = "0.1"
 bimap = "0.6"
 bitvec = "1.0.1"
+bytes = "1.5.0"
 chrono = "0.4"
 derive_builder = "0.13.0"
 either = "1"
@@ -53,6 +54,7 @@ opendal = "0.44"
 ordered-float = "4.0.0"
 pretty_assertions = "1.4.0"
 port_scanner = "0.1.5"
+parquet = "50.0.0"
 reqwest = { version = "^0.11", features = ["json"] }
 rust_decimal = "1.31.0"
 serde = { version = "^1.0", features = ["rc"] }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -36,6 +36,7 @@ arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 bimap = { workspace = true }
 bitvec = { workspace = true }
+bytes ={ workspace = true }
 chrono = { workspace = true }
 derive_builder = { workspace = true }
 either = { workspace = true }
@@ -49,6 +50,7 @@ opendal = { workspace = true }
 ordered-float = { workspace = true }
 reqwest = { workspace = true }
 rust_decimal = { workspace = true }
+parquet ={ workspace = true, features = ["async"] }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/iceberg/src/io.rs
+++ b/crates/iceberg/src/io.rs
@@ -215,9 +215,9 @@ pub struct InputFile {
 }
 
 /// Trait for reading file.
-pub trait FileRead: AsyncRead + AsyncSeek {}
+pub trait FileRead: AsyncRead + AsyncSeek + Send + Unpin {}
 
-impl<T> FileRead for T where T: AsyncRead + AsyncSeek {}
+impl<T> FileRead for T where T: AsyncRead + AsyncSeek + Send + Unpin {}
 
 impl InputFile {
     /// Absolute path to root uri.

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -855,6 +855,11 @@ impl ManifestEntry {
         self.data_file.content
     }
 
+    /// Return data file 
+    pub fn data_file(&self) -> &DataFile {
+        &self.data_file
+    }
+
     /// Data file path of this manifest entry.
     pub fn file_path(&self) -> &str {
         &self.data_file.file_path
@@ -934,11 +939,11 @@ pub struct DataFile {
     /// field id: 100
     ///
     /// Full URI for the file with FS scheme
-    file_path: String,
+    pub(crate) file_path: String,
     /// field id: 101
     ///
     /// String file format name, avro, orc or parquet
-    file_format: DataFileFormat,
+    pub(crate) file_format: DataFileFormat,
     /// field id: 102
     ///
     /// Partition data tuple, schema based on the partition spec output using


### PR DESCRIPTION
This PR aims to complete #125. After #66, we prepared the plan file(metadata) for the scan. This PR will uses these plan file to construct the stream for read record batch. 

This PR also changes the interface for scan:
Before it, our interface looks like this, the scan task will return directly by `table_scan.plan_files()`.
```
let file_scan_task_stream = table_scan.plan_files();
for file_scan_task in file_scan_task_stream {
   ...
}
```
And now, our interface looks like, the `table_scan.plan_files()` will return the metadata(PlanFile). And we can use the metadata to construct the scan task. The benefit of this is the more flexible interface, e.g. user can plan once and distribute these metadata to different node for scan.
```
let plan_files = table_scan.plan_files();
let file_scan_task = FileScanTask(plan_files);
```