### PR TITLE
feat: implement OAuth for catalog rest client

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -692,7 +692,7 @@ mod _serde {
     pub(super) struct TokenResponse {
         pub(super) access_token: String,
         pub(super) token_type: String,
-        pub(super) expires_in: u64,
+        pub(super) expires_in: Option<u64>,
         pub(super) issued_token_type: Option<String>,
     }
 

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -693,7 +693,7 @@ mod _serde {
         pub(super) access_token: String,
         pub(super) token_type: String,
         pub(super) expires_in: u64,
-        pub(super) issued_token_type: String,
+        pub(super) issued_token_type: Option<String>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -119,7 +119,7 @@ impl RestCatalogConfig {
 
         if let Some(token) = self.props.get("token") {
             headers.insert(
-                "Authorization",
+                header::AUTHORIZATION,
                 HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| {
                     Error::new(
                         ErrorKind::DataInvalid,

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -525,6 +525,9 @@ impl RestCatalog {
     }
 
     async fn fetch_access_token(&mut self) -> Result<()> {
+        if self.config.props.contains_key("token") {
+            return Ok(());
+        }
         if let Some(credential) = self.config.props.get("credential") {
             let (client_id, client_secret) = if credential.contains(':') {
                 let (client_id, client_secret) = credential.split_once(':').unwrap();

--- a/crates/catalog/rest/tests/rest_catalog_test.rs
+++ b/crates/catalog/rest/tests/rest_catalog_test.rs
@@ -66,6 +66,7 @@ async fn set_test_fixture(func: &str) -> TestFixture {
         rest_catalog,
     }
 }
+
 #[tokio::test]
 async fn test_get_non_exist_namespace() {
     let fixture = set_test_fixture("test_get_non_exist_namespace").await;


### PR DESCRIPTION
Resolve #238 

The docker image of tabular doesn't support credential settings, so it's impossible to write a test.

I just test it manually using their hosted iceberg service.