### PR TITLE
Add Struct Accessors to BoundReferences

### DIFF
--- a/crates/iceberg/src/expr/accessor.rs
+++ b/crates/iceberg/src/expr/accessor.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::spec::{Datum, Literal, PrimitiveType, Struct};
+use crate::{Error, ErrorKind};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct StructAccessor {
+    position: usize,
+    r#type: PrimitiveType,
+    inner: Option<Box<StructAccessor>>,
+}
+
+pub(crate) type StructAccessorRef = Arc<StructAccessor>;
+
+impl StructAccessor {
+    pub(crate) fn new(position: usize, r#type: PrimitiveType) -> Self {
+        StructAccessor {
+            position,
+            r#type,
+            inner: None,
+        }
+    }
+
+    pub(crate) fn wrap(position: usize, inner: Box<StructAccessor>) -> Self {
+        StructAccessor {
+            position,
+            r#type: inner.r#type().clone(),
+            inner: Some(inner),
+        }
+    }
+
+    pub(crate) fn position(&self) -> usize {
+        self.position
+    }
+
+    pub(crate) fn r#type(&self) -> &PrimitiveType {
+        &self.r#type
+    }
+
+    pub(crate) fn get<'a>(&'a self, container: &'a Struct) -> crate::Result<Datum> {
+        match &self.inner {
+            None => {
+                if let Literal::Primitive(literal) = &container[self.position] {
+                    Ok(Datum::new(self.r#type().clone(), literal.clone()))
+                } else {
+                    Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "Expected Literal to be Primitive",
+                    ))
+                }
+            }
+            Some(inner) => {
+                if let Literal::Struct(wrapped) = &container[self.position] {
+                    inner.get(wrapped)
+                } else {
+                    Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "Nested accessor should only be wrapping a Struct",
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::expr::accessor::StructAccessor;
+    use crate::spec::{Datum, Literal, PrimitiveType, Struct};
+
+    #[test]
+    fn test_single_level_accessor() {
+        let accessor = StructAccessor::new(1, PrimitiveType::Boolean);
+
+        assert_eq!(accessor.r#type(), &PrimitiveType::Boolean);
+        assert_eq!(accessor.position(), 1);
+
+        let test_struct =
+            Struct::from_iter(vec![Some(Literal::bool(false)), Some(Literal::bool(true))]);
+
+        assert_eq!(accessor.get(&test_struct).unwrap(), Datum::bool(true));
+    }
+
+    #[test]
+    fn test_nested_accessor() {
+        let nested_accessor = StructAccessor::new(1, PrimitiveType::Boolean);
+        let accessor = StructAccessor::wrap(2, Box::new(nested_accessor));
+
+        assert_eq!(accessor.r#type(), &PrimitiveType::Boolean);
+        //assert_eq!(accessor.position(), 1);
+
+        let nested_test_struct =
+            Struct::from_iter(vec![Some(Literal::bool(false)), Some(Literal::bool(true))]);
+
+        let test_struct = Struct::from_iter(vec![
+            Some(Literal::bool(false)),
+            Some(Literal::bool(false)),
+            Some(Literal::Struct(nested_test_struct)),
+        ]);
+
+        assert_eq!(accessor.get(&test_struct).unwrap(), Datum::bool(true));
+    }
+}

--- a/crates/iceberg/src/expr/mod.rs
+++ b/crates/iceberg/src/expr/mod.rs
@@ -22,6 +22,7 @@ mod term;
 use std::fmt::{Display, Formatter};
 
 pub use term::*;
+pub(crate) mod accessor;
 mod predicate;
 
 use crate::spec::SchemaRef;

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -20,6 +20,7 @@
  */
 
 use std::fmt::{Display, Formatter};
+use std::ops::Index;
 use std::str::FromStr;
 use std::{any::Any, collections::BTreeMap};
 
@@ -141,6 +142,11 @@ impl From<Datum> for Literal {
 }
 
 impl Datum {
+    /// Creates a `Datum` from a `PrimitiveType` and a `PrimitiveLiteral`
+    pub(crate) fn new(r#type: PrimitiveType, literal: PrimitiveLiteral) -> Self {
+        Datum { r#type, literal }
+    }
+
     /// Creates a boolean value.
     ///
     /// Example:
@@ -1140,6 +1146,14 @@ impl Struct {
                 }
             },
         )
+    }
+}
+
+impl Index<usize> for Struct {
+    type Output = Literal;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        &self.fields[idx]
     }
 }
 

--- a/crates/iceberg/src/transform/mod.rs
+++ b/crates/iceberg/src/transform/mod.rs
@@ -72,6 +72,8 @@ pub fn create_transform_function(transform: &Transform) -> Result<BoxedTransform
 
 #[cfg(test)]
 mod test {
+    use crate::expr::accessor::StructAccessor;
+    use crate::spec::PrimitiveType;
     use crate::{
         expr::{
             BinaryExpression, BoundPredicate, BoundReference, PredicateOperator, SetExpression,
@@ -108,7 +110,11 @@ mod test {
         ) -> BoundPredicate {
             BoundPredicate::Binary(BinaryExpression::new(
                 op,
-                BoundReference::new(self.name.clone(), self.field.clone()),
+                BoundReference::new(
+                    self.name.clone(),
+                    self.field.clone(),
+                    Arc::new(StructAccessor::new(1, PrimitiveType::Boolean)),
+                ),
                 literal,
             ))
         }
@@ -119,7 +125,11 @@ mod test {
         ) -> BoundPredicate {
             BoundPredicate::Set(SetExpression::new(
                 op,
-                BoundReference::new(self.name.clone(), self.field.clone()),
+                BoundReference::new(
+                    self.name.clone(),
+                    self.field.clone(),
+                    Arc::new(StructAccessor::new(1, PrimitiveType::Boolean)),
+                ),
                 HashSet::from_iter(literals),
             ))
         }


### PR DESCRIPTION
First PR to come out of breaking up https://github.com/apache/iceberg-rust/pull/241.

Adds `StructAccessor`, which is added to `BoundReference` as a means of retrieving a field's value from a (possibly nested) Struct.