### PR TITLE
fix: Make s3tables catalog public

### DIFF
--- a/crates/catalog/s3tables/Cargo.toml
+++ b/crates/catalog/s3tables/Cargo.toml
@@ -35,6 +35,7 @@ aws-config = { workspace = true }
 aws-sdk-s3tables = "1.8.0"
 iceberg = { workspace = true }
 serde_json = { workspace = true }
+typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -31,11 +31,12 @@ use iceberg::{
     Catalog, Error, ErrorKind, Namespace, NamespaceIdent, Result, TableCommit, TableCreation,
     TableIdent,
 };
+use typed_builder::TypedBuilder;
 
 use crate::utils::{create_metadata_location, create_sdk_config};
 
 /// S3Tables catalog configuration.
-#[derive(Debug)]
+#[derive(Debug, TypedBuilder)]
 pub struct S3TablesCatalogConfig {
     /// Unlike other buckets, S3Tables bucket is not a physical bucket, but a virtual bucket
     /// that is managed by s3tables. We can't directly access the bucket with path like
@@ -48,8 +49,10 @@ pub struct S3TablesCatalogConfig {
     /// - `aws_access_key_id`: The AWS access key ID to use.
     /// - `aws_secret_access_key`: The AWS secret access key to use.
     /// - `aws_session_token`: The AWS session token to use.
+    #[builder(default)]
     properties: HashMap<String, String>,
     /// Endpoint URL for the catalog.
+    #[builder(default, setter(strip_option(fallback = endpoint_url_opt)))]
     endpoint_url: Option<String>,
 }
 
@@ -515,12 +518,9 @@ mod tests {
             None => return Ok(None),
         };
 
-        let properties = HashMap::new();
-        let config = S3TablesCatalogConfig {
-            table_bucket_arn,
-            properties,
-            endpoint_url: None,
-        };
+        let config = S3TablesCatalogConfig::builder()
+            .table_bucket_arn(table_bucket_arn)
+            .build();
 
         Ok(Some(S3TablesCatalog::new(config).await?))
     }

--- a/crates/catalog/s3tables/src/lib.rs
+++ b/crates/catalog/s3tables/src/lib.rs
@@ -21,3 +21,5 @@
 
 mod catalog;
 mod utils;
+
+pub use catalog::*;


### PR DESCRIPTION
Hi!

I was testing s3tables catalog and found that it is not public. I don't know if it was done on purpose, but in order to use it I had to make it public. I also added `TypedBuilder` macro to match the api with other catalogs.