### PR TITLE
fix: fix version of mechete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ cargo-sort: install-cargo-sort
 	cargo sort -c -w
 
 install-cargo-machete:
-	cargo install cargo-machete
+	cargo install cargo-machete@0.7.0
 
 cargo-machete: install-cargo-machete
 	cargo machete


### PR DESCRIPTION
cargo-machete just released 0.8.0 and it needs new rust version. This PR fix it.

```
error: failed to download `cargo-machete v0.8.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/Users/ze/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-machete-0.8.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0-nightly (b1feb75d0 2024-06-07)).
  Consider trying a more recent nightly release.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
make: *** [install-cargo-machete] Error 101
```