### PR TITLE
fix: enable public access to ManifestEntry properties

### DIFF
--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -209,7 +209,7 @@ pub struct FileScanTask {
 pub type ArrowRecordBatchStream = BoxStream<'static, crate::Result<RecordBatch>>;
 
 impl FileScanTask {
-    pub(crate) fn data_file(&self) -> ManifestEntryRef {
+    pub fn data_file(&self) -> ManifestEntryRef {
         self.data_file.clone()
     }
 }

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -938,28 +938,28 @@ pub struct DataFile {
     ///
     /// Type of content stored by the data file: data, equality deletes,
     /// or position deletes (all v1 files are data files)
-    pub(crate) content: DataContentType,
+    pub content: DataContentType,
     /// field id: 100
     ///
     /// Full URI for the file with FS scheme
-    pub(crate) file_path: String,
+    pub file_path: String,
     /// field id: 101
     ///
     /// String file format name, avro, orc or parquet
-    pub(crate) file_format: DataFileFormat,
+    pub file_format: DataFileFormat,
     /// field id: 102
     ///
     /// Partition data tuple, schema based on the partition spec output using
     /// partition field ids for the struct field ids
-    pub(crate) partition: Struct,
+    pub partition: Struct,
     /// field id: 103
     ///
     /// Number of records in this file
-    pub(crate) record_count: u64,
+    pub record_count: u64,
     /// field id: 104
     ///
     /// Total file size in bytes
-    pub(crate) file_size_in_bytes: u64,
+    pub file_size_in_bytes: u64,
     /// field id: 108
     /// key field id: 117
     /// value field id: 118
@@ -968,7 +968,7 @@ pub struct DataFile {
     /// store the column. Does not include bytes necessary to read other
     /// columns, like footers. Leave null for row-oriented formats (Avro)
     #[builder(default)]
-    pub(crate) column_sizes: HashMap<i32, u64>,
+    pub column_sizes: HashMap<i32, u64>,
     /// field id: 109
     /// key field id: 119
     /// value field id: 120
@@ -976,21 +976,21 @@ pub struct DataFile {
     /// Map from column id to number of values in the column (including null
     /// and NaN values)
     #[builder(default)]
-    pub(crate) value_counts: HashMap<i32, u64>,
+    pub value_counts: HashMap<i32, u64>,
     /// field id: 110
     /// key field id: 121
     /// value field id: 122
     ///
     /// Map from column id to number of null values in the column
     #[builder(default)]
-    pub(crate) null_value_counts: HashMap<i32, u64>,
+    pub null_value_counts: HashMap<i32, u64>,
     /// field id: 137
     /// key field id: 138
     /// value field id: 139
     ///
     /// Map from column id to number of NaN values in the column
     #[builder(default)]
-    pub(crate) nan_value_counts: HashMap<i32, u64>,
+    pub nan_value_counts: HashMap<i32, u64>,
     /// field id: 125
     /// key field id: 126
     /// value field id: 127
@@ -1003,7 +1003,7 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub(crate) lower_bounds: HashMap<i32, Literal>,
+    pub lower_bounds: HashMap<i32, Literal>,
     /// field id: 128
     /// key field id: 129
     /// value field id: 130
@@ -1016,19 +1016,19 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub(crate) upper_bounds: HashMap<i32, Literal>,
+    pub upper_bounds: HashMap<i32, Literal>,
     /// field id: 131
     ///
     /// Implementation-specific key metadata for encryption
     #[builder(default)]
-    pub(crate) key_metadata: Vec<u8>,
+    pub key_metadata: Vec<u8>,
     /// field id: 132
     /// element field id: 133
     ///
     /// Split offsets for the data file. For example, all row group offsets
     /// in a Parquet file. Must be sorted ascending
     #[builder(default)]
-    pub(crate) split_offsets: Vec<i64>,
+    pub split_offsets: Vec<i64>,
     /// field id: 135
     /// element field id: 136
     ///
@@ -1037,7 +1037,7 @@ pub struct DataFile {
     /// otherwise. Fields with ids listed in this column must be present
     /// in the delete file
     #[builder(default)]
-    pub(crate) equality_ids: Vec<i32>,
+    pub equality_ids: Vec<i32>,
     /// field id: 140
     ///
     /// ID representing sort order for this file.
@@ -1049,7 +1049,7 @@ pub struct DataFile {
     /// order id to null. Readers must ignore sort order id for position
     /// delete files.
     #[builder(default, setter(strip_option))]
-    pub(crate) sort_order_id: Option<i32>,
+    pub sort_order_id: Option<i32>,
 }
 
 /// Type of content stored by the data file: data, equality deletes, or

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -938,28 +938,28 @@ pub struct DataFile {
     ///
     /// Type of content stored by the data file: data, equality deletes,
     /// or position deletes (all v1 files are data files)
-    pub content: DataContentType,
+    pub(crate) content: DataContentType,
     /// field id: 100
     ///
     /// Full URI for the file with FS scheme
-    pub file_path: String,
+    pub(crate) file_path: String,
     /// field id: 101
     ///
     /// String file format name, avro, orc or parquet
-    pub file_format: DataFileFormat,
+    pub(crate) file_format: DataFileFormat,
     /// field id: 102
     ///
     /// Partition data tuple, schema based on the partition spec output using
     /// partition field ids for the struct field ids
-    pub partition: Struct,
+    pub(crate) partition: Struct,
     /// field id: 103
     ///
     /// Number of records in this file
-    pub record_count: u64,
+    pub(crate) record_count: u64,
     /// field id: 104
     ///
     /// Total file size in bytes
-    pub file_size_in_bytes: u64,
+    pub(crate) file_size_in_bytes: u64,
     /// field id: 108
     /// key field id: 117
     /// value field id: 118
@@ -968,7 +968,7 @@ pub struct DataFile {
     /// store the column. Does not include bytes necessary to read other
     /// columns, like footers. Leave null for row-oriented formats (Avro)
     #[builder(default)]
-    pub column_sizes: HashMap<i32, u64>,
+    pub(crate) column_sizes: HashMap<i32, u64>,
     /// field id: 109
     /// key field id: 119
     /// value field id: 120
@@ -976,21 +976,21 @@ pub struct DataFile {
     /// Map from column id to number of values in the column (including null
     /// and NaN values)
     #[builder(default)]
-    pub value_counts: HashMap<i32, u64>,
+    pub(crate) value_counts: HashMap<i32, u64>,
     /// field id: 110
     /// key field id: 121
     /// value field id: 122
     ///
     /// Map from column id to number of null values in the column
     #[builder(default)]
-    pub null_value_counts: HashMap<i32, u64>,
+    pub(crate) null_value_counts: HashMap<i32, u64>,
     /// field id: 137
     /// key field id: 138
     /// value field id: 139
     ///
     /// Map from column id to number of NaN values in the column
     #[builder(default)]
-    pub nan_value_counts: HashMap<i32, u64>,
+    pub(crate) nan_value_counts: HashMap<i32, u64>,
     /// field id: 125
     /// key field id: 126
     /// value field id: 127
@@ -1003,7 +1003,7 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub lower_bounds: HashMap<i32, Literal>,
+    pub(crate) lower_bounds: HashMap<i32, Literal>,
     /// field id: 128
     /// key field id: 129
     /// value field id: 130
@@ -1016,19 +1016,19 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub upper_bounds: HashMap<i32, Literal>,
+    pub(crate) upper_bounds: HashMap<i32, Literal>,
     /// field id: 131
     ///
     /// Implementation-specific key metadata for encryption
     #[builder(default)]
-    pub key_metadata: Vec<u8>,
+    pub(crate) key_metadata: Vec<u8>,
     /// field id: 132
     /// element field id: 133
     ///
     /// Split offsets for the data file. For example, all row group offsets
     /// in a Parquet file. Must be sorted ascending
     #[builder(default)]
-    pub split_offsets: Vec<i64>,
+    pub(crate) split_offsets: Vec<i64>,
     /// field id: 135
     /// element field id: 136
     ///
@@ -1037,7 +1037,7 @@ pub struct DataFile {
     /// otherwise. Fields with ids listed in this column must be present
     /// in the delete file
     #[builder(default)]
-    pub equality_ids: Vec<i32>,
+    pub(crate) equality_ids: Vec<i32>,
     /// field id: 140
     ///
     /// ID representing sort order for this file.
@@ -1049,9 +1049,92 @@ pub struct DataFile {
     /// order id to null. Readers must ignore sort order id for position
     /// delete files.
     #[builder(default, setter(strip_option))]
-    pub sort_order_id: Option<i32>,
+    pub(crate) sort_order_id: Option<i32>,
 }
 
+impl DataFile {
+    /// Get the content type of the data file (data, equality deletes, or position deletes)
+    pub fn content(&self) -> DataContentType {
+        self.content
+    }
+    /// Get the file path as full URI with FS scheme
+    pub fn file_path(&self) -> &str {
+        &self.file_path
+    }
+    /// Get the file format of the file (avro, orc or parquet).
+    pub fn file_format(&self) -> DataFileFormat {
+        self.file_format
+    }
+    /// Get the partition values of the file.
+    pub fn partition(&self) -> &Struct {
+        &self.partition
+    }
+    /// Get the record count in the data file.
+    pub fn record_count(&self) -> u64 {
+        self.record_count
+    }
+    /// Get the file size in bytes.
+    pub fn file_size_in_bytes(&self) -> u64 {
+        self.file_size_in_bytes
+    }
+    /// Get the column sizes.
+    /// Map from column id to the total size on disk of all regions that
+    /// store the column. Does not include bytes necessary to read other
+    /// columns, like footers. Null for row-oriented formats (Avro)
+    pub fn column_sizes(&self) -> &HashMap<i32, u64> {
+        &self.column_sizes
+    }
+    /// Get the columns value counts for the data file.
+    /// Map from column id to number of values in the column (including null
+    /// and NaN values)
+    pub fn value_counts(&self) -> &HashMap<i32, u64> {
+        &self.value_counts
+    }
+    /// Get the null value counts of the data file.
+    /// Map from column id to number of null values in the column
+    pub fn null_value_counts(&self) -> &HashMap<i32, u64> {
+        &self.null_value_counts
+    }
+    /// Get the nan value counts of the data file.
+    /// Map from column id to number of NaN values in the column
+    pub fn nan_value_counts(&self) -> &HashMap<i32, u64> {
+        &self.nan_value_counts
+    }
+    /// Get the lower bounds of the data file values per column.
+    /// Map from column id to lower bound in the column serialized as binary.
+    pub fn lower_bounds(&self) -> &HashMap<i32, Literal> {
+        &self.lower_bounds
+    }
+    /// Get the upper bounds of the data file values per column.
+    /// Map from column id to upper bound in the column serialized as binary.
+    pub fn upper_bounds(&self) -> &HashMap<i32, Literal> {
+        &self.upper_bounds
+    }
+    /// Get the Implementation-specific key metadata for the data file.
+    pub fn key_metadata(&self) -> &[u8] {
+        &self.key_metadata
+    }
+    /// Get the split offsets of the data file.
+    /// For example, all row group offsets in a Parquet file.
+    pub fn split_offsets(&self) -> &[i64] {
+        &self.split_offsets
+    }
+    /// Get the equality ids of the data file.
+    /// Field ids used to determine row equality in equality delete files.
+    /// null when content is not EqualityDeletes.
+    pub fn equality_ids(&self) -> &[i32] {
+        &self.equality_ids
+    }
+    /// Get the sort order id of the data file.
+    /// Only data files and equality delete files should be
+    /// written with a non-null order id. Position deletes are required to be
+    /// sorted by file and position, not a table order, and should set sort
+    /// order id to null. Readers must ignore sort order id for position
+    /// delete files.
+    pub fn sort_order_id(&self) -> Option<i32> {
+        self.sort_order_id
+    }
+}
 /// Type of content stored by the data file: data, equality deletes, or
 /// position deletes (all v1 files are data files)
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
resolves #282 
The purpose of the PR is to change the ManifestEntry properties and FileScanTask data_file() method to public in order to enable public access to the file metadata API.
Some consumers are interested in the file paths that are part of the current table and their properties for query and monitoring purposes.