### PR TITLE
Feature: Schema into_builder method

### DIFF
--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -273,7 +273,7 @@ impl Schema {
     pub fn into_builder(self) -> SchemaBuilder {
         SchemaBuilder {
             schema_id: self.schema_id,
-            fields: self.r#struct.fields().iter().cloned().collect(),
+            fields: self.r#struct.fields().to_vec(),
             alias_to_id: self.alias_to_id,
             identifier_field_ids: self.identifier_field_ids,
         }


### PR DESCRIPTION
Convert a schema back to a builder.
Fixes https://github.com/apache/iceberg-rust/issues/382