### PR TITLE
feat: `StructAccessor.get` returns `Result<Option<Datum>>` instead of `Result<Datum>`

### DIFF
--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -1683,7 +1683,7 @@ table {
                 .unwrap()
                 .get(&test_struct)
                 .unwrap(),
-            Datum::string("foo value")
+            Some(Datum::string("foo value"))
         );
         assert_eq!(
             schema
@@ -1691,7 +1691,7 @@ table {
                 .unwrap()
                 .get(&test_struct)
                 .unwrap(),
-            Datum::int(1002)
+            Some(Datum::int(1002))
         );
         assert_eq!(
             schema
@@ -1699,7 +1699,7 @@ table {
                 .unwrap()
                 .get(&test_struct)
                 .unwrap(),
-            Datum::bool(true)
+            Some(Datum::bool(true))
         );
         assert_eq!(
             schema
@@ -1707,7 +1707,7 @@ table {
                 .unwrap()
                 .get(&test_struct)
                 .unwrap(),
-            Datum::string("Testy McTest")
+            Some(Datum::string("Testy McTest"))
         );
         assert_eq!(
             schema
@@ -1715,7 +1715,7 @@ table {
                 .unwrap()
                 .get(&test_struct)
                 .unwrap(),
-            Datum::int(33)
+            Some(Datum::int(33))
         );
     }
 

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -1440,6 +1440,11 @@ impl Struct {
             },
         )
     }
+
+    /// returns true if the field at position `index` is null
+    pub fn is_null_at_index(&self, index: usize) -> bool {
+        self.null_bitmap[index]
+    }
 }
 
 impl Index<usize> for Struct {


### PR DESCRIPTION
This is so that the accessor's result can represent null field values.

Fixes: [#379](https://github.com/apache/iceberg-rust/issues/379), unblocking https://github.com/apache/iceberg-rust/pull/363