### PR TITLE
refactor(iceberg): Remove an extra config parse logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@
 [workspace]
 resolver = "2"
 members = [
-  "crates/catalog/*",
-  "crates/examples",
-  "crates/iceberg",
-  "crates/integrations/*",
-  "crates/test_utils",
+    "crates/catalog/*",
+    "crates/examples",
+    "crates/iceberg",
+    "crates/integrations/*",
+    "crates/test_utils",
 ]
 
 [workspace.package]
@@ -67,7 +67,7 @@ log = "^0.4"
 mockito = "^1"
 murmur3 = "0.5.2"
 once_cell = "1"
-opendal = "0.47"
+opendal = "0.48"
 ordered-float = "4.0.0"
 parquet = "52"
 pilota = "0.11.2"

--- a/crates/iceberg/src/io/storage_fs.rs
+++ b/crates/iceberg/src/io/storage_fs.rs
@@ -15,37 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
-
-use opendal::{Operator, Scheme};
+use opendal::services::FsConfig;
+use opendal::Operator;
 
 use crate::Result;
 
-/// # TODO
-///
-/// opendal has a plan to introduce native config support.
-/// We manually parse the config here and those code will be finally removed.
-#[derive(Default, Clone)]
-pub(crate) struct FsConfig {}
+/// Build new opendal operator from give path.
+pub(crate) fn fs_config_build(_: &str) -> Result<Operator> {
+    let mut cfg = FsConfig::default();
+    cfg.root = Some("/".to_string());
 
-impl Debug for FsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FsConfig").finish()
-    }
-}
-
-impl FsConfig {
-    /// Decode from iceberg props.
-    pub fn new(_: HashMap<String, String>) -> Self {
-        Self::default()
-    }
-
-    /// Build new opendal operator from give path.
-    ///
-    /// fs always build from `/`
-    pub fn build(&self, _: &str) -> Result<Operator> {
-        let m = HashMap::from_iter([("root".to_string(), "/".to_string())]);
-        Ok(Operator::via_map(Scheme::Fs, m)?)
-    }
+    Ok(Operator::from_config(cfg)?.finish())
 }

--- a/crates/iceberg/src/io/storage_memory.rs
+++ b/crates/iceberg/src/io/storage_memory.rs
@@ -15,31 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
-
-use opendal::{Operator, Scheme};
+use opendal::services::MemoryConfig;
+use opendal::Operator;
 
 use crate::Result;
 
-#[derive(Default, Clone)]
-pub(crate) struct MemoryConfig {}
-
-impl Debug for MemoryConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryConfig").finish()
-    }
-}
-
-impl MemoryConfig {
-    /// Decode from iceberg props.
-    pub fn new(_: HashMap<String, String>) -> Self {
-        Self::default()
-    }
-
-    /// Build new opendal operator from given path.
-    pub fn build(&self, _: &str) -> Result<Operator> {
-        let m = HashMap::new();
-        Ok(Operator::via_map(Scheme::Memory, m)?)
-    }
+pub(crate) fn memory_config_build(_: &str) -> Result<Operator> {
+    Ok(Operator::from_config(MemoryConfig::default())?.finish())
 }


### PR DESCRIPTION
This PR will remove an extra config parse logic that maps iceberg props into config directly.