### PR TITLE
fix: speficy the version of munge for msrv check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
           # Some dependencies don't correctly specify a minimal version for their dependencies and will fail to build.
           # So we update these transitive dependencies here.
           cargo update tap faststr metainfo linkedbytes
+          # munge 0.4.2 will cause fail to use 1.7.1 so specify the correct version here.
+          cargo update -p munge --precise 0.4.1
       - name: Setup MSRV Rust toolchain
         uses: ./.github/actions/setup-builder
         with:


### PR DESCRIPTION
#704 fail in msrv check and I find that's because `cargo update faststr` will update the munge to `0.4.2` instead of `0.4.1`. The simple fix way is to specify the precise version of munge. But I'm not sure whether it's good practice here. Do you have any suggestions for this? cc @Xuanwo @xxchan  