### PR TITLE
feat(FileIO): Adds user extensible FileIO

### DIFF
--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -23,7 +23,7 @@ use opendal::services::GcsConfig;
 use opendal::services::S3Config;
 use opendal::{Operator, Scheme};
 
-use super::FileIOBuilder;
+use super::{FileIOBuilder, FileIOExtension};
 use crate::{Error, ErrorKind};
 
 /// The storage carries all supported storage services in iceberg
@@ -45,7 +45,10 @@ pub(crate) enum Storage {
         config: Arc<S3Config>,
     },
     #[cfg(feature = "storage-gcs")]
-    Gcs { config: Arc<GcsConfig> },
+    Gcs {
+        config: Arc<GcsConfig>,
+    },
+    Extension(Arc<dyn FileIOExtension>),
 }
 
 impl Storage {
@@ -133,6 +136,7 @@ impl Storage {
                     ))
                 }
             }
+            Storage::Extension(_) => todo!(),
             #[cfg(feature = "storage-gcs")]
             Storage::Gcs { config } => {
                 let operator = super::gcs_config_build(config, path)?;


### PR DESCRIPTION
 - Stubs out the initial required items to build a backwards compatible FileIO extension

##

Based on the discussion in #172 it seemed like a backwards compatible FileIO extension may be the desired path to allow user extensible implementations for FileIO operations. I often find it difficult to fully grasp how any given change may need to trickle through the existing codebase, so I wanted to do a quick implementation to help move along any design around extensible FileIO. I figured building a concrete implementation as a draft so the community can provide feedback would be a good path forward. Given the discussion, feedback from @Xuanwo is likely needed, as well as any others who'd like to chime in.