### PR TITLE
Add `fallback` attribute to all `strip_option`s.

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -39,9 +39,9 @@ use crate::with_catalog_id;
 #[derive(Debug, TypedBuilder)]
 /// Glue Catalog configuration
 pub struct GlueCatalogConfig {
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = uri_opt)))]
     uri: Option<String>,
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = catalog_id_opt)))]
     catalog_id: Option<String>,
     warehouse: String,
     #[builder(default)]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -50,7 +50,7 @@ const PATH_V1: &str = "v1";
 #[derive(Clone, Debug, TypedBuilder)]
 pub struct RestCatalogConfig {
     uri: String,
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = warehouse_opt)))]
     warehouse: Option<String>,
 
     #[builder(default)]

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -238,15 +238,15 @@ pub struct TableCreation {
     /// The name of the table.
     pub name: String,
     /// The location of the table.
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = location_opt)))]
     pub location: Option<String>,
     /// The schema of the table.
     pub schema: Schema,
     /// The partition spec of the table, could be None.
-    #[builder(default, setter(strip_option, into))]
+    #[builder(default, setter(strip_option(fallback = partition_spec_opt), into))]
     pub partition_spec: Option<UnboundPartitionSpec>,
     /// The sort order of the table.
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = sort_order_opt)))]
     pub sort_order: Option<SortOrder>,
     /// The properties of the table.
     #[builder(default)]

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -821,19 +821,19 @@ pub struct ManifestEntry {
     ///
     /// Snapshot id where the file was added, or deleted if status is 2.
     /// Inherited when null.
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = snapshot_id_opt)))]
     snapshot_id: Option<i64>,
     /// field id: 3
     ///
     /// Data sequence number of the file.
     /// Inherited when null and status is 1 (added).
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = sequence_number_opt)))]
     sequence_number: Option<i64>,
     /// field id: 4
     ///
     /// File sequence number indicating when the file was added.
     /// Inherited when null and status is 1 (added).
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = file_sequence_number_opt)))]
     file_sequence_number: Option<i64>,
     /// field id: 2
     ///

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -229,7 +229,7 @@ pub struct UnboundPartitionField {
     pub source_id: i32,
     /// A partition field id that is used to identify a partition field and is unique within a partition spec.
     /// In v2 table metadata, it is unique across all partition specs.
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(strip_option(fallback = field_id_opt)))]
     pub field_id: Option<i32>,
     /// A partition name.
     pub name: String,

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -93,7 +93,7 @@ pub struct Snapshot {
     /// A string map that summarizes the snapshot changes, including operation.
     summary: Summary,
     /// ID of the table’s current schema when the snapshot was created.
-    #[builder(setter(strip_option), default = None)]
+    #[builder(setter(strip_option(fallback = schema_id_opt)), default = None)]
     schema_id: Option<SchemaId>,
 }
 


### PR DESCRIPTION
Auto-derived `TypedBuilder` traits in combination with `strip_option` attributes are very hard to use in scenarios where options passed to the builder depend on user input. The problem is that this pattern doesn't work, since the two match branches return different types:

```rust
let builder = match x {
    None => builder,
    Some(x) => builder.x(x),
};
```

Fortunately typed_builder 0.20 supports an additional attribute (`fallback`) that generates a builder method that takes `Option<T>` in addition to the method that takes naked `T`.

With this attribute, we can write `let builder = builder.x_opt(x)`.

This commit adds the `fallback` attribute to all fields that have the `strip_option` annotation.