### PR TITLE
refactor: Remove spawn and channel inside arrow reader

### DIFF
--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -422,7 +422,10 @@ impl TableScan {
             arrow_reader_builder = arrow_reader_builder.with_batch_size(batch_size);
         }
 
-        arrow_reader_builder.build().read(self.plan_files().await?)
+        arrow_reader_builder
+            .build()
+            .read(self.plan_files().await?)
+            .await
     }
 
     /// Returns a reference to the column names of the table scan.
@@ -1404,12 +1407,14 @@ mod tests {
         let batch_stream = reader
             .clone()
             .read(Box::pin(stream::iter(vec![Ok(plan_task.remove(0))])))
+            .await
             .unwrap();
         let batche1: Vec<_> = batch_stream.try_collect().await.unwrap();
 
         let reader = ArrowReaderBuilder::new(fixture.table.file_io().clone()).build();
         let batch_stream = reader
             .read(Box::pin(stream::iter(vec![Ok(plan_task.remove(0))])))
+            .await
             .unwrap();
         let batche2: Vec<_> = batch_stream.try_collect().await.unwrap();
 


### PR DESCRIPTION
This PR will remove spwan and channel inside arrow reader so users can concurrently read data stream without extra cost.