### PR TITLE
Simplify partition structures

### DIFF
--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -367,7 +367,7 @@ mod tests {
                 .partition_specs_iter()
                 .map(|p| p.as_ref())
                 .collect_vec(),
-            vec![&expected_partition_spec.into_schemaless()]
+            vec![&expected_partition_spec.into_unbound()]
         );
 
         let expected_sorted_order = SortOrder::builder()

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -700,9 +700,9 @@ mod tests {
 
     use chrono::{TimeZone, Utc};
     use iceberg::spec::{
-        FormatVersion, NestedField, NullOrder, Operation, PrimitiveType, Schema, Snapshot,
-        SnapshotLog, SortDirection, SortField, SortOrder, Summary, Transform, Type,
-        UnboundPartitionField, UnboundPartitionSpec,
+        FormatVersion, NestedField, NullOrder, Operation, PartitionField, PrimitiveType, Schema,
+        Snapshot, SnapshotLog, SortDirection, SortField, SortOrder, Summary, Transform, Type,
+        UnboundPartitionSpec,
     };
     use iceberg::transaction::Transaction;
     use mockito::{Mock, Server, ServerGuard};
@@ -1489,9 +1489,10 @@ mod tests {
             .properties(HashMap::from([("owner".to_string(), "testx".to_string())]))
             .partition_spec(
                 UnboundPartitionSpec::builder()
-                    .add_partition_fields(vec![UnboundPartitionField::builder()
+                    .add_partition_fields(vec![PartitionField::builder()
                         .source_id(1)
                         .transform(Transform::Truncate(3))
+                        .field_id(1000)
                         .name("id".to_string())
                         .build()])
                     .unwrap()

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -880,7 +880,7 @@ mod tests {
             .with_spec_id(0)
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         assert_eq!(
             metadata

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -1318,6 +1318,49 @@ mod tests {
     }
 
     #[test]
+    fn test_add_spec_with_field_id() {
+        test_serde_json(
+            r#"
+{
+    "action": "add-spec",
+    "spec": {
+        "fields": [
+            {
+                "source-id": 4,
+                "name": "ts_day",
+                "transform": "day",
+                "field-id": 1000
+            },
+            {
+                "source-id": 1,
+                "name": "id_bucket",
+                "transform": "bucket[16]",
+                "field-id": 1001
+            },
+            {
+                "source-id": 2,
+                "name": "id_truncate",
+                "transform": "truncate[4]",
+                "field-id": 1002
+            }
+        ]
+    }
+}
+        "#,
+            TableUpdate::AddSpec {
+                spec: UnboundPartitionSpec::builder()
+                    .add_partition_field(4, "ts_day".to_string(), Transform::Day)
+                    .unwrap()
+                    .add_partition_field(1, "id_bucket".to_string(), Transform::Bucket(16))
+                    .unwrap()
+                    .add_partition_field(2, "id_truncate".to_string(), Transform::Truncate(4))
+                    .unwrap()
+                    .build(),
+            },
+        );
+    }
+
+    #[test]
     fn test_set_default_spec() {
         test_serde_json(
             r#"

--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -260,7 +260,6 @@ mod tests {
     use crate::spec::{
         BoundPartitionSpec, BoundPartitionSpecRef, DataContentType, DataFile, DataFileFormat,
         Datum, Literal, NestedField, PrimitiveType, Schema, Struct, Transform, Type,
-        UnboundPartitionField,
     };
     use crate::Result;
 
@@ -275,12 +274,7 @@ mod tests {
 
         let spec = BoundPartitionSpec::builder(schema.clone())
             .with_spec_id(1)
-            .add_unbound_fields(vec![UnboundPartitionField::builder()
-                .source_id(1)
-                .name("a".to_string())
-                .field_id(1)
-                .transform(Transform::Identity)
-                .build()])
+            .add_partition_field("a", "a", Transform::Identity)
             .unwrap()
             .build()
             .unwrap();
@@ -302,7 +296,7 @@ mod tests {
             .build()?;
 
         let mut inclusive_projection =
-            InclusiveProjection::new((*partition_spec).clone().into_schemaless().into());
+            InclusiveProjection::new((*partition_spec).clone().into_unbound().into());
 
         let partition_filter = inclusive_projection
             .project(predicate)?

--- a/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
@@ -496,7 +496,7 @@ mod test {
     };
     use crate::spec::{
         BoundPartitionSpec, DataContentType, DataFile, DataFileFormat, Datum, NestedField,
-        PrimitiveType, Schema, Struct, Transform, Type, UnboundPartitionField,
+        PrimitiveType, Schema, Struct, Transform, Type,
     };
 
     const INT_MIN_VALUE: i32 = 30;
@@ -1658,12 +1658,7 @@ mod test {
 
         let partition_spec = BoundPartitionSpec::builder(table_schema_ref.clone())
             .with_spec_id(1)
-            .add_unbound_fields(vec![UnboundPartitionField::builder()
-                .source_id(1)
-                .name("a".to_string())
-                .field_id(1)
-                .transform(Transform::Identity)
-                .build()])
+            .add_partition_field("a", "a", Transform::Identity)
             .unwrap()
             .build()
             .unwrap();

--- a/crates/iceberg/src/expr/visitors/inclusive_projection.rs
+++ b/crates/iceberg/src/expr/visitors/inclusive_projection.rs
@@ -21,16 +21,16 @@ use fnv::FnvHashSet;
 
 use crate::expr::visitors::bound_predicate_visitor::{visit, BoundPredicateVisitor};
 use crate::expr::{BoundPredicate, BoundReference, Predicate};
-use crate::spec::{Datum, PartitionField, SchemalessPartitionSpecRef};
+use crate::spec::{Datum, PartitionField, UnboundPartitionSpecRef};
 use crate::Error;
 
 pub(crate) struct InclusiveProjection {
-    partition_spec: SchemalessPartitionSpecRef,
+    partition_spec: UnboundPartitionSpecRef,
     cached_parts: HashMap<i32, Vec<PartitionField>>,
 }
 
 impl InclusiveProjection {
-    pub(crate) fn new(partition_spec: SchemalessPartitionSpecRef) -> Self {
+    pub(crate) fn new(partition_spec: UnboundPartitionSpecRef) -> Self {
         Self {
             partition_spec,
             cached_parts: HashMap::new(),
@@ -235,8 +235,8 @@ mod tests {
     use crate::expr::visitors::inclusive_projection::InclusiveProjection;
     use crate::expr::{Bind, Predicate, Reference};
     use crate::spec::{
-        BoundPartitionSpec, Datum, NestedField, PrimitiveType, Schema, Transform, Type,
-        UnboundPartitionField,
+        BoundPartitionSpec, Datum, NestedField, PartitionField, PrimitiveType, Schema, Transform,
+        Type,
     };
 
     fn build_test_schema() -> Schema {
@@ -271,7 +271,7 @@ mod tests {
             .with_spec_id(1)
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -301,7 +301,7 @@ mod tests {
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
             .add_unbound_field(
-                UnboundPartitionField::builder()
+                PartitionField::builder()
                     .source_id(1)
                     .name("a".to_string())
                     .field_id(1)
@@ -311,7 +311,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -338,16 +338,11 @@ mod tests {
 
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
-            .add_unbound_fields(vec![UnboundPartitionField {
-                source_id: 2,
-                name: "year".to_string(),
-                field_id: Some(1000),
-                transform: Transform::Year,
-            }])
+            .add_partition_field("date", "year", Transform::Year)
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -374,16 +369,11 @@ mod tests {
 
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
-            .add_unbound_fields(vec![UnboundPartitionField {
-                source_id: 2,
-                name: "month".to_string(),
-                field_id: Some(1000),
-                transform: Transform::Month,
-            }])
+            .add_partition_field("date", "month", Transform::Month)
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -410,16 +400,11 @@ mod tests {
 
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
-            .add_unbound_fields(vec![UnboundPartitionField {
-                source_id: 2,
-                name: "day".to_string(),
-                field_id: Some(1000),
-                transform: Transform::Day,
-            }])
+            .add_partition_field("date", "day", Transform::Day)
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -447,7 +432,7 @@ mod tests {
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
             .add_unbound_field(
-                UnboundPartitionField::builder()
+                PartitionField::builder()
                     .source_id(3)
                     .name("name_truncate".to_string())
                     .field_id(3)
@@ -457,7 +442,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 
@@ -488,7 +473,7 @@ mod tests {
         let partition_spec = BoundPartitionSpec::builder(arc_schema.clone())
             .with_spec_id(1)
             .add_unbound_field(
-                UnboundPartitionField::builder()
+                PartitionField::builder()
                     .source_id(1)
                     .name("a_bucket[7]".to_string())
                     .field_id(1)
@@ -498,7 +483,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap()
-            .into_schemaless();
+            .into_unbound();
 
         let arc_partition_spec = Arc::new(partition_spec);
 

--- a/crates/iceberg/src/spec/manifest.rs
+++ b/crates/iceberg/src/spec/manifest.rs
@@ -775,7 +775,7 @@ impl ManifestMetadata {
                 .unwrap_or(0);
             BoundPartitionSpec::builder(schema.clone())
                 .with_spec_id(spec_id)
-                .add_unbound_fields(fields.into_iter().map(|f| f.into_unbound()))?
+                .add_unbound_fields(fields)?
                 .build()?
         };
         let format_version = if let Some(bs) = meta.get("format-version") {


### PR DESCRIPTION
This PR removes `SchemalessPartitionSpec` and `UnboundPartitionSpecField`. We could also combine `BoundPartitionSpec` and `UnboundPartitionSpec` if we like, but this is already quite a big change.

From the spec:

> The field-id property was added for each partition field in v2.
> In v1, the reference implementation assigned field ids sequentially
> in each spec starting at 1,000. See Partition Evolution for more details.

> In v1, partition field IDs were not tracked, but were assigned sequentially
> starting at 1000 in the reference implementation. This assignment caused
> problems when reading metadata tables based on manifest files from multiple
> specs because partition fields with the same ID may contain different data types.

> For compatibility with old versions, the following rules are recommended for partition evolution in v1 tables:
> - Do not reorder partition fields
> - Do not drop partition fields; instead replace the field's transform with the void transform
> - Only add partition fields at the end of the previous partition spec

I think for simplicity, we should assign the field-IDs starting from 1000, and this will greatly simplify the objects that we need. For V1 the `field-ID` is missing, and we can just start assigning from 1000 onwards because the IDs are sequential, for V2 tables we deserialize the `field-ID` from the payload. While I also noticed that we write the `field-id` field for V1 tables in the reference implementation: https://github.com/apache/iceberg/pull/11708

Next to that, I also believe that users shouldn't have to worry about the field-IDs and that it should be kept internal to Iceberg-Rust. For the evolution of the partition spec, we should have something similar as Java and [PyIceberg](https://py.iceberg.apache.org/api/#partition-evolution), in particular for V1 tables, we have to take the rules above into account, otherwise, there is a serious issue of data-loss, or bricking a table. If we agree on this, I'm happy to implement that API.