### PR TITLE
feat: support timestamp columns in row filters

### DIFF
--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -20,10 +20,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow_array::types::{validate_decimal_precision_and_scale, Decimal128Type};
+use arrow_array::types::{
+    validate_decimal_precision_and_scale, Decimal128Type, TimestampMicrosecondType,
+};
 use arrow_array::{
     BooleanArray, Datum as ArrowDatum, Float32Array, Float64Array, Int32Array, Int64Array,
-    StringArray,
+    PrimitiveArray, Scalar, StringArray, TimestampMicrosecondArray,
 };
 use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
 use bitvec::macros::internal::funty::Fundamental;
@@ -613,6 +615,14 @@ pub(crate) fn get_arrow_datum(datum: &Datum) -> Result<Box<dyn ArrowDatum + Send
         PrimitiveLiteral::Float(value) => Ok(Box::new(Float32Array::new_scalar(value.as_f32()))),
         PrimitiveLiteral::Double(value) => Ok(Box::new(Float64Array::new_scalar(value.as_f64()))),
         PrimitiveLiteral::String(value) => Ok(Box::new(StringArray::new_scalar(value.as_str()))),
+        PrimitiveLiteral::Timestamp(value) => {
+            Ok(Box::new(TimestampMicrosecondArray::new_scalar(*value)))
+        }
+        PrimitiveLiteral::Timestamptz(value) => Ok(Box::new(Scalar::new(
+            PrimitiveArray::<TimestampMicrosecondType>::new(vec![*value; 1].into(), None)
+                .with_timezone("UTC"),
+        ))),
+
         l => Err(Error::new(
             ErrorKind::FeatureUnsupported,
             format!(


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-rust/issues/532.

Timezone needs to be explicitly set to `UTC` to match values written by Iceberg to underlying Parquet files.