### PR TITLE
feat: Add existing parquet files

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1117,14 +1117,14 @@ impl<'a> BoundPredicateVisitor for PredicateConverter<'a> {
 /// - `metadata_size_hint`: Provide a hint as to the size of the parquet file's footer.
 /// - `preload_column_index`: Load the Column Index  as part of [`Self::get_metadata`].
 /// - `preload_offset_index`: Load the Offset Index as part of [`Self::get_metadata`].
-struct ArrowFileReader<R: FileRead> {
+pub struct ArrowFileReader<R: FileRead> {
     meta: FileMetadata,
     r: R,
 }
 
 impl<R: FileRead> ArrowFileReader<R> {
     /// Create a new ArrowFileReader
-    fn new(meta: FileMetadata, r: R) -> Self {
+    pub fn new(meta: FileMetadata, r: R) -> Self {
         Self { meta, r }
     }
 }

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -981,7 +981,7 @@ pub mod tests {
     use crate::TableIdent;
 
     pub struct TableTestFixture {
-        table_location: String,
+        pub table_location: String,
         pub table: Table,
     }
 

--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -25,6 +25,7 @@ use std::ops::Index;
 use std::sync::{Arc, OnceLock};
 
 use ::serde::de::{MapAccess, Visitor};
+use ordered_float::OrderedFloat;
 use serde::de::{Error, IntoDeserializer};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
@@ -265,6 +266,28 @@ impl PrimitiveType {
                 | (PrimitiveType::Fixed(_), PrimitiveLiteral::Binary(_))
                 | (PrimitiveType::Binary, PrimitiveLiteral::Binary(_))
         )
+    }
+
+    /// Used to convert `PrimitiveType` to `Literal`.
+    pub fn type_to_literal(&self) -> Literal {
+        Literal::Primitive(match self {
+            PrimitiveType::Boolean => PrimitiveLiteral::Boolean(false),
+            PrimitiveType::Int => PrimitiveLiteral::Int(0),
+            PrimitiveType::Long => PrimitiveLiteral::Long(0),
+            PrimitiveType::Float => PrimitiveLiteral::Float(OrderedFloat(0.0)),
+            PrimitiveType::Double => PrimitiveLiteral::Double(OrderedFloat(0.0)),
+            PrimitiveType::Decimal { .. } => PrimitiveLiteral::Int128(0),
+            PrimitiveType::Date => PrimitiveLiteral::Int(0),
+            PrimitiveType::Time => PrimitiveLiteral::Long(0),
+            PrimitiveType::Timestamp => PrimitiveLiteral::Long(0),
+            PrimitiveType::Timestamptz => PrimitiveLiteral::Long(0),
+            PrimitiveType::TimestampNs => PrimitiveLiteral::Long(0),
+            PrimitiveType::TimestamptzNs => PrimitiveLiteral::Long(0),
+            PrimitiveType::String => PrimitiveLiteral::String(String::new()),
+            PrimitiveType::Uuid => PrimitiveLiteral::UInt128(0),
+            PrimitiveType::Fixed(_size) => PrimitiveLiteral::Binary(Vec::new()),
+            PrimitiveType::Binary => PrimitiveLiteral::Binary(Vec::new()),
+        })
     }
 }
 


### PR DESCRIPTION
Completes #932 

Allows for adding existing parquet files by using parquet metadata to create `DataFiles`. Then fast appending them using existing api