### PR TITLE
chore: fix typo in FileIO Schemes 

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -40,7 +40,7 @@ use crate::{Error, ErrorKind, Result};
 /// | Local file system  | `storage-fs`      | `file`     |
 /// | Memory             | `storage-memory`  | `memory`   |
 /// | S3                 | `storage-s3`      | `s3`, `s3a`|
-/// | GCS                | `storage-gcs`     | `gs`       |
+/// | GCS                | `storage-gcs`     | `gcs`       |
 #[derive(Clone, Debug)]
 pub struct FileIO {
     inner: Arc<Storage>,

--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -164,7 +164,7 @@ impl Storage {
             "memory" => Ok(Scheme::Memory),
             "file" | "" => Ok(Scheme::Fs),
             "s3" | "s3a" => Ok(Scheme::S3),
-            "gs" => Ok(Scheme::Gcs),
+            "gcs" => Ok(Scheme::Gcs),
             s => Ok(s.parse::<Scheme>()?),
         }
     }


### PR DESCRIPTION
For google cloud storage, it should be called `gcs` instead of `gs`