### PR TITLE
feat: implement prune column for schema

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -112,6 +112,21 @@ impl Type {
         matches!(self, Type::Struct(_))
     }
 
+    /// Whether the type is nested type.
+    #[inline(always)]
+    pub fn is_nested(&self) -> bool {
+        matches!(self, Type::Struct(_) | Type::List(_) | Type::Map(_))
+    }
+
+    /// Convert Type to StructType
+    pub fn as_struct_type(self) -> Option<StructType> {
+        if let Type::Struct(struct_type) = self {
+            Some(struct_type)
+        } else {
+            None
+        }
+    }
+
     /// Return max precision for decimal given [`num_bytes`] bytes.
     #[inline(always)]
     pub fn decimal_max_precision(num_bytes: u32) -> Result<u32> {
@@ -334,7 +349,7 @@ impl fmt::Display for PrimitiveType {
 }
 
 /// DataType for a specific struct
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Default)]
 #[serde(rename = "struct", tag = "type")]
 pub struct StructType {
     /// Struct fields

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -1540,58 +1540,78 @@ table {
     }
     #[test]
     fn test_schema_prune_columns_string() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            1,
-            "foo",
-            Type::Primitive(PrimitiveType::String),
-        )
-        .into()]));
-
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    1,
+                    "foo",
+                    Type::Primitive(PrimitiveType::String),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([1]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_schema_prune_columns_string_full() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            1,
-            "foo",
-            Type::Primitive(PrimitiveType::String),
-        )
-        .into()]));
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    1,
+                    "foo",
+                    Type::Primitive(PrimitiveType::String),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([1]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_schema_prune_columns_list() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            4,
-            "qux",
-            Type::List(ListType {
-                element_field: NestedField::list_element(
-                    5,
-                    Type::Primitive(PrimitiveType::String),
-                    true,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    4,
+                    "qux",
+                    Type::List(ListType {
+                        element_field: NestedField::list_element(
+                            5,
+                            Type::Primitive(PrimitiveType::String),
+                            true,
+                        )
+                        .into(),
+                    }),
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([5]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
@@ -1605,62 +1625,79 @@ table {
 
     #[test]
     fn test_schema_prune_columns_list_full() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            4,
-            "qux",
-            Type::List(ListType {
-                element_field: NestedField::list_element(
-                    5,
-                    Type::Primitive(PrimitiveType::String),
-                    true,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    4,
+                    "qux",
+                    Type::List(ListType {
+                        element_field: NestedField::list_element(
+                            5,
+                            Type::Primitive(PrimitiveType::String),
+                            true,
+                        )
+                        .into(),
+                    }),
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([5]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_prune_columns_map() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            6,
-            "quux",
-            Type::Map(MapType {
-                key_field: NestedField::map_key_element(7, Type::Primitive(PrimitiveType::String))
-                    .into(),
-                value_field: NestedField::map_value_element(
-                    8,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    6,
+                    "quux",
                     Type::Map(MapType {
                         key_field: NestedField::map_key_element(
-                            9,
+                            7,
                             Type::Primitive(PrimitiveType::String),
                         )
                         .into(),
                         value_field: NestedField::map_value_element(
-                            10,
-                            Type::Primitive(PrimitiveType::Int),
+                            8,
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    9,
+                                    Type::Primitive(PrimitiveType::String),
+                                )
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    10,
+                                    Type::Primitive(PrimitiveType::Int),
+                                    true,
+                                )
+                                .into(),
+                            }),
                             true,
                         )
                         .into(),
                     }),
-                    true,
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([9]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
@@ -1674,118 +1711,152 @@ table {
 
     #[test]
     fn test_prune_columns_map_full() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            6,
-            "quux",
-            Type::Map(MapType {
-                key_field: NestedField::map_key_element(7, Type::Primitive(PrimitiveType::String))
-                    .into(),
-                value_field: NestedField::map_value_element(
-                    8,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    6,
+                    "quux",
                     Type::Map(MapType {
                         key_field: NestedField::map_key_element(
-                            9,
+                            7,
                             Type::Primitive(PrimitiveType::String),
                         )
                         .into(),
                         value_field: NestedField::map_value_element(
-                            10,
-                            Type::Primitive(PrimitiveType::Int),
+                            8,
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    9,
+                                    Type::Primitive(PrimitiveType::String),
+                                )
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    10,
+                                    Type::Primitive(PrimitiveType::Int),
+                                    true,
+                                )
+                                .into(),
+                            }),
                             true,
                         )
                         .into(),
                     }),
-                    true,
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([9]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_prune_columns_map_key() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            6,
-            "quux",
-            Type::Map(MapType {
-                key_field: NestedField::map_key_element(7, Type::Primitive(PrimitiveType::String))
-                    .into(),
-                value_field: NestedField::map_value_element(
-                    8,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    6,
+                    "quux",
                     Type::Map(MapType {
                         key_field: NestedField::map_key_element(
-                            9,
+                            7,
                             Type::Primitive(PrimitiveType::String),
                         )
                         .into(),
                         value_field: NestedField::map_value_element(
-                            10,
-                            Type::Primitive(PrimitiveType::Int),
+                            8,
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    9,
+                                    Type::Primitive(PrimitiveType::String),
+                                )
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    10,
+                                    Type::Primitive(PrimitiveType::Int),
+                                    true,
+                                )
+                                .into(),
+                            }),
                             true,
                         )
                         .into(),
                     }),
-                    true,
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([10]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_prune_columns_struct() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            15,
-            "person",
-            Type::Struct(StructType::new(vec![NestedField::optional(
-                16,
-                "name",
-                Type::Primitive(PrimitiveType::String),
-            )
-            .into()])),
-        )
-        .into()]));
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    15,
+                    "person",
+                    Type::Struct(StructType::new(vec![NestedField::optional(
+                        16,
+                        "name",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .into()])),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([16]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
     fn test_prune_columns_struct_full() {
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            15,
-            "person",
-            Type::Struct(StructType::new(vec![NestedField::optional(
-                16,
-                "name",
-                Type::Primitive(PrimitiveType::String),
-            )
-            .into()])),
-        )
-        .into()]));
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    15,
+                    "person",
+                    Type::Struct(StructType::new(vec![NestedField::optional(
+                        16,
+                        "name",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .into()])),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let schema = table_schema_nested();
         let selected: HashSet<i32> = HashSet::from([16]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
@@ -1799,17 +1870,24 @@ table {
             .into()])
             .build()
             .unwrap();
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            15,
-            "person",
-            Type::Struct(StructType::new(vec![])),
-        )
-        .into()]));
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    15,
+                    "person",
+                    Type::Struct(StructType::new(vec![])),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let selected: HashSet<i32> = HashSet::from([15]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&empty_schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
@@ -1823,17 +1901,24 @@ table {
             .into()])
             .build()
             .unwrap();
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::optional(
-            15,
-            "person",
-            Type::Struct(StructType::new(vec![])),
-        )
-        .into()]));
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::optional(
+                    15,
+                    "person",
+                    Type::Struct(StructType::new(vec![])),
+                )
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let selected: HashSet<i32> = HashSet::from([15]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&empty_schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]
@@ -1861,31 +1946,41 @@ table {
             .into()])
             .build()
             .unwrap();
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            6,
-            "id_to_person",
-            Type::Map(MapType {
-                key_field: NestedField::map_key_element(7, Type::Primitive(PrimitiveType::Int))
-                    .into(),
-                value_field: NestedField::map_value_element(
-                    8,
-                    Type::Struct(StructType::new(vec![NestedField::required(
-                        11,
-                        "age",
-                        Primitive(PrimitiveType::Int),
-                    )
-                    .into()])),
-                    true,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    6,
+                    "id_to_person",
+                    Type::Map(MapType {
+                        key_field: NestedField::map_key_element(
+                            7,
+                            Type::Primitive(PrimitiveType::Int),
+                        )
+                        .into(),
+                        value_field: NestedField::map_value_element(
+                            8,
+                            Type::Struct(StructType::new(vec![NestedField::required(
+                                11,
+                                "age",
+                                Primitive(PrimitiveType::Int),
+                            )
+                            .into()])),
+                            true,
+                        )
+                        .into(),
+                    }),
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let selected: HashSet<i32> = HashSet::from([11]);
         let mut visitor = PruneColumn::new(selected, false);
         let result = visit_schema(&empty_schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
     #[test]
     fn test_prune_columns_struct_in_map_full() {
@@ -1912,31 +2007,41 @@ table {
             .into()])
             .build()
             .unwrap();
-        let expected_schema = Type::Struct(StructType::new(vec![NestedField::required(
-            6,
-            "id_to_person",
-            Type::Map(MapType {
-                key_field: NestedField::map_key_element(7, Type::Primitive(PrimitiveType::Int))
-                    .into(),
-                value_field: NestedField::map_value_element(
-                    8,
-                    Type::Struct(StructType::new(vec![NestedField::required(
-                        11,
-                        "age",
-                        Primitive(PrimitiveType::Int),
-                    )
-                    .into()])),
-                    true,
+        let expected_type = Type::from(
+            Schema::builder()
+                .with_fields(vec![NestedField::required(
+                    6,
+                    "id_to_person",
+                    Type::Map(MapType {
+                        key_field: NestedField::map_key_element(
+                            7,
+                            Type::Primitive(PrimitiveType::Int),
+                        )
+                        .into(),
+                        value_field: NestedField::map_value_element(
+                            8,
+                            Type::Struct(StructType::new(vec![NestedField::required(
+                                11,
+                                "age",
+                                Primitive(PrimitiveType::Int),
+                            )
+                            .into()])),
+                            true,
+                        )
+                        .into(),
+                    }),
                 )
-                .into(),
-            }),
-        )
-        .into()]));
+                .into()])
+                .build()
+                .unwrap()
+                .as_struct()
+                .clone(),
+        );
         let selected: HashSet<i32> = HashSet::from([11]);
         let mut visitor = PruneColumn::new(selected, true);
         let result = visit_schema(&empty_schema, &mut visitor);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().unwrap(), expected_schema);
+        assert_eq!(result.unwrap().unwrap(), expected_type);
     }
 
     #[test]

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -954,8 +954,6 @@ pub(super) mod _serde {
 
 #[cfg(test)]
 mod tests {
-    use arrow_schema::SchemaBuilder;
-
     use crate::spec::datatypes::Type::{List, Map, Primitive, Struct};
     use crate::spec::datatypes::{
         ListType, MapType, NestedField, NestedFieldRef, PrimitiveType, StructType, Type,
@@ -1850,15 +1848,11 @@ table {
                         .into(),
                     value_field: NestedField::map_value_element(
                         8,
-                        Type::Struct(
-                            StructType::new(vec![
-                                NestedField::optional(10, "name", Primitive(PrimitiveType::String))
-                                    .into(),
-                                NestedField::required(11, "age", Primitive(PrimitiveType::Int))
-                                    .into(),
-                            ])
-                            .into(),
-                        ),
+                        Type::Struct(StructType::new(vec![
+                            NestedField::optional(10, "name", Primitive(PrimitiveType::String))
+                                .into(),
+                            NestedField::required(11, "age", Primitive(PrimitiveType::Int)).into(),
+                        ])),
                         true,
                     )
                     .into(),
@@ -1875,15 +1869,12 @@ table {
                     .into(),
                 value_field: NestedField::map_value_element(
                     8,
-                    Type::Struct(
-                        StructType::new(vec![NestedField::required(
-                            11,
-                            "age",
-                            Primitive(PrimitiveType::Int),
-                        )
-                        .into()])
-                        .into(),
-                    ),
+                    Type::Struct(StructType::new(vec![NestedField::required(
+                        11,
+                        "age",
+                        Primitive(PrimitiveType::Int),
+                    )
+                    .into()])),
                     true,
                 )
                 .into(),
@@ -1908,15 +1899,11 @@ table {
                         .into(),
                     value_field: NestedField::map_value_element(
                         8,
-                        Type::Struct(
-                            StructType::new(vec![
-                                NestedField::optional(10, "name", Primitive(PrimitiveType::String))
-                                    .into(),
-                                NestedField::required(11, "age", Primitive(PrimitiveType::Int))
-                                    .into(),
-                            ])
-                            .into(),
-                        ),
+                        Type::Struct(StructType::new(vec![
+                            NestedField::optional(10, "name", Primitive(PrimitiveType::String))
+                                .into(),
+                            NestedField::required(11, "age", Primitive(PrimitiveType::Int)).into(),
+                        ])),
                         true,
                     )
                     .into(),
@@ -1933,15 +1920,12 @@ table {
                     .into(),
                 value_field: NestedField::map_value_element(
                     8,
-                    Type::Struct(
-                        StructType::new(vec![NestedField::required(
-                            11,
-                            "age",
-                            Primitive(PrimitiveType::Int),
-                        )
-                        .into()])
-                        .into(),
-                    ),
+                    Type::Struct(StructType::new(vec![NestedField::required(
+                        11,
+                        "age",
+                        Primitive(PrimitiveType::Int),
+                    )
+                    .into()])),
                     true,
                 )
                 .into(),


### PR DESCRIPTION
Aiming for https://github.com/apache/iceberg-rust/issues/251.
Basically implement `PruneColumn` based on [Java Implementation](https://github.com/apache/iceberg/blob/c07f2aabc0a1d02f068ecf1514d2479c0fbdd3b0/api/src/main/java/org/apache/iceberg/types/PruneColumns.java#L42) and add test cases [PyIceberg](https://github.com/apache/iceberg-python/blob/0ee7f1233e062b17b03fccc1eac6449c72e575f0/tests/test_schema.py#L564-L819)

One question, how to avoid warning like this since it will block `cargo clippy` check? (I did know this warning occurs because I never used `PruneColumn::new()` except test cases).
```bash
warning: associated function `new` is never used
   --> crates/iceberg/src/spec/schema.rs:638:8
    |
636 | impl PruneColumn {
    | ---------------- associated function in this implementation
637 |     
638 |     fn new(selected: HashSet<i32>, select_full_types: bool) -> Self {
    |        ^^^
    |
    = note: `#[warn(dead_code)]` on by default

```