### PR TITLE
ci: add sccache to speed up ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ env:
   rust_msrv: "1.77.1"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_LOG: "debug"
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ concurrency:
 
 env:
   rust_msrv: "1.77.1"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   check:
@@ -103,6 +105,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Check License Header
         uses: apache/skywalking-eyes/header@v0.6.0
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Install cargo-sort
         run: make install-cargo-sort
 
@@ -80,6 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
@@ -98,6 +104,10 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Build
         run: cargo build -p iceberg --no-default-features
 


### PR DESCRIPTION
e.g., the `unit` job takes 10min in total, and build takes 5min. So I think we can introduce cache to speed it up.
 
<img width="997" alt="image" src="https://github.com/user-attachments/assets/6e2b0c7c-6312-4201-aad3-44cd73f6d57e" />
