### PR TITLE
chore: update dep (https://rustsec.org/advisories/RUSTSEC-2024-0363)

### DIFF
--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -38,7 +38,7 @@ typed-builder = { workspace = true }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 itertools = { workspace = true }
 regex = "1.10.5"
-sqlx = { version = "0.8.0", features = [
+sqlx = { version = "0.8.1", features = [
   "tls-rustls",
   "runtime-tokio",
   "any",


### PR DESCRIPTION
There is a security advisory out for `sqlx` (https://rustsec.org/advisories/RUSTSEC-2024-0363) that causes our CI to fail.

Unfortunately the suggested mitigation of updating to 0.8.1 is not as yet possible, since 0.8.1 does not exist yet, until https://github.com/launchbadge/sqlx/pull/3441 gets merged.