### PR TITLE
Python: Use hatch for dependency management

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -78,6 +78,6 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install dist/pyiceberg_core-*.whl --force-reinstall
-          pip install pytest
-          pytest -v
+          pip install hatch==1.12.0
+          hatch run dev:pip install dist/pyiceberg_core-*.whl --force-reinstall
+          hatch run dev:test

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -24,21 +24,17 @@ This project is used to build an iceberg-rust powered core for pyiceberg.
 ## Setup
 
 ```shell
-python -m venv venv
-source ./venv/bin/activate
- 
-pip install maturin
+pip install hatch==1.12.0
 ```
 
 ## Build
 
 ```shell
-maturin develop
+hatch run dev:develop
 ```
 
 ## Test
 
 ```shell
-maturin develop -E test
-pytest -v
+hatch run dev:test
 ```

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,9 +31,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
-[project.optional-dependencies]
-test = ["pytest"]
-
 [tool.maturin]
 features = ["pyo3/extension-module"]
 python-source = "python"
@@ -41,3 +38,14 @@ module-name = "pyiceberg_core.pyiceberg_core_rust"
 
 [tool.ruff.lint]
 ignore = ["F403", "F405"]
+
+[tool.hatch.envs.dev]
+dependencies = [
+    "maturin>=1.0,<2.0",
+    "pytest>=8.3.2",
+]
+
+[tool.hatch.envs.dev.scripts]
+develop = "maturin develop"
+build = "maturin build --out dist --sdist"
+test = "pytest"


### PR DESCRIPTION
Currently, the dependency management is a bit awkward because we duplicate the list of optional dependencies in `pyproject.toml` under `[project.optional-dependencies]`, and then in `.github/workflows/bindings_python_ci.yml` in order to install the optional dependencies to test the built binary.

Hatch is a lightweight dependency manager that will allow us to manage the dependencies in one place, and reuse the hatch commands in both local development, builds and environment setup in the CI