### PR TITLE
fix: make PrimitiveLiteral and Literal not be Ord

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -118,6 +118,15 @@ impl Type {
         matches!(self, Type::Struct(_) | Type::List(_) | Type::Map(_))
     }
 
+    /// Convert Type to reference of PrimitiveType
+    pub fn as_primitive_type_ref(&self) -> Option<&PrimitiveType> {
+        if let Type::Primitive(primitive_type) = self {
+            Some(primitive_type)
+        } else {
+            None
+        }
+    }
+
     /// Convert Type to StructType
     pub fn as_struct_type(self) -> Option<StructType> {
         if let Type::Struct(struct_type) = self {

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -18,11 +18,11 @@
 //! Manifest for Iceberg.
 use self::_const_schema::{manifest_schema_v1, manifest_schema_v2};
 
+use super::UNASSIGNED_SEQUENCE_NUMBER;
 use super::{
-    FieldSummary, FormatVersion, ManifestContentType, ManifestFile, PartitionSpec, Schema,
+    Datum, FieldSummary, FormatVersion, ManifestContentType, ManifestFile, PartitionSpec, Schema,
     SchemaId, Struct, INITIAL_SEQUENCE_NUMBER,
 };
-use super::{Literal, UNASSIGNED_SEQUENCE_NUMBER};
 use crate::error::Result;
 use crate::io::OutputFile;
 use crate::spec::PartitionField;
@@ -1003,7 +1003,7 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub(crate) lower_bounds: HashMap<i32, Literal>,
+    pub(crate) lower_bounds: HashMap<i32, Datum>,
     /// field id: 128
     /// key field id: 129
     /// value field id: 130
@@ -1016,7 +1016,7 @@ pub struct DataFile {
     ///
     /// - [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization)
     #[builder(default)]
-    pub(crate) upper_bounds: HashMap<i32, Literal>,
+    pub(crate) upper_bounds: HashMap<i32, Datum>,
     /// field id: 131
     ///
     /// Implementation-specific key metadata for encryption
@@ -1102,12 +1102,12 @@ impl DataFile {
     }
     /// Get the lower bounds of the data file values per column.
     /// Map from column id to lower bound in the column serialized as binary.
-    pub fn lower_bounds(&self) -> &HashMap<i32, Literal> {
+    pub fn lower_bounds(&self) -> &HashMap<i32, Datum> {
         &self.lower_bounds
     }
     /// Get the upper bounds of the data file values per column.
     /// Map from column id to upper bound in the column serialized as binary.
-    pub fn upper_bounds(&self) -> &HashMap<i32, Literal> {
+    pub fn upper_bounds(&self) -> &HashMap<i32, Datum> {
         &self.upper_bounds
     }
     /// Get the Implementation-specific key metadata for the data file.
@@ -1207,7 +1207,9 @@ mod _serde {
     use serde_derive::{Deserialize, Serialize};
     use serde_with::serde_as;
 
+    use crate::spec::Datum;
     use crate::spec::Literal;
+    use crate::spec::PrimitiveLiteral;
     use crate::spec::RawLiteral;
     use crate::spec::Schema;
     use crate::spec::Struct;
@@ -1331,8 +1333,12 @@ mod _serde {
                 value_counts: Some(to_i64_entry(value.value_counts)?),
                 null_value_counts: Some(to_i64_entry(value.null_value_counts)?),
                 nan_value_counts: Some(to_i64_entry(value.nan_value_counts)?),
-                lower_bounds: Some(to_bytes_entry(value.lower_bounds)),
-                upper_bounds: Some(to_bytes_entry(value.upper_bounds)),
+                lower_bounds: Some(to_bytes_entry(
+                    value.lower_bounds.into_iter().map(|(k, v)| (k, v.into())),
+                )),
+                upper_bounds: Some(to_bytes_entry(
+                    value.upper_bounds.into_iter().map(|(k, v)| (k, v.into())),
+                )),
                 key_metadata: Some(serde_bytes::ByteBuf::from(value.key_metadata)),
                 split_offsets: Some(value.split_offsets),
                 equality_ids: Some(value.equality_ids),
@@ -1415,19 +1421,28 @@ mod _serde {
     fn parse_bytes_entry(
         v: Vec<BytesEntry>,
         schema: &Schema,
-    ) -> Result<HashMap<i32, Literal>, Error> {
+    ) -> Result<HashMap<i32, Datum>, Error> {
         let mut m = HashMap::with_capacity(v.len());
         for entry in v {
             // We ignore the entry if the field is not found in the schema, due to schema evolution.
             if let Some(field) = schema.field_by_id(entry.key) {
-                let data_type = &field.field_type;
-                m.insert(entry.key, Literal::try_from_bytes(&entry.value, data_type)?);
+                let data_type = field
+                    .field_type
+                    .as_primitive_type_ref()
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorKind::DataInvalid,
+                            format!("field {} is not a primitive type", field.name),
+                        )
+                    })?
+                    .clone();
+                m.insert(entry.key, Datum::try_from_bytes(&entry.value, data_type)?);
             }
         }
         Ok(m)
     }
 
-    fn to_bytes_entry(v: HashMap<i32, Literal>) -> Vec<BytesEntry> {
+    fn to_bytes_entry(v: impl IntoIterator<Item = (i32, PrimitiveLiteral)>) -> Vec<BytesEntry> {
         v.into_iter()
             .map(|e| BytesEntry {
                 key: e.0,
@@ -1495,6 +1510,7 @@ mod tests {
 
     use super::*;
     use crate::io::FileIOBuilder;
+    use crate::spec::Literal;
     use crate::spec::NestedField;
     use crate::spec::PrimitiveType;
     use crate::spec::Struct;
@@ -1824,8 +1840,8 @@ mod tests {
                     value_counts: HashMap::from([(1,1),(2,1),(3,1)]),
                     null_value_counts: HashMap::from([(1,0),(2,0),(3,0)]),
                     nan_value_counts: HashMap::new(),
-                    lower_bounds: HashMap::from([(1,Literal::int(1)),(2,Literal::string("a")),(3,Literal::string("AC/DC"))]),
-                    upper_bounds: HashMap::from([(1,Literal::int(1)),(2,Literal::string("a")),(3,Literal::string("AC/DC"))]),
+                    lower_bounds: HashMap::from([(1,Datum::int(1)),(2,Datum::string("a")),(3,Datum::string("AC/DC"))]),
+                    upper_bounds: HashMap::from([(1,Datum::int(1)),(2,Datum::string("a")),(3,Datum::string("AC/DC"))]),
                     key_metadata: vec![],
                     split_offsets: vec![4],
                     equality_ids: vec![],
@@ -1903,14 +1919,14 @@ mod tests {
                         null_value_counts: HashMap::from([(1, 0), (2, 0), (3, 0)]),
                         nan_value_counts: HashMap::new(),
                         lower_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::string("a")),
-                        (3, Literal::string("x"))
+                        (1, Datum::long(1)),
+                        (2, Datum::string("a")),
+                        (3, Datum::string("x"))
                         ]),
                         upper_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::string("a")),
-                        (3, Literal::string("x"))
+                        (1, Datum::long(1)),
+                        (2, Datum::string("a")),
+                        (3, Datum::string("x"))
                         ]),
                         key_metadata: vec![],
                         split_offsets: vec![4],
@@ -1926,8 +1942,8 @@ mod tests {
         let entry = test_manifest_read_write(manifest, writer).await;
 
         assert_eq!(entry.partitions.len(), 1);
-        assert_eq!(entry.partitions[0].lower_bound, Some(Literal::string("x")));
-        assert_eq!(entry.partitions[0].upper_bound, Some(Literal::string("x")));
+        assert_eq!(entry.partitions[0].lower_bound, Some(Datum::string("x")));
+        assert_eq!(entry.partitions[0].upper_bound, Some(Datum::string("x")));
     }
 
     #[tokio::test]
@@ -1978,14 +1994,14 @@ mod tests {
                     null_value_counts: HashMap::default(),
                     nan_value_counts: HashMap::new(),
                     lower_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::int(2)),
-                        (3, Literal::string("x"))
+                        (1, Datum::long(1)),
+                        (2, Datum::int(2)),
+                        (3, Datum::string("x"))
                     ]),
                     upper_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::int(2)),
-                        (3, Literal::string("x"))
+                        (1, Datum::long(1)),
+                        (2, Datum::int(2)),
+                        (3, Datum::string("x"))
                     ]),
                     key_metadata: vec![],
                     split_offsets: vec![4],
@@ -2050,12 +2066,12 @@ mod tests {
                     null_value_counts: HashMap::default(),
                     nan_value_counts: HashMap::new(),
                     lower_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::int(2)),
+                        (1, Datum::long(1)),
+                        (2, Datum::int(2)),
                     ]),
                     upper_bounds: HashMap::from([
-                        (1, Literal::long(1)),
-                        (2, Literal::int(2)),
+                        (1, Datum::long(1)),
+                        (2, Datum::int(2)),
                     ]),
                     key_metadata: vec![],
                     split_offsets: vec![4],

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -1056,8 +1056,9 @@ mod tests {
     };
     use crate::spec::schema::Schema;
     use crate::spec::schema::_serde::{SchemaEnum, SchemaV1, SchemaV2};
+    use crate::spec::values::Map as MapValue;
     use crate::spec::{prune_columns, Datum, Literal};
-    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::collections::{HashMap, HashSet};
 
     use super::DEFAULT_SCHEMA_ID;
 
@@ -1657,9 +1658,9 @@ table {
                 Some(Literal::string("qux item 1")),
                 Some(Literal::string("qux item 2")),
             ])),
-            Some(Literal::Map(BTreeMap::from([(
+            Some(Literal::Map(MapValue::from([(
                 Literal::string("quux key 1"),
-                Some(Literal::Map(BTreeMap::from([(
+                Some(Literal::Map(MapValue::from([(
                     Literal::string("quux nested key 1"),
                     Some(Literal::int(1000)),
                 )]))),

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -19,10 +19,12 @@
  * Value in iceberg
  */
 
+use std::any::Any;
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use std::hash::Hash;
 use std::ops::Index;
 use std::str::FromStr;
-use std::{any::Any, collections::BTreeMap};
 
 use bitvec::vec::BitVec;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
@@ -48,7 +50,7 @@ use super::datatypes::{PrimitiveType, Type};
 const MAX_TIME_VALUE: i64 = 24 * 60 * 60 * 1_000_000i64 - 1;
 
 /// Values present in iceberg type
-#[derive(Clone, Debug, PartialEq, Hash, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum PrimitiveLiteral {
     /// 0x00 for false, non-zero byte for true
     Boolean(bool),
@@ -103,6 +105,109 @@ pub struct Datum {
     literal: PrimitiveLiteral,
 }
 
+impl PartialOrd for Datum {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (&self.literal, &other.literal, &self.r#type, &other.r#type) {
+            // generate the arm with same type and same literal
+            (
+                PrimitiveLiteral::Boolean(val),
+                PrimitiveLiteral::Boolean(other_val),
+                PrimitiveType::Boolean,
+                PrimitiveType::Boolean,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Int(val),
+                PrimitiveLiteral::Int(other_val),
+                PrimitiveType::Int,
+                PrimitiveType::Int,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Long(val),
+                PrimitiveLiteral::Long(other_val),
+                PrimitiveType::Long,
+                PrimitiveType::Long,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Float(val),
+                PrimitiveLiteral::Float(other_val),
+                PrimitiveType::Float,
+                PrimitiveType::Float,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Double(val),
+                PrimitiveLiteral::Double(other_val),
+                PrimitiveType::Double,
+                PrimitiveType::Double,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Date(val),
+                PrimitiveLiteral::Date(other_val),
+                PrimitiveType::Date,
+                PrimitiveType::Date,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Time(val),
+                PrimitiveLiteral::Time(other_val),
+                PrimitiveType::Time,
+                PrimitiveType::Time,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Timestamp(val),
+                PrimitiveLiteral::Timestamp(other_val),
+                PrimitiveType::Timestamp,
+                PrimitiveType::Timestamp,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::TimestampTZ(val),
+                PrimitiveLiteral::TimestampTZ(other_val),
+                PrimitiveType::Timestamptz,
+                PrimitiveType::Timestamptz,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::String(val),
+                PrimitiveLiteral::String(other_val),
+                PrimitiveType::String,
+                PrimitiveType::String,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::UUID(val),
+                PrimitiveLiteral::UUID(other_val),
+                PrimitiveType::Uuid,
+                PrimitiveType::Uuid,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Fixed(val),
+                PrimitiveLiteral::Fixed(other_val),
+                PrimitiveType::Fixed(_),
+                PrimitiveType::Fixed(_),
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Binary(val),
+                PrimitiveLiteral::Binary(other_val),
+                PrimitiveType::Binary,
+                PrimitiveType::Binary,
+            ) => val.partial_cmp(other_val),
+            (
+                PrimitiveLiteral::Decimal(val),
+                PrimitiveLiteral::Decimal(other_val),
+                PrimitiveType::Decimal {
+                    precision: _,
+                    scale,
+                },
+                PrimitiveType::Decimal {
+                    precision: _,
+                    scale: other_scale,
+                },
+            ) => {
+                let val = Decimal::from_i128_with_scale(*val, *scale);
+                let other_val = Decimal::from_i128_with_scale(*other_val, *other_scale);
+                val.partial_cmp(&other_val)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl Display for Datum {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match (&self.r#type, &self.literal) {
@@ -153,10 +258,58 @@ impl From<Datum> for Literal {
     }
 }
 
+impl From<Datum> for PrimitiveLiteral {
+    fn from(value: Datum) -> Self {
+        value.literal
+    }
+}
+
 impl Datum {
     /// Creates a `Datum` from a `PrimitiveType` and a `PrimitiveLiteral`
     pub(crate) fn new(r#type: PrimitiveType, literal: PrimitiveLiteral) -> Self {
         Datum { r#type, literal }
+    }
+
+    /// Create iceberg value from bytes
+    pub fn try_from_bytes(bytes: &[u8], data_type: PrimitiveType) -> Result<Self> {
+        let literal = match data_type {
+            PrimitiveType::Boolean => {
+                if bytes.len() == 1 && bytes[0] == 0u8 {
+                    PrimitiveLiteral::Boolean(false)
+                } else {
+                    PrimitiveLiteral::Boolean(true)
+                }
+            }
+            PrimitiveType::Int => PrimitiveLiteral::Int(i32::from_le_bytes(bytes.try_into()?)),
+            PrimitiveType::Long => PrimitiveLiteral::Long(i64::from_le_bytes(bytes.try_into()?)),
+            PrimitiveType::Float => {
+                PrimitiveLiteral::Float(OrderedFloat(f32::from_le_bytes(bytes.try_into()?)))
+            }
+            PrimitiveType::Double => {
+                PrimitiveLiteral::Double(OrderedFloat(f64::from_le_bytes(bytes.try_into()?)))
+            }
+            PrimitiveType::Date => PrimitiveLiteral::Date(i32::from_le_bytes(bytes.try_into()?)),
+            PrimitiveType::Time => PrimitiveLiteral::Time(i64::from_le_bytes(bytes.try_into()?)),
+            PrimitiveType::Timestamp => {
+                PrimitiveLiteral::Timestamp(i64::from_le_bytes(bytes.try_into()?))
+            }
+            PrimitiveType::Timestamptz => {
+                PrimitiveLiteral::TimestampTZ(i64::from_le_bytes(bytes.try_into()?))
+            }
+            PrimitiveType::String => {
+                PrimitiveLiteral::String(std::str::from_utf8(bytes)?.to_string())
+            }
+            PrimitiveType::Uuid => {
+                PrimitiveLiteral::UUID(Uuid::from_u128(u128::from_be_bytes(bytes.try_into()?)))
+            }
+            PrimitiveType::Fixed(_) => PrimitiveLiteral::Fixed(Vec::from(bytes)),
+            PrimitiveType::Binary => PrimitiveLiteral::Binary(Vec::from(bytes)),
+            PrimitiveType::Decimal {
+                precision: _,
+                scale: _,
+            } => todo!(),
+        };
+        Ok(Datum::new(data_type, literal))
     }
 
     /// Creates a boolean value.
@@ -713,8 +866,99 @@ impl Datum {
     }
 }
 
+/// Map is a collection of key-value pairs with a key type and a value type.
+/// It used in Literal::Map, to make it hashable, the order of key-value pairs is stored in a separate vector
+/// so that we can hash the map in a deterministic way. But it also means that the order of key-value pairs is matter
+/// for the hash value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Map {
+    inner: HashMap<Literal, Option<Literal>>,
+    order: Vec<Literal>,
+}
+
+impl Map {
+    /// Creates a new empty map.
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+            order: Vec::new(),
+        }
+    }
+
+    /// Return the number of key-value pairs in the map.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Inserts a key-value pair into the map.
+    /// If the map did not have this key present, None is returned.
+    /// If the map did have this key present, the value is updated, and the old value is returned.
+    pub fn insert(&mut self, key: Literal, value: Option<Literal>) -> Option<Option<Literal>> {
+        self.order.push(key.clone());
+        self.inner.insert(key, value)
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    /// If the key is not present in the map, None is returned.
+    pub fn get(&self, key: &Literal) -> Option<&Option<Literal>> {
+        self.inner.get(key)
+    }
+}
+
+impl Default for Map {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Hash for Map {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for k in &self.order {
+            k.hash(state);
+            self.inner.get(k).unwrap().hash(state);
+        }
+    }
+}
+
+impl FromIterator<(Literal, Option<Literal>)> for Map {
+    fn from_iter<T: IntoIterator<Item = (Literal, Option<Literal>)>>(iter: T) -> Self {
+        let mut inner = HashMap::new();
+        let mut order = Vec::new();
+        for (k, v) in iter {
+            inner.insert(k.clone(), v.clone());
+            order.push(k);
+        }
+
+        Self { inner, order }
+    }
+}
+
+impl IntoIterator for Map {
+    type Item = (Literal, Option<Literal>);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.order
+            .into_iter()
+            .map(|k| (k.clone(), self.inner.get(&k).cloned().unwrap()))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
+impl<const N: usize> From<[(Literal, Option<Literal>); N]> for Map {
+    fn from(value: [(Literal, Option<Literal>); N]) -> Self {
+        value.iter().cloned().collect()
+    }
+}
+
 /// Values present in iceberg type
-#[derive(Clone, Debug, PartialEq, Hash, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Literal {
     /// A primitive value
     Primitive(PrimitiveLiteral),
@@ -729,7 +973,7 @@ pub enum Literal {
     /// A map is a collection of key-value pairs with a key type and a value type.
     /// Both the key field and value field each have an integer id that is unique in the table schema.
     /// Map keys are required and map values can be either optional or required. Both map keys and map values may be any type, including nested types.
-    Map(BTreeMap<Literal, Option<Literal>>),
+    Map(Map),
 }
 
 impl Literal {
@@ -1077,32 +1321,65 @@ impl Literal {
     }
 }
 
+impl From<PrimitiveLiteral> for ByteBuf {
+    fn from(value: PrimitiveLiteral) -> Self {
+        match value {
+            PrimitiveLiteral::Boolean(val) => {
+                if val {
+                    ByteBuf::from([1u8])
+                } else {
+                    ByteBuf::from([0u8])
+                }
+            }
+            PrimitiveLiteral::Int(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Long(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Float(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Double(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Date(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Time(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::Timestamp(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::TimestampTZ(val) => ByteBuf::from(val.to_le_bytes()),
+            PrimitiveLiteral::String(val) => ByteBuf::from(val.as_bytes()),
+            PrimitiveLiteral::UUID(val) => ByteBuf::from(val.as_u128().to_be_bytes()),
+            PrimitiveLiteral::Fixed(val) => ByteBuf::from(val),
+            PrimitiveLiteral::Binary(val) => ByteBuf::from(val),
+            PrimitiveLiteral::Decimal(_) => todo!(),
+        }
+    }
+}
+
 impl From<Literal> for ByteBuf {
     fn from(value: Literal) -> Self {
         match value {
-            Literal::Primitive(prim) => match prim {
-                PrimitiveLiteral::Boolean(val) => {
-                    if val {
-                        ByteBuf::from([1u8])
-                    } else {
-                        ByteBuf::from([0u8])
-                    }
-                }
-                PrimitiveLiteral::Int(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Long(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Float(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Double(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Date(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Time(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::Timestamp(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::TimestampTZ(val) => ByteBuf::from(val.to_le_bytes()),
-                PrimitiveLiteral::String(val) => ByteBuf::from(val.as_bytes()),
-                PrimitiveLiteral::UUID(val) => ByteBuf::from(val.as_u128().to_be_bytes()),
-                PrimitiveLiteral::Fixed(val) => ByteBuf::from(val),
-                PrimitiveLiteral::Binary(val) => ByteBuf::from(val),
-                PrimitiveLiteral::Decimal(_) => todo!(),
-            },
+            Literal::Primitive(val) => val.into(),
             _ => unimplemented!(),
+        }
+    }
+}
+
+impl From<PrimitiveLiteral> for Vec<u8> {
+    fn from(value: PrimitiveLiteral) -> Self {
+        match value {
+            PrimitiveLiteral::Boolean(val) => {
+                if val {
+                    Vec::from([1u8])
+                } else {
+                    Vec::from([0u8])
+                }
+            }
+            PrimitiveLiteral::Int(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Long(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Float(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Double(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Date(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Time(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::Timestamp(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::TimestampTZ(val) => Vec::from(val.to_le_bytes()),
+            PrimitiveLiteral::String(val) => Vec::from(val.as_bytes()),
+            PrimitiveLiteral::UUID(val) => Vec::from(val.as_u128().to_be_bytes()),
+            PrimitiveLiteral::Fixed(val) => val,
+            PrimitiveLiteral::Binary(val) => val,
+            PrimitiveLiteral::Decimal(_) => todo!(),
         }
     }
 }
@@ -1110,28 +1387,7 @@ impl From<Literal> for ByteBuf {
 impl From<Literal> for Vec<u8> {
     fn from(value: Literal) -> Self {
         match value {
-            Literal::Primitive(prim) => match prim {
-                PrimitiveLiteral::Boolean(val) => {
-                    if val {
-                        Vec::from([1u8])
-                    } else {
-                        Vec::from([0u8])
-                    }
-                }
-                PrimitiveLiteral::Int(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Long(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Float(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Double(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Date(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Time(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::Timestamp(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::TimestampTZ(val) => Vec::from(val.to_le_bytes()),
-                PrimitiveLiteral::String(val) => Vec::from(val.as_bytes()),
-                PrimitiveLiteral::UUID(val) => Vec::from(val.as_u128().to_be_bytes()),
-                PrimitiveLiteral::Fixed(val) => val,
-                PrimitiveLiteral::Binary(val) => val,
-                PrimitiveLiteral::Decimal(_) => todo!(),
-            },
+            Literal::Primitive(val) => val.into(),
             _ => unimplemented!(),
         }
     }
@@ -1140,7 +1396,7 @@ impl From<Literal> for Vec<u8> {
 /// The partition struct stores the tuple of partition values for each file.
 /// Its type is derived from the partition fields of the partition spec used to write the manifest file.
 /// In v2, the partition struct’s field ids must match the ids from the partition spec.
-#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Struct {
     /// Vector to store the field values
     fields: Vec<Literal>,
@@ -1237,55 +1493,10 @@ impl Literal {
     /// Create iceberg value from bytes
     pub fn try_from_bytes(bytes: &[u8], data_type: &Type) -> Result<Self> {
         match data_type {
-            Type::Primitive(primitive) => match primitive {
-                PrimitiveType::Boolean => {
-                    if bytes.len() == 1 && bytes[0] == 0u8 {
-                        Ok(Literal::Primitive(PrimitiveLiteral::Boolean(false)))
-                    } else {
-                        Ok(Literal::Primitive(PrimitiveLiteral::Boolean(true)))
-                    }
-                }
-                PrimitiveType::Int => Ok(Literal::Primitive(PrimitiveLiteral::Int(
-                    i32::from_le_bytes(bytes.try_into()?),
-                ))),
-                PrimitiveType::Long => Ok(Literal::Primitive(PrimitiveLiteral::Long(
-                    i64::from_le_bytes(bytes.try_into()?),
-                ))),
-                PrimitiveType::Float => Ok(Literal::Primitive(PrimitiveLiteral::Float(
-                    OrderedFloat(f32::from_le_bytes(bytes.try_into()?)),
-                ))),
-                PrimitiveType::Double => Ok(Literal::Primitive(PrimitiveLiteral::Double(
-                    OrderedFloat(f64::from_le_bytes(bytes.try_into()?)),
-                ))),
-                PrimitiveType::Date => Ok(Literal::Primitive(PrimitiveLiteral::Date(
-                    i32::from_le_bytes(bytes.try_into()?),
-                ))),
-                PrimitiveType::Time => Ok(Literal::Primitive(PrimitiveLiteral::Time(
-                    i64::from_le_bytes(bytes.try_into()?),
-                ))),
-                PrimitiveType::Timestamp => Ok(Literal::Primitive(PrimitiveLiteral::Timestamp(
-                    i64::from_le_bytes(bytes.try_into()?),
-                ))),
-                PrimitiveType::Timestamptz => Ok(Literal::Primitive(
-                    PrimitiveLiteral::TimestampTZ(i64::from_le_bytes(bytes.try_into()?)),
-                )),
-                PrimitiveType::String => Ok(Literal::Primitive(PrimitiveLiteral::String(
-                    std::str::from_utf8(bytes)?.to_string(),
-                ))),
-                PrimitiveType::Uuid => Ok(Literal::Primitive(PrimitiveLiteral::UUID(
-                    Uuid::from_u128(u128::from_be_bytes(bytes.try_into()?)),
-                ))),
-                PrimitiveType::Fixed(_) => Ok(Literal::Primitive(PrimitiveLiteral::Fixed(
-                    Vec::from(bytes),
-                ))),
-                PrimitiveType::Binary => Ok(Literal::Primitive(PrimitiveLiteral::Binary(
-                    Vec::from(bytes),
-                ))),
-                PrimitiveType::Decimal {
-                    precision: _,
-                    scale: _,
-                } => todo!(),
-            },
+            Type::Primitive(primitive_type) => {
+                let datum = Datum::try_from_bytes(bytes, primitive_type.clone())?;
+                Ok(Literal::Primitive(datum.literal))
+            }
             _ => Err(Error::new(
                 crate::ErrorKind::DataInvalid,
                 "Converting bytes to non-primitive types is not supported.",
@@ -1426,7 +1637,7 @@ impl Literal {
                     if let (Some(JsonValue::Array(keys)), Some(JsonValue::Array(values))) =
                         (object.remove("keys"), object.remove("values"))
                     {
-                        Ok(Some(Literal::Map(BTreeMap::from_iter(
+                        Ok(Some(Literal::Map(Map::from_iter(
                             keys.into_iter()
                                 .zip(values.into_iter())
                                 .map(|(key, value)| {
@@ -1667,8 +1878,6 @@ mod timestamptz {
 }
 
 mod _serde {
-    use std::collections::BTreeMap;
-
     use serde::{
         de::Visitor,
         ser::{SerializeMap, SerializeSeq, SerializeStruct},
@@ -1683,7 +1892,7 @@ mod _serde {
         Error, ErrorKind,
     };
 
-    use super::{Literal, PrimitiveLiteral};
+    use super::{Literal, Map, PrimitiveLiteral};
 
     #[derive(SerializeDerive, DeserializeDerive, Debug)]
     #[serde(transparent)]
@@ -2138,7 +2347,7 @@ mod _serde {
                         Type::Map(map_ty) => {
                             let key_ty = map_ty.key_field.field_type.as_ref();
                             let value_ty = map_ty.value_field.field_type.as_ref();
-                            let mut map = BTreeMap::new();
+                            let mut map = Map::new();
                             for k_v in v.list {
                                 let k_v = k_v.ok_or_else(|| invalid_err_with_reason("list","In deserialize, None will be represented as Some(RawLiteral::Null), all element in list must be valid"))?;
                                 if let RawLiteralEnum::Record(Record {
@@ -2221,7 +2430,7 @@ mod _serde {
                                 "Map key must be string",
                             ));
                         }
-                        let mut map = BTreeMap::new();
+                        let mut map = Map::new();
                         for (k, v) in required {
                             let value = v.try_into(&map_ty.value_field.field_type)?;
                             if map_ty.value_field.required && value.is_none() {
@@ -2523,7 +2732,7 @@ mod tests {
 
         check_json_serde(
             record,
-            Literal::Map(BTreeMap::from([
+            Literal::Map(Map::from([
                 (
                     Literal::Primitive(PrimitiveLiteral::String("a".to_string())),
                     Some(Literal::Primitive(PrimitiveLiteral::Int(1))),
@@ -2727,7 +2936,7 @@ mod tests {
     #[test]
     fn avro_convert_test_map() {
         check_convert_with_avro(
-            Literal::Map(BTreeMap::from([
+            Literal::Map(Map::from([
                 (
                     Literal::Primitive(PrimitiveLiteral::Int(1)),
                     Some(Literal::Primitive(PrimitiveLiteral::Long(1))),
@@ -2751,7 +2960,7 @@ mod tests {
         );
 
         check_convert_with_avro(
-            Literal::Map(BTreeMap::from([
+            Literal::Map(Map::from([
                 (
                     Literal::Primitive(PrimitiveLiteral::Int(1)),
                     Some(Literal::Primitive(PrimitiveLiteral::Long(1))),
@@ -2781,7 +2990,7 @@ mod tests {
     #[test]
     fn avro_convert_test_string_map() {
         check_convert_with_avro(
-            Literal::Map(BTreeMap::from([
+            Literal::Map(Map::from([
                 (
                     Literal::Primitive(PrimitiveLiteral::String("a".to_string())),
                     Some(Literal::Primitive(PrimitiveLiteral::Int(1))),
@@ -2808,7 +3017,7 @@ mod tests {
         );
 
         check_convert_with_avro(
-            Literal::Map(BTreeMap::from([
+            Literal::Map(Map::from([
                 (
                     Literal::Primitive(PrimitiveLiteral::String("a".to_string())),
                     Some(Literal::Primitive(PrimitiveLiteral::Int(1))),


### PR DESCRIPTION
This PR fix  #378. 
1. It makes PrimitiveLiteral and Literal not be PartialOrd, Ord. And only Datum PartialOrd.
2. After 1, it also changes the Manifest and ManifestList to use Datum in `lower_bound` && `upper_bound` 

After Literal is not Ord, we can't use `BTreeMap<Literal,_>` anymore. I use `HashMap` to replace it. But to make `HashMap` hashable, we need to assign an order for it. I implement this in `Map`.