### PR TITLE
fix: do not sort indices for  `ProjectionMask::leaves`

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -362,11 +362,10 @@ impl ArrowReader {
     ) -> Result<RowFilter> {
         // Collect Parquet column indices from field ids.
         // If the field id is not found in Parquet schema, it will be ignored due to schema evolution.
-        let mut column_indices = iceberg_field_ids
+        let column_indices = iceberg_field_ids
             .iter()
             .filter_map(|field_id| field_id_map.get(field_id).cloned())
             .collect::<Vec<_>>();
-        column_indices.sort();
 
         // The converter that converts `BoundPredicates` to `ArrowPredicates`
         let mut converter = PredicateConverter {


### PR DESCRIPTION
The order of indices passed into `ProjectionMask::leaves`  is meaningless, because "repeated or out of order indices will not impact the final mask"(refer to https://docs.rs/crate/parquet/latest/source/src/arrow/mod.rs#179).  Therefore, we don't need to perform an extra sort, which increases the overhead.