### PR TITLE
Metadata table scans as streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,28 +588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.92",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,7 +2913,6 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "async-std",
- "async-stream",
  "async-trait",
  "bimap",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2913,6 +2935,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "async-std",
+ "async-stream",
  "async-trait",
  "bimap",
  "bitvec",
@@ -6649,7 +6672,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -52,6 +52,7 @@ arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 arrow-string = { workspace = true }
 async-std = { workspace = true, optional = true, features = ["attributes"] }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bimap = { workspace = true }
 bitvec = { workspace = true }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -52,7 +52,6 @@ arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 arrow-string = { workspace = true }
 async-std = { workspace = true, optional = true, features = ["attributes"] }
-async-stream = { workspace = true }
 async-trait = { workspace = true }
 bimap = { workspace = true }
 bitvec = { workspace = true }

--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -23,8 +23,7 @@ use arrow_array::builder::{
 use arrow_array::types::{Int32Type, Int64Type, Int8Type};
 use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Fields, Schema};
-use async_stream::try_stream;
-use futures::StreamExt;
+use futures::{stream, StreamExt};
 
 use crate::scan::ArrowRecordBatchStream;
 use crate::table::Table;
@@ -78,92 +77,89 @@ impl<'a> ManifestsTable<'a> {
 
     /// Scans the manifests table.
     pub async fn scan(&self) -> Result<ArrowRecordBatchStream> {
-        let arrow_schema = Arc::new(self.schema());
-        let table_metadata = self.table.metadata_ref();
-        let file_io = self.table.file_io().clone();
+        let mut content = PrimitiveBuilder::<Int8Type>::new();
+        let mut path = StringBuilder::new();
+        let mut length = PrimitiveBuilder::<Int64Type>::new();
+        let mut partition_spec_id = PrimitiveBuilder::<Int32Type>::new();
+        let mut added_snapshot_id = PrimitiveBuilder::<Int64Type>::new();
+        let mut added_data_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut existing_data_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut deleted_data_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut added_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut existing_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut deleted_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
+        let mut partition_summaries = ListBuilder::new(StructBuilder::from_fields(
+            Fields::from(Self::partition_summary_fields()),
+            0,
+        ))
+        .with_field(Arc::new(Field::new_struct(
+            "item",
+            Self::partition_summary_fields(),
+            false,
+        )));
 
-        Ok(try_stream! {
-            let mut content = PrimitiveBuilder::<Int8Type>::new();
-            let mut path = StringBuilder::new();
-            let mut length = PrimitiveBuilder::<Int64Type>::new();
-            let mut partition_spec_id = PrimitiveBuilder::<Int32Type>::new();
-            let mut added_snapshot_id = PrimitiveBuilder::<Int64Type>::new();
-            let mut added_data_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut existing_data_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut deleted_data_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut added_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut existing_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut deleted_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
-            let mut partition_summaries = ListBuilder::new(StructBuilder::from_fields(
-                Fields::from(Self::partition_summary_fields()),
-                0,
-            ))
-                .with_field(Arc::new(Field::new_struct(
-                    "item",
-                    Self::partition_summary_fields(),
-                    false,
-                )));
+        if let Some(snapshot) = self.table.metadata().current_snapshot() {
+            let manifest_list = snapshot
+                .load_manifest_list(self.table.file_io(), &self.table.metadata_ref())
+                .await?;
+            for manifest in manifest_list.entries() {
+                content.append_value(manifest.content as i8);
+                path.append_value(manifest.manifest_path.clone());
+                length.append_value(manifest.manifest_length);
+                partition_spec_id.append_value(manifest.partition_spec_id);
+                added_snapshot_id.append_value(manifest.added_snapshot_id);
+                added_data_files_count.append_value(manifest.added_files_count.unwrap_or(0) as i32);
+                existing_data_files_count
+                    .append_value(manifest.existing_files_count.unwrap_or(0) as i32);
+                deleted_data_files_count
+                    .append_value(manifest.deleted_files_count.unwrap_or(0) as i32);
+                added_delete_files_count
+                    .append_value(manifest.added_files_count.unwrap_or(0) as i32);
+                existing_delete_files_count
+                    .append_value(manifest.existing_files_count.unwrap_or(0) as i32);
+                deleted_delete_files_count
+                    .append_value(manifest.deleted_files_count.unwrap_or(0) as i32);
 
-            if let Some(snapshot) = table_metadata.current_snapshot() {
-                let manifest_list = snapshot.load_manifest_list(&file_io, &table_metadata).await?;
-                for manifest in manifest_list.entries() {
-                    content.append_value(manifest.content as i8);
-                    path.append_value(manifest.manifest_path.clone());
-                    length.append_value(manifest.manifest_length);
-                    partition_spec_id.append_value(manifest.partition_spec_id);
-                    added_snapshot_id.append_value(manifest.added_snapshot_id);
-                    added_data_files_count.append_value(manifest.added_files_count.unwrap_or(0) as i32);
-                    existing_data_files_count
-                        .append_value(manifest.existing_files_count.unwrap_or(0) as i32);
-                    deleted_data_files_count
-                        .append_value(manifest.deleted_files_count.unwrap_or(0) as i32);
-                    added_delete_files_count
-                        .append_value(manifest.added_files_count.unwrap_or(0) as i32);
-                    existing_delete_files_count
-                        .append_value(manifest.existing_files_count.unwrap_or(0) as i32);
-                    deleted_delete_files_count
-                        .append_value(manifest.deleted_files_count.unwrap_or(0) as i32);
-
-                    let partition_summaries_builder = partition_summaries.values();
-                    for summary in &manifest.partitions {
-                        partition_summaries_builder
-                            .field_builder::<BooleanBuilder>(0)
-                            .unwrap()
-                            .append_value(summary.contains_null);
-                        partition_summaries_builder
-                            .field_builder::<BooleanBuilder>(1)
-                            .unwrap()
-                            .append_option(summary.contains_nan);
-                        partition_summaries_builder
-                            .field_builder::<StringBuilder>(2)
-                            .unwrap()
-                            .append_option(summary.lower_bound.as_ref().map(|v| v.to_string()));
-                        partition_summaries_builder
-                            .field_builder::<StringBuilder>(3)
-                            .unwrap()
-                            .append_option(summary.upper_bound.as_ref().map(|v| v.to_string()));
-                        partition_summaries_builder.append(true);
-                    }
-                    partition_summaries.append(true);
+                let partition_summaries_builder = partition_summaries.values();
+                for summary in &manifest.partitions {
+                    partition_summaries_builder
+                        .field_builder::<BooleanBuilder>(0)
+                        .unwrap()
+                        .append_value(summary.contains_null);
+                    partition_summaries_builder
+                        .field_builder::<BooleanBuilder>(1)
+                        .unwrap()
+                        .append_option(summary.contains_nan);
+                    partition_summaries_builder
+                        .field_builder::<StringBuilder>(2)
+                        .unwrap()
+                        .append_option(summary.lower_bound.as_ref().map(|v| v.to_string()));
+                    partition_summaries_builder
+                        .field_builder::<StringBuilder>(3)
+                        .unwrap()
+                        .append_option(summary.upper_bound.as_ref().map(|v| v.to_string()));
+                    partition_summaries_builder.append(true);
                 }
+                partition_summaries.append(true);
             }
-
-            yield RecordBatch::try_new(arrow_schema, vec![
-                Arc::new(content.finish()),
-                Arc::new(path.finish()),
-                Arc::new(length.finish()),
-                Arc::new(partition_spec_id.finish()),
-                Arc::new(added_snapshot_id.finish()),
-                Arc::new(added_data_files_count.finish()),
-                Arc::new(existing_data_files_count.finish()),
-                Arc::new(deleted_data_files_count.finish()),
-                Arc::new(added_delete_files_count.finish()),
-                Arc::new(existing_delete_files_count.finish()),
-                Arc::new(deleted_delete_files_count.finish()),
-                Arc::new(partition_summaries.finish()),
-            ])?;
         }
-        .boxed())
+
+        let batch = RecordBatch::try_new(Arc::new(self.schema()), vec![
+            Arc::new(content.finish()),
+            Arc::new(path.finish()),
+            Arc::new(length.finish()),
+            Arc::new(partition_spec_id.finish()),
+            Arc::new(added_snapshot_id.finish()),
+            Arc::new(added_data_files_count.finish()),
+            Arc::new(existing_data_files_count.finish()),
+            Arc::new(deleted_data_files_count.finish()),
+            Arc::new(added_delete_files_count.finish()),
+            Arc::new(existing_delete_files_count.finish()),
+            Arc::new(deleted_delete_files_count.finish()),
+            Arc::new(partition_summaries.finish()),
+        ])?;
+
+        Ok(stream::iter(vec![Ok(batch)]).boxed())
     }
 }
 

--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -22,8 +22,12 @@ use arrow_array::builder::{
 };
 use arrow_array::types::{Int32Type, Int64Type, Int8Type};
 use arrow_array::RecordBatch;
-use arrow_schema::{DataType, Field, Fields, Schema};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use futures::StreamExt;
 
+use crate::io::FileIO;
+use crate::scan::ArrowRecordBatchStream;
+use crate::spec::TableMetadata;
 use crate::table::Table;
 use crate::Result;
 
@@ -38,7 +42,7 @@ impl<'a> ManifestsTable<'a> {
         Self { table }
     }
 
-    fn partition_summary_fields(&self) -> Vec<Field> {
+    fn partition_summary_fields() -> Vec<Field> {
         vec![
             Field::new("contains_null", DataType::Boolean, false),
             Field::new("contains_nan", DataType::Boolean, true),
@@ -65,7 +69,7 @@ impl<'a> ManifestsTable<'a> {
                 "partition_summaries",
                 DataType::List(Arc::new(Field::new_struct(
                     "item",
-                    self.partition_summary_fields(),
+                    Self::partition_summary_fields(),
                     false,
                 ))),
                 false,
@@ -74,7 +78,22 @@ impl<'a> ManifestsTable<'a> {
     }
 
     /// Scans the manifests table.
-    pub async fn scan(&self) -> Result<RecordBatch> {
+    pub async fn scan(&self) -> Result<ArrowRecordBatchStream> {
+        let arrow_schema = Arc::new(self.schema());
+        let table_metadata = self.table.metadata_ref();
+        let file_io = self.table.file_io().clone();
+
+        Ok(futures::stream::once(async move {
+            Self::build_batch(arrow_schema, &table_metadata, &file_io).await
+        })
+        .boxed())
+    }
+
+    async fn build_batch(
+        arrow_schema: SchemaRef,
+        table_metadata: &TableMetadata,
+        file_io: &FileIO,
+    ) -> Result<RecordBatch> {
         let mut content = PrimitiveBuilder::<Int8Type>::new();
         let mut path = StringBuilder::new();
         let mut length = PrimitiveBuilder::<Int64Type>::new();
@@ -87,19 +106,17 @@ impl<'a> ManifestsTable<'a> {
         let mut existing_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
         let mut deleted_delete_files_count = PrimitiveBuilder::<Int32Type>::new();
         let mut partition_summaries = ListBuilder::new(StructBuilder::from_fields(
-            Fields::from(self.partition_summary_fields()),
+            Fields::from(Self::partition_summary_fields()),
             0,
         ))
         .with_field(Arc::new(Field::new_struct(
             "item",
-            self.partition_summary_fields(),
+            Self::partition_summary_fields(),
             false,
         )));
 
-        if let Some(snapshot) = self.table.metadata().current_snapshot() {
-            let manifest_list = snapshot
-                .load_manifest_list(self.table.file_io(), &self.table.metadata_ref())
-                .await?;
+        if let Some(snapshot) = table_metadata.current_snapshot() {
+            let manifest_list = snapshot.load_manifest_list(file_io, table_metadata).await?;
             for manifest in manifest_list.entries() {
                 content.append_value(manifest.content as i8);
                 path.append_value(manifest.manifest_path.clone());
@@ -142,7 +159,7 @@ impl<'a> ManifestsTable<'a> {
             }
         }
 
-        Ok(RecordBatch::try_new(Arc::new(self.schema()), vec![
+        Ok(RecordBatch::try_new(arrow_schema, vec![
             Arc::new(content.finish()),
             Arc::new(path.finish()),
             Arc::new(length.finish()),
@@ -163,7 +180,7 @@ impl<'a> ManifestsTable<'a> {
 mod tests {
     use expect_test::expect;
 
-    use crate::inspect::metadata_table::tests::check_record_batch;
+    use crate::inspect::metadata_table::tests::check_record_batches;
     use crate::scan::tests::TableTestFixture;
 
     #[tokio::test]
@@ -171,10 +188,10 @@ mod tests {
         let mut fixture = TableTestFixture::new();
         fixture.setup_manifest_files().await;
 
-        let record_batch = fixture.table.inspect().manifests().scan().await.unwrap();
+        let batch_stream = fixture.table.inspect().manifests().scan().await.unwrap();
 
-        check_record_batch(
-            record_batch,
+        check_record_batches(
+            batch_stream,
             expect![[r#"
                 Field { name: "content", data_type: Int8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} },
                 Field { name: "path", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} },
@@ -259,6 +276,6 @@ mod tests {
                 ]"#]],
             &["path", "length"],
             Some("path"),
-        );
+        ).await;
     }
 }

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -203,7 +203,7 @@ impl Table {
 
     /// Creates a metadata table which provides table-like APIs for inspecting metadata.
     /// See [`MetadataTable`] for more details.
-    pub fn inspect(self) -> MetadataTable {
+    pub fn inspect(&self) -> MetadataTable<'_> {
         MetadataTable::new(self)
     }
 


### PR DESCRIPTION
This changes the metadata table APIs to have `scan()` return streams instead of a single `RecordBatch`.

Context for this is https://github.com/apache/iceberg-rust/pull/863#discussion_r1901545620, where we're adding a metadata table for which we need to read multiple files. @liurenjie1024 suggested we better consume those as stream.

I'm splitting out to discuss the API change separately, even though the existing metadata tables `snapshots` and `manifests` only read a single file we're just returning async streams of a single record batch.

cc @liurenjie1024 @Xuanwo 