### PR TITLE
feat(core): expose remove_snapshots at Transaction API

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -1557,7 +1557,7 @@ mod tests {
         1,
         2
     ]
-}  
+}
         "#;
 
         let update = TableUpdate::RemoveSnapshots {

--- a/crates/iceberg/src/transaction.rs
+++ b/crates/iceberg/src/transaction.rs
@@ -130,6 +130,14 @@ impl<'a> Transaction<'a> {
         snapshot_id
     }
 
+    /// Remove snapshots from table.
+    pub fn remove_snapshots(&mut self, snapshot_ids: Vec<i64>) -> Result<Self> {
+        self.append_updates(vec![TableUpdate::RemoveSnapshots {
+            snapshot_ids: snapshot_ids,
+        }])?;
+        Ok(self)
+    }
+
     /// Creates a fast append action.
     pub fn fast_append(
         self,


### PR DESCRIPTION
A part of #743 

For consistency with [spark-procedure](https://iceberg.apache.org/docs/1.6.1/spark-procedures/#expire_snapshots), may a better name is `expire_snapshots`. Before we support the entire list of parameters, a `remove_snapshots` public method that only supports specified snapshot_ids is still useful. We can consider deprecating this API in the future.