### PR TITLE
Refactor: Extract `partition_filters` from `ManifestEvaluator`

### DIFF
--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -32,7 +32,7 @@ use crate::spec::{Datum, SchemaRef};
 use crate::{Error, ErrorKind};
 
 /// Logical expression, such as `AND`, `OR`, `NOT`.
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct LogicalExpression<T, const N: usize> {
     inputs: [Box<T>; N],
 }
@@ -79,7 +79,7 @@ where
 }
 
 /// Unary predicate, for example, `a IS NULL`.
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct UnaryExpression<T> {
     /// Operator of this predicate, must be single operand operator.
     op: PredicateOperator,
@@ -126,7 +126,7 @@ impl<T> UnaryExpression<T> {
 }
 
 /// Binary predicate, for example, `a > 10`.
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct BinaryExpression<T> {
     /// Operator of this predicate, must be binary operator, such as `=`, `>`, `<`, etc.
     op: PredicateOperator,
@@ -184,7 +184,7 @@ impl<T: Bind> Bind for BinaryExpression<T> {
 }
 
 /// Set predicates, for example, `a in (1, 2, 3)`.
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct SetExpression<T> {
     /// Operator of this predicate, must be set operator, such as `IN`, `NOT IN`, etc.
     op: PredicateOperator,
@@ -613,7 +613,7 @@ impl Not for Predicate {
 }
 
 /// Bound predicate expression after binding to a schema.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BoundPredicate {
     /// An expression always evaluates to true.
     AlwaysTrue,

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -21,6 +21,7 @@ use crate::spec::{Datum, FieldSummary, ManifestFile};
 use crate::{Error, ErrorKind, Result};
 use fnv::FnvHashSet;
 
+#[derive(Debug)]
 /// Evaluates a [`ManifestFile`] to see if the partition summaries
 /// match a provided [`BoundPredicate`].
 ///

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -16,74 +16,48 @@
 // under the License.
 
 use crate::expr::visitors::bound_predicate_visitor::{visit, BoundPredicateVisitor};
-use crate::expr::visitors::inclusive_projection::InclusiveProjection;
-use crate::expr::{Bind, BoundPredicate, BoundReference};
-use crate::spec::{Datum, FieldSummary, ManifestFile, PartitionSpecRef, Schema, SchemaRef};
-use crate::{Error, ErrorKind};
+use crate::expr::{BoundPredicate, BoundReference};
+use crate::spec::{Datum, FieldSummary, ManifestFile};
+use crate::{Error, ErrorKind, Result};
 use fnv::FnvHashSet;
-use std::sync::Arc;
 
-/// Evaluates [`ManifestFile`]s to see if their partition summary matches a provided
-/// [`BoundPredicate`]. Used by [`TableScan`] to filter down the list of [`ManifestFile`]s
+/// Evaluates a [`ManifestFile`] to see if the partition summaries
+/// match a provided [`BoundPredicate`].
+///
+/// Used by [`TableScan`] to prune the list of [`ManifestFile`]s
 /// in which data might be found that matches the TableScan's filter.
 pub(crate) struct ManifestEvaluator {
-    partition_schema: SchemaRef,
+    partition_schema_id: i32,
     partition_filter: BoundPredicate,
     case_sensitive: bool,
 }
 
 impl ManifestEvaluator {
     pub(crate) fn new(
-        partition_spec: PartitionSpecRef,
-        table_schema: SchemaRef,
-        filter: BoundPredicate,
+        partition_schema_id: i32,
+        partition_filter: BoundPredicate,
         case_sensitive: bool,
-    ) -> crate::Result<Self> {
-        let partition_type = partition_spec.partition_type(&table_schema)?;
-
-        // this is needed as SchemaBuilder.with_fields expects an iterator over
-        // Arc<NestedField> rather than &Arc<NestedField>
-        let cloned_partition_fields: Vec<_> =
-            partition_type.fields().iter().map(Arc::clone).collect();
-
-        // The partition_schema's schema_id is set to the partition
-        // spec's spec_id here, and used to perform a sanity check
-        // during eval to confirm that it matches the spec_id
-        // of the ManifestFile we're evaluating
-        let partition_schema = Schema::builder()
-            .with_schema_id(partition_spec.spec_id)
-            .with_fields(cloned_partition_fields)
-            .build()?;
-
-        let partition_schema_ref = Arc::new(partition_schema);
-
-        let mut inclusive_projection = InclusiveProjection::new(partition_spec.clone());
-        let unbound_partition_filter = inclusive_projection.project(&filter)?;
-
-        let partition_filter = unbound_partition_filter
-            .rewrite_not()
-            .bind(partition_schema_ref.clone(), case_sensitive)?;
-
-        Ok(Self {
-            partition_schema: partition_schema_ref,
+    ) -> Self {
+        Self {
+            partition_schema_id,
             partition_filter,
             case_sensitive,
-        })
+        }
     }
 
     /// Evaluate this `ManifestEvaluator`'s filter predicate against the
     /// provided [`ManifestFile`]'s partitions. Used by [`TableScan`] to
     /// see if this `ManifestFile` could possibly contain data that matches
     /// the scan's filter.
-    pub(crate) fn eval(&self, manifest_file: &ManifestFile) -> crate::Result<bool> {
+    pub(crate) fn eval(&self, manifest_file: &ManifestFile) -> Result<bool> {
         if manifest_file.partitions.is_empty() {
             return Ok(true);
         }
 
-        // The schema_id of self.partition_schema is set to the
-        // spec_id of the partition spec that this ManifestEvaluator
-        // was created from in ManifestEvaluator::new
-        if self.partition_schema.schema_id() != manifest_file.partition_spec_id {
+        // A [`ManifestEvaluator`] is created for a specific schema id
+        // based on the partition spec. This id should match the partition
+        // spec id of the [`ManifestFile`].
+        if self.partition_schema_id != manifest_file.partition_spec_id {
             return Err(Error::new(
                 ErrorKind::Unexpected,
                 format!(
@@ -273,137 +247,28 @@ impl ManifestFilterVisitor<'_> {
 
 #[cfg(test)]
 mod test {
+    use crate::expr::visitors::inclusive_projection::InclusiveProjection;
     use crate::expr::visitors::manifest_evaluator::ManifestEvaluator;
-    use crate::expr::{Bind, Predicate, PredicateOperator, Reference, UnaryExpression};
+    use crate::expr::{
+        Bind, BoundPredicate, Predicate, PredicateOperator, Reference, UnaryExpression,
+    };
     use crate::spec::{
         FieldSummary, ManifestContentType, ManifestFile, NestedField, PartitionField,
-        PartitionSpec, PrimitiveType, Schema, Transform, Type,
+        PartitionSpec, PartitionSpecRef, PrimitiveType, Schema, SchemaRef, Transform, Type,
     };
+    use crate::Result;
     use std::sync::Arc;
 
-    #[test]
-    fn test_manifest_file_no_partitions() {
-        let (table_schema_ref, partition_spec_ref) = create_test_schema_and_partition_spec();
-
-        let partition_filter = Predicate::AlwaysTrue
-            .bind(table_schema_ref.clone(), false)
-            .unwrap();
-
-        let case_sensitive = false;
-
-        let manifest_file_partitions = vec![];
-        let manifest_file = create_test_manifest_file(manifest_file_partitions);
-
-        let manifest_evaluator = ManifestEvaluator::new(
-            partition_spec_ref,
-            table_schema_ref,
-            partition_filter,
-            case_sensitive,
-        )
-        .unwrap();
-
-        let result = manifest_evaluator.eval(&manifest_file).unwrap();
-
-        assert!(result);
-    }
-
-    #[test]
-    fn test_manifest_file_trivial_partition_passing_filter() {
-        let (table_schema_ref, partition_spec_ref) = create_test_schema_and_partition_spec();
-
-        let partition_filter = Predicate::Unary(UnaryExpression::new(
-            PredicateOperator::IsNull,
-            Reference::new("a"),
-        ))
-        .bind(table_schema_ref.clone(), true)
-        .unwrap();
-
-        let manifest_file_partitions = vec![FieldSummary {
-            contains_null: true,
-            contains_nan: None,
-            lower_bound: None,
-            upper_bound: None,
-        }];
-        let manifest_file = create_test_manifest_file(manifest_file_partitions);
-
-        let manifest_evaluator =
-            ManifestEvaluator::new(partition_spec_ref, table_schema_ref, partition_filter, true)
-                .unwrap();
-
-        let result = manifest_evaluator.eval(&manifest_file).unwrap();
-
-        assert!(result);
-    }
-
-    #[test]
-    fn test_manifest_file_partition_id_mismatch_returns_error() {
-        let (table_schema_ref, partition_spec_ref) =
-            create_test_schema_and_partition_spec_with_id_mismatch();
-
-        let partition_filter = Predicate::Unary(UnaryExpression::new(
-            PredicateOperator::IsNull,
-            Reference::new("a"),
-        ))
-        .bind(table_schema_ref.clone(), true)
-        .unwrap();
-
-        let manifest_file_partitions = vec![FieldSummary {
-            contains_null: true,
-            contains_nan: None,
-            lower_bound: None,
-            upper_bound: None,
-        }];
-        let manifest_file = create_test_manifest_file(manifest_file_partitions);
-
-        let manifest_evaluator =
-            ManifestEvaluator::new(partition_spec_ref, table_schema_ref, partition_filter, true)
-                .unwrap();
-
-        let result = manifest_evaluator.eval(&manifest_file);
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_manifest_file_trivial_partition_rejected_filter() {
-        let (table_schema_ref, partition_spec_ref) = create_test_schema_and_partition_spec();
-
-        let partition_filter = Predicate::Unary(UnaryExpression::new(
-            PredicateOperator::IsNan,
-            Reference::new("a"),
-        ))
-        .bind(table_schema_ref.clone(), true)
-        .unwrap();
-
-        let manifest_file_partitions = vec![FieldSummary {
-            contains_null: false,
-            contains_nan: None,
-            lower_bound: None,
-            upper_bound: None,
-        }];
-        let manifest_file = create_test_manifest_file(manifest_file_partitions);
-
-        let manifest_evaluator =
-            ManifestEvaluator::new(partition_spec_ref, table_schema_ref, partition_filter, true)
-                .unwrap();
-
-        let result = manifest_evaluator.eval(&manifest_file).unwrap();
-
-        assert!(!result);
-    }
-
-    fn create_test_schema_and_partition_spec() -> (Arc<Schema>, Arc<PartitionSpec>) {
-        let table_schema = Schema::builder()
+    fn create_schema_and_partition_spec() -> Result<(SchemaRef, PartitionSpecRef)> {
+        let schema = Schema::builder()
             .with_fields(vec![Arc::new(NestedField::optional(
                 1,
                 "a",
                 Type::Primitive(PrimitiveType::Float),
             ))])
-            .build()
-            .unwrap();
-        let table_schema_ref = Arc::new(table_schema);
+            .build()?;
 
-        let partition_spec = PartitionSpec::builder()
+        let spec = PartitionSpec::builder()
             .with_spec_id(1)
             .with_fields(vec![PartitionField::builder()
                 .source_id(1)
@@ -413,24 +278,21 @@ mod test {
                 .build()])
             .build()
             .unwrap();
-        let partition_spec_ref = Arc::new(partition_spec);
-        (table_schema_ref, partition_spec_ref)
+
+        Ok((Arc::new(schema), Arc::new(spec)))
     }
 
-    fn create_test_schema_and_partition_spec_with_id_mismatch() -> (Arc<Schema>, Arc<PartitionSpec>)
+    fn create_schema_and_partition_spec_with_id_mismatch() -> Result<(SchemaRef, PartitionSpecRef)>
     {
-        let table_schema = Schema::builder()
+        let schema = Schema::builder()
             .with_fields(vec![Arc::new(NestedField::optional(
                 1,
                 "a",
                 Type::Primitive(PrimitiveType::Float),
             ))])
-            .build()
-            .unwrap();
-        let table_schema_ref = Arc::new(table_schema);
+            .build()?;
 
-        let partition_spec = PartitionSpec::builder()
-            // Spec ID here deliberately doesn't match the one from create_test_manifest_file
+        let spec = PartitionSpec::builder()
             .with_spec_id(999)
             .with_fields(vec![PartitionField::builder()
                 .source_id(1)
@@ -440,11 +302,11 @@ mod test {
                 .build()])
             .build()
             .unwrap();
-        let partition_spec_ref = Arc::new(partition_spec);
-        (table_schema_ref, partition_spec_ref)
+
+        Ok((Arc::new(schema), Arc::new(spec)))
     }
 
-    fn create_test_manifest_file(manifest_file_partitions: Vec<FieldSummary>) -> ManifestFile {
+    fn create_manifest_file(partitions: Vec<FieldSummary>) -> ManifestFile {
         ManifestFile {
             manifest_path: "/test/path".to_string(),
             manifest_length: 0,
@@ -459,8 +321,170 @@ mod test {
             added_rows_count: None,
             existing_rows_count: None,
             deleted_rows_count: None,
-            partitions: manifest_file_partitions,
+            partitions,
             key_metadata: vec![],
         }
+    }
+
+    fn create_partition_schema(
+        partition_spec: &PartitionSpecRef,
+        schema: &SchemaRef,
+    ) -> Result<SchemaRef> {
+        let partition_type = partition_spec.partition_type(schema)?;
+
+        let partition_fields: Vec<_> = partition_type.fields().iter().map(Arc::clone).collect();
+
+        let partition_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(partition_spec.spec_id)
+                .with_fields(partition_fields)
+                .build()?,
+        );
+
+        Ok(partition_schema)
+    }
+
+    fn create_partition_filter(
+        partition_spec: PartitionSpecRef,
+        partition_schema: SchemaRef,
+        filter: &BoundPredicate,
+        case_sensitive: bool,
+    ) -> Result<BoundPredicate> {
+        let mut inclusive_projection = InclusiveProjection::new(partition_spec);
+
+        let partition_filter = inclusive_projection
+            .project(filter)?
+            .rewrite_not()
+            .bind(partition_schema, case_sensitive)?;
+
+        Ok(partition_filter)
+    }
+
+    fn create_manifest_evaluator(
+        schema: SchemaRef,
+        partition_spec: PartitionSpecRef,
+        filter: &BoundPredicate,
+        case_sensitive: bool,
+    ) -> Result<ManifestEvaluator> {
+        let partition_schema = create_partition_schema(&partition_spec, &schema)?;
+        let partition_filter = create_partition_filter(
+            partition_spec,
+            partition_schema.clone(),
+            filter,
+            case_sensitive,
+        )?;
+
+        Ok(ManifestEvaluator::new(
+            partition_schema.schema_id(),
+            partition_filter,
+            case_sensitive,
+        ))
+    }
+
+    #[test]
+    fn test_manifest_file_empty_partitions() -> Result<()> {
+        let case_sensitive = false;
+
+        let (schema, partition_spec) = create_schema_and_partition_spec()?;
+
+        let filter = Predicate::AlwaysTrue.bind(schema.clone(), case_sensitive)?;
+
+        let manifest_file = create_manifest_file(vec![]);
+
+        let manifest_evaluator =
+            create_manifest_evaluator(schema, partition_spec, &filter, case_sensitive)?;
+
+        let result = manifest_evaluator.eval(&manifest_file)?;
+
+        assert!(result);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_manifest_file_trivial_partition_passing_filter() -> Result<()> {
+        let case_sensitive = true;
+
+        let (schema, partition_spec) = create_schema_and_partition_spec()?;
+
+        let filter = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::IsNull,
+            Reference::new("a"),
+        ))
+        .bind(schema.clone(), case_sensitive)?;
+
+        let manifest_file = create_manifest_file(vec![FieldSummary {
+            contains_null: true,
+            contains_nan: None,
+            lower_bound: None,
+            upper_bound: None,
+        }]);
+
+        let manifest_evaluator =
+            create_manifest_evaluator(schema, partition_spec, &filter, case_sensitive)?;
+
+        let result = manifest_evaluator.eval(&manifest_file)?;
+
+        assert!(result);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_manifest_file_partition_id_mismatch_returns_error() -> Result<()> {
+        let case_sensitive = true;
+
+        let (schema, partition_spec) = create_schema_and_partition_spec_with_id_mismatch()?;
+
+        let filter = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::IsNull,
+            Reference::new("a"),
+        ))
+        .bind(schema.clone(), case_sensitive)?;
+
+        let manifest_file = create_manifest_file(vec![FieldSummary {
+            contains_null: true,
+            contains_nan: None,
+            lower_bound: None,
+            upper_bound: None,
+        }]);
+
+        let manifest_evaluator =
+            create_manifest_evaluator(schema, partition_spec, &filter, case_sensitive)?;
+
+        let result = manifest_evaluator.eval(&manifest_file);
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_manifest_file_trivial_partition_rejected_filter() -> Result<()> {
+        let case_sensitive = true;
+
+        let (schema, partition_spec) = create_schema_and_partition_spec()?;
+
+        let filter = Predicate::Unary(UnaryExpression::new(
+            PredicateOperator::IsNan,
+            Reference::new("a"),
+        ))
+        .bind(schema.clone(), case_sensitive)?;
+
+        let manifest_file = create_manifest_file(vec![FieldSummary {
+            contains_null: false,
+            contains_nan: None,
+            lower_bound: None,
+            upper_bound: None,
+        }]);
+
+        let manifest_evaluator =
+            create_manifest_evaluator(schema, partition_spec, &filter, case_sensitive)?;
+
+        let result = manifest_evaluator.eval(&manifest_file).unwrap();
+
+        assert!(!result);
+
+        Ok(())
     }
 }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -214,7 +214,6 @@ impl TableScan {
                     )?;
 
                     let manifest_evaluator = manifest_evaluator_cache.get(
-                        partition_spec_id,
                         partition_schema.schema_id(),
                         partition_filter.clone(),
                         context.case_sensitive,
@@ -434,15 +433,12 @@ impl ManifestEvaluatorCache {
     fn get(
         &mut self,
         spec_id: i32,
-        partition_schema_id: i32,
         partition_filter: BoundPredicate,
         case_sensitive: bool,
     ) -> &mut ManifestEvaluator {
-        self.0.entry(spec_id).or_insert(ManifestEvaluator::new(
-            partition_schema_id,
-            partition_filter,
-            case_sensitive,
-        ))
+        self.0
+            .entry(spec_id)
+            .or_insert(ManifestEvaluator::new(partition_filter, case_sensitive))
     }
 }
 

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -107,7 +107,7 @@ impl<'a> TableScanBuilder<'a> {
     }
 
     /// Build the table scan.
-    pub fn build(self) -> crate::Result<TableScan> {
+    pub fn build(self) -> Result<TableScan> {
         let snapshot = match self.snapshot_id {
             Some(snapshot_id) => self
                 .table
@@ -179,7 +179,7 @@ pub struct TableScan {
 
 impl TableScan {
     /// Returns a stream of file scan tasks.
-    pub async fn plan_files(&self) -> crate::Result<FileScanTaskStream> {
+    pub async fn plan_files(&self) -> Result<FileScanTaskStream> {
         let context = FileScanStreamContext::new(
             self.schema.clone(),
             self.snapshot.clone(),
@@ -233,7 +233,7 @@ impl TableScan {
                             ))?;
                         }
                         DataContentType::Data => {
-                            let scan_task: crate::Result<FileScanTask> = Ok(FileScanTask {
+                            let scan_task: Result<FileScanTask> = Ok(FileScanTask {
                                 data_manifest_entry: manifest_entry.clone(),
                                 start: 0,
                                 length: manifest_entry.file_size_in_bytes(),
@@ -248,7 +248,7 @@ impl TableScan {
     }
 
     /// Returns an [`ArrowRecordBatchStream`].
-    pub async fn to_arrow(&self) -> crate::Result<ArrowRecordBatchStream> {
+    pub async fn to_arrow(&self) -> Result<ArrowRecordBatchStream> {
         let mut arrow_reader_builder =
             ArrowReaderBuilder::new(self.file_io.clone(), self.schema.clone());
 

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -207,7 +207,7 @@ impl TableScan {
 
                     let partition_filter = partition_filter_cache.get(
                         partition_spec_id,
-                        partition_spec.clone(),
+                        partition_spec,
                         partition_schema.clone(),
                         filter,
                         context.case_sensitive,
@@ -353,11 +353,11 @@ impl FileScanStreamContext {
     }
 
     /// Creates a reference-counted [`PartitionSpec`] and a
-    /// corresponding schema based on the specified partition spec id.
+    /// corresponding [`Schema`] based on the specified partition spec id.
     fn create_partition_spec_and_schema(
         &self,
         spec_id: i32,
-    ) -> Result<(&PartitionSpecRef, SchemaRef)> {
+    ) -> Result<(PartitionSpecRef, SchemaRef)> {
         let partition_spec =
             self.table_metadata
                 .partition_spec_by_id(spec_id)
@@ -375,7 +375,7 @@ impl FileScanStreamContext {
                 .build()?,
         );
 
-        Ok((partition_spec, partition_schema))
+        Ok((partition_spec.clone(), partition_schema))
     }
 }
 


### PR DESCRIPTION
### Which issue does this PR close?
Closes #359

### Rationale for this change
The `partition_filter` (inclusive projection) is not only required by the `ManifestEvaluator` but also by the (incoming) `ExpressionEvaluator`. In order to avoid duplicate code as well as unnecessary computation of the partition filters, we should extract the computation of the partition filters and cache the results per partition_spec_id.

With this refactor we (hopefully) should be able to integrate the `ExpressionEvaluator` and the `InclusiveMetricsEvaluator` more easily.

### What changes are included in this PR?
- refactor: Extract and decouple computation of partition filters from construction logic of ManifestEvaluator
- refactor: testsuite ManifestEvaluator
- refactor: add FileScanStreamContext + helper fn to construct partition_spec & schema
- refactor: add thin wrapper for PartitionFileCache & ManifestEvaluatorCache for better encapsulation

### Are these changes tested?
Yes. Unit tests are included.
If PR is okay; I will add some basis tests for the new structs (FileScanStreamContext, etc.) as well. 