### PR TITLE
fix(datafusion): Align schemas for DataFusion plan and stream

### DIFF
--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -45,8 +45,6 @@ pub(crate) struct IcebergTableScan {
     table: Table,
     /// Snapshot of the table to scan.
     snapshot_id: Option<i64>,
-    /// A reference-counted arrow `Schema`.
-    schema: ArrowSchemaRef,
     /// Stores certain, often expensive to compute,
     /// plan properties used in query optimization.
     plan_properties: PlanProperties,
@@ -76,7 +74,6 @@ impl IcebergTableScan {
         Self {
             table,
             snapshot_id,
-            schema,
             plan_properties,
             projection,
             predicates,
@@ -134,7 +131,7 @@ impl ExecutionPlan for IcebergTableScan {
         let stream = futures::stream::once(fut).try_flatten();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.schema.clone(),
+            self.schema(),
             stream,
         )))
     }


### PR DESCRIPTION
Closes #828.

Return the projected schema instead of the full schema, and thus align with the schema in `ExecutionPlan::schema`.