### PR TITLE
[doc] Remove registry mirror recommendations

### DIFF
--- a/docs/contributing/orbstack.md
+++ b/docs/contributing/orbstack.md
@@ -34,6 +34,6 @@
    
     ```
     {
-        "registry-mirrors": ["https://registry.docker.ir", "https://docker.iranserver.com"]
+        "registry-mirrors": ["<mirror_addr>"]
     }
    ```


### PR DESCRIPTION
Following up https://github.com/apache/iceberg-rust/pull/856
Removes registry mirror recommendations
