### PR TITLE
refactor: avoid async_trait for FileWrite and provide extra dyn methods

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -363,6 +363,9 @@ pub struct OutputFile {
     relative_path_pos: usize,
 }
 
+/// A static opaque type of trait `FileWrite` returned from the `writer` method of `OutputFile`
+pub type OutputFileWrite = impl FileWrite;
+
 impl OutputFile {
     /// Relative path to root uri.
     pub fn location(&self) -> &str {
@@ -401,7 +404,7 @@ impl OutputFile {
     /// # Notes
     ///
     /// For one-time writing, use [`Self::write`] instead.
-    pub async fn writer(&self) -> crate::Result<opendal::Writer> {
+    pub async fn writer(&self) -> Result<OutputFileWrite> {
         Ok(self.op.writer(&self.path[self.relative_path_pos..]).await?)
     }
 }

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -52,6 +52,7 @@
 //! ```
 
 #![deny(missing_docs)]
+#![feature(type_alias_impl_trait)]
 
 #[macro_use]
 extern crate derive_builder;

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -28,7 +28,7 @@ use self::_const_schema::{MANIFEST_LIST_AVRO_SCHEMA_V1, MANIFEST_LIST_AVRO_SCHEM
 use self::_serde::{ManifestFileV1, ManifestFileV2};
 use super::{Datum, FormatVersion, Manifest, StructType};
 use crate::error::Result;
-use crate::io::{FileIO, OutputFile};
+use crate::io::{FileIO, FileWrite, OutputFile};
 use crate::{Error, ErrorKind};
 
 /// Placeholder for sequence number. The field with this value must be replaced with the actual sequence number before it write.
@@ -1197,7 +1197,7 @@ mod test {
                     added_rows_count: Some(3),
                     existing_rows_count: Some(0),
                     deleted_rows_count: Some(0),
-                    partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1))}],
+                    partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1)) }],
                     key_metadata: vec![],
                 },
                 ManifestFile {
@@ -1214,7 +1214,7 @@ mod test {
                     added_rows_count: Some(3),
                     existing_rows_count: Some(0),
                     deleted_rows_count: Some(0),
-                    partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::float(1.1)), upper_bound: Some(Datum::float(2.1))}],
+                    partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::float(1.1)), upper_bound: Some(Datum::float(2.1)) }],
                     key_metadata: vec![],
                 }
             ]
@@ -1270,7 +1270,7 @@ mod test {
 
     #[test]
     fn test_serialize_manifest_list_v1() {
-        let manifest_list:ManifestListV1 = ManifestList {
+        let manifest_list: ManifestListV1 = ManifestList {
             entries: vec![ManifestFile {
                 manifest_path: "/opt/bitnami/spark/warehouse/db/table/metadata/10d28031-9739-484c-92db-cdf2975cead4-m0.avro".to_string(),
                 manifest_length: 5806,
@@ -1298,7 +1298,7 @@ mod test {
 
     #[test]
     fn test_serialize_manifest_list_v2() {
-        let manifest_list:ManifestListV2 = ManifestList {
+        let manifest_list: ManifestListV2 = ManifestList {
             entries: vec![ManifestFile {
                 manifest_path: "s3a://icebergdata/demo/s1/t1/metadata/05ffe08b-810f-49b3-a8f4-e88fc99b254a-m0.avro".to_string(),
                 manifest_length: 6926,
@@ -1313,7 +1313,7 @@ mod test {
                 added_rows_count: Some(3),
                 existing_rows_count: Some(0),
                 deleted_rows_count: Some(0),
-                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1))}],
+                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1)) }],
                 key_metadata: vec![],
             }]
         }.try_into().unwrap();
@@ -1341,7 +1341,7 @@ mod test {
                 added_rows_count: Some(3),
                 existing_rows_count: Some(0),
                 deleted_rows_count: Some(0),
-                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1))}],
+                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1)) }],
                 key_metadata: vec![],
             }]
         };
@@ -1397,7 +1397,7 @@ mod test {
                 added_rows_count: Some(3),
                 existing_rows_count: Some(0),
                 deleted_rows_count: Some(0),
-                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1))}],
+                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1)) }],
                 key_metadata: vec![],
             }]
         };
@@ -1451,7 +1451,7 @@ mod test {
                 added_rows_count: Some(3),
                 existing_rows_count: Some(0),
                 deleted_rows_count: Some(0),
-                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1))}],
+                partitions: vec![FieldSummary { contains_null: false, contains_nan: Some(false), lower_bound: Some(Datum::long(1)), upper_bound: Some(Datum::long(1)) }],
                 key_metadata: vec![],
             }]
         };

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -213,7 +213,7 @@ impl SchemaVisitor for IndexByParquetPathName {
 pub struct ParquetWriter {
     schema: SchemaRef,
     out_file: OutputFile,
-    writer: AsyncArrowWriter<AsyncFileWriter<TrackWriter>>,
+    writer: AsyncArrowWriter<AsyncFileWriter<TrackWriter<opendal::Writer>>>,
     written_size: Arc<AtomicI64>,
     current_row_num: usize,
 }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -37,7 +37,7 @@ use super::{FileWriter, FileWriterBuilder};
 use crate::arrow::{
     get_parquet_stat_max_as_datum, get_parquet_stat_min_as_datum, DEFAULT_MAP_FIELD_NAME,
 };
-use crate::io::{FileIO, FileWrite, OutputFile};
+use crate::io::{FileIO, FileWrite, OutputFile, OutputFileWrite};
 use crate::spec::{
     visit_schema, DataFileBuilder, DataFileFormat, Datum, ListType, MapType, NestedFieldRef,
     PrimitiveType, Schema, SchemaRef, SchemaVisitor, StructType, Type,
@@ -213,7 +213,7 @@ impl SchemaVisitor for IndexByParquetPathName {
 pub struct ParquetWriter {
     schema: SchemaRef,
     out_file: OutputFile,
-    writer: AsyncArrowWriter<AsyncFileWriter<TrackWriter<opendal::Writer>>>,
+    writer: AsyncArrowWriter<AsyncFileWriter<TrackWriter<OutputFileWrite>>>,
     written_size: Arc<AtomicI64>,
     current_row_num: usize,
 }

--- a/crates/iceberg/src/writer/file_writer/track_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/track_writer.rs
@@ -24,13 +24,13 @@ use crate::io::FileWrite;
 use crate::Result;
 
 /// `TrackWriter` is used to track the written size.
-pub(crate) struct TrackWriter {
-    inner: Box<dyn FileWrite>,
+pub(crate) struct TrackWriter<W: FileWrite> {
+    inner: W,
     written_size: Arc<AtomicI64>,
 }
 
-impl TrackWriter {
-    pub fn new(writer: Box<dyn FileWrite>, written_size: Arc<AtomicI64>) -> Self {
+impl<W: FileWrite> TrackWriter<W> {
+    pub fn new(writer: W, written_size: Arc<AtomicI64>) -> Self {
         Self {
             inner: writer,
             written_size,
@@ -38,8 +38,7 @@ impl TrackWriter {
     }
 }
 
-#[async_trait::async_trait]
-impl FileWrite for TrackWriter {
+impl<W: FileWrite> FileWrite for TrackWriter<W> {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let size = bs.len();
         self.inner.write(bs).await.map(|v| {


### PR DESCRIPTION
With the same motivation to https://github.com/apache/iceberg-rust/pull/760, but for the `FileWrite` trait.