### PR TITLE
scan: change ErrorKind when table dont have spanshots

### DIFF
--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -197,10 +197,7 @@ impl<'a> TableScanBuilder<'a> {
                 .metadata()
                 .current_snapshot()
                 .ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::FeatureUnsupported,
-                        "Can't scan table without snapshots",
-                    )
+                    Error::new(ErrorKind::Unexpected, "Can't scan table without snapshots")
                 })?
                 .clone(),
         };


### PR DESCRIPTION
Previously TableScan struct was requiring a Snapshot to plan files and for empty tables without a snapshot an error was being returned instead of an empty result.

Following the same approach of Java [0] and Python [1] implementation this commit change the snapshot property to accept None values and the `plan_files` method was also changed to return an empty stream if the snapshot is not present on on PlanContext.

[0] https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/SnapshotScan.java#L119
[1] https://github.com/apache/iceberg-python/blob/main/pyiceberg/table/__init__.py#L1979

Fixes: https://github.com/apache/iceberg-rust/issues/580