### PR TITLE
feat: Expose length of Iterators via ExactSizeIterator

### DIFF
--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -358,7 +358,7 @@ impl Schema {
 
     /// Returns [`identifier_field_ids`].
     #[inline]
-    pub fn identifier_field_ids(&self) -> impl Iterator<Item = i32> + '_ {
+    pub fn identifier_field_ids(&self) -> impl ExactSizeIterator<Item = i32> + '_ {
         self.identifier_field_ids.iter().copied()
     }
 

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -203,7 +203,7 @@ impl TableMetadata {
 
     /// Returns schemas
     #[inline]
-    pub fn schemas_iter(&self) -> impl Iterator<Item = &SchemaRef> {
+    pub fn schemas_iter(&self) -> impl ExactSizeIterator<Item = &SchemaRef> {
         self.schemas.values()
     }
 
@@ -228,7 +228,9 @@ impl TableMetadata {
 
     /// Returns all partition specs.
     #[inline]
-    pub fn partition_specs_iter(&self) -> impl Iterator<Item = &SchemalessPartitionSpecRef> {
+    pub fn partition_specs_iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &SchemalessPartitionSpecRef> {
         self.partition_specs.values()
     }
 
@@ -252,7 +254,7 @@ impl TableMetadata {
 
     /// Returns all snapshots
     #[inline]
-    pub fn snapshots(&self) -> impl Iterator<Item = &SnapshotRef> {
+    pub fn snapshots(&self) -> impl ExactSizeIterator<Item = &SnapshotRef> {
         self.snapshots.values()
     }
 
@@ -301,7 +303,7 @@ impl TableMetadata {
 
     /// Return all sort orders.
     #[inline]
-    pub fn sort_orders_iter(&self) -> impl Iterator<Item = &SortOrderRef> {
+    pub fn sort_orders_iter(&self) -> impl ExactSizeIterator<Item = &SortOrderRef> {
         self.sort_orders.values()
     }
 

--- a/crates/iceberg/src/spec/values.rs
+++ b/crates/iceberg/src/spec/values.rs
@@ -1560,7 +1560,7 @@ impl Struct {
     }
 
     /// Create a iterator to read the field in order of field_value.
-    pub fn iter(&self) -> impl Iterator<Item = Option<&Literal>> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = Option<&Literal>> {
         self.null_bitmap.iter().zip(self.fields.iter()).map(
             |(null, value)| {
                 if *null {

--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -94,7 +94,7 @@ impl ViewMetadata {
 
     /// Returns all view versions.
     #[inline]
-    pub fn versions(&self) -> impl Iterator<Item = &ViewVersionRef> {
+    pub fn versions(&self) -> impl ExactSizeIterator<Item = &ViewVersionRef> {
         self.versions.values()
     }
 
@@ -114,7 +114,7 @@ impl ViewMetadata {
 
     /// Returns schemas
     #[inline]
-    pub fn schemas_iter(&self) -> impl Iterator<Item = &SchemaRef> {
+    pub fn schemas_iter(&self) -> impl ExactSizeIterator<Item = &SchemaRef> {
         self.schemas.values()
     }
 


### PR DESCRIPTION
In `iceberg-rust` we currently have quite a few `Iterators` over fields without a lightweight option to determine length. In `Lakekeeper` we have some places where we need to know the length of fields - especially for the `Iterators` used in `TableMetadata`. Using `xx_iter().count()` isn't nice.

It would be great if we could expose the `len` in a more straightforward way, either by explicit methods or by using `ExactSizeIterator` as proposed in this PR.

Let me know what you think!