### PR TITLE
feat: sql catalog support update table

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -255,7 +255,7 @@ pub struct TableCreation {
 
 /// TableCommit represents the commit of a table in the catalog.
 #[derive(Debug, TypedBuilder)]
-#[builder(build_method(vis = "pub(crate)"))]
+#[builder(build_method(vis = "pub"))]
 pub struct TableCommit {
     /// The table ident.
     ident: TableIdent,

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -626,6 +626,12 @@ impl TableMetadata {
 
         Ok(())
     }
+
+    /// Returns snapshot references.
+    #[inline]
+    pub fn snapshot_refs(&self) -> &HashMap<String, SnapshotReference> {
+        &self.refs
+    }
 }
 
 pub(super) mod _serde {


### PR DESCRIPTION
This PR support `update_table` interface for sql catalog

- support `update_table`
- add some UT 

Other PRs for reference:
- https://github.com/apache/iceberg-rust/pull/610
- https://github.com/apache/iceberg-rust/pull/853

After these PRs have been merged, we can use sql database as the catalog backend