### PR TITLE
make predicate accessor functions public

### DIFF
--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -147,12 +147,12 @@ impl<T> UnaryExpression<T> {
     }
 
     /// Return the operator of this predicate.
-    pub(crate) fn op(&self) -> PredicateOperator {
+    pub fn op(&self) -> PredicateOperator {
         self.op
     }
 
     /// Return the term of this predicate.
-    pub(crate) fn term(&self) -> &T {
+    pub fn term(&self) -> &T {
         &self.term
     }
 }
@@ -199,17 +199,17 @@ impl<T> BinaryExpression<T> {
         Self { op, term, literal }
     }
 
-    pub(crate) fn op(&self) -> PredicateOperator {
+    pub fn op(&self) -> PredicateOperator {
         self.op
     }
 
     /// Return the literal of this predicate.
-    pub(crate) fn literal(&self) -> &Datum {
+    pub fn literal(&self) -> &Datum {
         &self.literal
     }
 
     /// Return the term of this predicate.
-    pub(crate) fn term(&self) -> &T {
+    pub fn term(&self) -> &T {
         &self.term
     }
 }
@@ -261,16 +261,16 @@ impl<T> SetExpression<T> {
     }
 
     /// Return the operator of this predicate.
-    pub(crate) fn op(&self) -> PredicateOperator {
+    pub fn op(&self) -> PredicateOperator {
         self.op
     }
 
-    pub(crate) fn literals(&self) -> &FnvHashSet<Datum> {
+    pub fn literals(&self) -> &FnvHashSet<Datum> {
         &self.literals
     }
 
     /// Return the term of this predicate.
-    pub(crate) fn term(&self) -> &T {
+    pub fn term(&self) -> &T {
         &self.term
     }
 }


### PR DESCRIPTION
Makes the accessor functions on `UnaryExpression`, `BinaryExpression`, and `SetExpression` public, making it easier to programmatically transform `iceberg::expr::Predicate` expressions from outside of the `iceberg` crate.

Closes #1003 