### PR TITLE
refactor: refine writer interface to support directory hierarchy

### DIFF
--- a/crates/iceberg/src/writer/file_writer/mod.rs
+++ b/crates/iceberg/src/writer/file_writer/mod.rs
@@ -21,14 +21,12 @@ use arrow_array::RecordBatch;
 use futures::Future;
 
 use super::CurrentFileStatus;
-use crate::spec::DataFileBuilder;
+use crate::{io::OutputFile, spec::DataFileBuilder};
 use crate::Result;
 
 mod parquet_writer;
 pub use parquet_writer::{ParquetWriter, ParquetWriterBuilder};
 mod track_writer;
-
-pub mod location_generator;
 
 type DefaultOutput = Vec<DataFileBuilder>;
 
@@ -37,7 +35,7 @@ pub trait FileWriterBuilder<O = DefaultOutput>: Send + Clone + 'static {
     /// The associated file writer type.
     type R: FileWriter<O>;
     /// Build file writer.
-    fn build(self) -> impl Future<Output = Result<Self::R>> + Send;
+    fn build(self, output_file: OutputFile) -> impl Future<Output = Result<Self::R>> + Send;
 }
 
 /// File writer focus on writing record batch to different physical file format.(Such as parquet. orc)

--- a/crates/iceberg/src/writer/function_writer/mod.rs
+++ b/crates/iceberg/src/writer/function_writer/mod.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Function writer for Iceberg
+
+pub mod partition_writer;

--- a/crates/iceberg/src/writer/function_writer/partition_writer.rs
+++ b/crates/iceberg/src/writer/function_writer/partition_writer.rs
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Partition writer
+
+use crate::spec::Struct;
+use crate::writer::{IcebergWriterBuilder, SinglePartitionWriterBuilder};
+use crate::Result;
+
+#[derive(Clone)]
+struct PartitionWriterBuilder<B> {
+    inner_writer_builer: B,
+    partition_value: Option<Struct>,
+}
+
+impl<B: SinglePartitionWriterBuilder> PartitionWriterBuilder<B> {
+    pub fn new(inner_writer_builer: B, partition_value: Option<Struct>) -> Self {
+        Self {
+            inner_writer_builer,
+            partition_value,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<B: SinglePartitionWriterBuilder> IcebergWriterBuilder for PartitionWriterBuilder<B> {
+    type R = B::R;
+
+    async fn build(self) -> Result<Self::R> {
+        self.inner_writer_builer.build(self.partition_value).await
+    }
+}

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -45,12 +45,14 @@
 //! let data_files = data_file_writer.flush().await.unwrap();
 //! ```
 
+pub mod function_writer;
 pub mod base_writer;
 pub mod file_writer;
+pub mod output_file_generator;
 
 use arrow_array::RecordBatch;
 
-use crate::spec::DataFile;
+use crate::spec::{DataFile, Struct};
 use crate::Result;
 
 type DefaultInput = RecordBatch;
@@ -63,8 +65,19 @@ pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>:
 {
     /// The associated writer type.
     type R: IcebergWriter<I, O>;
-    /// Build the iceberg writer.
+    /// Build the iceberg writer with single partition.
     async fn build(self) -> Result<Self::R>;
+}
+
+/// The builder for iceberg writer for single partition.
+#[async_trait::async_trait]
+pub trait SinglePartitionWriterBuilder<I = DefaultInput, O = DefaultOutput>:
+    Send + Clone + 'static
+{
+    /// The associated writer type.
+    type R: IcebergWriter<I, O>;
+    /// Build the iceberg writer with single partition.
+    async fn build(self, partition: Option<Struct>) -> Result<Self::R>;
 }
 
 /// The iceberg writer used to write data to iceberg table.

--- a/crates/integration_tests/tests/append_data_file_test.rs
+++ b/crates/integration_tests/tests/append_data_file_test.rs
@@ -29,7 +29,7 @@ use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use iceberg::writer::{IcebergWriter, SinglePartitionWriterBuilder};
 use iceberg::{Catalog, Namespace, NamespaceIdent, TableCreation};
 use iceberg_integration_tests::set_test_fixture;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;

--- a/crates/integration_tests/tests/append_partition_data_file_test.rs
+++ b/crates/integration_tests/tests/append_partition_data_file_test.rs
@@ -33,7 +33,7 @@ use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use iceberg::writer::{IcebergWriter, SinglePartitionWriterBuilder};
 use iceberg::{Catalog, Namespace, NamespaceIdent, TableCreation};
 use iceberg_integration_tests::set_test_fixture;
 use parquet::file::properties::WriterProperties;

--- a/crates/integration_tests/tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/conflict_commit_test.rs
@@ -29,7 +29,7 @@ use iceberg::writer::file_writer::location_generator::{
     DefaultFileNameGenerator, DefaultLocationGenerator,
 };
 use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use iceberg::writer::{IcebergWriter, SinglePartitionWriterBuilder};
 use iceberg::{Catalog, Namespace, NamespaceIdent, TableCreation};
 use iceberg_integration_tests::set_test_fixture;
 use parquet::file::properties::WriterProperties;


### PR DESCRIPTION
This PR is intended to resolve #891. On our original design, we allow the user to create the writer builder and combine them and build them finally. However, original design is not support to change the config of builder after we combine them. But in some case, we hope to recreate the writer for different partition using writer builder. E.g. in #819, we want to regenerate the table location for different partition. So I follow the design from iceberg-java https://github.com/apache/iceberg/blob/d96901b843395fe669f6bd4f618f8e5e46c0eed4/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java#L334 : 
1. separate the OutputFile from FileWriter. 
2. create a new abstract `SinglePartitionWriterBuilder`.
3. introduce the OutputFileGenerator following https://github.com/apache/iceberg/blob/d96901b843395fe669f6bd4f618f8e5e46c0eed4/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java#L36

It's the responsibility of SinglePartitionWriterBuilder to create the OutputFile. And the build function of SinglePartitionWriterBuilder take a partition value which means that we can create different partition of writer from this Builder.