### PR TITLE
Implement basic support for `rest.sigv4_enabled` for the Iceberg REST catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "reqwest",
+ "reqwest-middleware",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -3024,7 +3025,11 @@ dependencies = [
 name = "iceberg-catalog-rest"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
  "chrono",
  "ctor",
  "http 1.2.0",
@@ -3035,6 +3040,7 @@ dependencies = [
  "mockito",
  "port_scanner",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4791,6 +4797,21 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.2.0",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2675,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -3047,6 +3071,7 @@ dependencies = [
  "tokio",
  "typed-builder 0.20.0",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -3906,6 +3931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,7 +4400,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -6880,6 +6915,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ arrow-schema = { version = "53.4.0" }
 arrow-select = { version = "53.3.0" }
 arrow-string = { version = "53.3.0" }
 async-stream = "0.3.5"
-async-trait = "0.1.85"
+async-trait = "0.1"
 async-std = "1.12"
 aws-config = "1"
 aws-sdk-glue = "1.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ async-trait = "0.1"
 async-std = "1.12"
 aws-config = "1"
 aws-sdk-glue = "1.39"
-aws-sigv4 = { version = "1.2.7", features = ["sign-http"] }
-aws-credential-types = "1.2.1"
+aws-sigv4 = { version = "1.2", features = ["sign-http"] }
+aws-credential-types = "1.2"
 bimap = "0.6"
 bitvec = "1.0.1"
 bytes = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,13 @@ rust-version = "1.77.1"
 anyhow = "1.0.72"
 apache-avro = "0.17"
 array-init = "2"
-arrow-arith = { version = "53.3.0" }
-arrow-array = { version = "53.3.0" }
-arrow-cast = { version = "53.3.0" }
-arrow-ord = { version = "53.3.0" }
-arrow-schema = { version = "53.4.0" }
-arrow-select = { version = "53.3.0" }
-arrow-string = { version = "53.3.0" }
+arrow-arith = { version = "53" }
+arrow-array = { version = "53" }
+arrow-cast = { version = "53" }
+arrow-ord = { version = "53" }
+arrow-schema = { version = "53" }
+arrow-select = { version = "53" }
+arrow-string = { version = "53" }
 async-stream = "0.3.5"
 async-trait = "0.1"
 async-std = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ async-trait = "0.1.85"
 async-std = "1.12"
 aws-config = "1"
 aws-sdk-glue = "1.39"
+aws-sigv4 = { version = "1.2.7", features = ["sign-http"] }
+aws-credential-types = "1.2.1"
 bimap = "0.6"
 bitvec = "1.0.1"
 bytes = "1.6"
@@ -85,6 +87,7 @@ port_scanner = "0.1.5"
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = { version = "0.12.2", default-features = false, features = ["json"] }
+reqwest-middleware = { version = "0.4.0", features = ["json"] }
 rust_decimal = "1.31"
 serde = { version = "1.0.204", features = ["rc"] }
 serde_bytes = "0.11.15"

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -55,7 +55,7 @@ iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
 port_scanner = { workspace = true }
 tokio = { workspace = true }
+wiremock = "0.6"
 
 [features]
-default = ["sigv4"]
 sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types"]

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -30,13 +30,18 @@ keywords = ["iceberg", "rest", "catalog"]
 
 [dependencies]
 # async-trait = { workspace = true }
+anyhow = { workspace = true }
 async-trait = { workspace = true }
+aws-config = { workspace = true, optional = true }
+aws-sigv4 = { workspace = true, optional = true }
+aws-credential-types = { workspace = true, optional = true }
 chrono = { workspace = true }
 http = "1.1.0"
 iceberg = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -50,3 +55,7 @@ iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
 port_scanner = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+default = ["sigv4"]
+sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types"]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -66,6 +66,10 @@ impl RestCatalogConfig {
             .join("/")
     }
 
+    pub(crate) fn base_url(&self) -> String {
+        [&self.uri, PATH_V1].join("/")
+    }
+
     fn config_endpoint(&self) -> String {
         [&self.uri, PATH_V1, "config"].join("/")
     }
@@ -212,6 +216,23 @@ impl RestCatalogConfig {
 
         self.props = props;
         self
+    }
+}
+
+#[cfg(feature = "sigv4")]
+impl RestCatalogConfig {
+    pub(crate) fn sigv4_enabled(&self) -> bool {
+        self.props
+            .get("rest.sigv4-enabled")
+            .map_or(false, |v| v == "true")
+    }
+
+    pub(crate) fn signing_region(&self) -> Option<String> {
+        self.props.get("rest.signing-region").cloned()
+    }
+
+    pub(crate) fn signing_name(&self) -> Option<String> {
+        self.props.get("rest.signing-name").cloned()
     }
 }
 

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -58,16 +58,17 @@ pub struct RestCatalogConfig {
 }
 
 impl RestCatalogConfig {
+    /// Returns the base URL for the REST catalog API
+    pub fn base_url(&self) -> String {
+        [&self.uri, PATH_V1].join("/")
+    }
+
     fn url_prefixed(&self, parts: &[&str]) -> String {
         [&self.uri, PATH_V1]
             .into_iter()
             .chain(self.props.get("prefix").map(|s| &**s))
             .chain(parts.iter().cloned())
             .join("/")
-    }
-
-    pub(crate) fn base_url(&self) -> String {
-        [&self.uri, PATH_V1].join("/")
     }
 
     fn config_endpoint(&self) -> String {

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -21,14 +21,15 @@ use std::sync::Mutex;
 
 use iceberg::{Error, ErrorKind, Result};
 use reqwest::header::HeaderMap;
-use reqwest::{Client, IntoUrl, Method, Request, RequestBuilder, Response};
+use reqwest::{Client, IntoUrl, Method, Request, Response};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use serde::de::DeserializeOwned;
 
 use crate::types::{ErrorResponse, TokenResponse, OK};
 use crate::RestCatalogConfig;
 
 pub(crate) struct HttpClient {
-    client: Client,
+    client: ClientWithMiddleware,
 
     /// The token to be used for authentication.
     ///
@@ -55,9 +56,21 @@ impl Debug for HttpClient {
 
 impl HttpClient {
     /// Create a new http client.
+    #[allow(unused_mut)]
     pub fn new(cfg: &RestCatalogConfig) -> Result<Self> {
+        let mut client_builder = ClientBuilder::new(Client::new());
+
+        #[cfg(feature = "sigv4")]
+        if cfg.sigv4_enabled() {
+            client_builder = client_builder.with(crate::middleware::sigv4::SigV4Middleware::new(
+                &cfg.base_url(),
+                cfg.signing_name().as_deref().unwrap_or("glue"),
+                cfg.signing_region().as_deref(),
+            ));
+        }
+
         Ok(HttpClient {
-            client: Client::new(),
+            client: client_builder.build(),
 
             token: Mutex::new(cfg.token()),
             token_endpoint: cfg.get_token_endpoint(),

--- a/crates/catalog/rest/src/middleware/mod.rs
+++ b/crates/catalog/rest/src/middleware/mod.rs
@@ -15,13 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Iceberg REST API implementation.
+//! Middleware that is applied on requests to the Rest Catalog API.
 
-#![deny(missing_docs)]
-
-mod catalog;
-mod client;
-mod middleware;
-mod types;
-
-pub use catalog::*;
+#[cfg(feature = "sigv4")]
+pub(crate) mod sigv4;

--- a/crates/catalog/rest/src/middleware/sigv4.rs
+++ b/crates/catalog/rest/src/middleware/sigv4.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Middleware that signs requests using the AWS SigV4 signing process.
+
+use std::time::SystemTime;
+
+use anyhow::anyhow;
+use aws_config::{BehaviorVersion, Region};
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
+use aws_sigv4::sign::v4;
+use http::Extensions;
+use reqwest::{Request, Response};
+use reqwest_middleware::{Middleware, Next, Result};
+use tokio::sync::OnceCell;
+
+pub(crate) struct SigV4Middleware {
+    catalog_uri: String,
+    signing_name: String,
+    signing_region: Option<String>,
+    config: OnceCell<aws_config::SdkConfig>,
+}
+
+impl SigV4Middleware {
+    pub(crate) fn new(catalog_uri: &str, signing_name: &str, signing_region: Option<&str>) -> Self {
+        Self {
+            catalog_uri: catalog_uri.to_string(),
+            signing_name: signing_name.to_string(),
+            signing_region: signing_region.map(|s| s.to_string()),
+            config: OnceCell::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Middleware for SigV4Middleware {
+    async fn handle(
+        &self,
+        mut req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        // Skip requests not matching the catalog URI prefix
+        if !req.url().as_str().starts_with(&self.catalog_uri) {
+            return next.run(req, extensions).await;
+        }
+
+        let signing_region = self.signing_region.clone();
+        let config = self
+            .config
+            .get_or_init(|| async {
+                let mut config_loader = aws_config::defaults(BehaviorVersion::v2024_03_28());
+                if let Some(signing_region) = signing_region {
+                    config_loader = config_loader.region(Region::new(signing_region));
+                }
+                config_loader.load().await
+            })
+            .await;
+
+        let credential_provider = config.credentials_provider().ok_or_else(|| {
+            reqwest_middleware::Error::Middleware(anyhow!("No credentials provider found"))
+        })?;
+
+        let region: &str = config.region().map(|r| r.as_ref()).unwrap_or("us-east-1");
+
+        // Prepare signing parameters
+        let credentials = credential_provider
+            .provide_credentials()
+            .await
+            .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?
+            .into();
+        let signing_params = v4::SigningParams::builder()
+            .identity(&credentials)
+            .region(region)
+            .name(&self.signing_name)
+            .time(SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?;
+
+        // In order to sign the request, we need to read the body into bytes.
+        let body = match req.body() {
+            Some(body) => SignableBody::Bytes(body.as_bytes().ok_or_else(|| {
+                reqwest_middleware::Error::Middleware(anyhow!("Unable to read body as bytes"))
+            })?),
+            None => SignableBody::Bytes(&[]),
+        };
+        let signable_request = SignableRequest::new(
+            req.method().as_str(),
+            req.url().as_str(),
+            req.headers()
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.to_str().expect("Invalid header value"))),
+            body,
+        )
+        .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?;
+
+        // Sign the request
+        let signed_request = sign(signable_request, &signing_params.into())
+            .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?;
+
+        // Rebuild the reqwest request with signed headers
+        let (signed_parts, _signature) = signed_request.into_parts();
+
+        let (new_headers, _) = signed_parts.into_parts();
+        for header in new_headers.into_iter() {
+            let mut value = http::HeaderValue::from_str(header.value()).unwrap();
+            value.set_sensitive(header.sensitive());
+            req.headers_mut().insert(header.name(), value);
+        }
+
+        next.run(req, extensions).await
+    }
+}

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -71,6 +71,7 @@ parquet = { workspace = true, features = ["async"] }
 paste = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -314,6 +314,12 @@ define_from_err!(
 );
 
 define_from_err!(
+    reqwest_middleware::Error,
+    ErrorKind::Unexpected,
+    "Failed to execute http request"
+);
+
+define_from_err!(
     serde_json::Error,
     ErrorKind::DataInvalid,
     "Failed to parse json string"


### PR DESCRIPTION
Implements basic support for connecting to the AWS Glue Iceberg REST catalog by supporting the parameters `rest.sigv4-enabled`, `rest.signing-name` and `rest.signing-region`. See the corresponding parameters in the PyIceberg docs: https://py.iceberg.apache.org/configuration/#rest-catalog

I've added a new feature to the `iceberg-catalog-rest` called `sigv4` which when enabled, will recognize the above configuration parameters. I've left this disabled by default.

I added the crate `request_middleware` to allow running middleware on requests, and if the `rest.sigv4-enabled` configuration is enabled, the middleware to sign the request and add the correct `Authorization` header is enabled.

I've tested this implementation in my project, and it works great for connecting to the AWS Glue REST catalog, i.e. `https://glue.<region>.amazonaws.com/iceberg`