### PR TITLE
Support identifier warehouses

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use itertools::Itertools;
 use reqwest::header::{self, HeaderMap, HeaderName, HeaderValue};
-use reqwest::{Client, Request, Response, StatusCode};
+use reqwest::{Client, Request, Response, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use typed_builder::TypedBuilder;
 use urlencoding::encode;
@@ -617,8 +617,10 @@ impl RestCatalog {
             props.extend(config);
         }
 
+        // If the warehouse is a logical identifier instead of a URL we don't want
+        // to raise an exception
         let warehouse_path = match self.config.warehouse.as_deref() {
-            Some(url) if url.contains("://") => Some(url),
+            Some(url) if Url::parse(url).is_ok() => Some(url),
             Some(_) => None,
             None => None,
         };

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -617,7 +617,13 @@ impl RestCatalog {
             props.extend(config);
         }
 
-        let file_io = match self.config.warehouse.as_deref().or(metadata_location) {
+        let warehouse_path = match self.config.warehouse.as_deref() {
+            Some(url) if url.contains("://") => Some(url),
+            Some(_) => None,
+            None => None,
+        };
+
+        let file_io = match warehouse_path.or(metadata_location) {
             Some(url) => FileIO::from_path(url)?.with_props(props).build()?,
             None => {
                 return Err(Error::new(


### PR DESCRIPTION
This is a bit confusing if you come from a Hive background where the warehouse is always a path to hdfs/s3/etc.

With the REST catalog, the warehouse can also be a logical identifier:
https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L72-L78

This means that we have to make sure that we only parse paths that are an actual path, and not an identifier.

I'm open to suggestions. The check is now very simple, but can be extended for example using a regex. But I'm not sure what the implications are of importing additional packages (in Python you want to keep it as lightweight as possible).