### PR TITLE
refine: refine interface of ManifestWriter

### DIFF
--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -265,7 +265,7 @@ mod tests {
             // Write data files
             let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
-                current_snapshot.snapshot_id(),
+                Some(current_snapshot.snapshot_id()),
                 vec![],
                 current_schema.clone(),
                 current_partition_spec.as_ref().clone(),

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -192,9 +192,8 @@ mod tests {
     use super::*;
     use crate::io::{FileIO, OutputFile};
     use crate::spec::{
-        DataContentType, DataFileBuilder, DataFileFormat, FormatVersion, Literal, Manifest,
-        ManifestContentType, ManifestEntry, ManifestListWriter, ManifestMetadata, ManifestStatus,
-        ManifestWriter, Struct, TableMetadata,
+        DataContentType, DataFileBuilder, DataFileFormat, Literal, ManifestEntry,
+        ManifestListWriter, ManifestStatus, ManifestWriterBuilder, Struct, TableMetadata,
     };
     use crate::table::Table;
     use crate::TableIdent;
@@ -264,37 +263,33 @@ mod tests {
             let current_partition_spec = self.table.metadata().default_partition_spec();
 
             // Write data files
-            let data_file_manifest = ManifestWriter::new(
+            let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
                 current_snapshot.snapshot_id(),
                 vec![],
+                current_schema.clone(),
+                current_partition_spec.as_ref().clone(),
             )
-            .write(Manifest::new(
-                ManifestMetadata::builder()
-                    .schema(current_schema.clone())
-                    .content(ManifestContentType::Data)
-                    .format_version(FormatVersion::V2)
-                    .partition_spec((**current_partition_spec).clone())
-                    .schema_id(current_schema.schema_id())
-                    .build(),
-                vec![ManifestEntry::builder()
-                    .status(ManifestStatus::Added)
-                    .data_file(
-                        DataFileBuilder::default()
-                            .content(DataContentType::Data)
-                            .file_path(format!("{}/1.parquet", &self.table_location))
-                            .file_format(DataFileFormat::Parquet)
-                            .file_size_in_bytes(100)
-                            .record_count(1)
-                            .partition(Struct::from_iter([Some(Literal::long(100))]))
-                            .key_metadata(None)
-                            .build()
-                            .unwrap(),
-                    )
-                    .build()],
-            ))
-            .await
-            .unwrap();
+            .build_v2_data();
+            writer
+                .add(
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Added)
+                        .data_file(
+                            DataFileBuilder::default()
+                                .content(DataContentType::Data)
+                                .file_path(format!("{}/1.parquet", &self.table_location))
+                                .file_format(DataFileFormat::Parquet)
+                                .file_size_in_bytes(100)
+                                .record_count(1)
+                                .partition(Struct::from_iter([Some(Literal::long(100))]))
+                                .build()
+                                .unwrap(),
+                        )
+                        .build(),
+                )
+                .unwrap();
+            let data_file_manifest = writer.to_manifest_file().await.unwrap();
 
             // Write to manifest list
             let mut manifest_list_write = ManifestListWriter::v2(

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -272,7 +272,7 @@ mod tests {
             )
             .build_v2_data();
             writer
-                .add(
+                .add_entry(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Added)
                         .data_file(
@@ -289,7 +289,7 @@ mod tests {
                         .build(),
                 )
                 .unwrap();
-            let data_file_manifest = writer.to_manifest_file().await.unwrap();
+            let data_file_manifest = writer.write_manifest_file().await.unwrap();
 
             // Write to manifest list
             let mut manifest_list_write = ManifestListWriter::v2(

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -1061,7 +1061,7 @@ pub mod tests {
             // Write data files
             let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
-                current_snapshot.snapshot_id(),
+                Some(current_snapshot.snapshot_id()),
                 vec![],
                 current_schema.clone(),
                 current_partition_spec.as_ref().clone(),

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -983,9 +983,9 @@ pub mod tests {
     use crate::io::{FileIO, OutputFile};
     use crate::scan::FileScanTask;
     use crate::spec::{
-        DataContentType, DataFileBuilder, DataFileFormat, Datum, FormatVersion, Literal, Manifest,
-        ManifestContentType, ManifestEntry, ManifestListWriter, ManifestMetadata, ManifestStatus,
-        ManifestWriter, NestedField, PrimitiveType, Schema, Struct, TableMetadata, Type,
+        DataContentType, DataFileBuilder, DataFileFormat, Datum, Literal, ManifestEntry,
+        ManifestListWriter, ManifestStatus, ManifestWriterBuilder, NestedField, PrimitiveType,
+        Schema, Struct, TableMetadata, Type,
     };
     use crate::table::Table;
     use crate::TableIdent;
@@ -1059,20 +1059,16 @@ pub mod tests {
             let current_partition_spec = self.table.metadata().default_partition_spec();
 
             // Write data files
-            let data_file_manifest = ManifestWriter::new(
+            let mut writer = ManifestWriterBuilder::new(
                 self.next_manifest_file(),
                 current_snapshot.snapshot_id(),
                 vec![],
+                current_schema.clone(),
+                current_partition_spec.as_ref().clone(),
             )
-            .write(Manifest::new(
-                ManifestMetadata::builder()
-                    .schema(current_schema.clone())
-                    .content(ManifestContentType::Data)
-                    .format_version(FormatVersion::V2)
-                    .partition_spec((**current_partition_spec).clone())
-                    .schema_id(current_schema.schema_id())
-                    .build(),
-                vec![
+            .build_v2_data();
+            writer
+                .add(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Added)
                         .data_file(
@@ -1088,6 +1084,10 @@ pub mod tests {
                                 .unwrap(),
                         )
                         .build(),
+                )
+                .unwrap();
+            writer
+                .delete(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Deleted)
                         .snapshot_id(parent_snapshot.snapshot_id())
@@ -1105,6 +1105,10 @@ pub mod tests {
                                 .unwrap(),
                         )
                         .build(),
+                )
+                .unwrap();
+            writer
+                .existing(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Existing)
                         .snapshot_id(parent_snapshot.snapshot_id())
@@ -1122,10 +1126,9 @@ pub mod tests {
                                 .unwrap(),
                         )
                         .build(),
-                ],
-            ))
-            .await
-            .unwrap();
+                )
+                .unwrap();
+            let data_file_manifest = writer.to_manifest_file().await.unwrap();
 
             // Write to manifest list
             let mut manifest_list_write = ManifestListWriter::v2(

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -1068,7 +1068,7 @@ pub mod tests {
             )
             .build_v2_data();
             writer
-                .add(
+                .add_entry(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Added)
                         .data_file(
@@ -1087,7 +1087,7 @@ pub mod tests {
                 )
                 .unwrap();
             writer
-                .delete(
+                .add_delete_entry(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Deleted)
                         .snapshot_id(parent_snapshot.snapshot_id())
@@ -1108,7 +1108,7 @@ pub mod tests {
                 )
                 .unwrap();
             writer
-                .existing(
+                .add_existing_entry(
                     ManifestEntry::builder()
                         .status(ManifestStatus::Existing)
                         .snapshot_id(parent_snapshot.snapshot_id())
@@ -1128,7 +1128,7 @@ pub mod tests {
                         .build(),
                 )
                 .unwrap();
-            let data_file_manifest = writer.to_manifest_file().await.unwrap();
+            let data_file_manifest = writer.write_manifest_file().await.unwrap();
 
             // Write to manifest list
             let mut manifest_list_write = ManifestListWriter::v2(

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -114,6 +114,70 @@ impl Manifest {
     }
 }
 
+/// The builder used to create a [`ManifestWriter`].
+pub struct ManifestWriterBuilder {
+    output: OutputFile,
+    snapshot_id: i64,
+    key_metadata: Vec<u8>,
+    schema: SchemaRef,
+    partition_spec: PartitionSpec,
+}
+
+impl ManifestWriterBuilder {
+    /// Create a new builder.
+    pub fn new(
+        output: OutputFile,
+        snapshot_id: i64,
+        key_metadata: Vec<u8>,
+        schema: SchemaRef,
+        partition_spec: PartitionSpec,
+    ) -> Self {
+        Self {
+            output,
+            snapshot_id,
+            key_metadata,
+            schema,
+            partition_spec,
+        }
+    }
+
+    /// Build a [`ManifestWriter`] for format version 1.
+    pub fn build_v1(self) -> ManifestWriter {
+        let metadata = ManifestMetadata::builder()
+            .schema_id(self.schema.schema_id())
+            .schema(self.schema)
+            .partition_spec(self.partition_spec)
+            .format_version(FormatVersion::V1)
+            .content(ManifestContentType::Data)
+            .build();
+        ManifestWriter::new(self.output, self.snapshot_id, self.key_metadata, metadata)
+    }
+
+    /// Build a [`ManifestWriter`] for format version 2, data content.
+    pub fn build_v2_data(self) -> ManifestWriter {
+        let metadata = ManifestMetadata::builder()
+            .schema_id(self.schema.schema_id())
+            .schema(self.schema)
+            .partition_spec(self.partition_spec)
+            .format_version(FormatVersion::V2)
+            .content(ManifestContentType::Data)
+            .build();
+        ManifestWriter::new(self.output, self.snapshot_id, self.key_metadata, metadata)
+    }
+
+    /// Build a [`ManifestWriter`] for format version 2, deletes content.
+    pub fn build_v2_deletes(self) -> ManifestWriter {
+        let metadata = ManifestMetadata::builder()
+            .schema_id(self.schema.schema_id())
+            .schema(self.schema)
+            .partition_spec(self.partition_spec)
+            .format_version(FormatVersion::V2)
+            .content(ManifestContentType::Deletes)
+            .build();
+        ManifestWriter::new(self.output, self.snapshot_id, self.key_metadata, metadata)
+    }
+}
+
 /// A manifest writer.
 pub struct ManifestWriter {
     output: OutputFile,
@@ -131,7 +195,9 @@ pub struct ManifestWriter {
 
     key_metadata: Vec<u8>,
 
-    partitions: Vec<Struct>,
+    manifset_entries: Vec<ManifestEntry>,
+
+    metadata: ManifestMetadata,
 }
 
 struct PartitionFieldStats {
@@ -198,7 +264,12 @@ impl PartitionFieldStats {
 
 impl ManifestWriter {
     /// Create a new manifest writer.
-    pub fn new(output: OutputFile, snapshot_id: i64, key_metadata: Vec<u8>) -> Self {
+    pub(crate) fn new(
+        output: OutputFile,
+        snapshot_id: i64,
+        key_metadata: Vec<u8>,
+        metadata: ManifestMetadata,
+    ) -> Self {
         Self {
             output,
             snapshot_id,
@@ -210,7 +281,8 @@ impl ManifestWriter {
             deleted_rows: 0,
             min_seq_num: None,
             key_metadata,
-            partitions: vec![],
+            manifset_entries: Vec::new(),
+            metadata,
         }
     }
 
@@ -218,14 +290,13 @@ impl ManifestWriter {
         &mut self,
         partition_type: &StructType,
     ) -> Result<Vec<FieldSummary>> {
-        let partitions = std::mem::take(&mut self.partitions);
         let mut field_stats: Vec<_> = partition_type
             .fields()
             .iter()
             .map(|f| PartitionFieldStats::new(f.field_type.as_primitive_type().unwrap().clone()))
             .collect();
-        for partition in partitions {
-            for (literal, stat) in partition.into_iter().zip_eq(field_stats.iter_mut()) {
+        for partition in self.manifset_entries.iter().map(|e| &e.data_file.partition) {
+            for (literal, stat) in partition.iter().zip_eq(field_stats.iter_mut()) {
                 let primitive_literal = literal.map(|v| v.as_primitive_literal().unwrap());
                 stat.update(primitive_literal)?;
             }
@@ -233,15 +304,118 @@ impl ManifestWriter {
         Ok(field_stats.into_iter().map(|stat| stat.finish()).collect())
     }
 
-    /// Write a manifest.
-    pub async fn write(mut self, manifest: Manifest) -> Result<ManifestFile> {
+    fn check_entry(&self, entry: &ManifestEntry) -> Result<()> {
+        match self.metadata.content {
+            ManifestContentType::Data => {
+                if entry.data_file.content != DataContentType::Data {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Content type of entry {:?} should have DataContentType::Data",
+                            entry.data_file.content
+                        ),
+                    ));
+                }
+            }
+            ManifestContentType::Deletes => {
+                if entry.data_file.content != DataContentType::EqualityDeletes
+                    && entry.data_file.content != DataContentType::PositionDeletes
+                {
+                    return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!("Content type of entry {:?} should have DataContentType::EqualityDeletes or DataContentType::PositionDeletes", entry.data_file.content),
+                ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Add a new manifest entry. This method will update following status of the entry:
+    /// - Update the entry status to `Added`
+    /// - Set the snapshot id to the current snapshot id
+    /// - Set the sequence number to `None` if it is invalid(smaller than 0)
+    /// - Set the file sequence number to `None`
+    pub fn add(&mut self, mut entry: ManifestEntry) -> Result<()> {
+        self.check_entry(&entry)?;
+        if entry.sequence_number().is_some_and(|n| n >= 0) {
+            entry.status = ManifestStatus::Added;
+            entry.snapshot_id = Some(self.snapshot_id);
+            entry.file_sequence_number = None;
+        } else {
+            entry.status = ManifestStatus::Added;
+            entry.snapshot_id = Some(self.snapshot_id);
+            entry.sequence_number = None;
+            entry.file_sequence_number = None;
+        };
+        self.add_entry(entry)?;
+        Ok(())
+    }
+
+    /// Add a delete manifest entry. This method will update following status of the entry:
+    /// - Update the entry status to `Deleted`
+    /// - Set the snapshot id to the current snapshot id
+    pub fn delete(&mut self, mut entry: ManifestEntry) -> Result<()> {
+        self.check_entry(&entry)?;
+        entry.status = ManifestStatus::Deleted;
+        entry.snapshot_id = Some(self.snapshot_id);
+        self.add_entry(entry)?;
+        Ok(())
+    }
+
+    /// Add an existing manifest entry. This method will update following status of the entry:
+    /// - Update the entry status to `Existing`
+    pub fn existing(&mut self, mut entry: ManifestEntry) -> Result<()> {
+        self.check_entry(&entry)?;
+        entry.status = ManifestStatus::Existing;
+        self.add_entry(entry)?;
+        Ok(())
+    }
+
+    fn add_entry(&mut self, entry: ManifestEntry) -> Result<()> {
+        // Check if the entry has sequence number
+        if (entry.status == ManifestStatus::Deleted || entry.status == ManifestStatus::Existing)
+            && (entry.sequence_number.is_none() || entry.file_sequence_number.is_none())
+        {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Manifest entry with status Existing or Deleted should have sequence number",
+            ));
+        }
+
+        // Update the statistics
+        match entry.status {
+            ManifestStatus::Added => {
+                self.added_files += 1;
+                self.added_rows += entry.data_file.record_count;
+            }
+            ManifestStatus::Deleted => {
+                self.deleted_files += 1;
+                self.deleted_rows += entry.data_file.record_count;
+            }
+            ManifestStatus::Existing => {
+                self.existing_files += 1;
+                self.existing_rows += entry.data_file.record_count;
+            }
+        }
+        if entry.is_alive() {
+            if let Some(seq_num) = entry.sequence_number {
+                self.min_seq_num = Some(self.min_seq_num.map_or(seq_num, |v| min(v, seq_num)));
+            }
+        }
+        self.manifset_entries.push(entry);
+        Ok(())
+    }
+
+    /// Write manifest file and return it.
+    pub async fn to_manifest_file(mut self) -> Result<ManifestFile> {
         // Create the avro writer
-        let partition_type = manifest
+        let partition_type = self
             .metadata
             .partition_spec
-            .partition_type(&manifest.metadata.schema)?;
-        let table_schema = &manifest.metadata.schema;
-        let avro_schema = match manifest.metadata.format_version {
+            .partition_type(&self.metadata.schema)?;
+        let table_schema = &self.metadata.schema;
+        let avro_schema = match self.metadata.format_version {
             FormatVersion::V1 => manifest_schema_v1(&partition_type)?,
             FormatVersion::V2 => manifest_schema_v2(&partition_type)?,
         };
@@ -259,69 +433,36 @@ impl ManifestWriter {
         )?;
         avro_writer.add_user_metadata(
             "partition-spec".to_string(),
-            to_vec(&manifest.metadata.partition_spec.fields()).map_err(|err| {
+            to_vec(&self.metadata.partition_spec.fields()).map_err(|err| {
                 Error::new(ErrorKind::DataInvalid, "Fail to serialize partition spec")
                     .with_source(err)
             })?,
         )?;
         avro_writer.add_user_metadata(
             "partition-spec-id".to_string(),
-            manifest.metadata.partition_spec.spec_id().to_string(),
+            self.metadata.partition_spec.spec_id().to_string(),
         )?;
         avro_writer.add_user_metadata(
             "format-version".to_string(),
-            (manifest.metadata.format_version as u8).to_string(),
+            (self.metadata.format_version as u8).to_string(),
         )?;
-        if manifest.metadata.format_version == FormatVersion::V2 {
+        if self.metadata.format_version == FormatVersion::V2 {
             avro_writer
-                .add_user_metadata("content".to_string(), manifest.metadata.content.to_string())?;
+                .add_user_metadata("content".to_string(), self.metadata.content.to_string())?;
         }
 
+        let partition_summary = self.construct_partition_summaries(&partition_type)?;
         // Write manifest entries
-        for entry in manifest.entries {
-            if (entry.status == ManifestStatus::Deleted || entry.status == ManifestStatus::Existing)
-                && (entry.sequence_number.is_none() || entry.file_sequence_number.is_none())
-            {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Manifest entry with status Existing or Deleted should have sequence number",
-                ));
-            }
-
-            match entry.status {
-                ManifestStatus::Added => {
-                    self.added_files += 1;
-                    self.added_rows += entry.data_file.record_count;
+        for entry in std::mem::take(&mut self.manifset_entries) {
+            let value = match self.metadata.format_version {
+                FormatVersion::V1 => {
+                    to_value(_serde::ManifestEntryV1::try_from(entry, &partition_type)?)?
+                        .resolve(&avro_schema)?
                 }
-                ManifestStatus::Deleted => {
-                    self.deleted_files += 1;
-                    self.deleted_rows += entry.data_file.record_count;
+                FormatVersion::V2 => {
+                    to_value(_serde::ManifestEntryV2::try_from(entry, &partition_type)?)?
+                        .resolve(&avro_schema)?
                 }
-                ManifestStatus::Existing => {
-                    self.existing_files += 1;
-                    self.existing_rows += entry.data_file.record_count;
-                }
-            }
-
-            if entry.is_alive() {
-                if let Some(seq_num) = entry.sequence_number {
-                    self.min_seq_num = Some(self.min_seq_num.map_or(seq_num, |v| min(v, seq_num)));
-                }
-            }
-
-            self.partitions.push(entry.data_file.partition.clone());
-
-            let value = match manifest.metadata.format_version {
-                FormatVersion::V1 => to_value(_serde::ManifestEntryV1::try_from(
-                    (*entry).clone(),
-                    &partition_type,
-                )?)?
-                .resolve(&avro_schema)?,
-                FormatVersion::V2 => to_value(_serde::ManifestEntryV2::try_from(
-                    (*entry).clone(),
-                    &partition_type,
-                )?)?
-                .resolve(&avro_schema)?,
             };
 
             avro_writer.append(value)?;
@@ -331,13 +472,11 @@ impl ManifestWriter {
         let length = content.len();
         self.output.write(Bytes::from(content)).await?;
 
-        let partition_summary = self.construct_partition_summaries(&partition_type)?;
-
         Ok(ManifestFile {
             manifest_path: self.output.location().to_string(),
             manifest_length: length as i64,
-            partition_spec_id: manifest.metadata.partition_spec.spec_id(),
-            content: manifest.metadata.content,
+            partition_spec_id: self.metadata.partition_spec.spec_id(),
+            content: self.metadata.content,
             // sequence_number and min_sequence_number with UNASSIGNED_SEQUENCE_NUMBER will be replace with
             // real sequence number in `ManifestListWriter`.
             sequence_number: UNASSIGNED_SEQUENCE_NUMBER,
@@ -1699,16 +1838,18 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 0,
-                schema: schema.clone(),
-                partition_spec: PartitionSpec::builder(schema).with_spec_id(0).build().unwrap(),
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V2,
-            },
-            entries: vec![
-                Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .with_spec_id(0)
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V2,
+        };
+        let mut entries = vec![
+                ManifestEntry {
                     status: ManifestStatus::Added,
                     snapshot_id: None,
                     sequence_number: None,
@@ -1731,13 +1872,34 @@ mod tests {
                         equality_ids: Vec::new(),
                         sort_order_id: None,
                     }
-                })
-            ]
-        };
+                }
+            ];
 
-        let writer = |output_file: OutputFile| ManifestWriter::new(output_file, 1, vec![]);
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            1,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v2_data();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        writer.to_manifest_file().await.unwrap();
 
-        test_manifest_read_write(manifest, writer).await;
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
+        // The snapshot id is assigned when the entry is added to the manifest.
+        entries[0].snapshot_id = Some(1);
+        assert_eq!(actual_manifest, Manifest::new(metadata, entries));
     }
 
     #[tokio::test]
@@ -1812,17 +1974,21 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 0,
-                schema: schema.clone(),
-                partition_spec: PartitionSpec::builder(schema)
-                .with_spec_id(0).add_partition_field("v_int", "v_int", Transform::Identity).unwrap()
-                .add_partition_field("v_long", "v_long", Transform::Identity).unwrap().build().unwrap(),
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V2,
-            },
-            entries: vec![Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .with_spec_id(0)
+                .add_partition_field("v_int", "v_int", Transform::Identity)
+                .unwrap()
+                .add_partition_field("v_long", "v_long", Transform::Identity)
+                .unwrap()
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V2,
+        };
+        let mut entries = vec![ManifestEntry {
                 status: ManifestStatus::Added,
                 snapshot_id: None,
                 sequence_number: None,
@@ -1887,15 +2053,38 @@ mod tests {
                     equality_ids: vec![],
                     sort_order_id: None,
                 },
-            })],
-        };
+            }];
 
-        let writer = |output_file: OutputFile| ManifestWriter::new(output_file, 1, vec![]);
+        // write manifest to file and check the return manifest file.
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            2,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v2_data();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        let manifest_file = writer.to_manifest_file().await.unwrap();
+        assert_eq!(manifest_file.sequence_number, UNASSIGNED_SEQUENCE_NUMBER);
+        assert_eq!(
+            manifest_file.min_sequence_number,
+            UNASSIGNED_SEQUENCE_NUMBER
+        );
 
-        let res = test_manifest_read_write(manifest, writer).await;
-
-        assert_eq!(res.sequence_number, UNASSIGNED_SEQUENCE_NUMBER);
-        assert_eq!(res.min_sequence_number, UNASSIGNED_SEQUENCE_NUMBER);
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
+        // The snapshot id is assigned when the entry is added to the manifest.
+        entries[0].snapshot_id = Some(2);
+        assert_eq!(actual_manifest, Manifest::new(metadata, entries));
     }
 
     #[tokio::test]
@@ -1923,15 +2112,17 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 1,
-                schema: schema.clone(),
-                partition_spec: PartitionSpec::builder(schema).with_spec_id(0).build().unwrap(),
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V1,
-            },
-            entries: vec![Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 1,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .with_spec_id(0)
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V1,
+        };
+        let mut entries = vec![ManifestEntry {
                 status: ManifestStatus::Added,
                 snapshot_id: Some(0),
                 sequence_number: Some(0),
@@ -1954,13 +2145,33 @@ mod tests {
                     equality_ids: vec![],
                     sort_order_id: Some(0),
                 }
-            })],
-        };
+            }];
 
-        let writer =
-            |output_file: OutputFile| ManifestWriter::new(output_file, 2966623707104393227, vec![]);
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            3,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v1();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        writer.to_manifest_file().await.unwrap();
 
-        test_manifest_read_write(manifest, writer).await;
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
+        // The snapshot id is assigned when the entry is added to the manifest.
+        entries[0].snapshot_id = Some(3);
+        assert_eq!(actual_manifest, Manifest::new(metadata, entries));
     }
 
     #[tokio::test]
@@ -1987,16 +2198,19 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 0,
-                schema: schema.clone(),
-                partition_spec: PartitionSpec::builder(schema).add_partition_field("category", "category", Transform::Identity).unwrap().build().unwrap(),
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V1,
-            },
-            entries: vec![
-                Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .add_partition_field("category", "category", Transform::Identity)
+                .unwrap()
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V1,
+        };
+        let mut entries = vec![
+                ManifestEntry {
                     status: ManifestStatus::Added,
                     snapshot_id: Some(0),
                     sequence_number: Some(0),
@@ -2034,17 +2248,43 @@ mod tests {
                         equality_ids: vec![],
                         sort_order_id: Some(0),
                     },
-                })
-            ]
-        };
+                }
+            ];
 
-        let writer = |output_file: OutputFile| ManifestWriter::new(output_file, 1, vec![]);
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            2,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v1();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        let manifest_file = writer.to_manifest_file().await.unwrap();
+        assert_eq!(manifest_file.partitions.len(), 1);
+        assert_eq!(
+            manifest_file.partitions[0].lower_bound,
+            Some(Datum::string("x"))
+        );
+        assert_eq!(
+            manifest_file.partitions[0].upper_bound,
+            Some(Datum::string("x"))
+        );
 
-        let entry = test_manifest_read_write(manifest, writer).await;
-
-        assert_eq!(entry.partitions.len(), 1);
-        assert_eq!(entry.partitions[0].lower_bound, Some(Datum::string("x")));
-        assert_eq!(entry.partitions[0].upper_bound, Some(Datum::string("x")));
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
+        // The snapshot id is assigned when the entry is added to the manifest.
+        entries[0].snapshot_id = Some(2);
+        assert_eq!(actual_manifest, Manifest::new(metadata, entries));
     }
 
     #[tokio::test]
@@ -2066,15 +2306,17 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 0,
-                schema: schema.clone(),
-                partition_spec: PartitionSpec::builder(schema).with_spec_id(0).build().unwrap(),
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V2,
-            },
-            entries: vec![Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .with_spec_id(0)
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V2,
+        };
+        let entries = vec![ManifestEntry {
                 status: ManifestStatus::Added,
                 snapshot_id: None,
                 sequence_number: None,
@@ -2109,18 +2351,34 @@ mod tests {
                     equality_ids: vec![],
                     sort_order_id: None,
                 },
-            })],
-        };
+            }];
 
-        let writer = |output_file: OutputFile| ManifestWriter::new(output_file, 1, vec![]);
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            2,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v2_data();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        writer.to_manifest_file().await.unwrap();
 
-        let (avro_bytes, _) = write_manifest(&manifest, writer).await;
-
-        // The parse should succeed.
-        let actual_manifest = Manifest::parse_avro(avro_bytes.as_slice()).unwrap();
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
 
         // Compared with original manifest, the lower_bounds and upper_bounds no longer has data for field 3, and
         // other parts should be same.
+        // The snapshot id is assigned when the entry is added to the manifest.
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
@@ -2148,7 +2406,7 @@ mod tests {
             },
             entries: vec![Arc::new(ManifestEntry {
                 status: ManifestStatus::Added,
-                snapshot_id: None,
+                snapshot_id: Some(2),
                 sequence_number: None,
                 file_sequence_number: None,
                 data_file: DataFile {
@@ -2219,16 +2477,15 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        let manifest = Manifest {
-            metadata: ManifestMetadata {
-                schema_id: 0,
-                schema,
-                partition_spec,
-                content: ManifestContentType::Data,
-                format_version: FormatVersion::V2,
-            },
-            entries: vec![
-                Arc::new(ManifestEntry {
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema,
+            partition_spec,
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V2,
+        };
+        let entries = vec![
+                ManifestEntry {
                     status: ManifestStatus::Added,
                     snapshot_id: None,
                     sequence_number: None,
@@ -2257,8 +2514,7 @@ mod tests {
                         equality_ids: Vec::new(),
                         sort_order_id: None,
                     }
-                }),
-                Arc::new(
+                },
                     ManifestEntry {
                         status: ManifestStatus::Added,
                         snapshot_id: None,
@@ -2288,9 +2544,7 @@ mod tests {
                             equality_ids: Vec::new(),
                             sort_order_id: None,
                         }
-                    }
-                ),
-                Arc::new(
+                    },
                     ManifestEntry {
                         status: ManifestStatus::Added,
                         snapshot_id: None,
@@ -2320,9 +2574,7 @@ mod tests {
                             equality_ids: Vec::new(),
                             sort_order_id: None,
                         }
-                    }
-                ),
-                Arc::new(
+                    },
                     ManifestEntry {
                         status: ManifestStatus::Added,
                         snapshot_id: None,
@@ -2352,14 +2604,27 @@ mod tests {
                             equality_ids: Vec::new(),
                             sort_order_id: None,
                         }
-                    }
-                ),
-            ]
-        };
+                    },
+            ];
 
-        let writer = |output_file: OutputFile| ManifestWriter::new(output_file, 1, vec![]);
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
+        let io = FileIOBuilder::new_fs_io().build().unwrap();
+        let output_file = io.new_output(path.to_str().unwrap()).unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            1,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v2_data();
+        for entry in &entries {
+            writer.add(entry.clone()).unwrap();
+        }
+        let res = writer.to_manifest_file().await.unwrap();
 
-        let res = test_manifest_read_write(manifest, writer).await;
         assert!(res.partitions.len() == 3);
         assert!(res.partitions[0].lower_bound == Some(Datum::int(1111)));
         assert!(res.partitions[0].upper_bound == Some(Datum::int(2021)));
@@ -2377,31 +2642,139 @@ mod tests {
         assert!(res.partitions[2].contains_nan == Some(false));
     }
 
-    async fn test_manifest_read_write(
-        manifest: Manifest,
-        writer_builder: impl FnOnce(OutputFile) -> ManifestWriter,
-    ) -> ManifestFile {
-        let (bs, res) = write_manifest(&manifest, writer_builder).await;
-        let actual_manifest = Manifest::parse_avro(bs.as_slice()).unwrap();
+    #[tokio::test]
+    async fn test_add_delete_existing() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    Arc::new(NestedField::optional(
+                        1,
+                        "id",
+                        Type::Primitive(PrimitiveType::Int),
+                    )),
+                    Arc::new(NestedField::optional(
+                        2,
+                        "name",
+                        Type::Primitive(PrimitiveType::String),
+                    )),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let metadata = ManifestMetadata {
+            schema_id: 0,
+            schema: schema.clone(),
+            partition_spec: PartitionSpec::builder(schema)
+                .with_spec_id(0)
+                .build()
+                .unwrap(),
+            content: ManifestContentType::Data,
+            format_version: FormatVersion::V2,
+        };
+        let mut entries = vec![
+                ManifestEntry {
+                    status: ManifestStatus::Added,
+                    snapshot_id: None,
+                    sequence_number: Some(1),
+                    file_sequence_number: Some(1),
+                    data_file: DataFile {
+                        content: DataContentType::Data,
+                        file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                        file_format: DataFileFormat::Parquet,
+                        partition: Struct::empty(),
+                        record_count: 1,
+                        file_size_in_bytes: 5442,
+                        column_sizes: HashMap::from([(1, 61), (2, 73)]),
+                        value_counts: HashMap::from([(1, 1), (2, 1)]),
+                        null_value_counts: HashMap::from([(1, 0), (2, 0)]),
+                        nan_value_counts: HashMap::new(),
+                        lower_bounds: HashMap::new(),
+                        upper_bounds: HashMap::new(),
+                        key_metadata: Some(Vec::new()),
+                        split_offsets: vec![4],
+                        equality_ids: Vec::new(),
+                        sort_order_id: None,
+                    },
+                },
+                ManifestEntry {
+                    status: ManifestStatus::Deleted,
+                    snapshot_id: Some(1),
+                    sequence_number: Some(1),
+                    file_sequence_number: Some(1),
+                    data_file: DataFile {
+                        content: DataContentType::Data,
+                        file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                        file_format: DataFileFormat::Parquet,
+                        partition: Struct::empty(),
+                        record_count: 1,
+                        file_size_in_bytes: 5442,
+                        column_sizes: HashMap::from([(1, 61), (2, 73)]),
+                        value_counts: HashMap::from([(1, 1), (2, 1)]),
+                        null_value_counts: HashMap::from([(1, 0), (2, 0)]),
+                        nan_value_counts: HashMap::new(),
+                        lower_bounds: HashMap::new(),
+                        upper_bounds: HashMap::new(),
+                        key_metadata: Some(Vec::new()),
+                        split_offsets: vec![4],
+                        equality_ids: Vec::new(),
+                        sort_order_id: None,
+                    },
+                },
+                ManifestEntry {
+                    status: ManifestStatus::Existing,
+                    snapshot_id: Some(1),
+                    sequence_number: Some(1),
+                    file_sequence_number: Some(1),
+                    data_file: DataFile {
+                        content: DataContentType::Data,
+                        file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                        file_format: DataFileFormat::Parquet,
+                        partition: Struct::empty(),
+                        record_count: 1,
+                        file_size_in_bytes: 5442,
+                        column_sizes: HashMap::from([(1, 61), (2, 73)]),
+                        value_counts: HashMap::from([(1, 1), (2, 1)]),
+                        null_value_counts: HashMap::from([(1, 0), (2, 0)]),
+                        nan_value_counts: HashMap::new(),
+                        lower_bounds: HashMap::new(),
+                        upper_bounds: HashMap::new(),
+                        key_metadata: Some(Vec::new()),
+                        split_offsets: vec![4],
+                        equality_ids: Vec::new(),
+                        sort_order_id: None,
+                    },
+                },
+            ];
 
-        assert_eq!(actual_manifest, manifest);
-        res
-    }
-
-    /// Utility method which writes out a manifest and returns the bytes.
-    async fn write_manifest(
-        manifest: &Manifest,
-        writer_builder: impl FnOnce(OutputFile) -> ManifestWriter,
-    ) -> (Vec<u8>, ManifestFile) {
-        let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("test_manifest.avro");
+        // write manifest to file
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("test_manifest.avro");
         let io = FileIOBuilder::new_fs_io().build().unwrap();
         let output_file = io.new_output(path.to_str().unwrap()).unwrap();
-        let writer = writer_builder(output_file);
-        let res = writer.write(manifest.clone()).await.unwrap();
+        let mut writer = ManifestWriterBuilder::new(
+            output_file,
+            3,
+            vec![],
+            metadata.schema.clone(),
+            metadata.partition_spec.clone(),
+        )
+        .build_v2_data();
+        writer.add(entries[0].clone()).unwrap();
+        writer.delete(entries[1].clone()).unwrap();
+        writer.existing(entries[2].clone()).unwrap();
+        writer.to_manifest_file().await.unwrap();
 
-        // Verify manifest
-        (fs::read(path).expect("read_file must succeed"), res)
+        // read back the manifest file and check the content
+        let actual_manifest =
+            Manifest::parse_avro(fs::read(path).expect("read_file must succeed").as_slice())
+                .unwrap();
+
+        // The snapshot id is assigned when the entry is added and delete to the manifest. Existing entries are keep original.
+        entries[0].snapshot_id = Some(3);
+        entries[1].snapshot_id = Some(3);
+        // file sequence number is assigned to None when the entry is added and delete to the manifest.
+        entries[0].file_sequence_number = None;
+        assert_eq!(actual_manifest, Manifest::new(metadata, entries));
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -34,6 +34,8 @@ use crate::{Error, ErrorKind};
 
 /// The ref name of the main branch of the table.
 pub const MAIN_BRANCH: &str = "main";
+/// Placeholder for snapshot ID. The field with this value must be replaced with the actual snapshot ID before it is committed.
+pub const UNASSIGNED_SNAPSHOT_ID: i64 = -1;
 
 /// Reference to [`Snapshot`].
 pub type SnapshotRef = Arc<Snapshot>;

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -410,9 +410,9 @@ impl<'a> SnapshotProduceAction<'a> {
             }
         };
         for entry in manifest_entries {
-            writer.add(entry)?;
+            writer.add_entry(entry)?;
         }
-        writer.to_manifest_file().await
+        writer.write_manifest_file().await
     }
 
     async fn manifest_file<OP: SnapshotProduceOperation, MP: ManifestProcess>(

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -393,7 +393,7 @@ impl<'a> SnapshotProduceAction<'a> {
         let mut writer = {
             let builder = ManifestWriterBuilder::new(
                 self.new_manifest_output()?,
-                self.snapshot_id,
+                Some(self.snapshot_id),
                 self.key_metadata.clone(),
                 self.tx.table.metadata().current_schema().clone(),
                 self.tx


### PR DESCRIPTION
This PR refine the write interface of ManifestWriter according to [ManifestWriter from pyiceberg](https://github.com/apache/iceberg-python/blob/5bef1bfe677df7016dc37b8db87650c34faceb7a/pyiceberg/manifest.py#L829). It add 3 interface `add`, `delete`, `existing` which will rewrite some metadata of manifest entry, e.g. snapshot id, sequence number, file sequence number. 

These refined interfaces are benefit for MergeAppend.( I' m working on it now.