### PR TITLE
fix: chrono dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,7 @@
 
 [workspace]
 resolver = "2"
-members = [
-    "crates/catalog/*",
-    "crates/examples",
-    "crates/iceberg",
-    "crates/test_utils",
-]
+members = ["crates/catalog/*", "crates/examples", "crates/iceberg", "crates/test_utils"]
 
 [workspace.package]
 version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/catalog/*", "crates/examples", "crates/iceberg", "crates/test_utils"]
+members = [
+    "crates/catalog/*",
+    "crates/examples",
+    "crates/iceberg",
+    "crates/test_utils",
+]
 
 [workspace.package]
 version = "0.2.0"
@@ -39,7 +44,7 @@ async-trait = "0.1"
 bimap = "0.6"
 bitvec = "1.0.1"
 bytes = "1.5"
-chrono = "0.4"
+chrono = "0.4.34"
 derive_builder = "0.20.0"
 either = "1"
 env_logger = "0.11.0"


### PR DESCRIPTION
#234 used `TimeDelta`
`TimeDelta` was first introduced in [v0.4.34](https://github.com/chronotope/chrono/releases/tag/v0.4.34). 