### PR TITLE
Modify `Bind` calls so that they don't consume `self` and instead return a new struct, leaving the original unmoved

### DIFF
--- a/crates/iceberg/src/expr/mod.rs
+++ b/crates/iceberg/src/expr/mod.rs
@@ -154,7 +154,7 @@ pub trait Bind {
     /// The type of the bound result.
     type Bound;
     /// Bind an expression to a schema.
-    fn bind(self, schema: SchemaRef, case_sensitive: bool) -> crate::Result<Self::Bound>;
+    fn bind(&self, schema: SchemaRef, case_sensitive: bool) -> crate::Result<Self::Bound>;
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/expr/term.rs
+++ b/crates/iceberg/src/expr/term.rs
@@ -175,7 +175,7 @@ impl Display for Reference {
 impl Bind for Reference {
     type Bound = BoundReference;
 
-    fn bind(self, schema: SchemaRef, case_sensitive: bool) -> crate::Result<Self::Bound> {
+    fn bind(&self, schema: SchemaRef, case_sensitive: bool) -> crate::Result<Self::Bound> {
         let field = if case_sensitive {
             schema.field_by_name(&self.name)
         } else {
@@ -188,7 +188,7 @@ impl Bind for Reference {
                 format!("Field {} not found in schema", self.name),
             )
         })?;
-        Ok(BoundReference::new(self.name, field.clone()))
+        Ok(BoundReference::new(self.name.clone(), field.clone()))
     }
 }
 

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -84,7 +84,7 @@ pub enum PrimitiveLiteral {
 ///
 /// By default, we decouple the type and value of a literal, so we can use avoid the cost of storing extra type info
 /// for each literal. But associate type with literal can be useful in some cases, for example, in unbound expression.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Datum {
     r#type: PrimitiveType,
     literal: PrimitiveLiteral,


### PR DESCRIPTION
This is a pre-requisite to https://github.com/apache/iceberg-rust/pull/241 and was a part of that PR but has been pulled into it's own PR after discussions with @liurenjie1024.

The existing Predicate `Bind` implementation consumes `self` when `bind()` is called. This was done for performance reasons but has the consequence that it is not possible to create a `BoundPredicate` whilst keeping the original `Predicate` unconsumed, which we need to do in the table scan file planner when a filter predicate is specified.

The consequences of this change are that the literals within the expressions in the predicate are cloned in order to create a `BoundPredicate`. Most of the constituent parts of a Predicate were cloned or newly-created anyway even in the original implementation. The alternative would be that `Clone` would need to be implemented for `Predicate` and the whole `Predicate` would need to be cloned before calling bind, which would be more expensive. Alternatively we could have two `bind` methods, one consuming self and the other not doing so, which would be a bit ugly.