### PR TITLE
fix: return type for year and month transform should be int

### DIFF
--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -197,7 +197,27 @@ impl Transform {
                     ))
                 }
             }
-            Transform::Year | Transform::Month | Transform::Day => {
+            Transform::Year | Transform::Month => {
+                if let Type::Primitive(p) = input_type {
+                    match p {
+                        PrimitiveType::Timestamp
+                        | PrimitiveType::Timestamptz
+                        | PrimitiveType::TimestampNs
+                        | PrimitiveType::TimestamptzNs
+                        | PrimitiveType::Date => Ok(Type::Primitive(PrimitiveType::Int)),
+                        _ => Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!("{input_type} is not a valid input type of {self} transform",),
+                        )),
+                    }
+                } else {
+                    Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("{input_type} is not a valid input type of {self} transform",),
+                    ))
+                }
+            }
+            Transform::Day => {
                 if let Type::Primitive(p) = input_type {
                     match p {
                         PrimitiveType::Timestamp

--- a/crates/iceberg/src/transform/mod.rs
+++ b/crates/iceberg/src/transform/mod.rs
@@ -157,6 +157,7 @@ mod test {
     }
 
     impl TestTransformFixture {
+        #[track_caller]
         pub(crate) fn assert_transform(&self, trans: Transform) {
             assert_eq!(self.display, format!("{trans}"));
             assert_eq!(self.json, serde_json::to_string(&trans).unwrap());
@@ -175,8 +176,13 @@ mod test {
                 );
             }
 
-            for (input_type, result_type) in &self.trans_types {
-                assert_eq!(result_type, &trans.result_type(input_type).ok());
+            for (i, (input_type, result_type)) in self.trans_types.iter().enumerate() {
+                let actual = trans.result_type(input_type).ok();
+                assert_eq!(
+                    result_type, &actual,
+                    "type mismatch at index {}, input: {}, expected: {:?}, actual: {:?}",
+                    i, input_type, result_type, actual
+                );
             }
         }
     }

--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -428,7 +428,7 @@ mod test {
             ],
             trans_types: vec![
                 (Primitive(Binary), None),
-                (Primitive(Date), Some(Primitive(Date))),
+                (Primitive(Date), Some(Primitive(Int))),
                 (
                     Primitive(Decimal {
                         precision: 8,
@@ -442,10 +442,10 @@ mod test {
                 (Primitive(StringType), None),
                 (Primitive(Uuid), None),
                 (Primitive(Time), None),
-                (Primitive(Timestamp), Some(Primitive(Date))),
-                (Primitive(Timestamptz), Some(Primitive(Date))),
-                (Primitive(TimestampNs), Some(Primitive(Date))),
-                (Primitive(TimestamptzNs), Some(Primitive(Date))),
+                (Primitive(Timestamp), Some(Primitive(Int))),
+                (Primitive(Timestamptz), Some(Primitive(Int))),
+                (Primitive(TimestampNs), Some(Primitive(Int))),
+                (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![NestedField::optional(
                         1,
@@ -480,7 +480,7 @@ mod test {
             ],
             trans_types: vec![
                 (Primitive(Binary), None),
-                (Primitive(Date), Some(Primitive(Date))),
+                (Primitive(Date), Some(Primitive(Int))),
                 (
                     Primitive(Decimal {
                         precision: 8,
@@ -494,10 +494,10 @@ mod test {
                 (Primitive(StringType), None),
                 (Primitive(Uuid), None),
                 (Primitive(Time), None),
-                (Primitive(Timestamp), Some(Primitive(Date))),
-                (Primitive(Timestamptz), Some(Primitive(Date))),
-                (Primitive(TimestampNs), Some(Primitive(Date))),
-                (Primitive(TimestamptzNs), Some(Primitive(Date))),
+                (Primitive(Timestamp), Some(Primitive(Int))),
+                (Primitive(Timestamptz), Some(Primitive(Int))),
+                (Primitive(TimestampNs), Some(Primitive(Int))),
+                (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![NestedField::optional(
                         1,


### PR DESCRIPTION
Seems to be changed together with `date` transform by mistake in #479