### PR TITLE
chore(ci): upgrade to manylinux_2_28 for aarch64 Python wheels

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -62,7 +62,7 @@ jobs:
           - { os: windows-latest }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
-          - { os: ubuntu-latest, target: "aarch64" }
+          - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
         - uses: actions/checkout@v4
@@ -76,13 +76,10 @@ jobs:
         - uses: PyO3/maturin-action@v1
           with:
             target: ${{ matrix.target }}
-            manylinux: auto
+            manylinux: ${{ matrix.manylinux || 'auto' }}
             working-directory: "bindings/python"
             command: build
             args: --release -o dist
-          env:
-            # Workaround ring 0.17 build issue
-            CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
         - name: Upload wheels
           uses: actions/upload-artifact@v4
           with:


### PR DESCRIPTION
Context: https://github.com/apache/iceberg-rust/pull/948#discussion_r1959179801
Following the changes in https://github.com/apache/opendal/pull/5522 and https://github.com/apache/opendal/issues/5483

Tested github action run on my fork: https://github.com/kevinjqliu/iceberg-rust/actions/runs/13394221916