### PR TITLE
chore: Enable projects.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,7 +46,7 @@ github:
   features:
     wiki: false
     issues: true
-    projects: false
+    projects: true
   collaborators:
     - Xuanwo
     - liurenjie1024
@@ -55,7 +55,7 @@ github:
   ghp_path: /
 
 notifications:
-    commits:      commits@iceberg.apache.org
-    issues:       issues@iceberg.apache.org
-    pullrequests: issues@iceberg.apache.org
-    jira_options: link label link label
+  commits: commits@iceberg.apache.org
+  issues: issues@iceberg.apache.org
+  pullrequests: issues@iceberg.apache.org
+  jira_options: link label link label


### PR DESCRIPTION
See discussion in https://github.com/apache/iceberg-rust/issues/113. 

We have more and more contributors, and I want to enable projects so that we can schedule development better.