### PR TITLE
[infra] nightly pypi build for `pyiceberg_core`

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: 'Update Package Version'
+description: 'Updates pyproject.toml version with timestamp'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install toml
+      run: pip install toml
+      shell: bash
+
+    - name: Get and update version
+      shell: bash
+      run: |
+        CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
+        TIMESTAMP=$(date +%Y%m%d%H%M%S)
+        NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
+        NEW_VERSION=$NEW_VERSION python -c "
+        import toml
+        import os
+        config = toml.load('bindings/python/pyproject.toml')
+        config['project']['version'] = os.environ['NEW_VERSION']
+        with open('bindings/python/pyproject.toml', 'w') as f:
+            toml.dump(config, f)
+        print(f'Updated version to: {config[\"project\"][\"version\"]}')
+        "

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -113,31 +113,3 @@ jobs:
       with:
         skip-existing: true
         packages-dir: bindings/python/dist
-
-  testpypi-publish:
-    name: Publish Python 🐍 distribution 📦 to TestPypi
-    needs: [ sdist, wheels ]
-    runs-on: ubuntu-latest
-    # Only publish to TestPyPi if the tag is a pre-release
-    if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-')}}
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/pyiceberg_core
-
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: bindings/python/dist
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: true
-        packages-dir: bindings/python/dist

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "Nightly PyPI Build"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs at midnight UTC every day
+  workflow_dispatch:  # Allows manual triggering
+
+env:
+  rust_msrv: "1.77.1"
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install toml
+        run: pip install toml
+
+      # Override the library version
+      - name: Get current version
+        run: |
+          CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          
+      - name: Update version with timestamp
+        run: |
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
+          NEW_VERSION=$NEW_VERSION python -c "
+          import toml
+          import os
+          config = toml.load('bindings/python/pyproject.toml')
+          config['project']['version'] = os.environ['NEW_VERSION']
+          with open('bindings/python/pyproject.toml', 'w') as f:
+              toml.dump(config, f)
+          print(f'Updated version to: {config[\"project\"][\"version\"]}')
+          "
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: "bindings/python"
+          command: sdist
+          args: -o dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: bindings/python/dist
+
+  wheels:
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        include:
+          - { os: windows-latest }
+          - { os: macos-latest, target: "universal2-apple-darwin" }
+          - { os: ubuntu-latest, target: "x86_64" }
+          - { os: ubuntu-latest, target: "aarch64" }
+          - { os: ubuntu-latest, target: "armv7l" }
+    steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: 3.9
+        - name: Setup Rust toolchain
+          uses: ./.github/actions/setup-builder
+          with:
+            rust-version: ${{ env.rust_msrv }}
+        - uses: PyO3/maturin-action@v1
+          with:
+            target: ${{ matrix.target }}
+            manylinux: auto
+            working-directory: "bindings/python"
+            command: build
+            args: --release -o dist
+          env:
+            # Workaround ring 0.17 build issue
+            CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+        - name: Upload wheels
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-${{ matrix.os }}-${{ matrix.target }}
+            path: bindings/python/dist
+
+  testpypi-publish:
+    name: Publish Python 🐍 distribution 📦 to TestPypi
+    needs: [ sdist, wheels ]
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pyiceberg_core
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheels-*
+        merge-multiple: true
+        path: bindings/python/dist
+    - name: List downloaded artifacts
+      run: ls -R bindings/python/dist
+    # - name: Publish to TestPyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     repository-url: https://test.pypi.org/legacy/
+    #     skip-existing: true
+    #     packages-dir: bindings/python/dist

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -57,7 +57,7 @@ jobs:
           - { os: windows-latest }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
-          - { os: ubuntu-latest, target: "aarch64" }
+          - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
         - uses: actions/checkout@v4
@@ -72,13 +72,10 @@ jobs:
         - uses: PyO3/maturin-action@v1
           with:
             target: ${{ matrix.target }}
-            manylinux: auto
+            manylinux: ${{ matrix.manylinux || 'auto' }}
             working-directory: "bindings/python"
             command: build
             args: --release -o dist
-          env:
-            # Workaround ring 0.17 build issue
-            CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
         - name: Upload wheels
           uses: actions/upload-artifact@v4
           with:

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -103,9 +103,9 @@ jobs:
         path: bindings/python/dist
     - name: List downloaded artifacts
       run: ls -R bindings/python/dist
-    # - name: Publish to TestPyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     repository-url: https://test.pypi.org/legacy/
-    #     skip-existing: true
-    #     packages-dir: bindings/python/dist
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        packages-dir: bindings/python/dist

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -34,33 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install toml
-        run: pip install toml
-
-      # Override the library version
-      - name: Get current version
-        run: |
-          CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
-          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
-          
-      - name: Update version with timestamp
-        run: |
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
-          NEW_VERSION=$NEW_VERSION python -c "
-          import toml
-          import os
-          config = toml.load('bindings/python/pyproject.toml')
-          config['project']['version'] = os.environ['NEW_VERSION']
-          with open('bindings/python/pyproject.toml', 'w') as f:
-              toml.dump(config, f)
-          print(f'Updated version to: {config[\"project\"][\"version\"]}')
-          "
+      - uses: ./.github/actions/overwrite-package-version  # overwrite the pacakge version with current timestamp
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -85,6 +59,7 @@ jobs:
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
         - uses: actions/checkout@v4
+        - uses: ./.github/actions/overwrite-package-version  # overwrite the pacakge version with current timestamp
         - uses: actions/setup-python@v5
           with:
             python-version: 3.9
@@ -109,7 +84,6 @@ jobs:
             path: bindings/python/dist
 
   testpypi-publish:
-    name: Publish Python 🐍 distribution 📦 to TestPypi
     needs: [ sdist, wheels ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   sdist:
+    if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
           path: bindings/python/dist
 
   wheels:
+    if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:


### PR DESCRIPTION
Inspired by [pyiceberg#1601](https://github.com/apache/iceberg-python/pull/1601) & https://github.com/apache/iceberg-python/blob/main/.github/workflows/nightly-pypi-build.yml

This PR adds nightly build of `pyiceberg_core` to testpypi. 

I have successfully tested the github action on my fork by pushing to my own package,
* Action run: https://github.com/kevinjqliu/iceberg-rust/actions/runs/13381378488
* testpypi artifact: https://test.pypi.org/project/pyiceberg-core-kevinliu/

I've also verified library versions locally
```
(3.12.8) ➜  python git:(kevinjqliu/nightly-pyiceberg-core) pip install -i https://test.pypi.org/simple/ pyiceberg-core-kevinliu --prefer-binary --force
Looking in indexes: https://test.pypi.org/simple/
Collecting pyiceberg-core-kevinliu
  Using cached https://test-files.pythonhosted.org/packages/4b/c7/771857185d3d96e4ce0b59293540d0e1df9a8a39dbc938e0770328504c25/pyiceberg_core_kevinliu-0.4.0.dev20250218012743-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl.metadata (1.7 kB)
Using cached https://test-files.pythonhosted.org/packages/4b/c7/771857185d3d96e4ce0b59293540d0e1df9a8a39dbc938e0770328504c25/pyiceberg_core_kevinliu-0.4.0.dev20250218012743-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl (1.3 MB)
Installing collected packages: pyiceberg-core-kevinliu
  Attempting uninstall: pyiceberg-core-kevinliu
    Found existing installation: pyiceberg_core-kevinliu 0.4.0.dev20250218012743
    Uninstalling pyiceberg_core-kevinliu-0.4.0.dev20250218012743:
      Successfully uninstalled pyiceberg_core-kevinliu-0.4.0.dev20250218012743
Successfully installed pyiceberg-core-kevinliu-0.4.0.dev20250218012743

pip show pyiceberg-core-kevinliu

(3.12.8) ➜  python git:(kevinjqliu/nightly-pyiceberg-core) pip show pyiceberg-core-kevinliu
Name: pyiceberg_core-kevinliu
Version: 0.4.0.dev20250218012743
Summary: 
Home-page: https://rust.iceberg.apache.org
Author: 
Author-email: 
License: Apache-2.0
Location: /Users/kevinliu/.pyenv/versions/3.12.8/lib/python3.12/site-packages
Requires: 
Required-by: 
```