### PR TITLE
Feat: Reassign field ids for schema

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -668,6 +668,12 @@ impl NestedField {
         self.write_default = Some(value);
         self
     }
+
+    /// Set the id of the field.
+    pub(crate) fn with_id(mut self, id: i32) -> Self {
+        self.id = id;
+        self
+    }
 }
 
 impl fmt::Display for NestedField {


### PR DESCRIPTION
Required for `TableMetadataBuilder` (https://github.com/apache/iceberg-rust/pull/587).

When new TableMetadata is created, field ids should be reassign to ensure that field numbering is normalized and started from 0.