### PR TITLE
ci(dependabot): Ignore all patch updates for iceberg-rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 50
+    ignore:
+       # For all packages, ignore all patch updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
iceberg-rust will always maintain the minimal versions for deps, so we don't need to update for patch versions.