### PR TITLE
feat: Added `UpdatePartitionSpec`

### DIFF
--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -46,6 +46,16 @@ pub struct PartitionField {
 }
 
 impl PartitionField {
+    /// Creates new `PartitionField`` instance
+    pub fn new(source_id: i32, field_id: i32, name: String, transform: Transform) -> Self {
+        Self {
+            source_id,
+            field_id,
+            name,
+            transform,
+        }
+    }
+
     /// To unbound partition field
     pub fn into_unbound(self) -> UnboundPartitionField {
         self.into()

--- a/crates/iceberg/src/spec/schema.rs
+++ b/crates/iceberg/src/spec/schema.rs
@@ -60,6 +60,13 @@ pub struct Schema {
     field_id_to_accessor: HashMap<i32, Arc<StructAccessor>>,
 }
 
+impl Schema {
+    /// Returns id to field mapping
+    pub fn id_to_field(&self) -> HashMap<i32, NestedFieldRef> {
+        self.id_to_field.clone()
+    }
+}
+
 impl PartialEq for Schema {
     fn eq(&self, other: &Self) -> bool {
         self.r#struct == other.r#struct

--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -45,7 +45,7 @@ use crate::ErrorKind;
 /// predicates and partition predicates.
 ///
 /// All transforms must return `null` for a `null` input value.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum Transform {
     /// Source value, unmodified
     ///
@@ -355,9 +355,28 @@ impl Transform {
     }
 
     /// Check if `Transform` is applicable on datum's `PrimitiveType`
-    fn can_transform(&self, datum: &Datum) -> bool {
+    pub fn can_transform(&self, datum: &Datum) -> bool {
         let input_type = datum.data_type().clone();
         self.result_type(&Type::Primitive(input_type)).is_ok()
+    }
+
+    /// Checks if can transform from type
+    pub fn can_transform_from_primitive_type(&self, primitive_type: &PrimitiveType) -> bool {
+        self.result_type(&Type::Primitive(primitive_type.clone()))
+            .is_ok()
+    }
+
+    /// Checks if time transform
+    pub fn is_time_transform(&self) -> bool {
+        matches!(
+            self,
+            Transform::Hour | Transform::Day | Transform::Month | Transform::Year
+        )
+    }
+
+    /// Checks if void transform
+    pub fn is_void_transform(&self) -> bool {
+        matches!(self, Transform::Void)
     }
 
     /// Creates a unary predicate from a given operator and a reference name.


### PR DESCRIPTION
Closes #732.

Adds `UpdatePartitionSpec` according to pyiceberg specifications. Allows for batch processing of partition spec renames, add field, remove field.