### PR TITLE
chore: Don't enable reqwest default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@
 [workspace]
 resolver = "2"
 members = [
-  "crates/catalog/*",
-  "crates/examples",
-  "crates/iceberg",
-  "crates/integrations/*",
-  "crates/test_utils",
+    "crates/catalog/*",
+    "crates/examples",
+    "crates/iceberg",
+    "crates/integrations/*",
+    "crates/test_utils",
 ]
 
 [workspace.package]
@@ -72,7 +72,7 @@ parquet = "52"
 pilota = "0.11.2"
 pretty_assertions = "1.4.0"
 port_scanner = "0.1.5"
-reqwest = { version = "^0.12", features = ["json"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json"] }
 rust_decimal = "1.31.0"
 serde = { version = "^1.0", features = ["rc"] }
 serde_bytes = "0.11.8"


### PR DESCRIPTION
Don't enable reqwest default features, let users to decide the tls suites.