### PR TITLE
fix(type): fix type promote to ignore field name.

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -143,8 +143,9 @@ impl RecordBatchTransformer {
                 ref target_schema,
                 ref operations,
             }) => {
-                let options =
-                    RecordBatchOptions::default().with_row_count(Some(record_batch.num_rows()));
+                let options = RecordBatchOptions::default()
+                    .with_match_field_names(false)
+                    .with_row_count(Some(record_batch.num_rows()));
                 RecordBatch::try_new_with_options(
                     target_schema.clone(),
                     self.transform_columns(record_batch.columns(), operations)?,


### PR DESCRIPTION
Iceberg-rust changes the arrow map type field name from `entries` to `key_value`. I think we should ignore the field name check when performing type promoting.