### PR TITLE
feat: add check compatible func for primitive type

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -33,6 +33,7 @@ use super::values::Literal;
 use crate::ensure_data_valid;
 use crate::error::Result;
 use crate::spec::datatypes::_decimal::{MAX_PRECISION, REQUIRED_LENGTH};
+use crate::spec::PrimitiveLiteral;
 
 /// Field name for list type.
 pub(crate) const LIST_FILED_NAME: &str = "element";
@@ -232,6 +233,29 @@ pub enum PrimitiveType {
     Fixed(u64),
     /// Arbitrary-length byte array.
     Binary,
+}
+
+impl PrimitiveType {
+    /// Check whether literal is compatible with the type.
+    pub fn compatible(&self, literal: &PrimitiveLiteral) -> bool {
+        matches!(
+            (self, literal),
+            (PrimitiveType::Boolean, PrimitiveLiteral::Boolean(_))
+                | (PrimitiveType::Int, PrimitiveLiteral::Int(_))
+                | (PrimitiveType::Long, PrimitiveLiteral::Long(_))
+                | (PrimitiveType::Float, PrimitiveLiteral::Float(_))
+                | (PrimitiveType::Double, PrimitiveLiteral::Double(_))
+                | (PrimitiveType::Decimal { .. }, PrimitiveLiteral::Decimal(_))
+                | (PrimitiveType::Date, PrimitiveLiteral::Date(_))
+                | (PrimitiveType::Time, PrimitiveLiteral::Time(_))
+                | (PrimitiveType::Timestamp, PrimitiveLiteral::Timestamp(_))
+                | (PrimitiveType::Timestamptz, PrimitiveLiteral::Timestamptz(_))
+                | (PrimitiveType::String, PrimitiveLiteral::String(_))
+                | (PrimitiveType::Uuid, PrimitiveLiteral::Uuid(_))
+                | (PrimitiveType::Fixed(_), PrimitiveLiteral::Fixed(_))
+                | (PrimitiveType::Binary, PrimitiveLiteral::Binary(_))
+        )
+    }
 }
 
 impl Serialize for Type {
@@ -896,10 +920,10 @@ mod tests {
             Type::Struct(StructType {
                 fields: vec![
                     NestedField::required(1, "id", Type::Primitive(PrimitiveType::Uuid))
-                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::UUID(
+                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::Uuid(
                             Uuid::parse_str("0db3e2a8-9d1d-42b9-aa7b-74ebe558dceb").unwrap(),
                         )))
-                        .with_write_default(Literal::Primitive(PrimitiveLiteral::UUID(
+                        .with_write_default(Literal::Primitive(PrimitiveLiteral::Uuid(
                             Uuid::parse_str("ec5911be-b0a7-458c-8438-c9a3e53cffae").unwrap(),
                         )))
                         .into(),
@@ -965,10 +989,10 @@ mod tests {
 
         let struct_type = Type::Struct(StructType::new(vec![
             NestedField::required(1, "id", Type::Primitive(PrimitiveType::Uuid))
-                .with_initial_default(Literal::Primitive(PrimitiveLiteral::UUID(
+                .with_initial_default(Literal::Primitive(PrimitiveLiteral::Uuid(
                     Uuid::parse_str("0db3e2a8-9d1d-42b9-aa7b-74ebe558dceb").unwrap(),
                 )))
-                .with_write_default(Literal::Primitive(PrimitiveLiteral::UUID(
+                .with_write_default(Literal::Primitive(PrimitiveLiteral::Uuid(
                     Uuid::parse_str("ec5911be-b0a7-458c-8438-c9a3e53cffae").unwrap(),
                 )))
                 .into(),
@@ -1086,5 +1110,49 @@ mod tests {
 
         assert_eq!(5, Type::decimal_required_bytes(10).unwrap());
         assert_eq!(16, Type::decimal_required_bytes(38).unwrap());
+    }
+
+    #[test]
+    fn test_primitive_type_compatitable() {
+        let types = vec![
+            PrimitiveType::Boolean,
+            PrimitiveType::Int,
+            PrimitiveType::Long,
+            PrimitiveType::Float,
+            PrimitiveType::Double,
+            PrimitiveType::Decimal {
+                precision: 9,
+                scale: 2,
+            },
+            PrimitiveType::Date,
+            PrimitiveType::Time,
+            PrimitiveType::Timestamp,
+            PrimitiveType::Timestamptz,
+            PrimitiveType::String,
+            PrimitiveType::Uuid,
+            PrimitiveType::Fixed(8),
+            PrimitiveType::Binary,
+        ];
+        let literals = vec![
+            PrimitiveLiteral::Boolean(true),
+            PrimitiveLiteral::Int(1),
+            PrimitiveLiteral::Long(1),
+            PrimitiveLiteral::Float(1.0.into()),
+            PrimitiveLiteral::Double(1.0.into()),
+            PrimitiveLiteral::Decimal(1),
+            PrimitiveLiteral::Date(1),
+            PrimitiveLiteral::Time(1),
+            PrimitiveLiteral::Timestamp(1),
+            PrimitiveLiteral::Timestamptz(1),
+            PrimitiveLiteral::String("1".to_string()),
+            PrimitiveLiteral::Uuid(Uuid::new_v4()),
+            PrimitiveLiteral::Fixed(vec![1]),
+            PrimitiveLiteral::Binary(vec![1]),
+        ];
+        for (i, t) in types.iter().enumerate() {
+            for (j, l) in literals.iter().enumerate() {
+                assert_eq!(i == j, t.compatible(l));
+            }
+        }
     }
 }

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -76,7 +76,7 @@ pub enum PrimitiveLiteral {
     /// UTF-8 bytes (without length)
     String(String),
     /// 16-byte big-endian value
-    UUID(Uuid),
+    Uuid(Uuid),
     /// Binary value
     Fixed(Vec<u8>),
     /// Binary value (without length)
@@ -278,8 +278,8 @@ impl PartialOrd for Datum {
                 PrimitiveType::String,
             ) => val.partial_cmp(other_val),
             (
-                PrimitiveLiteral::UUID(val),
-                PrimitiveLiteral::UUID(other_val),
+                PrimitiveLiteral::Uuid(val),
+                PrimitiveLiteral::Uuid(other_val),
                 PrimitiveType::Uuid,
                 PrimitiveType::Uuid,
             ) => val.partial_cmp(other_val),
@@ -333,7 +333,7 @@ impl Display for Datum {
                 write!(f, "{}", microseconds_to_datetimetz(*val))
             }
             (_, PrimitiveLiteral::String(val)) => write!(f, r#""{}""#, val),
-            (_, PrimitiveLiteral::UUID(val)) => write!(f, "{}", val),
+            (_, PrimitiveLiteral::Uuid(val)) => write!(f, "{}", val),
             (_, PrimitiveLiteral::Fixed(val)) => display_bytes(val, f),
             (_, PrimitiveLiteral::Binary(val)) => display_bytes(val, f),
             (
@@ -410,7 +410,7 @@ impl Datum {
                 PrimitiveLiteral::String(std::str::from_utf8(bytes)?.to_string())
             }
             PrimitiveType::Uuid => {
-                PrimitiveLiteral::UUID(Uuid::from_u128(u128::from_be_bytes(bytes.try_into()?)))
+                PrimitiveLiteral::Uuid(Uuid::from_u128(u128::from_be_bytes(bytes.try_into()?)))
             }
             PrimitiveType::Fixed(_) => PrimitiveLiteral::Fixed(Vec::from(bytes)),
             PrimitiveType::Binary => PrimitiveLiteral::Binary(Vec::from(bytes)),
@@ -443,7 +443,7 @@ impl Datum {
             PrimitiveLiteral::Timestamp(val) => ByteBuf::from(val.to_le_bytes()),
             PrimitiveLiteral::Timestamptz(val) => ByteBuf::from(val.to_le_bytes()),
             PrimitiveLiteral::String(val) => ByteBuf::from(val.as_bytes()),
-            PrimitiveLiteral::UUID(val) => ByteBuf::from(val.as_u128().to_be_bytes()),
+            PrimitiveLiteral::Uuid(val) => ByteBuf::from(val.as_u128().to_be_bytes()),
             PrimitiveLiteral::Fixed(val) => ByteBuf::from(val.as_slice()),
             PrimitiveLiteral::Binary(val) => ByteBuf::from(val.as_slice()),
             PrimitiveLiteral::Decimal(_) => todo!(),
@@ -868,7 +868,7 @@ impl Datum {
     pub fn uuid(uuid: Uuid) -> Self {
         Self {
             r#type: PrimitiveType::Uuid,
-            literal: PrimitiveLiteral::UUID(uuid),
+            literal: PrimitiveLiteral::Uuid(uuid),
         }
     }
 
@@ -1408,7 +1408,7 @@ impl Literal {
 
     /// Creates uuid literal.
     pub fn uuid(uuid: Uuid) -> Self {
-        Self::Primitive(PrimitiveLiteral::UUID(uuid))
+        Self::Primitive(PrimitiveLiteral::Uuid(uuid))
     }
 
     /// Creates uuid from str. See [`Uuid::parse_str`].
@@ -1655,7 +1655,7 @@ impl Literal {
                     Ok(Some(Literal::Primitive(PrimitiveLiteral::String(s))))
                 }
                 (PrimitiveType::Uuid, JsonValue::String(s)) => Ok(Some(Literal::Primitive(
-                    PrimitiveLiteral::UUID(Uuid::parse_str(&s)?),
+                    PrimitiveLiteral::Uuid(Uuid::parse_str(&s)?),
                 ))),
                 (PrimitiveType::Fixed(_), JsonValue::String(_)) => todo!(),
                 (PrimitiveType::Binary, JsonValue::String(_)) => todo!(),
@@ -1793,7 +1793,7 @@ impl Literal {
                         .to_string(),
                 )),
                 PrimitiveLiteral::String(val) => Ok(JsonValue::String(val.clone())),
-                PrimitiveLiteral::UUID(val) => Ok(JsonValue::String(val.to_string())),
+                PrimitiveLiteral::Uuid(val) => Ok(JsonValue::String(val.to_string())),
                 PrimitiveLiteral::Fixed(val) => Ok(JsonValue::String(val.iter().fold(
                     String::new(),
                     |mut acc, x| {
@@ -1882,7 +1882,7 @@ impl Literal {
                 PrimitiveLiteral::Fixed(any) => Box::new(any),
                 PrimitiveLiteral::Binary(any) => Box::new(any),
                 PrimitiveLiteral::String(any) => Box::new(any),
-                PrimitiveLiteral::UUID(any) => Box::new(any),
+                PrimitiveLiteral::Uuid(any) => Box::new(any),
                 PrimitiveLiteral::Decimal(any) => Box::new(any),
             },
             _ => unimplemented!(),
@@ -2189,7 +2189,7 @@ mod _serde {
                     super::PrimitiveLiteral::Timestamp(v) => RawLiteralEnum::Long(v),
                     super::PrimitiveLiteral::Timestamptz(v) => RawLiteralEnum::Long(v),
                     super::PrimitiveLiteral::String(v) => RawLiteralEnum::String(v),
-                    super::PrimitiveLiteral::UUID(v) => {
+                    super::PrimitiveLiteral::Uuid(v) => {
                         RawLiteralEnum::Bytes(ByteBuf::from(v.as_u128().to_be_bytes()))
                     }
                     super::PrimitiveLiteral::Fixed(v) => RawLiteralEnum::Bytes(ByteBuf::from(v)),
@@ -2818,7 +2818,7 @@ mod tests {
 
         check_json_serde(
             record,
-            Literal::Primitive(PrimitiveLiteral::UUID(
+            Literal::Primitive(PrimitiveLiteral::Uuid(
                 Uuid::parse_str("f79c3e09-677c-4bbd-a479-3f349cb785e7").unwrap(),
             )),
             &Type::Primitive(PrimitiveType::Uuid),

--- a/crates/iceberg/src/transform/bucket.rs
+++ b/crates/iceberg/src/transform/bucket.rs
@@ -229,7 +229,7 @@ impl TransformFunction for Bucket {
             PrimitiveLiteral::Time(v) => self.bucket_time(*v),
             PrimitiveLiteral::Timestamp(v) => self.bucket_timestamp(*v),
             PrimitiveLiteral::String(v) => self.bucket_str(v.as_str()),
-            PrimitiveLiteral::UUID(v) => self.bucket_bytes(v.as_ref()),
+            PrimitiveLiteral::Uuid(v) => self.bucket_bytes(v.as_ref()),
             PrimitiveLiteral::Binary(v) => self.bucket_bytes(v.as_ref()),
             PrimitiveLiteral::Fixed(v) => self.bucket_bytes(v.as_ref()),
             _ => {


### PR DESCRIPTION
This PR is separated from  https://github.com/apache/iceberg-rust/pull/349, we need to check whether the partition value(Struct) is compatible(same) as the partition spec. https://github.com/apache/iceberg-rust/blob/e5c330478e05b1e7f9c371024fc70269aab34dc5/crates/iceberg/src/transaction.rs#L277

This PR adds the function to check compatibility for PrimitiveType.