### PR TITLE
fix: support both gs and gcs schemes for google cloud storage

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -40,7 +40,7 @@ use crate::{Error, ErrorKind, Result};
 /// | Local file system  | `storage-fs`      | `file`     |
 /// | Memory             | `storage-memory`  | `memory`   |
 /// | S3                 | `storage-s3`      | `s3`, `s3a`|
-/// | GCS                | `storage-gcs`     | `gs`       |
+/// | GCS                | `storage-gcs`     | `gs`, `gcs`|
 #[derive(Clone, Debug)]
 pub struct FileIO {
     builder: FileIOBuilder,

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -40,7 +40,7 @@ use crate::{Error, ErrorKind, Result};
 /// | Local file system  | `storage-fs`      | `file`     |
 /// | Memory             | `storage-memory`  | `memory`   |
 /// | S3                 | `storage-s3`      | `s3`, `s3a`|
-/// | GCS                | `storage-gcs`     | `gcs`       |
+/// | GCS                | `storage-gcs`     | `gs`       |
 #[derive(Clone, Debug)]
 pub struct FileIO {
     builder: FileIOBuilder,

--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -171,7 +171,7 @@ impl Storage {
             "memory" => Ok(Scheme::Memory),
             "file" | "" => Ok(Scheme::Fs),
             "s3" | "s3a" => Ok(Scheme::S3),
-            "gs" => Ok(Scheme::Gcs),
+            "gs" | "gcs" => Ok(Scheme::Gcs),
             s => Ok(s.parse::<Scheme>()?),
         }
     }

--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -171,7 +171,7 @@ impl Storage {
             "memory" => Ok(Scheme::Memory),
             "file" | "" => Ok(Scheme::Fs),
             "s3" | "s3a" => Ok(Scheme::S3),
-            "gcs" => Ok(Scheme::Gcs),
+            "gs" => Ok(Scheme::Gcs),
             s => Ok(s.parse::<Scheme>()?),
         }
     }


### PR DESCRIPTION
~~- This reverts commit cda4a0c595af2606e2f4076e9ef81d79d4428f4b.~~
~~- The scheme of google cloud storage should be `gs` instead of `gcs` and `gs` is not a typo. `gs` is widely used by google and opendal.~~
- support both `gs` and `gcs` schemes for google cloud storage