### PR TITLE
docs: Add an example to scan an iceberg table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ futures = "0.3"
 iceberg = { version = "0.2.0", path = "./crates/iceberg" }
 iceberg-catalog-rest = { version = "0.2.0", path = "./crates/catalog/rest" }
 iceberg-catalog-hms = { version = "0.2.0", path = "./crates/catalog/hms" }
+iceberg-catalog-memory = { version = "0.2.0", path = "./crates/catalog/memory" }
 itertools = "0.13"
 log = "^0.4"
 mockito = "^1"

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -81,6 +81,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 iceberg_test_utils = { path = "../test_utils", features = ["tests"] }
+iceberg-catalog-memory = {workspace = true}
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tera = { workspace = true }

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -15,7 +15,41 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Native Rust implementation of Apache Iceberg
+//! Apache Iceberg Official Native Rust Implementation
+//!
+//! # Examples
+//!
+//! ## Scan A Table
+//!
+//! ```rust, no_run
+//! use futures::TryStreamExt;
+//! use iceberg::io::{FileIO, FileIOBuilder};
+//! use iceberg::{Catalog, Result, TableIdent};
+//! use iceberg_catalog_memory::MemoryCatalog;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<()> {
+//!     // Build your file IO.
+//!     let file_io = FileIOBuilder::new("memory").build()?;
+//!     // Connect to a catalog.
+//!     let catalog = MemoryCatalog::new(file_io, None);
+//!     // Load table from catalog.
+//!     let table = catalog
+//!         .load_table(&TableIdent::from_strs(["hello", "world"])?)
+//!         .await?;
+//!     // Build table scan.
+//!     let stream = table
+//!         .scan()
+//!         .select(["name", "id"])
+//!         .build()?
+//!         .to_arrow()
+//!         .await?;
+//!
+//!     // Consume this stream like arrow record batch stream.
+//!     let _data: Vec<_> = stream.try_collect().await?;
+//!     Ok(())
+//! }
+//! ```
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
This PR adds an example to scan an iceberg table.

Close https://github.com/apache/iceberg-rust/issues/415