### PR TITLE
docs: fix main iceberg example

### DIFF
--- a/crates/iceberg/README.md
+++ b/crates/iceberg/README.md
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // Consume this stream like arrow record batch stream.
-    let _data: Vec<_> = stream. try_collect().await?;
+    let _data: Vec<_> = stream.try_collect().await?;
     Ok(())
 }
 ```


### PR DESCRIPTION
Small typo in the main example for `iceberg`

This would still work, but no doubt `cargo fmt` would alter it everytime for people testing it out :smile:

