### PR TITLE
chore: remove compose obsolete version (#452)

### DIFF
--- a/crates/catalog/glue/testdata/glue_catalog/docker-compose.yaml
+++ b/crates/catalog/glue/testdata/glue_catalog/docker-compose.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   minio:
     image: minio/minio:RELEASE.2024-03-07T00-43-48Z

--- a/crates/catalog/hms/testdata/hms_catalog/docker-compose.yaml
+++ b/crates/catalog/hms/testdata/hms_catalog/docker-compose.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   minio:
     image: minio/minio:RELEASE.2024-03-07T00-43-48Z

--- a/crates/catalog/rest/testdata/rest_catalog/docker-compose.yaml
+++ b/crates/catalog/rest/testdata/rest_catalog/docker-compose.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   rest:
     image: tabulario/iceberg-rest:0.10.0

--- a/crates/iceberg/testdata/file_io_s3/docker-compose.yaml
+++ b/crates/iceberg/testdata/file_io_s3/docker-compose.yaml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3'
 services:
   minio:
     image: minio/minio:RELEASE.2024-02-26T09-33-48Z

--- a/crates/integrations/datafusion/testdata/docker-compose.yaml
+++ b/crates/integrations/datafusion/testdata/docker-compose.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   minio:
     image: minio/minio:RELEASE.2024-03-07T00-43-48Z


### PR DESCRIPTION
reference: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete