### PR TITLE
fix: reorder record batch

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -338,7 +338,10 @@ impl ArrowReader {
                 .map(|idx| mask_indices.iter().position(|&i| i == *idx).unwrap())
                 .collect::<Vec<_>>();
 
-            Ok((ProjectionMask::leaves(parquet_schema, indices), Some(reorder)))
+            Ok((
+                ProjectionMask::leaves(parquet_schema, indices),
+                Some(reorder),
+            ))
         }
     }
 

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -236,7 +236,7 @@ impl ArrowReader {
         let mut record_batch_stream = record_batch_stream_builder.build()?;
         while let Some(batch) = record_batch_stream.try_next().await? {
             let batch = if let Some(reorder) = reorder.as_ref() {
-                batch.project(&reorder).expect("must be able to reorder")
+                batch.project(reorder).expect("must be able to reorder")
             } else {
                 batch
             };


### PR DESCRIPTION
- Resolve https://github.com/apache/iceberg-rust/issues/627
- As we know, FileScanTask has two fields project_field_ids and schema. I think the RecordBatch from the reader of this FileScanTask should always follow the schema specified in FileScanTask. However, Parquet projection mask might lose the original order which is unexpected. This PR tries to fix this issue by apply a reorder to the RecordBatch