### PR TITLE
chore: fix Cargo.lock diff always present after `cargo build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,7 @@ dependencies = [
  "itertools",
  "serde_json",
  "tokio",
+ "typed-builder 0.20.0",
  "uuid",
 ]
 


### PR DESCRIPTION
Noticed a small thing when building the project, let me know if that's not right.