### PR TITLE
[fix] nightly pypi build for `pyiceberg_core`

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -16,7 +16,11 @@
 # under the License.
 
 name: 'Update Package Version'
-description: 'Updates pyproject.toml version with timestamp'
+description: 'Updates pyproject.toml version with a provided timestamp'
+inputs:
+  timestamp:
+    description: 'Timestamp to override to the package version'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -33,8 +37,7 @@ runs:
       shell: bash
       run: |
         CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
-        TIMESTAMP=$(date +%Y%m%d%H%M%S)
-        NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
+        NEW_VERSION="${CURRENT_VERSION}.dev${{ inputs.timestamp }}"
         NEW_VERSION=$NEW_VERSION python -c "
         import toml
         import os

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -29,19 +29,32 @@ permissions:
   contents: read
 
 jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.set-ts.outputs.TIMESTAMP }}
+    steps:
+      - name: Generate version timestamp
+        id: set-ts
+        run: echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
+
   sdist:
+    needs: set-version
     if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/overwrite-package-version  # overwrite the pacakge version with current timestamp
+      
+      - uses: ./.github/actions/overwrite-package-version  # Overwrite package version with timestamp
+        with:
+          timestamp: ${{ needs.set-version.outputs.TIMESTAMP }}
 
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: "bindings/python"
           command: sdist
           args: -o dist
+      
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
@@ -49,6 +62,7 @@ jobs:
           path: bindings/python/dist
 
   wheels:
+    needs: set-version
     if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
     runs-on: "${{ matrix.os }}"
     strategy:
@@ -61,14 +75,20 @@ jobs:
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
         - uses: actions/checkout@v4
-        - uses: ./.github/actions/overwrite-package-version  # overwrite the pacakge version with current timestamp
+
+        - uses: ./.github/actions/overwrite-package-version  # Overwrite package version with timestamp
+          with:
+            timestamp: ${{ needs.set-version.outputs.TIMESTAMP }}
+
         - uses: actions/setup-python@v5
           with:
             python-version: 3.9
+
         - name: Setup Rust toolchain
           uses: ./.github/actions/setup-builder
           with:
             rust-version: ${{ env.rust_msrv }}
+
         - uses: PyO3/maturin-action@v1
           with:
             target: ${{ matrix.target }}
@@ -76,6 +96,7 @@ jobs:
             working-directory: "bindings/python"
             command: build
             args: --release -o dist
+
         - name: Upload wheels
           uses: actions/upload-artifact@v4
           with:


### PR DESCRIPTION
Follow up to #948 
I found a bug in the nightly pypi build where the version timestamp changes within the jobs, causing a single run to push multiple versions. 
This PR fixes the issue by setting the version timestamp once for the entire workflow and then pass it down to individual jobs. This should ensure a consistency version

Workflow run: https://github.com/apache/iceberg-rust/actions/runs/13460497360
Testpypi: https://test.pypi.org/project/pyiceberg-core-kevinliu/#history

Tested on my fork: 
Worfklow run: https://github.com/kevinjqliu/iceberg-rust/actions/runs/13461643730
Testpypi on my fork: https://test.pypi.org/project/pyiceberg-core-kevinliu/0.4.0.dev20250221170617/#files