### PR TITLE
fix: ensure S3 and GCS integ tests are conditionally compiled only when the storage-s3 and storage-gcs features are enabled

### DIFF
--- a/crates/iceberg/tests/file_io_gcs_test.rs
+++ b/crates/iceberg/tests/file_io_gcs_test.rs
@@ -17,109 +17,112 @@
 
 //! Integration tests for FileIO Google Cloud Storage (GCS).
 
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::RwLock;
+#[cfg(all(test, feature = "storage-gcs"))]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::RwLock;
 
-use bytes::Bytes;
-use ctor::{ctor, dtor};
-use iceberg::io::{FileIO, FileIOBuilder, GCS_NO_AUTH, GCS_SERVICE_PATH};
-use iceberg_test_utils::docker::DockerCompose;
-use iceberg_test_utils::{normalize_test_name, set_up};
+    use bytes::Bytes;
+    use ctor::{ctor, dtor};
+    use iceberg::io::{FileIO, FileIOBuilder, GCS_NO_AUTH, GCS_SERVICE_PATH};
+    use iceberg_test_utils::docker::DockerCompose;
+    use iceberg_test_utils::{normalize_test_name, set_up};
 
-static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
-static FAKE_GCS_PORT: u16 = 4443;
-static FAKE_GCS_BUCKET: &str = "test-bucket";
+    static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
+    static FAKE_GCS_PORT: u16 = 4443;
+    static FAKE_GCS_BUCKET: &str = "test-bucket";
 
-#[ctor]
-fn before_all() {
-    let mut guard = DOCKER_COMPOSE_ENV.write().unwrap();
-    let docker_compose = DockerCompose::new(
-        normalize_test_name(module_path!()),
-        format!("{}/testdata/file_io_gcs", env!("CARGO_MANIFEST_DIR")),
-    );
-    docker_compose.run();
-    guard.replace(docker_compose);
-}
+    #[ctor]
+    fn before_all() {
+        let mut guard = DOCKER_COMPOSE_ENV.write().unwrap();
+        let docker_compose = DockerCompose::new(
+            normalize_test_name(module_path!()),
+            format!("{}/testdata/file_io_gcs", env!("CARGO_MANIFEST_DIR")),
+        );
+        docker_compose.run();
+        guard.replace(docker_compose);
+    }
 
-#[dtor]
-fn after_all() {
-    let mut guard = DOCKER_COMPOSE_ENV.write().unwrap();
-    guard.take();
-}
+    #[dtor]
+    fn after_all() {
+        let mut guard = DOCKER_COMPOSE_ENV.write().unwrap();
+        guard.take();
+    }
 
-async fn get_file_io_gcs() -> FileIO {
-    set_up();
+    async fn get_file_io_gcs() -> FileIO {
+        set_up();
 
-    let ip = DOCKER_COMPOSE_ENV
-        .read()
-        .unwrap()
-        .as_ref()
-        .unwrap()
-        .get_container_ip("gcs-server");
-    let addr = SocketAddr::new(ip, FAKE_GCS_PORT);
+        let ip = DOCKER_COMPOSE_ENV
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .get_container_ip("gcs-server");
+        let addr = SocketAddr::new(ip, FAKE_GCS_PORT);
 
-    // A bucket must exist for FileIO
-    create_bucket(FAKE_GCS_BUCKET, addr.to_string())
-        .await
-        .unwrap();
+        // A bucket must exist for FileIO
+        create_bucket(FAKE_GCS_BUCKET, addr.to_string())
+            .await
+            .unwrap();
 
-    FileIOBuilder::new("gcs")
-        .with_props(vec![
-            (GCS_SERVICE_PATH, format!("http://{}", addr)),
-            (GCS_NO_AUTH, "true".to_string()),
-        ])
-        .build()
-        .unwrap()
-}
+        FileIOBuilder::new("gcs")
+            .with_props(vec![
+                (GCS_SERVICE_PATH, format!("http://{}", addr)),
+                (GCS_NO_AUTH, "true".to_string()),
+            ])
+            .build()
+            .unwrap()
+    }
 
-// Create a bucket against the emulated GCS storage server.
-async fn create_bucket(name: &str, server_addr: String) -> anyhow::Result<()> {
-    let mut bucket_data = HashMap::new();
-    bucket_data.insert("name", name);
+    // Create a bucket against the emulated GCS storage server.
+    async fn create_bucket(name: &str, server_addr: String) -> anyhow::Result<()> {
+        let mut bucket_data = HashMap::new();
+        bucket_data.insert("name", name);
 
-    let client = reqwest::Client::new();
-    let endpoint = format!("http://{}/storage/v1/b", server_addr);
-    client.post(endpoint).json(&bucket_data).send().await?;
-    Ok(())
-}
+        let client = reqwest::Client::new();
+        let endpoint = format!("http://{}/storage/v1/b", server_addr);
+        client.post(endpoint).json(&bucket_data).send().await?;
+        Ok(())
+    }
 
-fn get_gs_path() -> String {
-    format!("gs://{}", FAKE_GCS_BUCKET)
-}
+    fn get_gs_path() -> String {
+        format!("gs://{}", FAKE_GCS_BUCKET)
+    }
 
-#[tokio::test]
-async fn gcs_exists() {
-    let file_io = get_file_io_gcs().await;
-    assert!(file_io
-        .is_exist(format!("{}/", get_gs_path()))
-        .await
-        .unwrap());
-}
+    #[tokio::test]
+    async fn gcs_exists() {
+        let file_io = get_file_io_gcs().await;
+        assert!(file_io
+            .is_exist(format!("{}/", get_gs_path()))
+            .await
+            .unwrap());
+    }
 
-#[tokio::test]
-async fn gcs_write() {
-    let gs_file = format!("{}/write-file", get_gs_path());
-    let file_io = get_file_io_gcs().await;
-    let output = file_io.new_output(&gs_file).unwrap();
-    output
-        .write(bytes::Bytes::from_static(b"iceberg-gcs!"))
-        .await
-        .expect("Write to test output file");
-    assert!(file_io.is_exist(gs_file).await.unwrap())
-}
+    #[tokio::test]
+    async fn gcs_write() {
+        let gs_file = format!("{}/write-file", get_gs_path());
+        let file_io = get_file_io_gcs().await;
+        let output = file_io.new_output(&gs_file).unwrap();
+        output
+            .write(bytes::Bytes::from_static(b"iceberg-gcs!"))
+            .await
+            .expect("Write to test output file");
+        assert!(file_io.is_exist(gs_file).await.unwrap())
+    }
 
-#[tokio::test]
-async fn gcs_read() {
-    let gs_file = format!("{}/read-gcs", get_gs_path());
-    let file_io = get_file_io_gcs().await;
-    let output = file_io.new_output(&gs_file).unwrap();
-    output
-        .write(bytes::Bytes::from_static(b"iceberg!"))
-        .await
-        .expect("Write to test output file");
-    assert!(file_io.is_exist(&gs_file).await.unwrap());
+    #[tokio::test]
+    async fn gcs_read() {
+        let gs_file = format!("{}/read-gcs", get_gs_path());
+        let file_io = get_file_io_gcs().await;
+        let output = file_io.new_output(&gs_file).unwrap();
+        output
+            .write(bytes::Bytes::from_static(b"iceberg!"))
+            .await
+            .expect("Write to test output file");
+        assert!(file_io.is_exist(&gs_file).await.unwrap());
 
-    let input = file_io.new_input(gs_file).unwrap();
-    assert_eq!(input.read().await.unwrap(), Bytes::from_static(b"iceberg!"));
+        let input = file_io.new_input(gs_file).unwrap();
+        assert_eq!(input.read().await.unwrap(), Bytes::from_static(b"iceberg!"));
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg-rust/issues/551