### PR TITLE
Check binary array length when applying truncate

### DIFF
--- a/crates/iceberg/src/transform/truncate.rs
+++ b/crates/iceberg/src/transform/truncate.rs
@@ -44,7 +44,11 @@ impl Truncate {
 
     #[inline]
     fn truncate_binary(s: &[u8], width: usize) -> &[u8] {
-        &s[0..width]
+        if s.len() > width {
+            &s[0..width]
+        } else {
+            &s
+        }
     }
 
     #[inline]

--- a/crates/iceberg/src/transform/truncate.rs
+++ b/crates/iceberg/src/transform/truncate.rs
@@ -47,7 +47,7 @@ impl Truncate {
         if s.len() > width {
             &s[0..width]
         } else {
-            &s
+            s
         }
     }
 


### PR DESCRIPTION
We found an issue in https://github.com/apache/iceberg-python/pull/1592