### PR TITLE
Sql catalog

### DIFF
--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -32,7 +32,6 @@ keywords = ["iceberg", "sql", "catalog"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-dashmap = "5.5.3"
 futures = { workspace = true }
 iceberg = { workspace = true }
 log = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -40,7 +40,7 @@ opendal = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { version = "0.7.2", features = ["tls-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
+sqlx = { version = "0.7.4", features = ["tls-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
 typed-builder = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
@@ -48,6 +48,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
-sqlx = { version = "0.7.2", features = ["tls-rustls", "runtime-tokio", "any", "sqlite", "postgres", "mysql","migrate"], default-features = false }
+sqlx = { version = "0.7.4", features = ["tls-rustls", "runtime-tokio", "any", "sqlite", "postgres", "mysql","migrate"], default-features = false }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "iceberg-catalog-sql"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+rust-version = { workspace = true }
+
+categories = ["database"]
+description = "Apache Iceberg Rust Sql Catalog"
+repository = { workspace = true }
+license = { workspace = true }
+keywords = ["iceberg", "sql", "catalog"]
+
+[dependencies]
+# async-trait = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+iceberg = { workspace = true }
+log = "0.4.20"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+typed-builder = { workspace = true }
+urlencoding = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+dashmap = "5.5.3"
+futures.workspace = true
+sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
+url.workspace = true
+opendal.workspace = true
+
+[dev-dependencies]
+iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
+tokio = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -41,10 +41,10 @@ typed-builder = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 dashmap = "5.5.3"
-futures.workspace = true
+futures = { workspace = true }
 sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
-url.workspace = true
-opendal.workspace = true
+url = { workspace = true }
+opendal = { workspace = true }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -32,19 +32,19 @@ keywords = ["iceberg", "sql", "catalog"]
 anyhow = "1"
 async-trait = { workspace = true }
 chrono = { workspace = true }
+dashmap = "5.5.3"
+futures = { workspace = true }
 iceberg = { workspace = true }
 log = "0.4.20"
+opendal = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 typed-builder = { workspace = true }
+url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-dashmap = "5.5.3"
-futures = { workspace = true }
 sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
-url = { workspace = true }
-opendal = { workspace = true }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -29,18 +29,18 @@ license = { workspace = true }
 keywords = ["iceberg", "sql", "catalog"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 dashmap = "5.5.3"
 futures = { workspace = true }
 iceberg = { workspace = true }
-log = "0.4.20"
+log = { workspace = true }
 opendal = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
+sqlx = { version = "0.7.2", features = ["tls-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
 typed-builder = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -48,5 +48,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
+sqlx = { version = "0.7.2", features = ["tls-rustls", "runtime-tokio", "any", "sqlite", "postgres", "mysql"], default-features = false }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -40,11 +40,11 @@ opendal = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
 typed-builder = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-sqlx = { version = "0.7.2", features = ["runtime-tokio-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -40,7 +40,7 @@ opendal = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { version = "0.7.4", features = ["tls-rustls", "any", "sqlite", "postgres", "mysql"], default-features = false }
+sqlx = { version = "0.7.4", features = ["tls-rustls", "any" ], default-features = false }
 typed-builder = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
@@ -48,6 +48,11 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
-sqlx = { version = "0.7.4", features = ["tls-rustls", "runtime-tokio", "any", "sqlite", "postgres", "mysql","migrate"], default-features = false }
+sqlx = { version = "0.7.4", features = ["tls-rustls", "runtime-tokio", "any", "sqlite", "migrate"], default-features = false }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres"]
+mysql = ["sqlx/mysql"]

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -29,7 +29,7 @@ license = { workspace = true }
 keywords = ["iceberg", "sql", "catalog"]
 
 [dependencies]
-# async-trait = { workspace = true }
+anyhow = "1"
 async-trait = { workspace = true }
 chrono = { workspace = true }
 iceberg = { workspace = true }
@@ -48,4 +48,5 @@ opendal.workspace = true
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
+tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/catalog/sql/README.md
+++ b/crates/catalog/sql/README.md
@@ -1,0 +1,21 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# Apache Iceberg Sql Catalog Official Native Rust Implementation
+

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -63,7 +63,7 @@ pub struct SqlCatalogConfig {
 pub struct SqlCatalog {
     name: String,
     connection: AnyPool,
-    storage: FileIO,
+    fileio: FileIO,
     cache: Arc<DashMap<TableIdent, (String, TableMetadata)>>,
 }
 

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -49,6 +49,11 @@ static PREVIOUS_METADATA_LOCATION_PROP: &str = "previous_metadata_location";
 static RECORD_TYPE: &str = "iceberg_type";
 static TABLE_RECORD_TYPE: &str = "TABLE";
 
+static NAMESPACE_PROPERTIES_TABLE_NAME: &str = "iceberg_namespace_properties";
+static NAMESPACE_NAME: &str = "namespace";
+static NAMESPACE_PROPERTY_KEY: &str = "property_key";
+static NAMESPACE_PROPERTY_VALUE: &str = "property_value";
+
 static MAX_CONNECTIONS: u32 = 10;
 static IDLE_TIMEOUT: u64 = 10;
 static TEST_BEFORE_ACQUIRE: bool = true;
@@ -129,13 +134,23 @@ impl SqlCatalog {
         .map_err(from_sqlx_error)?;
 
         sqlx::query(
-            "create table if not exists iceberg_namespace_properties (
-                            catalog_name varchar(255) not null,
-                            namespace varchar(255) not null,
-                            property_key varchar(255),
-                            property_value varchar(255),
-                            primary key (catalog_name, namespace, property_key)
-                        );",
+            &("create table if not exists ".to_owned()
+                + NAMESPACE_PROPERTIES_TABLE_NAME
+                + " ( "
+                + CATALOG_NAME
+                + " varchar(255) not null, "
+                + NAMESPACE_NAME
+                + " varchar(255) not null, "
+                + NAMESPACE_PROPERTY_KEY
+                + " varchar(255),  "
+                + NAMESPACE_PROPERTY_VALUE
+                + " varchar(255), primary key ("
+                + CATALOG_NAME
+                + ", "
+                + NAMESPACE_NAME
+                + ", "
+                + NAMESPACE_PROPERTY_KEY
+                + ") );"),
         )
         .execute(&pool)
         .await

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -51,7 +51,7 @@ static TABLE_RECORD_TYPE: &str = "TABLE";
 
 static MAX_CONNECTIONS: u32 = 10;
 static IDLE_TIMEOUT: u64 = 10;
-static TEST_BEFORE_AQUIRE: bool = true;
+static TEST_BEFORE_ACQUIRE: bool = true;
 
 /// Sql catalog config
 #[derive(Debug, TypedBuilder)]
@@ -90,7 +90,7 @@ impl SqlCatalog {
             .props
             .get("pool.test-before-acquire")
             .map(|v| v.parse().unwrap())
-            .unwrap_or(TEST_BEFORE_AQUIRE);
+            .unwrap_or(TEST_BEFORE_ACQUIRE);
 
         let pool = AnyPoolOptions::new()
             .max_connections(max_connections)

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -1,0 +1,396 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::lock::Mutex;
+use sqlx::{
+    any::{install_default_drivers, AnyConnectOptions, AnyRow},
+    AnyConnection, ConnectOptions, Connection, Row,
+};
+use std::collections::HashMap;
+
+use iceberg::{
+    spec::TableMetadata, table::Table, Catalog, Error, ErrorKind, Namespace, NamespaceIdent,
+    Result, TableCommit, TableCreation, TableIdent,
+};
+use opendal::Operator;
+use uuid::Uuid;
+
+#[derive(Debug)]
+/// Sql catalog implementation.
+pub struct SqlCatalog {
+    name: String,
+    connection: Arc<Mutex<AnyConnection>>,
+    operator: Operator,
+    cache: Arc<DashMap<TableIdent, (String, TableMetadata)>>,
+}
+
+// impl SqlCatalog {
+//     pub async fn new(url: &str, name: &str, operator: Operator) -> Result<Self> {
+//         install_default_drivers();
+
+//         let mut connection =
+//             AnyConnectOptions::connect(&AnyConnectOptions::from_url(&url.try_into()?)?).await?;
+
+//         connection
+//             .transaction(|txn| {
+//                 Box::pin(async move {
+//                     sqlx::query(
+//                         "create table if not exists iceberg_tables (
+//                                 catalog_name text not null,
+//                                 table_namespace text not null,
+//                                 table_name text not null,
+//                                 metadata_location text not null,
+//                                 previous_metadata_location text,
+//                                 primary key (catalog_name, table_namespace, table_name)
+//                             );",
+//                     )
+//                     .execute(&mut **txn)
+//                     .await
+//                 })
+//             })
+//             .await?;
+
+//         connection
+//             .transaction(|txn| {
+//                 Box::pin(async move {
+//                     sqlx::query(
+//                         "create table if not exists iceberg_namespace_properties (
+//                                 catalog_name text not null,
+//                                 namespace text not null,
+//                                 property_key text,
+//                                 property_value text,
+//                                 primary key (catalog_name, namespace, property_key)
+//                             );",
+//                     )
+//                     .execute(&mut **txn)
+//                     .await
+//                 })
+//             })
+//             .await?;
+
+//         Ok(SqlCatalog {
+//             name: name.to_owned(),
+//             connection: Arc::new(Mutex::new(connection)),
+//             operator,
+//             cache: Arc::new(DashMap::new()),
+//         })
+//     }
+// }
+
+// #[derive(Debug)]
+// struct TableRef {
+//     table_namespace: String,
+//     table_name: String,
+//     metadata_location: String,
+//     _previous_metadata_location: Option<String>,
+// }
+
+// fn query_map(row: &AnyRow) -> std::result::Result<TableRef, sqlx::Error> {
+//     Ok(TableRef {
+//         table_namespace: row.try_get(0)?,
+//         table_name: row.try_get(1)?,
+//         metadata_location: row.try_get(2)?,
+//         _previous_metadata_location: row.try_get::<String, _>(3).map(Some).or_else(|err| {
+//             if let sqlx::Error::ColumnDecode {
+//                 index: _,
+//                 source: _,
+//             } = err
+//             {
+//                 Ok(None)
+//             } else {
+//                 Err(err)
+//             }
+//         })?,
+//     })
+// }
+
+#[async_trait]
+impl Catalog for SqlCatalog {
+    async fn list_namespaces(
+        &self,
+        _parent: Option<&NamespaceIdent>,
+    ) -> Result<Vec<NamespaceIdent>> {
+        // let mut connection = self.connection.lock().await;
+        // let rows = connection.transaction(|txn|{
+        //     let name = self.name.clone();
+        //     Box::pin(async move {
+        //     sqlx::query(&format!("select distinct table_namespace from iceberg_tables where catalog_name = '{}';",&name)).fetch_all(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        // let iter = rows.iter().map(|row| row.try_get::<String, _>(0));
+
+        // Ok(iter
+        //     .map(|x| {
+        //         x.and_then(|y| {
+        //             Namespace::try_new(&y.split('.').map(ToString::to_string).collect::<Vec<_>>())
+        //                 .map_err(|err| sqlx::Error::Decode(Box::new(err)))
+        //         })
+        //     })
+        //     .collect::<Result<_, sqlx::Error>>()
+        //     .map_err(Error::from)?)
+        todo!()
+    }
+    async fn create_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> Result<Namespace> {
+        todo!()
+    }
+
+    async fn get_namespace(&self, _namespace: &NamespaceIdent) -> Result<Namespace> {
+        todo!()
+    }
+
+    async fn namespace_exists(&self, _namespace: &NamespaceIdent) -> Result<bool> {
+        todo!()
+    }
+
+    async fn update_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    async fn drop_namespace(&self, _namespace: &NamespaceIdent) -> Result<()> {
+        todo!()
+    }
+
+    async fn list_tables(&self, namespace: &NamespaceIdent) -> Result<Vec<TableIdent>> {
+        // let mut connection = self.connection.lock().await;
+        // let rows = connection.transaction(|txn|{
+        //     let name = self.name.clone();
+        //     let namespace = namespace.to_string();
+        //     Box::pin(async move {
+        //     sqlx::query(&format!("select table_namespace, table_name, metadata_location, previous_metadata_location from iceberg_tables where catalog_name = '{}' and table_namespace = '{}';",&name, &namespace)).fetch_all(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        // let iter = rows.iter().map(query_map);
+        todo!()
+
+        // Ok(iter
+        //     .map(|x| {
+        //         x.and_then(|y| {
+        //             TableIdent::parse(&(y.table_namespace.to_string() + "." + &y.table_name))
+        //                 .map_err(|err| sqlx::Error::Decode(Box::new(err)))
+        //         })
+        //     })
+        //     .collect::<Result<_, sqlx::Error>>()
+        //     .map_err(Error::from)?)
+    }
+
+    async fn stat_table(&self, identifier: &TableIdent) -> Result<bool> {
+        // let mut connection = self.connection.lock().await;
+        // let rows = connection.transaction(|txn|{
+        //     let catalog_name = self.name.clone();
+        //     let namespace = identifier.namespace().to_string();
+        //     let name = identifier.name().to_string();
+        //     Box::pin(async move {
+        //     sqlx::query(&format!("select table_namespace, table_name, metadata_location, previous_metadata_location from iceberg_tables where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}';",&catalog_name,
+        //         &namespace,
+        //         &name)).fetch_all(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        // let mut iter = rows.iter().map(query_map);
+
+        // Ok(iter.next().is_some())
+        todo!()
+    }
+
+    async fn drop_table(&self, identifier: &TableIdent) -> Result<()> {
+        // let mut connection = self.connection.lock().await;
+        // connection.transaction(|txn|{
+        //     let catalog_name = self.name.clone();
+        //     let namespace = identifier.namespace().to_string();
+        //     let name = identifier.name().to_string();
+        //     Box::pin(async move {
+        //     sqlx::query(&format!("delete from iceberg_tables where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}';",&catalog_name,
+        //         &namespace,
+        //         &name)).execute(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        Ok(())
+    }
+
+    async fn load_table(&self, identifier: &TableIdent) -> Result<Table> {
+        // let path = {
+        //     let mut connection = self.connection.lock().await;
+        //     let row = connection.transaction(|txn|{
+        //     let catalog_name = self.name.clone();
+        //     let namespace = identifier.namespace().to_string();
+        //     let name = identifier.name().to_string();
+        //         Box::pin(async move {
+        //     sqlx::query(&format!("select table_namespace, table_name, metadata_location, previous_metadata_location from iceberg_tables where catalog_name = '{}' and table_namespace = '{}' and table_name = '{}';",&catalog_name,
+        //             &namespace,
+        //             &name)).fetch_one(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        //     let row = query_map(&row).map_err(Error::from)?;
+
+        //     row.metadata_location
+        // };
+        todo!()
+        // let bytes = &self
+        //     .operator
+        //     .get(&strip_prefix(&path).as_str().into())
+        //     .await?
+        //     .bytes()
+        //     .await?;
+        // let metadata: TabularMetadata = serde_json::from_str(std::str::from_utf8(bytes)?)?;
+        // self.cache
+        //     .insert(identifier.clone(), (path.clone(), metadata.clone()));
+        // match metadata {
+        //     TabularMetadata::Table(metadata) => Ok(Tabular::Table(
+        //         Table::new(identifier.clone(), self.clone(), metadata).await?,
+        //     )),
+        //     TabularMetadata::View(metadata) => Ok(Tabular::View(
+        //         View::new(identifier.clone(), self.clone(), metadata).await?,
+        //     )),
+        //     TabularMetadata::MaterializedView(metadata) => Ok(Tabular::MaterializedView(
+        //         MaterializedView::new(identifier.clone(), self.clone(), metadata).await?,
+        //     )),
+        // }
+    }
+
+    async fn create_table(
+        &self,
+        namespace: &NamespaceIdent,
+        creation: TableCreation,
+    ) -> Result<Table> {
+        // Create metadata
+        // let location = metadata.location.to_string();
+
+        // let uuid = Uuid::new_v4();
+        // let version = &metadata.last_sequence_number;
+        // let metadata_json = serde_json::to_string(&metadata)?;
+        // let metadata_location = location
+        //     + "/metadata/"
+        //     + &version.to_string()
+        //     + "-"
+        //     + &uuid.to_string()
+        //     + ".metadata.json";
+        // operator
+        //     .put(
+        //         &strip_prefix(&metadata_location).into(),
+        //         metadata_json.into(),
+        //     )
+        //     .await?;
+        // {
+        //     let mut connection = self.connection.lock().await;
+        //     connection.transaction(|txn|{
+        //         let catalog_name = self.name.clone();
+        //         let namespace = identifier.namespace().to_string();
+        //         let name = identifier.name().to_string();
+        //         let metadata_location = metadata_location.to_string();
+        //         Box::pin(async move {
+        //     sqlx::query(&format!("insert into iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) values ('{}', '{}', '{}', '{}');",catalog_name,namespace,name, metadata_location)).execute(&mut **txn).await
+        // })}).await.map_err(Error::from)?;
+        // }
+        // self.clone()
+        //     .load_tabular(&identifier)
+        //     .await
+        todo!()
+    }
+
+    async fn rename_table(&self, _src: &TableIdent, _dest: &TableIdent) -> Result<()> {
+        todo!()
+    }
+
+    async fn update_table(&self, commit: TableCommit) -> Result<Table> {
+        todo!()
+    }
+}
+
+// #[cfg(test)]
+// pub mod tests {
+//     use iceberg_rust::{
+//         catalog::{identifier::TableIdent, namespace::Namespace, Catalog},
+//         spec::{
+//             schema::Schema,
+//             types::{PrimitiveType, StructField, StructType, Type},
+//         },
+//         table::table_builder::TableBuilder,
+//     };
+//     use operator::{memory::InMemory, ObjectStore};
+//     use std::sync::Arc;
+
+//     use crate::SqlCatalog;
+
+//     #[tokio::test]
+//     async fn test_create_update_drop_table() {
+//         let operator: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+//         let catalog: Arc<dyn Catalog> = Arc::new(
+//             SqlCatalog::new("sqlite://", "test", operator)
+//                 .await
+//                 .unwrap(),
+//         );
+//         let identifier = TableIdent::parse("load_table.table3").unwrap();
+//         let schema = Schema::builder()
+//             .with_schema_id(1)
+//             .with_identifier_field_ids(vec![1, 2])
+//             .with_fields(
+//                 StructType::builder()
+//                     .with_struct_field(StructField {
+//                         id: 1,
+//                         name: "one".to_string(),
+//                         required: false,
+//                         field_type: Type::Primitive(PrimitiveType::String),
+//                         doc: None,
+//                     })
+//                     .with_struct_field(StructField {
+//                         id: 2,
+//                         name: "two".to_string(),
+//                         required: false,
+//                         field_type: Type::Primitive(PrimitiveType::String),
+//                         doc: None,
+//                     })
+//                     .build()
+//                     .unwrap(),
+//             )
+//             .build()
+//             .unwrap();
+
+//         let mut builder = TableBuilder::new(&identifier, catalog.clone())
+//             .expect("Failed to create table builder.");
+//         builder
+//             .location("/")
+//             .with_schema((1, schema))
+//             .current_schema_id(1);
+//         let mut table = builder.build().await.expect("Failed to create table.");
+
+//         let exists = Arc::clone(&catalog)
+//             .table_exists(&identifier)
+//             .await
+//             .expect("Table doesn't exist");
+//         assert!(exists);
+
+//         let tables = catalog
+//             .clone()
+//             .list_tables(
+//                 &Namespace::try_new(&["load_table".to_owned()])
+//                     .expect("Failed to create namespace"),
+//             )
+//             .await
+//             .expect("Failed to list Tables");
+//         assert_eq!(tables[0].to_string(), "load_table.table3".to_owned());
+
+//         let namespaces = catalog
+//             .clone()
+//             .list_namespaces(None)
+//             .await
+//             .expect("Failed to list namespaces");
+//         assert_eq!(namespaces[0].to_string(), "load_table");
+
+//         let transaction = table.new_transaction(None);
+//         transaction.commit().await.expect("Transaction failed.");
+
+//         catalog
+//             .drop_table(&identifier)
+//             .await
+//             .expect("Failed to drop table.");
+
+//         let exists = Arc::clone(&catalog)
+//             .table_exists(&identifier)
+//             .await
+//             .expect("Table exists failed");
+//         assert!(!exists);
+//     }
+// }

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -44,7 +44,7 @@ static CATALOG_TABLE_VIEW_NAME: &str = "iceberg_tables";
 static CATALOG_NAME: &str = "catalog_name";
 static TABLE_NAME: &str = "table_name";
 static TABLE_NAMESPACE: &str = "table_namespace";
-static METADATA_LOCATION_PROP: &str = "metadata_locaion";
+static METADATA_LOCATION_PROP: &str = "metadata_location";
 static PREVIOUS_METADATA_LOCATION_PROP: &str = "previous_metadata_location";
 static RECORD_TYPE: &str = "iceberg_type";
 

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -89,11 +89,11 @@ impl SqlCatalog {
 
         sqlx::query(
             "create table if not exists iceberg_tables (
-                            catalog_name text not null,
-                            table_namespace text not null,
-                            table_name text not null,
-                            metadata_location text,
-                            previous_metadata_location text,
+                            catalog_name varchar(255) not null,
+                            table_namespace varchar(255) not null,
+                            table_name varchar(255) not null,
+                            metadata_location varchar(255),
+                            previous_metadata_location varchar(255),
                             primary key (catalog_name, table_namespace, table_name)
                         );",
         )
@@ -103,10 +103,10 @@ impl SqlCatalog {
 
         sqlx::query(
             "create table if not exists iceberg_namespace_properties (
-                            catalog_name text not null,
-                            namespace text not null,
-                            property_key text,
-                            property_value text,
+                            catalog_name varchar(255) not null,
+                            namespace varchar(255) not null,
+                            property_key varchar(255),
+                            property_value varchar(255),
                             primary key (catalog_name, namespace, property_key)
                         );",
         )

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -47,6 +47,7 @@ static TABLE_NAMESPACE: &str = "table_namespace";
 static METADATA_LOCATION_PROP: &str = "metadata_location";
 static PREVIOUS_METADATA_LOCATION_PROP: &str = "previous_metadata_location";
 static RECORD_TYPE: &str = "iceberg_type";
+static TABLE_RECORD_TYPE: &str = "TABLE";
 
 static MAX_CONNECTIONS: u32 = 10;
 static IDLE_TIMEOUT: u64 = 10;
@@ -121,7 +122,7 @@ impl SqlCatalog {
                 + ", "
                 + TABLE_NAME
                 + ")
-                        );"),
+                );"),
         )
         .execute(&pool)
         .await
@@ -253,7 +254,13 @@ impl Catalog for SqlCatalog {
                 + CATALOG_NAME
                 + " = ? and "
                 + TABLE_NAMESPACE
-                + "= ?;"),
+                + " = ? and ("
+                + RECORD_TYPE
+                + " = '"
+                + TABLE_RECORD_TYPE
+                + "' or "
+                + RECORD_TYPE
+                + " is null);"),
         )
         .bind(&name)
         .bind(&namespace)
@@ -295,7 +302,13 @@ impl Catalog for SqlCatalog {
                 + TABLE_NAMESPACE
                 + " = ? and "
                 + TABLE_NAME
-                + " = ?;"),
+                + " = ? and ("
+                + RECORD_TYPE
+                + " = '"
+                + TABLE_RECORD_TYPE
+                + "' or "
+                + RECORD_TYPE
+                + " is null);"),
         )
         .bind(&catalog_name)
         .bind(&namespace)
@@ -334,7 +347,13 @@ impl Catalog for SqlCatalog {
                     + TABLE_NAMESPACE
                     + " = ? and "
                     + TABLE_NAME
-                    + " = ?;"),
+                    + " = ? and ("
+                    + RECORD_TYPE
+                    + " = '"
+                    + TABLE_RECORD_TYPE
+                    + "' or "
+                    + RECORD_TYPE
+                    + " is null);"),
             )
             .bind(&catalog_name)
             .bind(&namespace)
@@ -445,7 +464,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_create_update_drop_table() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::with_prefix("sql-test").unwrap();
         let warehouse_root = dir.path().to_str().unwrap();
 
         //name of the database should be part of the url. usually for sqllite it creates or opens one if (.db found)

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -48,6 +48,10 @@ static METADATA_LOCATION_PROP: &str = "metadata_location";
 static PREVIOUS_METADATA_LOCATION_PROP: &str = "previous_metadata_location";
 static RECORD_TYPE: &str = "iceberg_type";
 
+static MAX_CONNECTIONS: u32 = 10;
+static IDLE_TIMEOUT: u64 = 10;
+static TEST_BEFORE_AQUIRE = true;
+
 /// Sql catalog config
 #[derive(Debug, TypedBuilder)]
 pub struct SqlCatalogConfig {
@@ -75,17 +79,17 @@ impl SqlCatalog {
             .props
             .get("pool.max-connections")
             .map(|v| v.parse().unwrap())
-            .unwrap_or(10);
+            .unwrap_or(MAX_CONNECTIONS);
         let idle_timeout: u64 = config
             .props
             .get("pool.idle-timeout")
             .map(|v| v.parse().unwrap())
-            .unwrap_or(10);
+            .unwrap_or(IDLE_TIMEOUT);
         let test_before_acquire: bool = config
             .props
             .get("pool.test-before-acquire")
             .map(|v| v.parse().unwrap())
-            .unwrap_or(true);
+            .unwrap_or(TEST_BEFORE_AQUIRE);
 
         let pool = AnyPoolOptions::new()
             .max_connections(max_connections)

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -50,7 +50,7 @@ static RECORD_TYPE: &str = "iceberg_type";
 
 static MAX_CONNECTIONS: u32 = 10;
 static IDLE_TIMEOUT: u64 = 10;
-static TEST_BEFORE_AQUIRE = true;
+static TEST_BEFORE_AQUIRE: bool = true;
 
 /// Sql catalog config
 #[derive(Debug, TypedBuilder)]
@@ -186,11 +186,11 @@ impl Catalog for SqlCatalog {
         &self,
         _parent: Option<&NamespaceIdent>,
     ) -> Result<Vec<NamespaceIdent>> {
-        let name = self.name.clone();
+        let name = &self.name;
         let rows = sqlx::query(
             "select distinct table_namespace from iceberg_tables where catalog_name = ?;",
         )
-        .bind(&name)
+        .bind(name)
         .fetch_all(&self.connection)
         .await
         .map_err(from_sqlx_error)?;
@@ -445,7 +445,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_create_update_drop_table() {
-        let dir = TempDir::with_prefix("sql-test").unwrap();
+        let dir = TempDir::new().unwrap();
         let warehouse_root = dir.path().to_str().unwrap();
 
         //name of the database should be part of the url. usually for sqllite it creates or opens one if (.db found)

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -51,7 +51,7 @@ static RECORD_TYPE: &str = "iceberg_type";
 /// Sql catalog config
 #[derive(Debug, TypedBuilder)]
 pub struct SqlCatalogConfig {
-    url: String,
+    uri: String,
     name: String,
     warehouse: String,
     #[builder(default)]
@@ -91,7 +91,7 @@ impl SqlCatalog {
             .max_connections(max_connections)
             .idle_timeout(Duration::from_secs(idle_timeout))
             .test_before_acquire(test_before_acquire)
-            .connect(&config.url)
+            .connect(&config.uri)
             .await
             .map_err(from_sqlx_error)?;
 
@@ -445,14 +445,14 @@ pub mod tests {
         let warehouse_root = dir.path().to_str().unwrap();
 
         //name of the database should be part of the url. usually for sqllite it creates or opens one if (.db found)
-        let sql_lite_url = "sqlite://iceberg";
+        let sql_lite_uri = "sqlite://iceberg";
 
-        if !sqlx::Sqlite::database_exists(sql_lite_url).await.unwrap() {
-            sqlx::Sqlite::create_database(sql_lite_url).await.unwrap();
+        if !sqlx::Sqlite::database_exists(sql_lite_uri).await.unwrap() {
+            sqlx::Sqlite::create_database(sql_lite_uri).await.unwrap();
         }
 
         let config = SqlCatalogConfig::builder()
-            .url(sql_lite_url.to_string())
+            .uri(sql_lite_uri.to_string())
             .name("iceberg".to_string())
             .warehouse(warehouse_root.to_owned())
             .build();
@@ -505,6 +505,6 @@ pub mod tests {
         assert!(table.metadata().location().ends_with("/warehouse/table1"));
 
         //tear down the database and tables
-        sqlx::Sqlite::drop_database(sql_lite_url).await.unwrap();
+        sqlx::Sqlite::drop_database(sql_lite_uri).await.unwrap();
     }
 }

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -210,7 +210,7 @@ impl Catalog for SqlCatalog {
         Ok(iter
             .map(|x| {
                 x.and_then(|y| {
-                    NamespaceIdent::from_strs(y.split("."))
+                    NamespaceIdent::from_strs(y.split('.'))
                         .map_err(|err| sqlx::Error::Decode(Box::new(err)))
                 })
             })
@@ -282,7 +282,7 @@ impl Catalog for SqlCatalog {
         Ok(iter
             .map(|x| {
                 x.and_then(|y| {
-                    let namespace = NamespaceIdent::from_strs(y.table_namespace.split("."))
+                    let namespace = NamespaceIdent::from_strs(y.table_namespace.split('.'))
                         .map_err(|err| sqlx::Error::Decode(Box::new(err)))?;
                     Ok(TableIdent::new(namespace, y.table_name))
                 })

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -46,6 +46,7 @@ static TABLE_NAME: &str = "table_name";
 static TABLE_NAMESPACE: &str = "table_namespace";
 static METADATA_LOCATION_PROP: &str = "metadata_locaion";
 static PREVIOUS_METADATA_LOCATION_PROP: &str = "previous_metadata_location";
+static RECORD_TYPE: &str = "iceberg_type";
 
 /// Sql catalog config
 #[derive(Debug, TypedBuilder)]
@@ -107,7 +108,9 @@ impl SqlCatalog {
                 + METADATA_LOCATION_PROP
                 + " varchar(255),"
                 + PREVIOUS_METADATA_LOCATION_PROP
-                + " varchar(255), primary key ("
+                + " varchar(255),"
+                + RECORD_TYPE
+                + " varchar(5), primary key ("
                 + CATALOG_NAME
                 + ", "
                 + TABLE_NAMESPACE
@@ -232,7 +235,7 @@ impl Catalog for SqlCatalog {
 
     async fn list_tables(&self, namespace: &NamespaceIdent) -> Result<Vec<TableIdent>> {
         let name = self.name.clone();
-        let namespace = namespace.encode_in_url();
+        let namespace = namespace.join(".");
         let rows = sqlx::query(
             &("select ".to_string()
                 + TABLE_NAMESPACE

--- a/crates/catalog/sql/src/error.rs
+++ b/crates/catalog/sql/src/error.rs
@@ -21,7 +21,7 @@ use iceberg::{Error, ErrorKind};
 pub fn from_sqlx_error(error: sqlx::Error) -> Error {
     Error::new(
         ErrorKind::Unexpected,
-        "operation failed for hitting io error".to_string(),
+        "operation failed for hitting sqlx error".to_string(),
     )
     .with_source(error)
 }

--- a/crates/catalog/sql/src/error.rs
+++ b/crates/catalog/sql/src/error.rs
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Iceberg REST API implementation.
+use iceberg::{Error, ErrorKind};
 
-#![deny(missing_docs)]
-
-mod catalog;
-mod error;
-pub use catalog::*;
+/// Format an sqlx error into iceberg error.
+pub fn from_sqlx_error(error: sqlx::Error) -> Error {
+    Error::new(
+        ErrorKind::Unexpected,
+        "operation failed for hitting io error".to_string(),
+    )
+    .with_source(error)
+}

--- a/crates/catalog/sql/src/lib.rs
+++ b/crates/catalog/sql/src/lib.rs
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Iceberg REST API implementation.
+
+#![deny(missing_docs)]
+
+mod catalog;
+pub use catalog::*;

--- a/crates/catalog/sql/src/lib.rs
+++ b/crates/catalog/sql/src/lib.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Iceberg REST API implementation.
+//! Iceberg sql catalog implementation.
 
 #![deny(missing_docs)]
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -22,12 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::{
-    collections::HashMap,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
-use typed_builder::TypedBuilder;
+use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
 use super::{
@@ -52,27 +47,21 @@ pub(crate) static INITIAL_SEQUENCE_NUMBER: i64 = 0;
 /// Reference to [`TableMetadata`].
 pub type TableMetadataRef = Arc<TableMetadata>;
 
-#[derive(Debug, PartialEq, Deserialize, Eq, Clone, TypedBuilder)]
+#[derive(Debug, PartialEq, Deserialize, Eq, Clone)]
 #[serde(try_from = "TableMetadataEnum")]
 /// Fields for the version 2 of the table metadata.
 ///
 /// We assume that this data structure is always valid, so we will panic when invalid error happens.
 /// We check the validity of this data structure when constructing.
 pub struct TableMetadata {
-    #[builder(default)]
     /// Integer Version for the format.
     pub(crate) format_version: FormatVersion,
-    #[builder(default_code = "Uuid::new_v4()")]
     /// A UUID that identifies the table
     pub(crate) table_uuid: Uuid,
     /// Location tables base location
     pub(crate) location: String,
-    #[builder(default)]
     /// The tables highest sequence number
     pub(crate) last_sequence_number: i64,
-    #[builder(
-        default_code = "SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_micros() as i64"
-    )]
     /// Timestamp in milliseconds from the unix epoch when the table was last updated.
     pub(crate) last_updated_ms: i64,
     /// An integer; the highest assigned column ID for the table.
@@ -83,27 +72,22 @@ pub struct TableMetadata {
     pub(crate) current_schema_id: i32,
     /// A list of partition specs, stored as full partition spec objects.
     pub(crate) partition_specs: HashMap<i32, PartitionSpecRef>,
-    #[builder(default = DEFAULT_SPEC_ID)]
     /// ID of the “current” spec that writers should use by default.
     pub(crate) default_spec_id: i32,
     /// An integer; the highest assigned partition field ID across all partition specs for the table.
     pub(crate) last_partition_id: i32,
-    #[builder(default)]
     ///A string to string map of table properties. This is used to control settings that
     /// affect reading and writing and is not intended to be used for arbitrary metadata.
     /// For example, commit.retry.num-retries is used to control the number of commit retries.
     pub(crate) properties: HashMap<String, String>,
-    #[builder(setter(strip_option))]
     /// long ID of the current table snapshot; must be the same as the current
     /// ID of the main branch in refs.
     pub(crate) current_snapshot_id: Option<i64>,
-    #[builder(default)]
     ///A list of valid snapshots. Valid snapshots are snapshots for which all
     /// data files exist in the file system. A data file must not be deleted
     /// from the file system until the last snapshot in which it was listed is
     /// garbage collected.
     pub(crate) snapshots: HashMap<i64, SnapshotRef>,
-    #[builder(default)]
     /// A list (optional) of timestamp and snapshot ID pairs that encodes changes
     /// to the current snapshot for the table. Each time the current-snapshot-id
     /// is changed, a new entry should be added with the last-updated-ms
@@ -111,7 +95,6 @@ pub struct TableMetadata {
     /// the list of valid snapshots, all entries before a snapshot that has
     /// expired should be removed.
     pub(crate) snapshot_log: Vec<SnapshotLog>,
-    #[builder(default)]
 
     /// A list (optional) of timestamp and metadata file location pairs
     /// that encodes changes to the previous metadata files for the table.
@@ -122,12 +105,10 @@ pub struct TableMetadata {
     pub(crate) metadata_log: Vec<MetadataLog>,
     /// A list of sort orders, stored as full sort order objects.
     pub(crate) sort_orders: HashMap<i64, SortOrderRef>,
-    #[builder(default = DEFAULT_SORT_ORDER_ID)]
     /// Default sort order id of the table. Note that this could be used by
     /// writers, but is not used when reading because reads use the specs
     /// stored in manifest files.
     pub(crate) default_sort_order_id: i64,
-    #[builder(default)]
     ///A map of snapshot references. The map keys are the unique snapshot reference
     /// names in the table, and the map values are snapshot reference objects.
     /// There is always a main branch reference pointing to the current-snapshot-id

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -885,10 +885,12 @@ pub(super) mod _serde {
 #[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 /// Iceberg format version
+#[derive(Default)]
 pub enum FormatVersion {
     /// Iceberg spec version 1
     V1 = 1u8,
     /// Iceberg spec version 2
+    #[default]
     V2 = 2u8,
 }
 
@@ -913,11 +915,7 @@ impl Display for FormatVersion {
     }
 }
 
-impl Default for FormatVersion {
-    fn default() -> Self {
-        FormatVersion::V2
-    }
-}
+
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -915,8 +915,6 @@ impl Display for FormatVersion {
     }
 }
 
-
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]
 /// Encodes changes to the previous metadata files for the table

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -22,7 +22,12 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 use super::{
@@ -47,21 +52,27 @@ pub(crate) static INITIAL_SEQUENCE_NUMBER: i64 = 0;
 /// Reference to [`TableMetadata`].
 pub type TableMetadataRef = Arc<TableMetadata>;
 
-#[derive(Debug, PartialEq, Deserialize, Eq, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Eq, Clone, TypedBuilder)]
 #[serde(try_from = "TableMetadataEnum")]
 /// Fields for the version 2 of the table metadata.
 ///
 /// We assume that this data structure is always valid, so we will panic when invalid error happens.
 /// We check the validity of this data structure when constructing.
 pub struct TableMetadata {
+    #[builder(default)]
     /// Integer Version for the format.
     pub(crate) format_version: FormatVersion,
+    #[builder(default_code = "Uuid::new_v4()")]
     /// A UUID that identifies the table
     pub(crate) table_uuid: Uuid,
     /// Location tables base location
     pub(crate) location: String,
+    #[builder(default)]
     /// The tables highest sequence number
     pub(crate) last_sequence_number: i64,
+    #[builder(
+        default_code = "SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_micros() as i64"
+    )]
     /// Timestamp in milliseconds from the unix epoch when the table was last updated.
     pub(crate) last_updated_ms: i64,
     /// An integer; the highest assigned column ID for the table.
@@ -72,22 +83,27 @@ pub struct TableMetadata {
     pub(crate) current_schema_id: i32,
     /// A list of partition specs, stored as full partition spec objects.
     pub(crate) partition_specs: HashMap<i32, PartitionSpecRef>,
+    #[builder(default = DEFAULT_SPEC_ID)]
     /// ID of the “current” spec that writers should use by default.
     pub(crate) default_spec_id: i32,
     /// An integer; the highest assigned partition field ID across all partition specs for the table.
     pub(crate) last_partition_id: i32,
+    #[builder(default)]
     ///A string to string map of table properties. This is used to control settings that
     /// affect reading and writing and is not intended to be used for arbitrary metadata.
     /// For example, commit.retry.num-retries is used to control the number of commit retries.
     pub(crate) properties: HashMap<String, String>,
+    #[builder(setter(strip_option))]
     /// long ID of the current table snapshot; must be the same as the current
     /// ID of the main branch in refs.
     pub(crate) current_snapshot_id: Option<i64>,
+    #[builder(default)]
     ///A list of valid snapshots. Valid snapshots are snapshots for which all
     /// data files exist in the file system. A data file must not be deleted
     /// from the file system until the last snapshot in which it was listed is
     /// garbage collected.
     pub(crate) snapshots: HashMap<i64, SnapshotRef>,
+    #[builder(default)]
     /// A list (optional) of timestamp and snapshot ID pairs that encodes changes
     /// to the current snapshot for the table. Each time the current-snapshot-id
     /// is changed, a new entry should be added with the last-updated-ms
@@ -95,6 +111,7 @@ pub struct TableMetadata {
     /// the list of valid snapshots, all entries before a snapshot that has
     /// expired should be removed.
     pub(crate) snapshot_log: Vec<SnapshotLog>,
+    #[builder(default)]
 
     /// A list (optional) of timestamp and metadata file location pairs
     /// that encodes changes to the previous metadata files for the table.
@@ -103,13 +120,14 @@ pub struct TableMetadata {
     /// Tables can be configured to remove oldest metadata log entries and
     /// keep a fixed-size log of the most recent entries after a commit.
     pub(crate) metadata_log: Vec<MetadataLog>,
-
     /// A list of sort orders, stored as full sort order objects.
     pub(crate) sort_orders: HashMap<i64, SortOrderRef>,
+    #[builder(default = DEFAULT_SORT_ORDER_ID)]
     /// Default sort order id of the table. Note that this could be used by
     /// writers, but is not used when reading because reads use the specs
     /// stored in manifest files.
     pub(crate) default_sort_order_id: i64,
+    #[builder(default)]
     ///A map of snapshot references. The map keys are the unique snapshot reference
     /// names in the table, and the map values are snapshot reference objects.
     /// There is always a main branch reference pointing to the current-snapshot-id
@@ -892,6 +910,12 @@ impl Display for FormatVersion {
             FormatVersion::V1 => write!(f, "v1"),
             FormatVersion::V2 => write!(f, "v2"),
         }
+    }
+}
+
+impl Default for FormatVersion {
+    fn default() -> Self {
+        FormatVersion::V2
     }
 }
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -863,10 +863,9 @@ pub(super) mod _serde {
     }
 }
 
-#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq, Clone, Copy, Default)]
 #[repr(u8)]
 /// Iceberg format version
-#[derive(Default)]
 pub enum FormatVersion {
     /// Iceberg spec version 1
     V1 = 1u8,


### PR DESCRIPTION
This PR implements the basic operations for a Sql catalog. The implementation uses the `sqlx` crate which enables Postgres, MySQL and Sqlite. 

The `update_table` method is to be implemented later. 