### PR TITLE
feat: Make some REST methods public

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -94,7 +94,11 @@ impl RestCatalogConfig {
         self.url_prefixed(&["tables", "rename"])
     }
 
-    fn table_endpoint(&self, table: &TableIdent) -> String {
+    /// Builds a prefixed table endpoint from the given table identifier.
+    ///
+    /// Outputs an endpoint in the form of `/{base_url}/namespaces/{namespace}/tables/{table}`.
+    /// The base URL is defined by the catalog config, built from the URI, version and any specified prefix.
+    pub fn table_endpoint(&self, table: &TableIdent) -> String {
         self.url_prefixed(&[
             "namespaces",
             &table.namespace.to_url_string(),

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -27,7 +27,8 @@ use serde::de::DeserializeOwned;
 use crate::types::{ErrorResponse, TokenResponse, OK};
 use crate::RestCatalogConfig;
 
-pub(crate) struct HttpClient {
+/// The HTTP client for the REST catalog
+pub struct HttpClient {
     client: Client,
 
     /// The token to be used for authentication.
@@ -216,11 +217,19 @@ impl HttpClient {
         Ok(())
     }
 
+    /// Create a new request builder, from the inner client.
     #[inline]
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
         self.client.request(method, url)
     }
 
+    /// Send a request and parse the response into ``R`` on success, or ``E`` on error.
+    /// Assert the response code is ``SUCCESS_CODE``, otherwise return an error.
+    ///
+    /// # Errors
+    ///
+    /// - If the response code is not ``SUCCESS_CODE``, return an error.
+    /// - If the response body cannot be parsed into ``R`` or ``E``, return an error.
     pub async fn query<
         R: DeserializeOwned,
         E: DeserializeOwned + Into<Error>,
@@ -272,6 +281,13 @@ impl HttpClient {
         }
     }
 
+    /// Send a request, dropping any response body on success, parsing the response into ``E`` on error.
+    /// Assert the response code is ``SUCCESS_CODE``, otherwise return an error.
+    ///
+    /// # Errors
+    ///
+    /// - If the response code is not ``SUCCESS_CODE``, return an error.
+    /// - If the response body cannot be parsed into ``E``, return an error.
     pub async fn execute<E: DeserializeOwned + Into<Error>, const SUCCESS_CODE: u16>(
         &self,
         mut request: Request,

--- a/crates/catalog/rest/src/lib.rs
+++ b/crates/catalog/rest/src/lib.rs
@@ -24,3 +24,5 @@ mod client;
 mod types;
 
 pub use catalog::*;
+pub use client::HttpClient;
+pub use types::{ErrorResponse, OK};

--- a/crates/catalog/rest/src/types.rs
+++ b/crates/catalog/rest/src/types.rs
@@ -23,7 +23,8 @@ use iceberg::{
 };
 use serde_derive::{Deserialize, Serialize};
 
-pub(super) const OK: u16 = 200u16;
+/// HTTP status code for OK.
+pub const OK: u16 = 200u16;
 pub(super) const NO_CONTENT: u16 = 204u16;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -32,8 +33,9 @@ pub(super) struct CatalogConfig {
     pub(super) defaults: HashMap<String, String>,
 }
 
+/// Response for request errors.
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct ErrorResponse {
+pub struct ErrorResponse {
     error: ErrorModel,
 }
 


### PR DESCRIPTION
* Makes `ErrorResponse`, `OK`, and `HttpClient` public to support escape-hatching for REST catalogs that don't 100% support the iceberg catalog response formats.

I'd like to use `iceberg-rust` for some Iceberg-like clients that return partial `TableMetadata` responses, so I need to be able to access the underlying HTTP client to set my own response types. This enables that use case, and lets me re-use all of the nice work around endpoints, HTTP clients, etc.