### PR TITLE
feat: SortOrder methods should take schema ref if possible

### DIFF
--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -371,7 +371,7 @@ mod tests {
         let expected_sorted_order = SortOrder::builder()
             .with_order_id(0)
             .with_fields(vec![])
-            .build(expected_schema.clone())
+            .build(expected_schema)
             .unwrap();
 
         assert_eq!(

--- a/crates/iceberg/src/spec/sort.rs
+++ b/crates/iceberg/src/spec/sort.rs
@@ -135,10 +135,10 @@ impl SortOrder {
     }
 
     /// Set the order id for the sort order
-    pub fn with_order_id(&self, order_id: i64) -> SortOrder {
+    pub fn with_order_id(self, order_id: i64) -> SortOrder {
         SortOrder {
             order_id,
-            fields: self.fields.clone(),
+            fields: self.fields,
         }
     }
 }


### PR DESCRIPTION
Reduce clones

I also added two tests that didn't fail but where missing IMO