### PR TITLE
ci: use official typos github action

### DIFF
--- a/.github/workflows/ci_typos.yml
+++ b/.github/workflows/ci_typos.yml
@@ -41,7 +41,5 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - uses: actions/checkout@v4
-      - run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.14.8/typos-v1.14.8-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
-      - name: do typos check with typos-cli
-        run: typos
+      - name: Check typos
+        uses: crate-ci/typos@v1.22.9


### PR DESCRIPTION
`create-ci/typos` is whitelisted in https://issues.apache.org/jira/browse/INFRA-25798. I propose to switch, using official github actions will have better interactions in github PR.