### PR TITLE
Rename function name to `add_manifests`

### DIFF
--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -384,7 +384,7 @@ mod tests {
                 current_snapshot.sequence_number(),
             );
             manifest_list_write
-                .add_manifest_entries(vec![data_file_manifest].into_iter())
+                .add_manifests(vec![data_file_manifest].into_iter())
                 .unwrap();
             manifest_list_write.close().await.unwrap();
 

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -195,7 +195,7 @@ impl ManifestWriter {
         partition_summary
     }
 
-    /// Write a manifest entry.
+    /// Write a manifest.
     pub async fn write(mut self, manifest: Manifest) -> Result<ManifestFile> {
         // Create the avro writer
         let partition_type = manifest

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -165,45 +165,42 @@ impl ManifestListWriter {
         }
     }
 
-    /// Append manifest entries to be written.
-    pub fn add_manifest_entries(
-        &mut self,
-        manifest_entries: impl Iterator<Item = ManifestFile>,
-    ) -> Result<()> {
+    /// Append manifests to be written.
+    pub fn add_manifests(&mut self, manifests: impl Iterator<Item = ManifestFile>) -> Result<()> {
         match self.format_version {
             FormatVersion::V1 => {
-                for manifest_entry in manifest_entries {
-                    let manifest_entry: ManifestFileV1 = manifest_entry.try_into()?;
-                    self.avro_writer.append_ser(manifest_entry)?;
+                for manifest in manifests {
+                    let manifes: ManifestFileV1 = manifest.try_into()?;
+                    self.avro_writer.append_ser(manifes)?;
                 }
             }
             FormatVersion::V2 => {
-                for mut manifest_entry in manifest_entries {
-                    if manifest_entry.sequence_number == UNASSIGNED_SEQUENCE_NUMBER {
-                        if manifest_entry.added_snapshot_id != self.snapshot_id {
+                for mut manifest in manifests {
+                    if manifest.sequence_number == UNASSIGNED_SEQUENCE_NUMBER {
+                        if manifest.added_snapshot_id != self.snapshot_id {
                             return Err(Error::new(
                                 ErrorKind::DataInvalid,
                                 format!(
                                     "Found unassigned sequence number for a manifest from snapshot {}.",
-                                    manifest_entry.added_snapshot_id
+                                    manifest.added_snapshot_id
                                 ),
                             ));
                         }
-                        manifest_entry.sequence_number = self.sequence_number;
+                        manifest.sequence_number = self.sequence_number;
                     }
-                    if manifest_entry.min_sequence_number == UNASSIGNED_SEQUENCE_NUMBER {
-                        if manifest_entry.added_snapshot_id != self.snapshot_id {
+                    if manifest.min_sequence_number == UNASSIGNED_SEQUENCE_NUMBER {
+                        if manifest.added_snapshot_id != self.snapshot_id {
                             return Err(Error::new(
                                 ErrorKind::DataInvalid,
                                 format!(
                                     "Found unassigned sequence number for a manifest from snapshot {}.",
-                                    manifest_entry.added_snapshot_id
+                                    manifest.added_snapshot_id
                                 ),
                             ));
                         }
-                        manifest_entry.min_sequence_number = self.sequence_number;
+                        manifest.min_sequence_number = self.sequence_number;
                     }
-                    let manifest_entry: ManifestFileV2 = manifest_entry.try_into()?;
+                    let manifest_entry: ManifestFileV2 = manifest.try_into()?;
                     self.avro_writer.append_ser(manifest_entry)?;
                 }
             }
@@ -1144,7 +1141,7 @@ mod test {
         );
 
         writer
-            .add_manifest_entries(manifest_list.entries.clone().into_iter())
+            .add_manifests(manifest_list.entries.clone().into_iter())
             .unwrap();
         writer.close().await.unwrap();
 
@@ -1212,7 +1209,7 @@ mod test {
         );
 
         writer
-            .add_manifest_entries(manifest_list.entries.clone().into_iter())
+            .add_manifests(manifest_list.entries.clone().into_iter())
             .unwrap();
         writer.close().await.unwrap();
 
@@ -1331,7 +1328,7 @@ mod test {
 
         let mut writer = ManifestListWriter::v1(output_file, 1646658105718557341, 0);
         writer
-            .add_manifest_entries(expected_manifest_list.entries.clone().into_iter())
+            .add_manifests(expected_manifest_list.entries.clone().into_iter())
             .unwrap();
         writer.close().await.unwrap();
 
@@ -1387,7 +1384,7 @@ mod test {
 
         let mut writer = ManifestListWriter::v2(output_file, snapshot_id, 0, seq_num);
         writer
-            .add_manifest_entries(expected_manifest_list.entries.clone().into_iter())
+            .add_manifests(expected_manifest_list.entries.clone().into_iter())
             .unwrap();
         writer.close().await.unwrap();
 
@@ -1441,7 +1438,7 @@ mod test {
 
         let mut writer = ManifestListWriter::v2(output_file, 1646658105718557341, 0, 1);
         writer
-            .add_manifest_entries(expected_manifest_list.entries.clone().into_iter())
+            .add_manifests(expected_manifest_list.entries.clone().into_iter())
             .unwrap();
         writer.close().await.unwrap();
 


### PR DESCRIPTION
While I'm looking into #286, I found there is one function `add_manifest_entries` which is confusing to me.

In fact, it writes manifest instead of manifest entries. As I think manifest entries (i.e., `ManifestEntry`) should refer to the entries inside manifest (i.e., `Manifest`). I think updating the function names and a few comments make it less confusing.