### PR TITLE
feat: Glue Catalog - namespace operations (2/3)

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -195,7 +195,7 @@ impl Catalog for GlueCatalog {
         let db_name = validate_namespace(namespace)?;
         let table_list = self.list_tables(namespace).await?;
 
-        if table_list.len() > 0 {
+        if !table_list.is_empty() {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 format!("Database with name: {} is not empty", &db_name),

--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -25,7 +25,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use typed_builder::TypedBuilder;
 
-use crate::error::from_sdk_error;
+use crate::error::from_aws_sdk_error;
 use crate::utils::{
     convert_to_database, convert_to_namespace, create_sdk_config, validate_namespace,
 };
@@ -95,7 +95,7 @@ impl Catalog for GlueCatalog {
                 None => self.client.0.get_databases(),
             };
             let builder = with_catalog_id!(builder, self.config);
-            let resp = builder.send().await.map_err(from_sdk_error)?;
+            let resp = builder.send().await.map_err(from_aws_sdk_error)?;
 
             let dbs: Vec<NamespaceIdent> = resp
                 .database_list()
@@ -137,7 +137,7 @@ impl Catalog for GlueCatalog {
         let builder = self.client.0.create_database().database_input(db_input);
         let builder = with_catalog_id!(builder, self.config);
 
-        builder.send().await.map_err(from_sdk_error)?;
+        builder.send().await.map_err(from_aws_sdk_error)?;
 
         Ok(Namespace::with_properties(namespace.clone(), properties))
     }
@@ -158,7 +158,7 @@ impl Catalog for GlueCatalog {
         let builder = self.client.0.get_database().name(&db_name);
         let builder = with_catalog_id!(builder, self.config);
 
-        let resp = builder.send().await.map_err(from_sdk_error)?;
+        let resp = builder.send().await.map_err(from_aws_sdk_error)?;
 
         match resp.database() {
             Some(db) => {
@@ -202,7 +202,7 @@ impl Catalog for GlueCatalog {
                 {
                     return Ok(false);
                 }
-                Err(from_sdk_error(err))
+                Err(from_aws_sdk_error(err))
             }
         }
     }
@@ -233,7 +233,7 @@ impl Catalog for GlueCatalog {
             .database_input(db_input);
         let builder = with_catalog_id!(builder, self.config);
 
-        builder.send().await.map_err(from_sdk_error)?;
+        builder.send().await.map_err(from_aws_sdk_error)?;
 
         Ok(())
     }
@@ -262,7 +262,7 @@ impl Catalog for GlueCatalog {
         let builder = self.client.0.delete_database().name(db_name);
         let builder = with_catalog_id!(builder, self.config);
 
-        builder.send().await.map_err(from_sdk_error)?;
+        builder.send().await.map_err(from_aws_sdk_error)?;
 
         Ok(())
     }
@@ -291,7 +291,7 @@ impl Catalog for GlueCatalog {
                 None => self.client.0.get_tables().database_name(&db_name),
             };
             let builder = with_catalog_id!(builder, self.config);
-            let resp = builder.send().await.map_err(from_sdk_error)?;
+            let resp = builder.send().await.map_err(from_aws_sdk_error)?;
 
             let tables: Vec<_> = resp
                 .table_list()

--- a/crates/catalog/glue/src/error.rs
+++ b/crates/catalog/glue/src/error.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Iceberg Glue Catalog implementation.
-
 use anyhow::anyhow;
 use std::fmt::Debug;
 

--- a/crates/catalog/glue/src/error.rs
+++ b/crates/catalog/glue/src/error.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 use iceberg::{Error, ErrorKind};
 
 /// Format AWS SDK error into iceberg error
-pub fn from_aws_error<T>(error: aws_sdk_glue::error::SdkError<T>) -> Error
+pub fn from_sdk_error<T>(error: aws_sdk_glue::error::SdkError<T>) -> Error
 where
     T: Debug,
 {
@@ -32,4 +32,13 @@ where
         "Operation failed for hitting aws skd error".to_string(),
     )
     .with_source(anyhow!("aws sdk error: {:?}", error))
+}
+
+/// Format AWS Build error into iceberg error
+pub fn from_build_error(error: aws_sdk_glue::error::BuildError) -> Error {
+    Error::new(
+        ErrorKind::Unexpected,
+        "Operation failed for hitting aws build error".to_string(),
+    )
+    .with_source(anyhow!("aws build error: {:?}", error))
 }

--- a/crates/catalog/glue/src/error.rs
+++ b/crates/catalog/glue/src/error.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 use iceberg::{Error, ErrorKind};
 
 /// Format AWS SDK error into iceberg error
-pub fn from_sdk_error<T>(error: aws_sdk_glue::error::SdkError<T>) -> Error
+pub(crate) fn from_aws_sdk_error<T>(error: aws_sdk_glue::error::SdkError<T>) -> Error
 where
     T: Debug,
 {
@@ -33,7 +33,7 @@ where
 }
 
 /// Format AWS Build error into iceberg error
-pub fn from_build_error(error: aws_sdk_glue::error::BuildError) -> Error {
+pub(crate) fn from_aws_build_error(error: aws_sdk_glue::error::BuildError) -> Error {
     Error::new(
         ErrorKind::Unexpected,
         "Operation failed for hitting aws build error".to_string(),

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -20,9 +20,13 @@
 use std::collections::HashMap;
 
 use aws_config::{BehaviorVersion, Region, SdkConfig};
-use aws_sdk_glue::config::Credentials;
+use aws_sdk_glue::{config::Credentials, types::DatabaseInput};
+use iceberg::{Error, ErrorKind, NamespaceIdent, Result};
 
-const _GLUE_ID: &str = "glue.id";
+use crate::error::from_build_error;
+
+/// Property glue catalog id
+pub const GLUE_ID: &str = "glue.id";
 const _GLUE_SKIP_ARCHIVE: &str = "glue.skip-archive";
 const _GLUE_SKIP_ARCHIVE_DEFAULT: bool = true;
 /// Property aws profile name
@@ -35,6 +39,8 @@ pub const AWS_ACCESS_KEY_ID: &str = "aws_access_key_id";
 pub const AWS_SECRET_ACCESS_KEY: &str = "aws_secret_access_key";
 /// Property aws session token
 pub const AWS_SESSION_TOKEN: &str = "aws_session_token";
+/// Parameter namespace description
+const DESCRIPTION: &str = "description";
 
 /// Creates an AWS SDK configuration (SdkConfig) based on
 /// provided properties and an optional endpoint URL.
@@ -75,11 +81,96 @@ pub(crate) async fn create_sdk_config(
     config.load().await
 }
 
+/// Create `DatabaseInput` from name, uri and properties
+pub(crate) fn convert_to_database(
+    namespace: &NamespaceIdent,
+    location_uri: &Option<String>,
+    properties: &HashMap<String, String>,
+) -> Result<DatabaseInput> {
+    let db_name = validate_namespace(namespace)?;
+    let mut builder = DatabaseInput::builder().name(db_name);
+
+    if let Some(location_uri) = location_uri {
+        builder = builder.location_uri(location_uri);
+    }
+
+    for (k, v) in properties.iter() {
+        match k.as_ref() {
+            DESCRIPTION => {
+                builder = builder.description(v);
+            }
+            _ => {
+                builder = builder.parameters(k, v);
+            }
+        }
+    }
+
+    builder.build().map_err(from_build_error)
+}
+
+/// Checks if provided `NamespaceIdent` is valid.
+pub(crate) fn validate_namespace(namespace: &NamespaceIdent) -> Result<String> {
+    let name = namespace.as_ref();
+
+    if name.len() != 1 {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!(
+                "Invalid database name: {:?}, hierarchical namespaces are not supported",
+                namespace
+            ),
+        ));
+    }
+
+    let name = name[0].clone();
+
+    if name.is_empty() {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            "Invalid database, provided namespace is empty.",
+        ));
+    }
+
+    Ok(name)
+}
+
 #[cfg(test)]
 mod tests {
     use aws_sdk_glue::config::ProvideCredentials;
+    use iceberg::{Namespace, Result};
 
     use super::*;
+
+    #[test]
+    fn test_convert_to_database() -> Result<()> {
+        let namespace = NamespaceIdent::new("my_database".to_string());
+        let location_uri = Some("my_location".to_string());
+        let properties = HashMap::new();
+
+        let result = convert_to_database(&namespace, &location_uri, &properties)?;
+
+        assert_eq!("my_database", result.name());
+        assert_eq!(location_uri, result.location_uri);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_namespace() {
+        let valid_ns = Namespace::new(NamespaceIdent::new("ns".to_string()));
+        let empty_ns = Namespace::new(NamespaceIdent::new("".to_string()));
+        let hierarchical_ns = Namespace::new(
+            NamespaceIdent::from_vec(vec!["level1".to_string(), "level2".to_string()]).unwrap(),
+        );
+
+        let valid = validate_namespace(valid_ns.name());
+        let empty = validate_namespace(empty_ns.name());
+        let hierarchical = validate_namespace(hierarchical_ns.name());
+
+        assert!(valid.is_ok());
+        assert!(empty.is_err());
+        assert!(hierarchical.is_err());
+    }
 
     #[tokio::test]
     async fn test_config_with_custom_endpoint() {

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -132,6 +132,18 @@ pub(crate) fn validate_namespace(namespace: &NamespaceIdent) -> Result<String> {
     Ok(name)
 }
 
+#[macro_export]
+/// Extends aws sdk builder with catalog id if present
+macro_rules! with_catalog_id {
+    ($builder:expr, $config:expr) => {{
+        if let Some(catalog_id) = &$config.catalog_id {
+            $builder.catalog_id(catalog_id)
+        } else {
+            $builder
+        }
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use aws_sdk_glue::config::ProvideCredentials;

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Iceberg Glue Catalog implementation.
-
 use std::collections::HashMap;
 
 use aws_config::{BehaviorVersion, Region, SdkConfig};

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -25,8 +25,6 @@ use iceberg::{Error, ErrorKind, NamespaceIdent, Result};
 
 use crate::error::from_build_error;
 
-/// Property glue catalog id
-pub const GLUE_ID: &str = "glue.id";
 const _GLUE_SKIP_ARCHIVE: &str = "glue.skip-archive";
 const _GLUE_SKIP_ARCHIVE_DEFAULT: bool = true;
 /// Property aws profile name

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -40,18 +40,18 @@ pub const AWS_SECRET_ACCESS_KEY: &str = "aws_secret_access_key";
 pub const AWS_SESSION_TOKEN: &str = "aws_session_token";
 /// Parameter namespace description
 const DESCRIPTION: &str = "description";
-/// Parameter namespace description
+/// Parameter namespace location uri
 const LOCATION: &str = "location_uri";
 
-/// Creates an AWS SDK configuration (SdkConfig) based on
+/// Creates an aws sdk configuration based on
 /// provided properties and an optional endpoint URL.
 pub(crate) async fn create_sdk_config(
     properties: &HashMap<String, String>,
-    endpoint_url: Option<&String>,
+    endpoint_uri: Option<&String>,
 ) -> SdkConfig {
     let mut config = aws_config::defaults(BehaviorVersion::latest());
 
-    if let Some(endpoint) = endpoint_url {
+    if let Some(endpoint) = endpoint_uri {
         config = config.endpoint_url(endpoint)
     };
 
@@ -82,7 +82,7 @@ pub(crate) async fn create_sdk_config(
     config.load().await
 }
 
-/// Create `DatabaseInput` from name, uri and properties
+/// Create `DatabaseInput` from `NamespaceIdent` and properties
 pub(crate) fn convert_to_database(
     namespace: &NamespaceIdent,
     properties: &HashMap<String, String>,
@@ -125,7 +125,7 @@ pub(crate) fn convert_to_namespace(database: &Database) -> Namespace {
     Namespace::with_properties(NamespaceIdent::new(db_name), properties)
 }
 
-/// Checks if provided `NamespaceIdent` is valid.
+/// Checks if provided `NamespaceIdent` is valid
 pub(crate) fn validate_namespace(namespace: &NamespaceIdent) -> Result<String> {
     let name = namespace.as_ref();
 
@@ -152,7 +152,7 @@ pub(crate) fn validate_namespace(namespace: &NamespaceIdent) -> Result<String> {
 }
 
 #[macro_export]
-/// Extends aws sdk builder with catalog id if present
+/// Extends aws sdk builder with `catalog_id` if present
 macro_rules! with_catalog_id {
     ($builder:expr, $config:expr) => {{
         if let Some(catalog_id) = &$config.catalog_id {

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -24,7 +24,7 @@ use aws_sdk_glue::{
 };
 use iceberg::{Error, ErrorKind, Namespace, NamespaceIdent, Result};
 
-use crate::error::from_build_error;
+use crate::error::from_aws_build_error;
 
 const _GLUE_SKIP_ARCHIVE: &str = "glue.skip-archive";
 const _GLUE_SKIP_ARCHIVE_DEFAULT: bool = true;
@@ -104,7 +104,7 @@ pub(crate) fn convert_to_database(
         }
     }
 
-    builder.build().map_err(from_build_error)
+    builder.build().map_err(from_aws_build_error)
 }
 
 /// Create `Namespace` from aws sdk glue `Database`
@@ -177,7 +177,7 @@ mod tests {
             .location_uri("my_location")
             .description("my_description")
             .build()
-            .map_err(from_build_error)?;
+            .map_err(from_aws_build_error)?;
 
         let properties = HashMap::from([
             (DESCRIPTION.to_string(), "my_description".to_string()),

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -81,6 +81,29 @@ async fn set_test_fixture(func: &str) -> TestFixture {
 }
 
 #[tokio::test]
+async fn test_get_namespace() -> Result<()> {
+    let fixture = set_test_fixture("test_get_namespace").await;
+
+    let properties = HashMap::new();
+    let namespace = NamespaceIdent::new("my_database".into());
+
+    let does_not_exist = fixture.glue_catalog.get_namespace(&namespace).await;
+    assert!(does_not_exist.is_err());
+
+    fixture
+        .glue_catalog
+        .create_namespace(&namespace, properties)
+        .await?;
+
+    let result = fixture.glue_catalog.get_namespace(&namespace).await?;
+    let expected = Namespace::new(namespace);
+
+    assert_eq!(result, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_create_namespace() -> Result<()> {
     let fixture = set_test_fixture("test_create_namespace").await;
 

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -81,6 +81,27 @@ async fn set_test_fixture(func: &str) -> TestFixture {
 }
 
 #[tokio::test]
+async fn test_namespace_exists() -> Result<()> {
+    let fixture = set_test_fixture("test_namespace_exists").await;
+
+    let properties = HashMap::new();
+    let namespace = NamespaceIdent::new("my_database".into());
+
+    let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
+    assert!(!exists);
+
+    fixture
+        .glue_catalog
+        .create_namespace(&namespace, properties)
+        .await?;
+
+    let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
+    assert!(exists);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_get_namespace() -> Result<()> {
     let fixture = set_test_fixture("test_get_namespace").await;
 

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -81,6 +81,39 @@ async fn set_test_fixture(func: &str) -> TestFixture {
 }
 
 #[tokio::test]
+async fn test_update_namespace() -> Result<()> {
+    let fixture = set_test_fixture("test_update_namespace").await;
+
+    let properties = HashMap::new();
+    let namespace = NamespaceIdent::new("my_database".into());
+
+    fixture
+        .glue_catalog
+        .create_namespace(&namespace, properties)
+        .await?;
+
+    let before_update = fixture.glue_catalog.get_namespace(&namespace).await?;
+    let before_update = before_update.properties().get("description");
+    assert_eq!(before_update, None);
+
+    let properties = HashMap::from([("description".to_string(), "my_update".to_string())]);
+
+    fixture
+        .glue_catalog
+        .update_namespace(&namespace, properties)
+        .await?;
+
+    let after_update = fixture.glue_catalog.get_namespace(&namespace).await?;
+    let after_update = after_update.properties().get("description");
+    assert_eq!(
+        after_update.as_deref(),
+        Some("my_update".to_string()).as_ref()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_namespace_exists() -> Result<()> {
     let fixture = set_test_fixture("test_namespace_exists").await;
 

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -106,6 +106,23 @@ async fn test_list_tables() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_drop_namespace() -> Result<()> {
+    let fixture = set_test_fixture("test_drop_namespace").await;
+    let namespace = NamespaceIdent::new("my_database".to_string());
+    set_test_namespace(&fixture, &namespace).await?;
+
+    let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
+    assert!(exists);
+
+    fixture.glue_catalog.drop_namespace(&namespace).await?;
+
+    let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
+    assert!(!exists);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_update_namespace() -> Result<()> {
     let fixture = set_test_fixture("test_update_namespace").await;
     let namespace = NamespaceIdent::new("my_database".into());

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 
-use iceberg::{Catalog, Result};
+use iceberg::{Catalog, Namespace, NamespaceIdent, Result};
 use iceberg_catalog_glue::{
     GlueCatalog, GlueCatalogConfig, AWS_ACCESS_KEY_ID, AWS_REGION_NAME, AWS_SECRET_ACCESS_KEY,
 };
@@ -78,6 +78,25 @@ async fn set_test_fixture(func: &str) -> TestFixture {
         _docker_compose: docker_compose,
         glue_catalog,
     }
+}
+
+#[tokio::test]
+async fn test_create_namespace() -> Result<()> {
+    let fixture = set_test_fixture("test_create_namespace").await;
+
+    let properties = HashMap::new();
+    let namespace = NamespaceIdent::new("my_database".into());
+
+    let expected = Namespace::new(namespace.clone());
+
+    let result = fixture
+        .glue_catalog
+        .create_namespace(&namespace, properties)
+        .await?;
+
+    assert_eq!(result, expected);
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/catalog/glue/tests/glue_catalog_test.rs
+++ b/crates/catalog/glue/tests/glue_catalog_test.rs
@@ -80,20 +80,40 @@ async fn set_test_fixture(func: &str) -> TestFixture {
     }
 }
 
-#[tokio::test]
-async fn test_update_namespace() -> Result<()> {
-    let fixture = set_test_fixture("test_update_namespace").await;
-
+async fn set_test_namespace(fixture: &TestFixture, namespace: &NamespaceIdent) -> Result<()> {
     let properties = HashMap::new();
-    let namespace = NamespaceIdent::new("my_database".into());
 
     fixture
         .glue_catalog
-        .create_namespace(&namespace, properties)
+        .create_namespace(namespace, properties)
         .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_tables() -> Result<()> {
+    let fixture = set_test_fixture("test_list_tables").await;
+    let namespace = NamespaceIdent::new("my_database".to_string());
+    set_test_namespace(&fixture, &namespace).await?;
+
+    let expected = vec![];
+    let result = fixture.glue_catalog.list_tables(&namespace).await?;
+
+    assert_eq!(result, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_update_namespace() -> Result<()> {
+    let fixture = set_test_fixture("test_update_namespace").await;
+    let namespace = NamespaceIdent::new("my_database".into());
+    set_test_namespace(&fixture, &namespace).await?;
 
     let before_update = fixture.glue_catalog.get_namespace(&namespace).await?;
     let before_update = before_update.properties().get("description");
+
     assert_eq!(before_update, None);
 
     let properties = HashMap::from([("description".to_string(), "my_update".to_string())]);
@@ -105,10 +125,8 @@ async fn test_update_namespace() -> Result<()> {
 
     let after_update = fixture.glue_catalog.get_namespace(&namespace).await?;
     let after_update = after_update.properties().get("description");
-    assert_eq!(
-        after_update.as_deref(),
-        Some("my_update".to_string()).as_ref()
-    );
+
+    assert_eq!(after_update, Some("my_update".to_string()).as_ref());
 
     Ok(())
 }
@@ -117,16 +135,12 @@ async fn test_update_namespace() -> Result<()> {
 async fn test_namespace_exists() -> Result<()> {
     let fixture = set_test_fixture("test_namespace_exists").await;
 
-    let properties = HashMap::new();
     let namespace = NamespaceIdent::new("my_database".into());
 
     let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
     assert!(!exists);
 
-    fixture
-        .glue_catalog
-        .create_namespace(&namespace, properties)
-        .await?;
+    set_test_namespace(&fixture, &namespace).await?;
 
     let exists = fixture.glue_catalog.namespace_exists(&namespace).await?;
     assert!(exists);
@@ -138,16 +152,12 @@ async fn test_namespace_exists() -> Result<()> {
 async fn test_get_namespace() -> Result<()> {
     let fixture = set_test_fixture("test_get_namespace").await;
 
-    let properties = HashMap::new();
     let namespace = NamespaceIdent::new("my_database".into());
 
     let does_not_exist = fixture.glue_catalog.get_namespace(&namespace).await;
     assert!(does_not_exist.is_err());
 
-    fixture
-        .glue_catalog
-        .create_namespace(&namespace, properties)
-        .await?;
+    set_test_namespace(&fixture, &namespace).await?;
 
     let result = fixture.glue_catalog.get_namespace(&namespace).await?;
     let expected = Namespace::new(namespace);
@@ -182,7 +192,13 @@ async fn test_list_namespace() -> Result<()> {
 
     let expected = vec![];
     let result = fixture.glue_catalog.list_namespaces(None).await?;
+    assert_eq!(result, expected);
 
+    let namespace = NamespaceIdent::new("my_database".to_string());
+    set_test_namespace(&fixture, &namespace).await?;
+
+    let expected = vec![namespace];
+    let result = fixture.glue_catalog.list_namespaces(None).await?;
     assert_eq!(result, expected);
 
     Ok(())


### PR DESCRIPTION
### Which issue does this PR close?
Partly #249 (Task 2/3)

### Rationale for this change
Add support for Glue Catalog, to reach feature parity with other implementations.

### What changes are included in this PR?
- added namespace operations
- also implemented `list_tables` since it's needed for `drop_namespace`

### Are these changes tested?
Yes. Unit and integration tests are included.