### PR TITLE
refine: move binary serialize in literal to datum

### DIFF
--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -675,7 +675,7 @@ pub struct FieldSummary {
 /// [ManifestFileV1] and [ManifestFileV2] are internal struct that are only used for serialization and deserialization.
 pub(super) mod _serde {
     use crate::{
-        spec::{Datum, PrimitiveLiteral, PrimitiveType, StructType},
+        spec::{Datum, PrimitiveType, StructType},
         Error,
     };
     pub use serde_bytes::ByteBuf;
@@ -965,8 +965,8 @@ pub(super) mod _serde {
                     .map(|v| FieldSummary {
                         contains_null: v.contains_null,
                         contains_nan: v.contains_nan,
-                        lower_bound: v.lower_bound.map(|v| PrimitiveLiteral::from(v).into()),
-                        upper_bound: v.upper_bound.map(|v| PrimitiveLiteral::from(v).into()),
+                        lower_bound: v.lower_bound.map(|v| v.to_bytes()),
+                        upper_bound: v.upper_bound.map(|v| v.to_bytes()),
                     })
                     .collect(),
             )


### PR DESCRIPTION
In iceberg spec, I think there are 3 ways to serialize the iceberg value(literal) which will be stored in metadata:
1. [binary serialize](https://iceberg.apache.org/spec/#binary-single-value-serialization) using in lower_bound && upper bound
2. [json serialize](https://iceberg.apache.org/spec/#json-single-value-serialization) using in init default value 
3. [avro serialize](https://iceberg.apache.org/spec/#avro) using in struct in data file 

For now, we store lower_bound && upper_bound using datum. So we move the serialize function into datum.  And add some reference comments for this binary serialize function.