### PR TITLE
fix: allow nullable field of equality delete writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "array-init",
  "arrow-arith",
  "arrow-array",
+ "arrow-buffer",
  "arrow-cast",
  "arrow-ord",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ apache-avro = "0.17"
 array-init = "2"
 arrow-arith = { version = "53.3.0" }
 arrow-array = { version = "53.4.0" }
+arrow-buffer = { version = "53.4.0" }
 arrow-cast = { version = "53.4.0" }
 arrow-ord = { version = "53.4.0" }
 arrow-schema = { version = "53.4.0" }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -46,6 +46,7 @@ apache-avro = { workspace = true }
 array-init = { workspace = true }
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
 arrow-cast = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-schema = { workspace = true }


### PR DESCRIPTION
According to the doc fixed in https://github.com/apache/iceberg/pull/8981, the equality delete writer can have an optional field id. This PR fixes this.