### PR TITLE
docs(writer/docker): fix small typos and wording

### DIFF
--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -75,7 +75,7 @@ pub trait IcebergWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static {
     /// Close the writer and return the written data files.
     /// If close failed, the data written before maybe be lost. User may need to recreate the writer and rewrite the data again.
     /// # NOTE
-    /// After close, no matter successfully or fail,the writer should never be used again, otherwise the writer will panic.
+    /// After close, regardless of success or failure, the writer should never be used again, otherwise the writer will panic.
     async fn close(&mut self) -> Result<O>;
 }
 

--- a/crates/test_utils/src/docker.rs
+++ b/crates/test_utils/src/docker.rs
@@ -18,9 +18,9 @@
 use crate::cmd::{get_cmd_output, run_command};
 use std::process::Command;
 
-/// A utility to manage lifecycle of docker compose.
+/// A utility to manage the lifecycle of `docker compose`.
 ///
-/// It's will start docker compose when calling `run` method, and will be stopped when dropped.
+/// It will start `docker compose` when calling the `run` method and will be stopped via [`Drop`].
 #[derive(Debug)]
 pub struct DockerCompose {
     project_name: String,


### PR DESCRIPTION
Small no-op documentation changes that I came across whilst reading around the project to gain more familiarity :rocket: 
