### PR TITLE
chore: upgrade to DataFusion 43

### DIFF
--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -23,7 +23,7 @@ homepage = { workspace = true }
 rust-version = { workspace = true }
 
 categories = ["database"]
-description = "Apache Iceberg Datafusion Integration"
+description = "Apache Iceberg DataFusion Integration"
 repository = { workspace = true }
 license = { workspace = true }
 keywords = ["iceberg", "integrations", "datafusion"]
@@ -31,7 +31,7 @@ keywords = ["iceberg", "integrations", "datafusion"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-datafusion = { version = "42" }
+datafusion = { version = "43" }
 futures = { workspace = true }
 iceberg = { workspace = true }
 tokio = { workspace = true }

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -30,6 +30,7 @@ use crate::schema::IcebergSchemaProvider;
 ///
 /// Acts as a centralized catalog provider that aggregates
 /// multiple [`SchemaProvider`], each associated with distinct namespaces.
+#[derive(Debug)]
 pub struct IcebergCatalogProvider {
     /// A `HashMap` where keys are namespace names
     /// and values are dynamic references to objects implementing the

--- a/crates/integrations/datafusion/src/schema.rs
+++ b/crates/integrations/datafusion/src/schema.rs
@@ -30,6 +30,7 @@ use crate::table::IcebergTableProvider;
 
 /// Represents a [`SchemaProvider`] for the Iceberg [`Catalog`], managing
 /// access to table providers within a specific namespace.
+#[derive(Debug)]
 pub(crate) struct IcebergSchemaProvider {
     /// A `HashMap` where keys are table names
     /// and values are dynamic references to objects implementing the

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -35,6 +35,7 @@ use crate::physical_plan::scan::IcebergTableScan;
 
 /// Represents a [`TableProvider`] for the Iceberg [`Catalog`],
 /// managing access to a [`Table`].
+#[derive(Debug)]
 pub struct IcebergTableProvider {
     /// A table in the catalog.
     table: Table,

--- a/crates/integrations/datafusion/src/table/table_provider_factory.rs
+++ b/crates/integrations/datafusion/src/table/table_provider_factory.rs
@@ -97,7 +97,7 @@ use crate::to_datafusion_error;
 /// # Errors
 /// An error will be returned if any unsupported feature, such as partition columns,
 /// order expressions, constraints, or column defaults, is detected in the table creation command.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct IcebergTableProviderFactory {}
 
 impl IcebergTableProviderFactory {
@@ -241,6 +241,7 @@ mod tests {
             constraints: Constraints::empty(),
             column_defaults: Default::default(),
             if_not_exists: Default::default(),
+            temporary: false,
             definition: Default::default(),
             unbounded: Default::default(),
         }


### PR DESCRIPTION
The sole code change here is that `Debug` is a new trait bound for a lot of DataFusion traits now: https://github.com/apache/datafusion/issues/12555.