### PR TITLE
Make current-snapshot-id optional while maintaining backwards compatibility

### DIFF
--- a/crates/catalog/rest/testdata/create_table_response.json
+++ b/crates/catalog/rest/testdata/create_table_response.json
@@ -40,7 +40,6 @@
       "write.summary.partition-limit": "100",
       "write.parquet.compression-codec": "zstd"
     },
-    "current-snapshot-id": -1,
     "refs": {},
     "snapshots": [],
     "snapshot-log": [],

--- a/crates/catalog/rest/testdata/update_table_response.json
+++ b/crates/catalog/rest/testdata/update_table_response.json
@@ -31,7 +31,6 @@
       "write.summary.partition-limit": "100",
       "write.parquet.compression-codec": "zstd"
     },
-    "current-snapshot-id": -1,
     "refs": {},
     "snapshots": [],
     "snapshot-log": [],

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV1LegacySnapshotId.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV1LegacySnapshotId.json
@@ -37,5 +37,6 @@
     }
   ],
   "properties": {},
+  "current-snapshot-id": -1,
   "snapshots": []
 }


### PR DESCRIPTION
GitHub issue: https://github.com/apache/iceberg-rust/issues/352

**Problem:** Previous versions of Java (`<1.4.0`) implementations incorrectly assume the optional attribute `current-snapshot-id` to be a required attribute in TableMetadata.

**Solution**: Use `legacy-current-snapshot-id` environment variable to force iceberg-rust to create and load a table with a metadata file compatible with the older versions. 

**Testing**: Added new unit tests.

**Future work:**

- Implement a config file for iceberg-rust and provide users an additional option to set `legacy-current-snapshot-id` as a configuration value. 