### PR TITLE
chore: Align argument name with doc comment

### DIFF
--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -141,10 +141,10 @@ impl TableMetadataBuilder {
     #[must_use]
     pub fn new_from_metadata(
         previous: TableMetadata,
-        previous_file_location: Option<String>,
+        current_file_location: Option<String>,
     ) -> Self {
         Self {
-            previous_history_entry: previous_file_location.map(|l| MetadataLog {
+            previous_history_entry: current_file_location.map(|l| MetadataLog {
                 metadata_file: l,
                 timestamp_ms: previous.last_updated_ms,
             }),


### PR DESCRIPTION
Method TableMetadataBuilder::new_from_metadata was introduced in https://github.com/apache/iceberg-rust/pull/587

This PR aligns a method argument name with the method's documentation comment in L137-140