### PR TITLE
Fix day timestamp micro

### DIFF
--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -200,7 +200,7 @@ impl TransformFunction for Day {
                 .as_any()
                 .downcast_ref::<TimestampMicrosecondArray>()
                 .unwrap()
-                .unary(|v| -> i32 { Self::day_timestamp_micro(v).unwrap() }),
+                .try_unary(|v| -> Result<i32> { Self::day_timestamp_micro(v) })?,
             DataType::Date32 => input
                 .as_any()
                 .downcast_ref::<Date32Array>()


### PR DESCRIPTION
### Which issue does this PR close?
Closes #311

### Rationale for this change
Align timestamp conversion with Java implementation. Unblock #309

### What changes are included in this PR?
- changed `fn day_timestamp_micro`

### Are these changes tested?
Yes. Unit tests are included.