### PR TITLE
Rename 'metadata_table' to 'inspect'

### DIFF
--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -171,13 +171,7 @@ mod tests {
         let mut fixture = TableTestFixture::new();
         fixture.setup_manifest_files().await;
 
-        let record_batch = fixture
-            .table
-            .metadata_table()
-            .manifests()
-            .scan()
-            .await
-            .unwrap();
+        let record_batch = fixture.table.inspect().manifests().scan().await.unwrap();
 
         check_record_batch(
             record_batch,

--- a/crates/iceberg/src/inspect/snapshots.rs
+++ b/crates/iceberg/src/inspect/snapshots.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_snapshots_table() {
         let table = TableTestFixture::new().table;
-        let record_batch = table.metadata_table().snapshots().scan().unwrap();
+        let record_batch = table.inspect().snapshots().scan().unwrap();
         check_record_batch(
             record_batch,
             expect![[r#"

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -203,7 +203,7 @@ impl Table {
 
     /// Creates a metadata table which provides table-like APIs for inspecting metadata.
     /// See [`MetadataTable`] for more details.
-    pub fn metadata_table(self) -> MetadataTable {
+    pub fn inspect(self) -> MetadataTable {
         MetadataTable::new(self)
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/apache/iceberg-rust/pull/872#discussion_r1905099231. @Xuanwo suggested we rename `Table::metadata_table` to `Table::inspect`. It agrees with PyIceberg APIs and is more concise.