### PR TITLE
Move `zlib` and `unicode` licenses to `allow`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,17 +23,13 @@ allow = [
   "BSD-3-Clause",
   "ISC",
   "CC0-1.0",
+  "Unicode-DFS-2016",
+  "Zlib"
 ]
 exceptions = [
   { allow = [
     "OpenSSL",
-  ], name = "ring" },
-  { allow = [
-    "Unicode-DFS-2016",
-  ], name = "unicode-ident" },
-  { allow = [
-    "Zlib",
-  ], name = "adler32" },
+  ], name = "ring" }
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
Both licenses can be moved to the `allowed` section:

- **adler32** [ships](https://github.com/remram44/adler32-rs/blob/master/LICENSE) with a **zlib** license and is a category A-license
- **unicode-ident** ships with a **UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE** which is also a category A-license

The **ring** license is a bit [more involved](https://github.com/briansmith/ring/blob/main/LICENSE) and carries a lot of history, I think it is best to keep that as an exception for now, since the OpenSSL license is also not explicitly listed on the ASF page. I don't see anything alarming in the `LICENSE` file.

ASF page on the subject: https://www.apache.org/legal/resolved.html#category-a