### PR TITLE
feat: Expose disable_config_load opendal GCS option

### DIFF
--- a/crates/iceberg/src/io/mod.rs
+++ b/crates/iceberg/src/io/mod.rs
@@ -88,3 +88,7 @@ use storage_fs::*;
 mod storage_gcs;
 #[cfg(feature = "storage-gcs")]
 pub use storage_gcs::*;
+
+fn is_truthy(value: &str) -> bool {
+    ["true", "t", "1", "on"].contains(&value.to_lowercase().as_str())
+}

--- a/crates/iceberg/src/io/storage_gcs.rs
+++ b/crates/iceberg/src/io/storage_gcs.rs
@@ -22,6 +22,7 @@ use opendal::services::GcsConfig;
 use opendal::Operator;
 use url::Url;
 
+use crate::io::is_truthy;
 use crate::{Error, ErrorKind, Result};
 
 // Reference: https://github.com/apache/iceberg/blob/main/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -47,10 +48,6 @@ pub const GCS_ALLOW_ANONYMOUS: &str = "gcs.allow-anonymous";
 pub const GCS_DISABLE_VM_METADATA: &str = "gcs.disable-vm-metadata";
 /// Option to skip loading configuration from config file and the env.
 pub const GCS_DISABLE_CONFIG_LOAD: &str = "gcs.disable-config-load";
-
-fn is_truthy(value: &str) -> bool {
-    ["true", "t", "1", "on"].contains(&value)
-}
 
 /// Parse iceberg properties to [`GcsConfig`].
 pub(crate) fn gcs_config_parse(mut m: HashMap<String, String>) -> Result<GcsConfig> {

--- a/crates/iceberg/src/io/storage_gcs.rs
+++ b/crates/iceberg/src/io/storage_gcs.rs
@@ -41,6 +41,17 @@ pub const GCS_CREDENTIALS_JSON: &str = "gcs.credentials-json";
 /// Google Cloud Storage token
 pub const GCS_TOKEN: &str = "gcs.oauth2.token";
 
+/// Option to skip signing requests (e.g. for public buckets/folders).
+pub const GCS_ALLOW_ANONYMOUS: &str = "gcs.allow-anonymous";
+/// Option to skip loading the credential from GCE metadata server (typically used in conjunction with `GCS_ALLOW_ANONYMOUS`).
+pub const GCS_DISABLE_VM_METADATA: &str = "gcs.disable-vm-metadata";
+/// Option to skip loading configuration from config file and the env.
+pub const GCS_DISABLE_CONFIG_LOAD: &str = "gcs.disable-config-load";
+
+fn is_truthy(value: &str) -> bool {
+    ["true", "t", "1", "on"].contains(&value)
+}
+
 /// Parse iceberg properties to [`GcsConfig`].
 pub(crate) fn gcs_config_parse(mut m: HashMap<String, String>) -> Result<GcsConfig> {
     let mut cfg = GcsConfig::default();
@@ -62,6 +73,22 @@ pub(crate) fn gcs_config_parse(mut m: HashMap<String, String>) -> Result<GcsConf
         cfg.disable_vm_metadata = true;
         cfg.disable_config_load = true;
     }
+
+    if let Some(allow_anonymous) = m.remove(GCS_ALLOW_ANONYMOUS) {
+        if is_truthy(allow_anonymous.to_lowercase().as_str()) {
+            cfg.allow_anonymous = true;
+        }
+    }
+    if let Some(disable_ec2_metadata) = m.remove(GCS_DISABLE_VM_METADATA) {
+        if is_truthy(disable_ec2_metadata.to_lowercase().as_str()) {
+            cfg.disable_vm_metadata = true;
+        }
+    };
+    if let Some(disable_config_load) = m.remove(GCS_DISABLE_CONFIG_LOAD) {
+        if is_truthy(disable_config_load.to_lowercase().as_str()) {
+            cfg.disable_config_load = true;
+        }
+    };
 
     Ok(cfg)
 }

--- a/crates/iceberg/src/io/storage_s3.rs
+++ b/crates/iceberg/src/io/storage_s3.rs
@@ -22,6 +22,7 @@ use opendal::services::S3Config;
 use opendal::{Configurator, Operator};
 use url::Url;
 
+use crate::io::is_truthy;
 use crate::{Error, ErrorKind, Result};
 
 /// Following are arguments for [s3 file io](https://py.iceberg.apache.org/configuration/#s3).
@@ -65,10 +66,6 @@ pub const S3_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
 pub const S3_DISABLE_EC2_METADATA: &str = "s3.disable-ec2-metadata";
 /// Option to skip loading configuration from config file and the env.
 pub const S3_DISABLE_CONFIG_LOAD: &str = "s3.disable-config-load";
-
-fn is_truthy(value: &str) -> bool {
-    ["true", "t", "1", "on"].contains(&value)
-}
 
 /// Parse iceberg props to s3 config.
 pub(crate) fn s3_config_parse(mut m: HashMap<String, String>) -> Result<S3Config> {


### PR DESCRIPTION
- Expose `gcs.disable-config-load`, `gcs.disable-vm-metadata` and `gcs.allow-anonymous` for GCS.