### PR TITLE
ci: use officail rustsec/audit-check action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,12 +32,14 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
 
+  schedule:
+    - cron: '0 0 * * *'
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Run audit check
-        run: cargo audit
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,6 +28,9 @@ on:
       - "**/Cargo.lock"
 
   pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
 
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,9 +28,6 @@ on:
       - "**/Cargo.lock"
 
   pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
 
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
1. it installs binary instead of compile
2. add a cron job, and it can automatically create issues like https://github.com/risingwavelabs/risingwave/issues/14002