### PR TITLE
feat: improve compatibility of S3 test minio connection

### DIFF
--- a/crates/iceberg/tests/file_io_s3_test.rs
+++ b/crates/iceberg/tests/file_io_s3_test.rs
@@ -49,12 +49,12 @@ async fn get_file_io() -> FileIO {
 
     let guard = DOCKER_COMPOSE_ENV.read().unwrap();
     let docker_compose = guard.as_ref().unwrap();
-    let container_ip = docker_compose.get_container_ip("minio");
-    let read_port = format!("{}:{}", container_ip, 9000);
+    let host_port = docker_compose.get_host_port("minio");
+    let ip_and_port = format!("localhost:{}", host_port);
 
     FileIOBuilder::new("s3")
         .with_props(vec![
-            (S3_ENDPOINT, format!("http://{}", read_port)),
+            (S3_ENDPOINT, format!("http://{}", ip_and_port)),
             (S3_ACCESS_KEY_ID, "admin".to_string()),
             (S3_SECRET_ACCESS_KEY, "password".to_string()),
             (S3_REGION, "us-east-1".to_string()),

--- a/crates/test_utils/src/docker.rs
+++ b/crates/test_utils/src/docker.rs
@@ -88,6 +88,19 @@ impl DockerCompose {
             .trim()
             .to_string()
     }
+
+    pub fn get_host_port(&self, service_name: impl AsRef<str>) -> String {
+        let container_name = format!("{}-{}-1", self.project_name, service_name.as_ref());
+        let mut cmd = Command::new("docker");
+        cmd.arg("inspect")
+            .arg("-f")
+            .arg("{{ (index (index .NetworkSettings.Ports \"9000/tcp\") 0).HostPort }}")
+            .arg(&container_name);
+
+        get_cmd_output(cmd, format!("Get host port for {container_name}"))
+            .trim()
+            .to_string()
+    }
 }
 
 impl Drop for DockerCompose {


### PR DESCRIPTION
The file IO S3 tests do not work on OSX due to the connection to the docker container being blocked when connecting via the containers host IP address. This change connects to the port that Docker has exposed for minio on the localhost instead.