### PR TITLE
Fix ManifestFile length calculation

### DIFF
--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -289,8 +289,8 @@ impl ManifestWriter {
             avro_writer.append(value)?;
         }
 
-        let length = avro_writer.flush()?;
         let content = avro_writer.into_inner()?;
+        let length = content.len();
         self.output.write(Bytes::from(content)).await?;
 
         let partition_summary =


### PR DESCRIPTION
`Avro`  [Writer::flush](https://docs.rs/apache-avro/latest/apache_avro/struct.Writer.html#method.flush) only return the remaining byte length in the internal buf. It would be zero if the writer have already flushed which is incorrect.