### PR TITLE
chore: more consistently use type conversions

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -28,7 +28,6 @@ use arrow_schema::{
 };
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 
-use crate::arrow::schema_to_arrow_schema;
 use crate::spec::{Literal, PrimitiveLiteral, Schema as IcebergSchema};
 use crate::{Error, ErrorKind, Result};
 
@@ -179,7 +178,7 @@ impl RecordBatchTransformer {
         snapshot_schema: &IcebergSchema,
         projected_iceberg_field_ids: &[i32],
     ) -> Result<BatchTransform> {
-        let mapped_unprojected_arrow_schema = Arc::new(schema_to_arrow_schema(snapshot_schema)?);
+        let mapped_unprojected_arrow_schema = Arc::new(snapshot_schema.try_into()?);
         let field_id_to_mapped_schema_map =
             Self::build_field_id_to_arrow_schema_map(&mapped_unprojected_arrow_schema)?;
 

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -208,13 +208,13 @@ fn visit_schema<V: ArrowSchemaVisitor>(schema: &ArrowSchema, visitor: &mut V) ->
 }
 
 /// Convert Arrow schema to Iceberg schema.
-pub fn arrow_schema_to_schema(schema: &ArrowSchema) -> Result<Schema> {
+fn arrow_schema_to_schema(schema: &ArrowSchema) -> Result<Schema> {
     let mut visitor = ArrowSchemaConverter::new();
     visit_schema(schema, &mut visitor)
 }
 
 /// Convert Arrow type to iceberg type.
-pub fn arrow_type_to_type(ty: &DataType) -> Result<Type> {
+fn arrow_type_to_type(ty: &DataType) -> Result<Type> {
     let mut visitor = ArrowSchemaConverter::new();
     visit_type(ty, &mut visitor)
 }
@@ -621,7 +621,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 }
 
 /// Convert iceberg schema to an arrow schema.
-pub fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<ArrowSchema> {
+fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<ArrowSchema> {
     let mut converter = ToArrowSchemaConverter;
     match crate::spec::visit_schema(schema, &mut converter)? {
         ArrowSchemaOrFieldOrType::Schema(schema) => Ok(schema),
@@ -630,7 +630,7 @@ pub fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<Arr
 }
 
 /// Convert iceberg type to an arrow type.
-pub fn type_to_arrow_type(ty: &crate::spec::Type) -> crate::Result<DataType> {
+fn type_to_arrow_type(ty: &crate::spec::Type) -> crate::Result<DataType> {
     let mut converter = ToArrowSchemaConverter;
     match crate::spec::visit_type(ty, &mut converter)? {
         ArrowSchemaOrFieldOrType::Type(ty) => Ok(ty),
@@ -822,11 +822,35 @@ impl TryFrom<&ArrowSchema> for crate::spec::Schema {
     }
 }
 
+impl TryFrom<ArrowSchema> for crate::spec::Schema {
+    type Error = Error;
+
+    fn try_from(value: ArrowSchema) -> crate::Result<Self> {
+        (&value).try_into()
+    }
+}
+
 impl TryFrom<&crate::spec::Schema> for ArrowSchema {
     type Error = Error;
 
     fn try_from(schema: &crate::spec::Schema) -> crate::Result<Self> {
         schema_to_arrow_schema(schema)
+    }
+}
+
+impl TryFrom<&DataType> for crate::spec::Type {
+    type Error = Error;
+
+    fn try_from(value: &DataType) -> crate::Result<Self> {
+        arrow_type_to_type(value)
+    }
+}
+
+impl TryFrom<&crate::spec::Type> for DataType {
+    type Error = Error;
+
+    fn try_from(value: &crate::spec::Type) -> crate::Result<DataType> {
+        type_to_arrow_type(value)
     }
 }
 

--- a/crates/integrations/datafusion/src/table/table_provider_factory.rs
+++ b/crates/integrations/datafusion/src/table/table_provider_factory.rs
@@ -24,7 +24,6 @@ use datafusion::catalog::{Session, TableProvider, TableProviderFactory};
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::CreateExternalTable;
 use datafusion::sql::TableReference;
-use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::io::FileIO;
 use iceberg::table::StaticTable;
 use iceberg::{Error, ErrorKind, Result, TableIdent};
@@ -126,7 +125,11 @@ impl TableProviderFactory for IcebergTableProviderFactory {
             .map_err(to_datafusion_error)?
             .into_table();
 
-        let schema = schema_to_arrow_schema(table.metadata().current_schema())
+        let schema = table
+            .metadata()
+            .current_schema()
+            .as_ref()
+            .try_into()
             .map_err(to_datafusion_error)?;
 
         Ok(Arc::new(IcebergTableProvider::new(table, Arc::new(schema))))


### PR DESCRIPTION
Hey iceberg-rs!,

looking to start to more actively contribute to the iceberg ecosystem and trying to grock the codebase, I thought maybe some small contributions might be welcome :).

This PR just reduces the surface area for in internal module a little bit, by leveraging partially already defined `TryInto` traits rather then exporting dedicated functions for type conversion.

it is IMO a little bit more idiomatic, buf fully understand if you prefer the current way of doing things.