### PR TITLE
fix: page index evaluator min/max args inverted

### DIFF
--- a/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
@@ -246,10 +246,10 @@ impl<'a> PageIndexEvaluator<'a> {
                 .zip(row_counts.iter())
                 .map(|(item, &row_count)| {
                     predicate(
-                        item.max.map(|val| {
+                        item.min.map(|val| {
                             Datum::new(field_type.clone(), PrimitiveLiteral::Boolean(val))
                         }),
-                        item.min.map(|val| {
+                        item.max.map(|val| {
                             Datum::new(field_type.clone(), PrimitiveLiteral::Boolean(val))
                         }),
                         PageNullCount::from_row_and_null_counts(row_count, item.null_count),
@@ -262,9 +262,9 @@ impl<'a> PageIndexEvaluator<'a> {
                 .zip(row_counts.iter())
                 .map(|(item, &row_count)| {
                     predicate(
-                        item.max
-                            .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Int(val))),
                         item.min
+                            .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Int(val))),
+                        item.max
                             .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Int(val))),
                         PageNullCount::from_row_and_null_counts(row_count, item.null_count),
                     )
@@ -276,9 +276,9 @@ impl<'a> PageIndexEvaluator<'a> {
                 .zip(row_counts.iter())
                 .map(|(item, &row_count)| {
                     predicate(
-                        item.max
-                            .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Long(val))),
                         item.min
+                            .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Long(val))),
+                        item.max
                             .map(|val| Datum::new(field_type.clone(), PrimitiveLiteral::Long(val))),
                         PageNullCount::from_row_and_null_counts(row_count, item.null_count),
                     )
@@ -312,13 +312,13 @@ impl<'a> PageIndexEvaluator<'a> {
                 .zip(row_counts.iter())
                 .map(|(item, &row_count)| {
                     predicate(
-                        item.max.map(|val| {
+                        item.min.map(|val| {
                             Datum::new(
                                 field_type.clone(),
                                 PrimitiveLiteral::Double(OrderedFloat::from(val)),
                             )
                         }),
-                        item.min.map(|val| {
+                        item.max.map(|val| {
                             Datum::new(
                                 field_type.clone(),
                                 PrimitiveLiteral::Double(OrderedFloat::from(val)),

--- a/crates/iceberg/testdata/example_table_metadata_v2.json
+++ b/crates/iceberg/testdata/example_table_metadata_v2.json
@@ -16,7 +16,11 @@
         {"id": 1, "name": "x", "required": true, "type": "long"},
         {"id": 2, "name": "y", "required": true, "type": "long", "doc": "comment"},
         {"id": 3, "name": "z", "required": true, "type": "long"},
-        {"id": 4, "name": "a", "required": true, "type": "string"}
+        {"id": 4, "name": "a", "required": true, "type": "string"},
+        {"id": 5, "name": "dbl", "required": true, "type": "double"},
+        {"id": 6, "name": "i32", "required": true, "type": "int"},
+        {"id": 7, "name": "i64", "required": true, "type": "long"},
+        {"id": 8, "name": "bool", "required": true, "type": "boolean"}
       ]
     }
   ],


### PR DESCRIPTION
Fixes :https://github.com/apache/iceberg-rust/issues/647

I didn't catch all the places where I needed to change the order of the min / max args in an earlier refactor.

Added a few more tests to ensure this is covered properly. Also updated the other scan tests to ensure that they enable row selection as well so that this code path is covered in all of the scan tests.