### PR TITLE
refactor: Concurrent scan file planning

### DIFF
--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -333,6 +333,12 @@ define_from_err!(
 
 define_from_err!(std::io::Error, ErrorKind::Unexpected, "IO Operation failed");
 
+define_from_err!(
+    futures::channel::mpsc::SendError,
+    ErrorKind::Unexpected,
+    "Failed to send a message to a channel"
+);
+
 /// Helper macro to check arguments.
 ///
 ///


### PR DESCRIPTION
This is more of an experiment to see how things could look if we tried to process Manifest Lists and Manifest Files concurrently rather than sequentially.