### PR TITLE
[WIP] feat: Add `ExpressionEvaluator`

### DIFF
--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -1,0 +1,224 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fnv::FnvHashSet;
+
+use crate::{
+    expr::{BoundPredicate, BoundReference},
+    spec::{DataFile, Datum, Struct},
+    Result,
+};
+
+use super::bound_predicate_visitor::{visit, BoundPredicateVisitor};
+
+/// Evaluates a [`DataFile`]'s partition [`Struct`] to check
+/// if the partition tuples match the given [`BoundPredicate`].
+///
+/// Use within [`TableScan`] to prune the list of [`DataFile`]s
+/// that could potentially match the TableScan's filter.
+#[derive(Debug)]
+pub(crate) struct ExpressionEvaluator {
+    /// The provided partition filter.
+    partition_filter: BoundPredicate,
+}
+
+impl ExpressionEvaluator {
+    /// Creates a new [`ExpressionEvaluator`].
+    pub(crate) fn new(partition_filter: BoundPredicate) -> Self {
+        Self { partition_filter }
+    }
+
+    /// Evaluate this [`ExpressionEvaluator`]'s partition filter against
+    /// the provided [`DataFile`]'s partition [`Struct`]. Used by [`TableScan`]
+    /// to see if this [`DataFile`] could possible contain data that matches
+    /// the scan's filter.
+    pub(crate) fn eval(&self, data_file: &DataFile) -> Result<bool> {
+        let mut visitor = ExpressionEvaluatorVisitor::new(self, data_file.partition());
+
+        visit(&mut visitor, &self.partition_filter)
+    }
+}
+
+/// Acts as a visitor for [`ExpressionEvaluator`] to apply
+/// evaluation logic to different parts of a data structure,
+/// specifically for data file partitions.
+#[derive(Debug)]
+struct ExpressionEvaluatorVisitor<'a> {
+    /// Reference to an [`ExpressionEvaluator`].
+    expression_evaluator: &'a ExpressionEvaluator,
+    /// Reference to a [`DataFile`]'s partition [`Struct`].
+    partition: &'a Struct,
+}
+
+impl<'a> ExpressionEvaluatorVisitor<'a> {
+    fn new(expression_evaluator: &'a ExpressionEvaluator, partition: &'a Struct) -> Self {
+        Self {
+            expression_evaluator,
+            partition,
+        }
+    }
+}
+
+#[allow(unused_variables)]
+impl BoundPredicateVisitor for ExpressionEvaluatorVisitor<'_> {
+    type T = bool;
+
+    fn always_true(&mut self) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn always_false(&mut self) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn and(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn or(&mut self, lhs: Self::T, rhs: Self::T) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn not(&mut self, inner: Self::T) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn is_null(
+        &mut self,
+        reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn not_null(
+        &mut self,
+        reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn is_nan(
+        &mut self,
+        reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn not_nan(
+        &mut self,
+        reference: &BoundReference,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn less_than(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn less_than_or_eq(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn greater_than(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn greater_than_or_eq(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn eq(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        predicate: &BoundPredicate,
+    ) -> Result<Self::T> {
+        todo!()
+    }
+
+    fn not_eq(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        _predicate: &BoundPredicate,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn starts_with(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        _predicate: &BoundPredicate,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn not_starts_with(
+        &mut self,
+        reference: &BoundReference,
+        literal: &Datum,
+        _predicate: &BoundPredicate,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn r#in(
+        &mut self,
+        reference: &BoundReference,
+        literals: &FnvHashSet<Datum>,
+        _predicate: &BoundPredicate,
+    ) -> Result<bool> {
+        todo!()
+    }
+
+    fn not_in(
+        &mut self,
+        reference: &BoundReference,
+        literals: &FnvHashSet<Datum>,
+        _predicate: &BoundPredicate,
+    ) -> Result<bool> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -65,6 +65,7 @@ struct ExpressionEvaluatorVisitor<'a> {
 }
 
 impl<'a> ExpressionEvaluatorVisitor<'a> {
+    /// Creates a new [`ExpressionEvaluatorVisitor`].
     fn new(expression_evaluator: &'a ExpressionEvaluator, partition: &'a Struct) -> Self {
         Self {
             expression_evaluator,

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -21,12 +21,12 @@ use crate::spec::{Datum, FieldSummary, ManifestFile};
 use crate::Result;
 use fnv::FnvHashSet;
 
-#[derive(Debug)]
 /// Evaluates a [`ManifestFile`] to see if the partition summaries
 /// match a provided [`BoundPredicate`].
 ///
 /// Used by [`TableScan`] to prune the list of [`ManifestFile`]s
 /// in which data might be found that matches the TableScan's filter.
+#[derive(Debug)]
 pub(crate) struct ManifestEvaluator {
     partition_filter: BoundPredicate,
     case_sensitive: bool,

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -310,7 +310,7 @@ mod test {
 
     fn create_partition_schema(
         partition_spec: &PartitionSpecRef,
-        schema: &SchemaRef,
+        schema: &Schema,
     ) -> Result<SchemaRef> {
         let partition_type = partition_spec.partition_type(schema)?;
 

--- a/crates/iceberg/src/expr/visitors/mod.rs
+++ b/crates/iceberg/src/expr/visitors/mod.rs
@@ -16,5 +16,6 @@
 // under the License.
 
 pub(crate) mod bound_predicate_visitor;
+pub(crate) mod expression_evaluator;
 pub(crate) mod inclusive_projection;
 pub(crate) mod manifest_evaluator;

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -323,9 +323,9 @@ impl TableScan {
     }
 }
 
-#[derive(Debug)]
 /// Holds the context necessary for file scanning operations
 /// in a streaming environment.
+#[derive(Debug)]
 struct FileScanStreamContext {
     schema: SchemaRef,
     snapshot: SnapshotRef,
@@ -366,9 +366,9 @@ impl FileScanStreamContext {
     }
 }
 
-#[derive(Debug)]
 /// Manages the caching of [`BoundPredicate`] objects
 /// for [`PartitionSpec`]s based on partition spec id.
+#[derive(Debug)]
 struct PartitionFilterCache(HashMap<i32, BoundPredicate>);
 
 impl PartitionFilterCache {
@@ -412,9 +412,9 @@ impl PartitionFilterCache {
     }
 }
 
-#[derive(Debug)]
 /// Manages the caching of partition [`Schema`]s
 /// for [`PartitionSpec`]s based on partition spec id.
+#[derive(Debug)]
 struct PartitionSchemaCache(HashMap<i32, SchemaRef>);
 
 impl PartitionSchemaCache {
@@ -454,9 +454,9 @@ impl PartitionSchemaCache {
     }
 }
 
-#[derive(Debug)]
 /// Manages the caching of [`ManifestEvaluator`] objects
 /// for [`PartitionSpec`]s based on partition spec id.
+#[derive(Debug)]
 struct ManifestEvaluatorCache(HashMap<i32, ManifestEvaluator>);
 
 impl ManifestEvaluatorCache {

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -23,8 +23,8 @@ use crate::expr::visitors::manifest_evaluator::ManifestEvaluator;
 use crate::expr::{Bind, BoundPredicate, Predicate};
 use crate::io::FileIO;
 use crate::spec::{
-    DataContentType, ManifestContentType, ManifestEntryRef, ManifestFile, PartitionSpecRef, Schema,
-    SchemaRef, SnapshotRef, TableMetadataRef,
+    DataContentType, ManifestContentType, ManifestEntryRef, ManifestFile, Schema, SchemaRef,
+    SnapshotRef, TableMetadata, TableMetadataRef,
 };
 use crate::table::Table;
 use crate::{Error, ErrorKind, Result};
@@ -189,6 +189,7 @@ impl TableScan {
             self.case_sensitive,
         )?;
 
+        let mut partition_schema_cache = PartitionSchemaCache::new();
         let mut partition_filter_cache = PartitionFilterCache::new();
         let mut manifest_evaluator_cache = ManifestEvaluatorCache::new();
 
@@ -206,12 +207,15 @@ impl TableScan {
                 if let Some(filter) = context.bound_filter() {
                     let partition_spec_id = entry.partition_spec_id;
 
-                    let (partition_spec, partition_schema) =
-                        context.create_partition_spec_and_schema(partition_spec_id)?;
+                    let partition_schema = partition_schema_cache.get(
+                        partition_spec_id,
+                        &context.table_metadata,
+                        &context.schema
+                    )?;
 
                     let partition_filter = partition_filter_cache.get(
                         partition_spec_id,
-                        partition_spec,
+                        &context.table_metadata,
                         partition_schema.clone(),
                         filter,
                         context.case_sensitive,
@@ -362,32 +366,6 @@ impl FileScanStreamContext {
     fn bound_filter(&self) -> Option<&BoundPredicate> {
         self.bound_filter.as_ref()
     }
-
-    /// Creates a reference-counted [`PartitionSpec`] and a
-    /// corresponding [`Schema`] based on the specified partition spec id.
-    fn create_partition_spec_and_schema(
-        &self,
-        spec_id: i32,
-    ) -> Result<(PartitionSpecRef, SchemaRef)> {
-        let partition_spec =
-            self.table_metadata
-                .partition_spec_by_id(spec_id)
-                .ok_or(Error::new(
-                    ErrorKind::Unexpected,
-                    format!("Could not find partition spec for id {}", spec_id),
-                ))?;
-
-        let partition_type = partition_spec.partition_type(&self.schema)?;
-        let partition_fields = partition_type.fields().to_owned();
-        let partition_schema = Arc::new(
-            Schema::builder()
-                .with_schema_id(partition_spec.spec_id)
-                .with_fields(partition_fields)
-                .build()?,
-        );
-
-        Ok((partition_spec.clone(), partition_schema))
-    }
 }
 
 #[derive(Debug)]
@@ -407,7 +385,7 @@ impl PartitionFilterCache {
     fn get(
         &mut self,
         spec_id: i32,
-        partition_spec: PartitionSpecRef,
+        table_metadata: &TableMetadata,
         partition_schema: SchemaRef,
         filter: &BoundPredicate,
         case_sensitive: bool,
@@ -415,7 +393,15 @@ impl PartitionFilterCache {
         match self.0.entry(spec_id) {
             Entry::Occupied(e) => Ok(e.into_mut()),
             Entry::Vacant(e) => {
-                let mut inclusive_projection = InclusiveProjection::new(partition_spec);
+                let partition_spec =
+                    table_metadata
+                        .partition_spec_by_id(spec_id)
+                        .ok_or(Error::new(
+                            ErrorKind::Unexpected,
+                            format!("Could not find partition spec for id {}", spec_id),
+                        ))?;
+
+                let mut inclusive_projection = InclusiveProjection::new(partition_spec.clone());
 
                 let partition_filter = inclusive_projection
                     .project(filter)?
@@ -423,6 +409,52 @@ impl PartitionFilterCache {
                     .bind(partition_schema, case_sensitive)?;
 
                 Ok(e.insert(partition_filter))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Manages the caching of partition [`Schema`]s
+/// for [`PartitionSpec`]s based on partition spec id.
+struct PartitionSchemaCache(HashMap<i32, SchemaRef>);
+
+impl PartitionSchemaCache {
+    /// Creates a new [`PartitionSchemaCache`]
+    /// with an empty internal HashMap.
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Retrieves a partition [`SchemaRef`] from the cache
+    /// or computes it if not present.
+    fn get(
+        &mut self,
+        spec_id: i32,
+        table_metadata: &TableMetadata,
+        schema: &Schema,
+    ) -> Result<SchemaRef> {
+        match self.0.entry(spec_id) {
+            Entry::Occupied(e) => Ok(e.get().clone()),
+            Entry::Vacant(e) => {
+                let partition_spec =
+                    table_metadata
+                        .partition_spec_by_id(spec_id)
+                        .ok_or(Error::new(
+                            ErrorKind::Unexpected,
+                            format!("Could not find partition spec for id {}", spec_id),
+                        ))?;
+
+                let partition_type = partition_spec.partition_type(schema)?;
+                let partition_fields = partition_type.fields().to_owned();
+                let partition_schema = Arc::new(
+                    Schema::builder()
+                        .with_schema_id(partition_spec.spec_id)
+                        .with_fields(partition_fields)
+                        .build()?,
+                );
+
+                Ok(e.insert(partition_schema).clone())
             }
         }
     }


### PR DESCRIPTION
### Which issue does this PR close?
Closes #358 

### Rationale for this change
- adds the capability to prune `DataFile`s in TableScan

### What changes are included in this PR?
- feat: implementation of ExpressionEvaluator
- feat: add expression_evaluator_cache & integrate in TableScan

### Are these changes tested?
No - not yet.