### PR TITLE
test: Add S3 partition directory verification in integration test

### DIFF
--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -33,3 +33,7 @@ iceberg-catalog-rest = { workspace = true }
 iceberg_test_utils = { path = "../test_utils", features = ["tests"] }
 parquet = { workspace = true }
 tokio = { workspace = true }
+aws-sdk-s3 = "1.68.0" 
+url = "2.4.0"
+
+

--- a/crates/integration_tests/testdata/docker-compose.yaml
+++ b/crates/integration_tests/testdata/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - CATALOG_S3_ENDPOINT=http://minio:9000
     depends_on:
       - minio
+      - mc
     networks:
       rest_bridge:
     ports:
@@ -40,7 +41,7 @@ services:
       - 8181
 
   minio:
-    image: minio/minio:RELEASE.2024-03-07T00-43-48Z
+    image: minio/minio:latest
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
@@ -51,6 +52,7 @@ services:
       rest_bridge:
     ports:
       - 9001:9001
+      - 9000:9000
     expose:
       - 9001
       - 9000
@@ -69,17 +71,17 @@ services:
     networks:
       rest_bridge:
 
-  spark-iceberg:
-    build: spark/
-    networks:
-      rest_bridge:
-    depends_on:
-      - rest
-      - minio
-    environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
-      - AWS_REGION=us-east-1
-    links:
-      - rest:rest
-      - minio:minio
+ # spark-iceberg:
+ #   build: spark/
+ #   networks:
+ #     rest_bridge:
+ #   depends_on:
+ #     - rest
+ #     - minio
+ #   environment:
+ #     - AWS_ACCESS_KEY_ID=admin
+ #     - AWS_SECRET_ACCESS_KEY=password
+ #     - AWS_REGION=us-east-1
+ #   links:
+ #     - rest:rest
+ #     - minio:minio

--- a/crates/integration_tests/testdata/docker-compose.yaml
+++ b/crates/integration_tests/testdata/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - 8181
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
@@ -71,17 +71,17 @@ services:
     networks:
       rest_bridge:
 
- # spark-iceberg:
- #   build: spark/
- #   networks:
- #     rest_bridge:
- #   depends_on:
- #     - rest
- #     - minio
- #   environment:
- #     - AWS_ACCESS_KEY_ID=admin
- #     - AWS_SECRET_ACCESS_KEY=password
- #     - AWS_REGION=us-east-1
- #   links:
- #     - rest:rest
- #     - minio:minio
+  spark-iceberg:
+    build: spark/
+    networks:
+      rest_bridge:
+    depends_on:
+      - rest
+      - minio
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    links:
+      - rest:rest
+      - minio:minio


### PR DESCRIPTION
Enhances append_partition_data_file_test.rs to verify the correct partition
layout in MinIO:

- Add URL parsing to extract bucket and prefix from table location
- Implement S3 ListObjectsV2 check for partition directory
- Add debug logging for table location and data file paths
- Verify objects exist in the expected partition directory (id=100/)

This helps diagnose the partition layout issue by confirming whether files are being written to the correct partitioned directory structure.