### PR TITLE
fix: expand arrow to iceberg schema to handle nanosecond timestamp

### DIFF
--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -382,12 +382,15 @@ impl ArrowSchemaVisitor for ArrowSchemaConverter {
             DataType::Time64(unit) if unit == &TimeUnit::Microsecond => {
                 Ok(Type::Primitive(PrimitiveType::Time))
             }
-            DataType::Timestamp(unit, None) if unit == &TimeUnit::Microsecond => {
+            DataType::Timestamp(unit, None)
+                if unit == &TimeUnit::Microsecond || unit == &TimeUnit::Nanosecond =>
+            {
                 Ok(Type::Primitive(PrimitiveType::Timestamp))
             }
             DataType::Timestamp(unit, Some(zone))
                 if unit == &TimeUnit::Microsecond
-                    && (zone.as_ref() == "UTC" || zone.as_ref() == "+00:00") =>
+                    || unit == &TimeUnit::Nanosecond
+                        && (zone.as_ref() == "UTC" || zone.as_ref() == "+00:00") =>
             {
                 Ok(Type::Primitive(PrimitiveType::Timestamptz))
             }


### PR DESCRIPTION
Closes https://github.com/apache/iceberg-rust/issues/709

Nanosecond precision can be written by `parquet-rs` and [`iceberg-rust` has some support for this recently](https://github.com/apache/iceberg-rust/pull/542) too.

The `DataType::Timestamp` itself is caught by the Arrow's own [`is_temporal`](https://github.com/apache/arrow-rs/blob/853626ef519bd68bfd604bf6d136f8677bedb1eb/arrow-schema/src/datatype.rs#L497-L505) function usage within the [`is_primitive`](https://github.com/apache/iceberg-rust/blob/697a20060f2247da87f73073e8bf5ab407bd40ea/crates/iceberg/src/arrow/schema.rs#L116) usage for Iceberg - this is why I haven't expanded the `match` arm.
