### PR TITLE
WIP: Table Scan Delete File Handling

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -32,7 +32,9 @@ use fnv::FnvHashSet;
 use futures::channel::mpsc::{channel, Sender};
 use futures::future::BoxFuture;
 use futures::{try_join, SinkExt, StreamExt, TryFutureExt, TryStreamExt};
-use parquet::arrow::arrow_reader::{ArrowPredicateFn, ArrowReaderOptions, RowFilter, RowSelection};
+use parquet::arrow::arrow_reader::{
+    ArrowPredicateFn, ArrowReaderOptions, RowFilter, RowSelection, RowSelector,
+};
 use parquet::arrow::async_reader::{AsyncFileReader, MetadataLoader};
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask, PARQUET_FIELD_ID_META_KEY};
 use parquet::file::metadata::ParquetMetaData;
@@ -46,10 +48,34 @@ use crate::expr::visitors::row_group_metrics_evaluator::RowGroupMetricsEvaluator
 use crate::expr::{BoundPredicate, BoundReference};
 use crate::io::{FileIO, FileMetadata, FileRead};
 use crate::runtime::spawn;
-use crate::scan::{ArrowRecordBatchStream, FileScanTask, FileScanTaskStream};
+use crate::scan::{
+    ArrowRecordBatchStream, FileScanTask, FileScanTaskDeleteFile, FileScanTaskStream,
+};
 use crate::spec::{Datum, Schema};
 use crate::utils::available_parallelism;
 use crate::{Error, ErrorKind};
+
+// TODO: move to its own file, only here temporarily
+// Represents a parsed Delete file that can be safely stored
+// in the Object Cache.
+#[allow(dead_code)]
+enum Deletes {
+    // Positional delete files are parsed into a map of
+    // filename to a sorted list of row indices
+    Positional(HashMap<String, Vec<u64>>),
+
+    // Equality delete files are initially parsed solely as an
+    // unprocessed list of `RecordBatch`es from the equality
+    // delete files.
+    // I don't think we can do better than this by
+    // storing a Predicate (because the equality deletes use the
+    // field_id rather than the field name, so if we keep this as
+    // a Predicate then a field name change would break it).
+    // Similarly I don't think we can store this as a BoundPredicate
+    // as the column order could be different across different data
+    // files and so the accessor in the bound predicate could be invalid).
+    Equality(Vec<RecordBatch>),
+}
 
 /// Builder to create ArrowReader
 pub struct ArrowReaderBuilder {
@@ -175,6 +201,47 @@ impl ArrowReader {
         return Ok(rx.boxed());
     }
 
+    // retrieve all delete files concurrently from FileIO and parse them
+    // into `Deletes` objects
+    async fn get_deletes(
+        _delete_file_entries: Option<Arc<Vec<FileScanTaskDeleteFile>>>,
+    ) -> Vec<Deletes> {
+        // TODO: implementation
+        vec![]
+    }
+
+    fn get_positional_delete_indexes(data_file_path: &str, deletes: &[Deletes]) -> Vec<usize> {
+        let mut results = vec![];
+        deletes.iter().for_each(|d| {
+            if let Deletes::Positional(map) = d {
+                if let Some(indices) = map.get(data_file_path) {
+                    results.extend(indices.iter().map(|&i| i as usize));
+                }
+            }
+        });
+
+        results
+    }
+
+    fn get_equality_deletes(_delete_files: &[Deletes]) -> Result<Option<BoundPredicate>> {
+        let result = None;
+
+        // TODO:
+        //   reject DeleteFiles that are not equality deletes
+        //    * for each delete file:
+        //      * set `file_predicate` = AlwaysTrue
+        //      * for each row in the file:
+        //          * for each cell in the row:
+        //              * create a predicate of the form `field` = `val`
+        //                  where `field` is the column name and `val` is the value
+        //                  of the cell
+        //              * Bind this predicate to the table schema to get a `BoundPredicate`
+        //              * set file_predicate = file_predicate.and(bound_predicate_for_cell)
+        //      * set result = result.or(file_predicate)
+
+        Ok(result)
+    }
+
     async fn process_file_scan_task(
         task: FileScanTask,
         batch_size: Option<usize>,
@@ -183,6 +250,10 @@ impl ArrowReader {
         row_group_filtering_enabled: bool,
         row_selection_enabled: bool,
     ) -> Result<()> {
+        // start gathering the delete files
+        let delete_file_tasks = task.deletes.clone();
+        let delete_files_fut = spawn(async { Self::get_deletes(delete_file_tasks).await });
+
         // Get the metadata for the Parquet file we need to read and build
         // a reader for the data within
         let parquet_file = file_io.new_input(&task.data_file_path)?;
@@ -213,49 +284,106 @@ impl ArrowReader {
             record_batch_stream_builder = record_batch_stream_builder.with_batch_size(batch_size);
         }
 
-        if let Some(predicate) = &task.predicate {
+        let delete_files = delete_files_fut.await;
+        let delete_predicate = Self::get_equality_deletes(&delete_files)?;
+
+        // As well as the optional predicate supplied in the FileScanTask,
+        // if there are any equality delete files that apply to this file,
+        // we also need to construct a predicate that will implement the filtering
+        // that they require. If both are present, we logical-AND them together
+        // to form a single filter predicate that we can pass to
+        // Arrow's RecordBatchStreamBuilder.
+        let final_predicate = match (&task.predicate, delete_predicate) {
+            (None, None) => None,
+            (Some(predicate), None) => Some(predicate.clone()),
+            (None, Some(ref predicate)) => Some(predicate.clone()),
+            (Some(filter_predicate), Some(delete_predicate)) => {
+                Some(filter_predicate.clone().and(delete_predicate.clone()))
+            }
+        };
+
+        // Just as above with the row filter, there are two possible sources
+        // for potential lists of selected RowGroup indices and `RowSelection`s.
+        // Lists of selected RowGroup indices can come from two sources:
+        //   * As above, when there are equality delete files that are applicable;
+        //   * When there is a scan predicate
+        //  and row_group_filtering_enabled = true.
+        // `RowSelection`s can be created in either or both of the following cases:
+        //   * When there are positional delete files that are applicable;
+        //   * When there is a scan predicate and row_selection_enabled = true
+        // Note that, in the former case we only perform row group filtering when
+        // there is a scan predicate AND row_group_filtering_enabled = true,
+        // but we perform row selection filtering if there are applicable
+        // equality delete files OR (there is a scan predicate AND row_selection_enabled),
+        // since it is expected that the mos efficient way to apply positional deletes will
+        // always be by using a `RowSelection`.
+        let mut selected_row_group_indices = None;
+        let mut row_selection = None;
+
+        if let Some(predicate) = final_predicate {
             let (iceberg_field_ids, field_id_map) = Self::build_field_id_set_and_map(
                 record_batch_stream_builder.parquet_schema(),
-                predicate,
+                &predicate,
             )?;
 
             let row_filter = Self::get_row_filter(
-                predicate,
+                &predicate,
                 record_batch_stream_builder.parquet_schema(),
                 &iceberg_field_ids,
                 &field_id_map,
             )?;
             record_batch_stream_builder = record_batch_stream_builder.with_row_filter(row_filter);
 
-            let mut selected_row_groups = None;
             if row_group_filtering_enabled {
                 let result = Self::get_selected_row_group_indices(
-                    predicate,
+                    &predicate,
                     record_batch_stream_builder.metadata(),
                     &field_id_map,
                     &task.schema,
                 )?;
 
-                selected_row_groups = Some(result);
+                selected_row_group_indices = Some(result);
             }
 
             if row_selection_enabled {
-                let row_selection = Self::get_row_selection(
-                    predicate,
+                row_selection = Some(Self::get_predicate_row_selection(
+                    &predicate,
                     record_batch_stream_builder.metadata(),
-                    &selected_row_groups,
+                    &selected_row_group_indices,
                     &field_id_map,
                     &task.schema,
-                )?;
-
-                record_batch_stream_builder =
-                    record_batch_stream_builder.with_row_selection(row_selection);
+                )?);
             }
+        }
 
-            if let Some(selected_row_groups) = selected_row_groups {
-                record_batch_stream_builder =
-                    record_batch_stream_builder.with_row_groups(selected_row_groups);
-            }
+        let positional_delete_indexes =
+            Self::get_positional_delete_indexes(&task.data_file_path, &delete_files);
+
+        if !positional_delete_indexes.is_empty() {
+            let delete_row_selection = Self::get_deleted_row_selection(
+                record_batch_stream_builder.metadata(),
+                &selected_row_group_indices,
+                &positional_delete_indexes,
+            )?;
+
+            // merge the row selection from the delete files with the row selection
+            // from the filter predicate, if there is one from the filter predicate
+            row_selection = match row_selection {
+                None => Some(delete_row_selection),
+                Some(filter_row_selection) => {
+                    Some(filter_row_selection.intersection(&delete_row_selection))
+                }
+            };
+        }
+
+        if let Some(row_selection) = row_selection {
+            record_batch_stream_builder =
+                record_batch_stream_builder.with_row_selection(row_selection);
+        }
+
+        if let Some(selected_row_group_indices) = selected_row_group_indices {
+            record_batch_stream_builder =
+                record_batch_stream_builder.with_row_groups(selected_row_group_indices);
         }
 
         // Build the batch stream and send all the RecordBatches that it generates
@@ -406,7 +534,7 @@ impl ArrowReader {
         Ok(results)
     }
 
-    fn get_row_selection(
+    fn get_predicate_row_selection(
         predicate: &BoundPredicate,
         parquet_metadata: &Arc<ParquetMetaData>,
         selected_row_groups: &Option<Vec<usize>>,
@@ -465,6 +593,64 @@ impl ArrowReader {
         }
 
         Ok(results.into_iter().flatten().collect::<Vec<_>>().into())
+    }
+
+    fn get_deleted_row_selection(
+        parquet_metadata: &Arc<ParquetMetaData>,
+        selected_row_groups: &Option<Vec<usize>>,
+        positional_delete_indexes: &[usize],
+    ) -> Result<RowSelection> {
+        let Some(offset_index) = parquet_metadata.offset_index() else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "Parquet file metadata does not contain an offset index",
+            ));
+        };
+
+        let /*mut*/ selected_row_groups_idx = 0;
+
+        let page_index = offset_index
+            .iter()
+            .enumerate()
+            .zip(parquet_metadata.row_groups());
+
+        let results: Vec<RowSelector> = Vec::new();
+        let mut current_page_base_idx: usize = 0;
+        for ((idx, _offset_index), row_group_metadata) in page_index {
+            let page_num_rows = row_group_metadata.num_rows() as usize;
+            let _next_page_base_idx = current_page_base_idx + page_num_rows;
+
+            if let Some(selected_row_groups) = selected_row_groups {
+                // skip row groups that aren't present in selected_row_groups
+                if idx == selected_row_groups[selected_row_groups_idx] {
+                    // selected_row_groups_idx += 1;
+                } else {
+                    current_page_base_idx += page_num_rows;
+                    continue;
+                }
+            }
+
+            let Some(_next_delete_row_idx) = positional_delete_indexes.last() else {
+                break;
+            };
+
+            // TODO: logic goes here to create `RowSelection`s for the
+            //   current page, based on popping delete indices that are
+            //   on this page
+            break;
+            // while *next_delete_row_idx < next_page_base_idx {
+            // }
+
+            // if let Some(selected_row_groups) = selected_row_groups {
+            //     if selected_row_groups_idx == selected_row_groups.len() {
+            //         break;
+            //     }
+            // }
+            //
+            // current_page_base_idx += page_num_rows;
+        }
+
+        Ok(results.into())
     }
 }
 

--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -670,6 +670,12 @@ pub enum BoundPredicate {
     Set(SetExpression<BoundReference>),
 }
 
+impl BoundPredicate {
+    pub(crate) fn and(self, other: BoundPredicate) -> BoundPredicate {
+        BoundPredicate::And(LogicalExpression::new([Box::new(self), Box::new(other)]))
+    }
+}
+
 impl Display for BoundPredicate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -496,6 +496,16 @@ struct ManifestFileContext {
     object_cache: Arc<ObjectCache>,
     snapshot_schema: SchemaRef,
     expression_evaluator_cache: Arc<ExpressionEvaluatorCache>,
+    deletes: Option<Arc<Vec<FileScanTaskDeleteFile>>>,
+}
+
+impl ManifestFileContext {
+    fn with_deletes(self, deletes: Arc<Vec<FileScanTaskDeleteFile>>) -> Self {
+        Self {
+            deletes: Some(deletes),
+            ..self
+        }
+    }
 }
 
 /// Wraps a [`ManifestEntryRef`] alongside the objects that are needed
@@ -508,6 +518,7 @@ struct ManifestEntryContext {
     bound_predicates: Option<Arc<BoundPredicates>>,
     partition_spec_id: i32,
     snapshot_schema: SchemaRef,
+    deletes: Option<Arc<Vec<FileScanTaskDeleteFile>>>,
 }
 
 impl ManifestFileContext {
@@ -522,6 +533,7 @@ impl ManifestFileContext {
             field_ids,
             mut sender,
             expression_evaluator_cache,
+            deletes,
             ..
         } = self;
 
@@ -529,13 +541,14 @@ impl ManifestFileContext {
 
         for manifest_entry in manifest.entries() {
             let manifest_entry_context = ManifestEntryContext {
-                // TODO: refactor to avoid clone
+                // TODO: refactor to avoid the expensive ManifestEntry clone
                 manifest_entry: manifest_entry.clone(),
                 expression_evaluator_cache: expression_evaluator_cache.clone(),
                 field_ids: field_ids.clone(),
                 partition_spec_id: manifest_file.partition_spec_id,
                 bound_predicates: bound_predicates.clone(),
                 snapshot_schema: snapshot_schema.clone(),
+                deletes: deletes.clone(),
             };
 
             sender
@@ -566,6 +579,9 @@ impl ManifestEntryContext {
             predicate: self
                 .bound_predicates
                 .map(|x| x.as_ref().snapshot_bound_predicate.clone()),
+
+            // TODO
+            deletes: self.deletes,
         }
     }
 }
@@ -604,15 +620,19 @@ impl PlanContext {
         manifest_list: Arc<ManifestList>,
         sender: Sender<ManifestEntryContext>,
     ) -> Result<Box<impl Iterator<Item = Result<ManifestFileContext>>>> {
-        let filtered_entries = manifest_list
+        let manifest_files = manifest_list
             .entries()
             .iter()
-            .filter(|manifest_file| manifest_file.content == ManifestContentType::Data);
+            // .filter(|manifest_file| manifest_file.content == ManifestContentType::Data)
+        ;
+
+        let mut delete_files = vec![];
 
         // TODO: Ideally we could ditch this intermediate Vec as we return an iterator.
         let mut filtered_mfcs = vec![];
+
         if self.predicate.is_some() {
-            for manifest_file in filtered_entries {
+            for manifest_file in manifest_files {
                 let partition_bound_predicate = self.get_partition_filter(manifest_file)?;
 
                 // evaluate the ManifestFile against the partition filter. Skip
@@ -625,22 +645,38 @@ impl PlanContext {
                     )
                     .eval(manifest_file)?
                 {
-                    let mfc = self.create_manifest_file_context(
-                        manifest_file,
-                        Some(partition_bound_predicate),
-                        sender.clone(),
-                    );
-                    filtered_mfcs.push(Ok(mfc));
+                    if manifest_file.content == ManifestContentType::Data {
+                        let mfc = self.create_manifest_file_context(
+                            manifest_file,
+                            Some(partition_bound_predicate),
+                            sender.clone(),
+                        );
+                        filtered_mfcs.push(Ok(mfc));
+                    } else {
+                        delete_files.push(FileScanTaskDeleteFile {
+                            file_path: manifest_file.manifest_path.clone(),
+                        });
+                    }
                 }
             }
         } else {
-            for manifest_file in filtered_entries {
-                let mfc = self.create_manifest_file_context(manifest_file, None, sender.clone());
-                filtered_mfcs.push(Ok(mfc));
+            for manifest_file in manifest_files {
+                if manifest_file.content == ManifestContentType::Data {
+                    let mfc =
+                        self.create_manifest_file_context(manifest_file, None, sender.clone());
+                    filtered_mfcs.push(Ok(mfc));
+                } else {
+                    delete_files.push(FileScanTaskDeleteFile {
+                        file_path: manifest_file.manifest_path.clone(),
+                    });
+                }
             }
         }
 
-        Ok(Box::new(filtered_mfcs.into_iter()))
+        let deletes = Arc::new(delete_files);
+        Ok(Box::new(filtered_mfcs.into_iter().map(move |mfc| {
+            mfc.map(|mfc| mfc.with_deletes(deletes.clone()))
+        })))
     }
 
     fn create_manifest_file_context(
@@ -669,6 +705,7 @@ impl PlanContext {
             snapshot_schema: self.snapshot_schema.clone(),
             field_ids: self.field_ids.clone(),
             expression_evaluator_cache: self.expression_evaluator_cache.clone(),
+            deletes: None,
         }
     }
 }
@@ -895,8 +932,10 @@ pub struct FileScanTask {
 
     /// The data file path corresponding to the task.
     pub data_file_path: String,
+
     /// The content type of the file to scan.
     pub data_file_content: DataContentType,
+
     /// The format of the file to scan.
     pub data_file_format: DataFileFormat,
 
@@ -907,6 +946,16 @@ pub struct FileScanTask {
     /// The predicate to filter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub predicate: Option<BoundPredicate>,
+
+    /// The list of delete files that may need to be applied to this data file
+    pub deletes: Option<Arc<Vec<FileScanTaskDeleteFile>>>,
+}
+
+/// A task to scan part of file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileScanTaskDeleteFile {
+    /// The delete file path
+    pub file_path: String,
 }
 
 #[cfg(test)]
@@ -1614,6 +1663,7 @@ mod tests {
             schema: schema.clone(),
             record_count: Some(100),
             data_file_format: DataFileFormat::Parquet,
+            deletes: None,
         };
         test_fn(task);
 
@@ -1628,6 +1678,7 @@ mod tests {
             schema,
             record_count: None,
             data_file_format: DataFileFormat::Avro,
+            deletes: None,
         };
         test_fn(task);
     }


### PR DESCRIPTION
This Draft PR outlines an approach to add support for proper handling of delete files within table scans.

The approach taken is to include a list of delete file paths in every `FileScanTask`. At the moment it is assumed that this list refers to delete files that **may** apply to the data file in the scan, rather than having been filtered to only contain delete files that definitely do apply to this data file. Further optimisation of `plan_files` is expected in the future to ensure that this list is pre-filtered before being included in the FileScanTask.

The arrow reader now has the responsibility of retrieving the applicable delete files from FileIO as well as the data file. Thanks to the Object Cache already being in place, if there are file scan tasks being handled in parallel in the same process that both attempt to load the same delete file, the Object Cache should ensure that only a single load and parse occurs.

The approach taken for handling each type of delete file is as follows:

## Positional Deletes

Positional Delete support is implemented using the `RowSelection` functionality of the parquet arrow reader that we are already using. The list of applicable positional delete indices is turned into a `RowSelection`. If the scan already has `enable_row_selection` enabled and there is a scan filter predicate, then the `RowSelection` from this is intersected with the positional delete `RowSelection` to yield a single combined `RowSelection`.

## Equality Deletes

All rows from all applicable equality delete files are combined together to create a single `BoundPredicate`. If the scan also has a filter predicate, this is ANDed with the delete predicate to form a final combined `BoundPredicate` that is used as before to construct the arrow `RowFilter` and is also used in the row group filtering.

## TODO

There is deliberately quite a lot of TODOs in here. This PR exists to get buy-in on the approach before all the implementation details are added and tests written. The code in this branch still builds though and all the tests (should! 😅 ) pass.