### PR TITLE
Bump number of open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    open-pull-requests-limit: 50


### PR DESCRIPTION
I noticed that some groups of dependencies are out of sync: https://github.com/apache/iceberg-rust/pull/915#discussion_r1932478025

Therefore I think it is good to bump the limit a bit (default is 5).