### PR TITLE
docs: annotate precision and length to primitive types

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -193,15 +193,15 @@ pub enum PrimitiveType {
     },
     /// Calendar date without timezone or time.
     Date,
-    /// Time of day without date or timezone.
+    /// Time of day in microsecond precision, without date or timezone.
     Time,
-    /// Timestamp without timezone
+    /// Timestamp in microsecond precision, without timezone
     Timestamp,
-    /// Timestamp with timezone
+    /// Timestamp in microsecond precision, with timezone
     Timestamptz,
     /// Arbitrary-length character sequences encoded in utf-8
     String,
-    /// Universally Unique Identifiers
+    /// Universally Unique Identifiers, should use 16-byte fixed
     Uuid,
     /// Fixed length byte array
     Fixed(u64),


### PR DESCRIPTION
I found these contents are missing while reviewing https://github.com/apache/iceberg-rust/pull/258. Reference from [iceberg spec](https://iceberg.apache.org/spec/#primitive-types)