### PR TITLE
Scan Delete Support Part 6: Equality Delete Parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +2977,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "reqwest",
+ "roaring",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -4944,6 +4951,16 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roaring"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
 
 [[package]]
 name = "rsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ port_scanner = "0.1.5"
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = { version = "0.12.2", default-features = false, features = ["json"] }
+roaring = "0.10"
 rust_decimal = "1.31"
 serde = { version = "1.0.204", features = ["rc"] }
 serde_bytes = "0.11.15"

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -72,6 +72,7 @@ parquet = { workspace = true, features = ["async"] }
 paste = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
+roaring = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -329,11 +329,44 @@ impl DeleteFileManager {
     ///
     /// Returns a map of data file path to a delete vector
     async fn parse_positional_deletes_record_batch_stream(
-        stream: ArrowRecordBatchStream,
+        mut stream: ArrowRecordBatchStream,
     ) -> Result<HashMap<String, RoaringTreemap>> {
-        // TODO
+        let mut result: HashMap<String, RoaringTreemap> = HashMap::default();
 
-        Ok(HashMap::default())
+        while let Some(batch) = stream.next().await {
+            let batch = batch?;
+            let schema = batch.schema();
+            let columns = batch.columns();
+
+            let Some(file_paths) = columns[0].as_any().downcast_ref::<StringArray>() else {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Could not downcast file paths array to StringArray",
+                ));
+            };
+            let Some(positions) = columns[1].as_any().downcast_ref::<Int64Array>() else {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Could not downcast positions array to Int64Array",
+                ));
+            };
+
+            for (file_path, pos) in file_paths.iter().zip(positions.iter()) {
+                let (Some(file_path), Some(pos)) = (file_path, pos) else {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "null values in delete file",
+                    ));
+                };
+
+                result
+                    .entry(file_path.to_string())
+                    .or_default()
+                    .insert(pos as u64);
+            }
+        }
+
+        Ok(result)
     }
 
     /// Parses record batch streams from individual equality delete files
@@ -453,27 +486,67 @@ mod tests {
             .load_deletes(&file_scan_tasks[0].deletes, file_io, 5)
             .await
             .unwrap();
+
+        let result = delete_file_manager
+            .get_delete_vector_for_task(&file_scan_tasks[0])
+            .unwrap();
+        assert_eq!(result.len(), 3); // pos dels from pos del file 1 and 2
+
+        let result = delete_file_manager
+            .get_delete_vector_for_task(&file_scan_tasks[1])
+            .unwrap();
+        assert_eq!(result.len(), 3); // pos dels from pos del file 3
     }
 
     fn setup(table_location: &Path) -> Vec<FileScanTask> {
         let data_file_schema = Arc::new(Schema::builder().build().unwrap());
         let positional_delete_schema = create_pos_del_schema();
 
-        let file_path_values = vec![format!("{}/1.parquet", table_location.to_str().unwrap()); 8];
-        let pos_values = vec![0, 1, 3, 5, 6, 8, 1022, 1023];
+        let mut file_path_values = vec![];
+        let mut pos_values = vec![];
 
-        let file_path_col = Arc::new(StringArray::from_iter_values(file_path_values));
-        let pos_col = Arc::new(Int64Array::from_iter_values(pos_values));
+        file_path_values.push(vec![
+            format!(
+                "{}/1.parquet",
+                table_location.to_str().unwrap()
+            );
+            3
+        ]);
+        pos_values.push(vec![0, 1, 3]);
+
+        file_path_values.push(vec![
+            format!(
+                "{}/1.parquet",
+                table_location.to_str().unwrap()
+            );
+            3
+        ]);
+        pos_values.push(vec![5, 6, 8]);
+
+        file_path_values.push(vec![
+            format!(
+                "{}/2.parquet",
+                table_location.to_str().unwrap()
+            );
+            3
+        ]);
+        pos_values.push(vec![1022, 1023, 1024]);
+        // 9 rows in total pos deleted across 3 files
 
         let props = WriterProperties::builder()
             .set_compression(Compression::SNAPPY)
             .build();
 
         for n in 1..=3 {
+            let file_path_col = Arc::new(StringArray::from_iter_values(
+                file_path_values.pop().unwrap(),
+            ));
+            let pos_col = Arc::new(Int64Array::from_iter_values(pos_values.pop().unwrap()));
+
             let positional_deletes_to_write =
                 RecordBatch::try_new(positional_delete_schema.clone(), vec![
                     file_path_col.clone(),
-                    pos_col.clone(),
+                    pos_col,
                 ])
                 .unwrap();
 
@@ -521,7 +594,7 @@ mod tests {
                 start: 0,
                 length: 0,
                 record_count: None,
-                data_file_path: "".to_string(),
+                data_file_path: format!("{}/1.parquet", table_location.to_str().unwrap()),
                 data_file_content: DataContentType::Data,
                 data_file_format: DataFileFormat::Parquet,
                 schema: data_file_schema.clone(),
@@ -533,13 +606,13 @@ mod tests {
                 start: 0,
                 length: 0,
                 record_count: None,
-                data_file_path: "".to_string(),
+                data_file_path: format!("{}/2.parquet", table_location.to_str().unwrap()),
                 data_file_content: DataContentType::Data,
                 data_file_format: DataFileFormat::Parquet,
                 schema: data_file_schema.clone(),
                 project_field_ids: vec![],
                 predicate: None,
-                deletes: vec![pos_del_2, pos_del_3],
+                deletes: vec![pos_del_3],
             },
         ];
 

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::expr::BoundPredicate;
+use crate::io::FileIO;
+use crate::scan::FileScanTaskDeleteFile;
+use crate::spec::SchemaRef;
+use crate::{Error, ErrorKind, Result};
+
+pub(crate) struct DeleteFileManager {}
+
+#[allow(unused_variables)]
+impl DeleteFileManager {
+    pub(crate) async fn load_deletes(
+        delete_file_entries: Vec<FileScanTaskDeleteFile>,
+        file_io: FileIO,
+        concurrency_limit_data_files: usize,
+    ) -> Result<DeleteFileManager> {
+        // TODO
+
+        if !delete_file_entries.is_empty() {
+            Err(Error::new(
+                ErrorKind::FeatureUnsupported,
+                "Reading delete files is not yet supported",
+            ))
+        } else {
+            Ok(DeleteFileManager {})
+        }
+    }
+
+    pub(crate) fn build_delete_predicate(
+        &self,
+        snapshot_schema: SchemaRef,
+    ) -> Result<Option<BoundPredicate>> {
+        // TODO
+
+        Ok(None)
+    }
+
+    pub(crate) fn get_positional_delete_indexes_for_data_file(
+        &self,
+        data_file_path: &str,
+    ) -> Option<Vec<usize>> {
+        // TODO
+
+        None
+    }
+}

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -17,11 +17,12 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::ops::BitAndAssign;
+use std::ops::BitOrAssign;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::task::{Context, Poll};
 
+use arrow_array::{Int64Array, StringArray};
 use futures::channel::oneshot;
 use futures::future::join_all;
 use futures::{StreamExt, TryStreamExt};
@@ -296,7 +297,7 @@ impl DeleteFileManager {
         if let ParsedDeleteFileContext::DelVecs(del_vecs) = item {
             del_vecs.into_iter().for_each(|(key, val)| {
                 let entry = merged_delete_vectors.entry(key).or_default();
-                entry.bitand_assign(val);
+                entry.bitor_assign(val);
             });
         }
 

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -22,18 +22,22 @@ use std::pin::Pin;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::task::{Context, Poll};
 
-use arrow_array::{Int64Array, StringArray};
+use arrow_array::{
+    Array, ArrayRef, BooleanArray, Date32Array, Float32Array, Float64Array, Int32Array, Int64Array,
+    StringArray, Time64MicrosecondArray, TimestampMicrosecondArray, TimestampNanosecondArray,
+};
 use futures::channel::oneshot;
 use futures::future::join_all;
 use futures::{StreamExt, TryStreamExt};
+use itertools::Itertools;
 use roaring::RoaringTreemap;
 
-use crate::arrow::ArrowReader;
+use crate::arrow::{arrow_schema_to_schema, ArrowReader};
 use crate::expr::Predicate::AlwaysTrue;
-use crate::expr::{Bind, BoundPredicate, Predicate};
+use crate::expr::{Bind, BoundPredicate, Predicate, Reference};
 use crate::io::FileIO;
 use crate::scan::{ArrowRecordBatchStream, FileScanTask, FileScanTaskDeleteFile};
-use crate::spec::DataContentType;
+use crate::spec::{DataContentType, Datum, NestedFieldRef, PrimitiveType};
 use crate::{Error, ErrorKind, Result};
 
 // Equality deletes may apply to more than one DataFile in a scan, and so
@@ -373,11 +377,46 @@ impl DeleteFileManager {
     ///
     /// Returns an unbound Predicate for each batch stream
     async fn parse_equality_deletes_record_batch_stream(
-        streams: ArrowRecordBatchStream,
+        mut stream: ArrowRecordBatchStream,
     ) -> Result<Predicate> {
-        // TODO
+        let mut result_predicate = AlwaysTrue;
 
-        Ok(AlwaysTrue)
+        while let Some(record_batch) = stream.next().await {
+            let record_batch = record_batch?;
+
+            if record_batch.num_columns() == 0 {
+                return Ok(AlwaysTrue);
+            }
+
+            let batch_schema_arrow = record_batch.schema();
+            let batch_schema_iceberg = arrow_schema_to_schema(batch_schema_arrow.as_ref())?;
+
+            let mut datum_columns_with_names: Vec<_> = record_batch
+                .columns()
+                .iter()
+                .zip(batch_schema_iceberg.as_struct().fields())
+                .map(|(column, field)| {
+                    let col_as_datum_vec = arrow_array_to_datum_iterator(column, field);
+                    col_as_datum_vec.map(|c| (c, field.name.to_string()))
+                })
+                .try_collect()?;
+
+            // consume all the iterators in lockstep, creating per-row predicates that get combined
+            // into a single final predicate
+            while datum_columns_with_names[0].0.len() > 0 {
+                let mut row_predicate = AlwaysTrue;
+                for (ref mut column, ref field_name) in &mut datum_columns_with_names {
+                    if let Some(item) = column.next() {
+                        if let Some(datum) = item? {
+                            row_predicate = row_predicate
+                                .and(Reference::new(field_name.clone()).equal_to(datum.clone()));
+                        }
+                    }
+                }
+                result_predicate = result_predicate.or(row_predicate);
+            }
+        }
+        Ok(result_predicate)
     }
 
     /// Builds eq delete predicate for the provided task.
@@ -444,6 +483,83 @@ impl DeleteFileManager {
 
 pub(crate) fn is_equality_delete(f: &FileScanTaskDeleteFile) -> bool {
     matches!(f.file_type, DataContentType::EqualityDeletes)
+}
+
+macro_rules! prim_to_datum {
+    ($column:ident, $arr:ty, $dat:path) => {{
+        let arr = $column.as_any().downcast_ref::<$arr>().ok_or(Error::new(
+            ErrorKind::Unexpected,
+            format!("could not downcast ArrayRef to {}", stringify!($arr)),
+        ))?;
+        Ok(Box::new(arr.iter().map(|val| Ok(val.map($dat)))))
+    }};
+}
+
+fn eq_col_unsupported(ty: &str) -> Error {
+    Error::new(
+        ErrorKind::FeatureUnsupported,
+        format!(
+            "Equality deletes where a predicate acts upon a {} column are not yet supported",
+            ty
+        ),
+    )
+}
+
+fn arrow_array_to_datum_iterator<'a>(
+    column: &'a ArrayRef,
+    field: &NestedFieldRef,
+) -> Result<Box<dyn ExactSizeIterator<Item = Result<Option<Datum>>> + 'a>> {
+    match field.field_type.as_primitive_type() {
+        Some(primitive_type) => match primitive_type {
+            PrimitiveType::Int => prim_to_datum!(column, Int32Array, Datum::int),
+            PrimitiveType::Boolean => {
+                prim_to_datum!(column, BooleanArray, Datum::bool)
+            }
+            PrimitiveType::Long => prim_to_datum!(column, Int64Array, Datum::long),
+            PrimitiveType::Float => {
+                prim_to_datum!(column, Float32Array, Datum::float)
+            }
+            PrimitiveType::Double => {
+                prim_to_datum!(column, Float64Array, Datum::double)
+            }
+            PrimitiveType::String => {
+                prim_to_datum!(column, StringArray, Datum::string)
+            }
+            PrimitiveType::Date => prim_to_datum!(column, Date32Array, Datum::date),
+            PrimitiveType::Timestamp => {
+                prim_to_datum!(column, TimestampMicrosecondArray, Datum::timestamp_micros)
+            }
+            PrimitiveType::Timestamptz => {
+                prim_to_datum!(column, TimestampMicrosecondArray, Datum::timestamptz_micros)
+            }
+            PrimitiveType::TimestampNs => {
+                prim_to_datum!(column, TimestampNanosecondArray, Datum::timestamp_nanos)
+            }
+            PrimitiveType::TimestamptzNs => {
+                prim_to_datum!(column, TimestampNanosecondArray, Datum::timestamptz_nanos)
+            }
+            PrimitiveType::Time => {
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<Time64MicrosecondArray>()
+                    .ok_or(Error::new(
+                        ErrorKind::Unexpected,
+                        "could not downcast ArrayRef to Time64MicrosecondArray",
+                    ))?;
+                Ok(Box::new(arr.iter().map(|val| match val {
+                    None => Ok(None),
+                    Some(val) => Datum::time_micros(val).map(Some),
+                })))
+            }
+            PrimitiveType::Decimal { .. } => Err(eq_col_unsupported("Decimal")),
+            PrimitiveType::Uuid => Err(eq_col_unsupported("Uuid")),
+            PrimitiveType::Fixed(_) => Err(eq_col_unsupported("Fixed")),
+            PrimitiveType::Binary => Err(eq_col_unsupported("Binary")),
+        },
+        None => Err(eq_col_unsupported(
+            "non-primitive (i.e. Struct, List, or Map)",
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use roaring::RoaringTreemap;
+
 use crate::expr::BoundPredicate;
 use crate::io::FileIO;
 use crate::scan::FileScanTaskDeleteFile;
@@ -54,7 +56,7 @@ impl DeleteFileManager {
     pub(crate) fn get_positional_delete_indexes_for_data_file(
         &self,
         data_file_path: &str,
-    ) -> Option<Vec<usize>> {
+    ) -> Option<RoaringTreemap> {
         // TODO
 
         None

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -15,50 +15,526 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
+use std::future::Future;
+use std::ops::BitAndAssign;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+
+use futures::channel::oneshot;
+use futures::{StreamExt, TryStreamExt};
 use roaring::RoaringTreemap;
 
-use crate::expr::BoundPredicate;
+use crate::arrow::ArrowReader;
+use crate::expr::Predicate::AlwaysTrue;
+use crate::expr::{Bind, BoundPredicate, Predicate};
 use crate::io::FileIO;
-use crate::scan::FileScanTaskDeleteFile;
-use crate::spec::SchemaRef;
+use crate::scan::{ArrowRecordBatchStream, FileScanTask, FileScanTaskDeleteFile};
+use crate::spec::DataContentType;
 use crate::{Error, ErrorKind, Result};
 
-pub(crate) struct DeleteFileManager {}
+// Equality deletes may apply to more than one DataFile in a scan, and so
+// the same equality delete file may be present in more than one invocation of
+// DeleteFileManager::load_deletes in the same scan. We want to deduplicate these
+// to avoid having to load them twice, so we immediately store cloneable futures in the
+// state that can be awaited upon to get te EQ deletes. That way we can check to see if
+// a load of each Eq delete file is already in progress and avoid starting another one.
+#[derive(Debug, Clone)]
+struct EqDelFuture {}
+
+impl EqDelFuture {
+    pub fn new() -> (oneshot::Sender<Predicate>, Self) {
+        todo!()
+    }
+}
+
+impl Future for EqDelFuture {
+    type Output = Predicate;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        todo!()
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeleteFileManagerState {
+    // delete vectors and positional deletes get merged when loaded into a single delete vector
+    // per data file
+    delete_vectors: HashMap<String, RoaringTreemap>,
+
+    // equality delete files are parsed into unbound `Predicate`s. We store them here as
+    // cloneable futures (see note below)
+    equality_deletes: HashMap<String, EqDelFuture>,
+}
+
+type StateRef = Arc<RwLock<DeleteFileManagerState>>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct DeleteFileManager {
+    state: Arc<RwLock<DeleteFileManagerState>>,
+}
+
+// Intermediate context during processing of a delete file task.
+enum DeleteFileContext {
+    // TODO: Delete Vector loader from Puffin files
+    InProgEqDel(EqDelFuture),
+    PosDels(ArrowRecordBatchStream),
+    FreshEqDel {
+        batch_stream: ArrowRecordBatchStream,
+        sender: oneshot::Sender<Predicate>,
+    },
+}
+
+// Final result of the processing of a delete file task before
+// results are fully merged into the DeleteFileManager's state
+enum ParsedDeleteFileContext {
+    InProgEqDel(EqDelFuture),
+    DelVecs(HashMap<String, RoaringTreemap>),
+    EqDel,
+}
 
 #[allow(unused_variables)]
 impl DeleteFileManager {
-    pub(crate) async fn load_deletes(
-        delete_file_entries: Vec<FileScanTaskDeleteFile>,
-        file_io: FileIO,
-        concurrency_limit_data_files: usize,
-    ) -> Result<DeleteFileManager> {
-        // TODO
-
-        if !delete_file_entries.is_empty() {
-            Err(Error::new(
-                ErrorKind::FeatureUnsupported,
-                "Reading delete files is not yet supported",
-            ))
-        } else {
-            Ok(DeleteFileManager {})
+    pub(crate) fn new() -> DeleteFileManager {
+        Self {
+            state: Default::default(),
         }
     }
 
-    pub(crate) fn build_delete_predicate(
+    pub(crate) async fn load_deletes(
         &self,
-        snapshot_schema: SchemaRef,
-    ) -> Result<Option<BoundPredicate>> {
-        // TODO
+        delete_file_entries: &[FileScanTaskDeleteFile],
+        file_io: FileIO,
+        concurrency_limit_data_files: usize,
+    ) -> Result<()> {
+        /*
+               * Create a single stream of all delete file tasks irrespective of type,
+                   so that we can respect the combined concurrency limit
+               * We then process each in two phases: load and parse.
+               * for positional deletes the load phase instantiates an ArrowRecordBatchStream to
+                   stream the file contents out
+               * for eq deletes, we first check if the EQ delete is already loaded or being loaded by
+                   another concurrently processing data file scan task. If it is, we return a future
+                   for the pre-existing task from the load phase. If not, we create such a future
+                   and store it in the state to prevent other data file tasks from starting to load
+                   the same equality delete file, and return a record batch stream from the load phase
+                   as per the other delete file types - only this time it is accompanied by a one-shot
+                   channel sender that we will eventually use to resolve the shared future that we stored
+                   in the state.
+               * When this gets updated to add support for delete vectors, the load phase will return
+                   a PuffinReader for them.
+               * The parse phase parses each record batch stream according to its associated data type.
+                   The result of this is a map of data file paths to delete vectors for the positional
+                   delete tasks (and in future for the delete vector tasks). For equality delete
+                   file tasks, this results in an unbound Predicate.
+               * The unbound Predicates resulting from equality deletes are sent to their associated oneshot
+                   channel to store them in the right place in the delete file manager's state.
+               * The results of all of these futures are awaited on in parallel with the specified
+                   level of concurrency and collected into a vec. We then combine all of the delete
+                   vector maps that resulted from any positional delete or delete vector files into a
+                   single map and persist it in the state.
 
-        Ok(None)
+
+           Conceptually, the data flow is like this:
+
+                                         FileScanTaskDeleteFile
+                                                    |
+           Already-loading EQ Delete                |             Everything Else
+                    +---------------------------------------------------+
+                    |                                                   |
+           [get existing future]                         [load recordbatch stream / puffin]
+        DeleteFileContext::InProgEqDel                           DeleteFileContext
+                    |                                                   |
+                    |                                                   |
+                    |                     +-----------------------------+--------------------------+
+                    |                   Pos Del           Del Vec (Not yet Implemented)         EQ Del
+                    |                     |                             |                          |
+                    |          [parse pos del stream]         [parse del vec puffin]       [parse eq del]
+                    |  HashMap<String, RoaringTreeMap> HashMap<String, RoaringTreeMap>   (Predicate, Sender)
+                    |                     |                             |                          |
+                    |                     |                             |                 [persist to state]
+                    |                     |                             |                          ()
+                    |                     |                             |                          |
+                    |                     +-----------------------------+--------------------------+
+                    |                                                   |
+                    |                                            [buffer unordered]
+                    |                                                   |
+                    |                                            [combine del vectors]
+                    |                                      HashMap<String, RoaringTreeMap>
+                    |                                                   |
+                    |                                      [persist del vectors to state]
+                    |                                                   ()
+                    |                                                   |
+                    +-------------------------+-------------------------+
+                                              |
+                                           [join!]
+               */
+
+        let stream_items = delete_file_entries
+            .iter()
+            .map(|t| (t.clone(), file_io.clone(), self.state.clone()))
+            .collect::<Vec<_>>();
+        // NOTE: removing the collect and just passing the iterator to futures::stream:iter
+        // results in an error 'implementation of `std::ops::FnOnce` is not general enough'
+
+        let task_stream = futures::stream::iter(stream_items.into_iter());
+
+        let results: Vec<ParsedDeleteFileContext> = task_stream
+            .map(move |(task, file_io, state_ref)| async {
+                Self::load_file_for_task(task, file_io, state_ref).await
+            })
+            .map(move |ctx| Ok(async { Self::parse_file_content_for_task(ctx.await?).await }))
+            .try_buffer_unordered(concurrency_limit_data_files)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let merged_delete_vectors = results
+            .into_iter()
+            .fold(HashMap::default(), Self::merge_delete_vectors);
+
+        self.state.write().unwrap().delete_vectors = merged_delete_vectors;
+
+        Ok(())
     }
 
-    pub(crate) fn get_positional_delete_indexes_for_data_file(
-        &self,
+    async fn load_file_for_task(
+        task: FileScanTaskDeleteFile,
+        file_io: FileIO,
+        state: StateRef,
+    ) -> Result<DeleteFileContext> {
+        match task.file_type {
+            DataContentType::PositionDeletes => Ok(DeleteFileContext::PosDels(
+                Self::parquet_to_batch_stream(&task.file_path, file_io).await?,
+            )),
+
+            DataContentType::EqualityDeletes => {
+                let (sender, fut) = EqDelFuture::new();
+                {
+                    let mut state = state.write().unwrap();
+
+                    if let Some(existing) = state.equality_deletes.get(&task.file_path) {
+                        return Ok(DeleteFileContext::InProgEqDel(existing.clone()));
+                    }
+
+                    state
+                        .equality_deletes
+                        .insert(task.file_path.to_string(), fut);
+                }
+
+                Ok(DeleteFileContext::FreshEqDel {
+                    batch_stream: Self::parquet_to_batch_stream(&task.file_path, file_io).await?,
+                    sender,
+                })
+            }
+
+            DataContentType::Data => Err(Error::new(
+                ErrorKind::Unexpected,
+                "tasks with files of type Data not expected here",
+            )),
+        }
+    }
+
+    async fn parse_file_content_for_task(
+        ctx: DeleteFileContext,
+    ) -> Result<ParsedDeleteFileContext> {
+        match ctx {
+            DeleteFileContext::InProgEqDel(fut) => Ok(ParsedDeleteFileContext::InProgEqDel(fut)),
+            DeleteFileContext::PosDels(batch_stream) => {
+                let del_vecs =
+                    Self::parse_positional_deletes_record_batch_stream(batch_stream).await?;
+                Ok(ParsedDeleteFileContext::DelVecs(del_vecs))
+            }
+            DeleteFileContext::FreshEqDel {
+                sender,
+                batch_stream,
+            } => {
+                let predicate =
+                    Self::parse_equality_deletes_record_batch_stream(batch_stream).await?;
+
+                sender
+                    .send(predicate)
+                    .map_err(|err| {
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            "Could not send eq delete predicate to state",
+                        )
+                    })
+                    .map(|_| ParsedDeleteFileContext::EqDel)
+            }
+        }
+    }
+
+    fn merge_delete_vectors(
+        mut merged_delete_vectors: HashMap<String, RoaringTreemap>,
+        item: ParsedDeleteFileContext,
+    ) -> HashMap<String, RoaringTreemap> {
+        if let ParsedDeleteFileContext::DelVecs(del_vecs) = item {
+            del_vecs.into_iter().for_each(|(key, val)| {
+                let entry = merged_delete_vectors.entry(key).or_default();
+                entry.bitand_assign(val);
+            });
+        }
+
+        merged_delete_vectors
+    }
+
+    /// Loads a RecordBatchStream for a given datafile.
+    async fn parquet_to_batch_stream(
         data_file_path: &str,
-    ) -> Option<RoaringTreemap> {
+        file_io: FileIO,
+    ) -> Result<ArrowRecordBatchStream> {
+        /*
+           Essentially a super-cut-down ArrowReader. We can't use ArrowReader directly
+           as that introduces a circular dependency.
+        */
+        let record_batch_stream = ArrowReader::create_parquet_record_batch_stream_builder(
+            data_file_path,
+            file_io.clone(),
+            false,
+        )
+        .await?
+        .build()?
+        .map_err(|e| Error::new(ErrorKind::Unexpected, format!("{}", e)));
+
+        Ok(Box::pin(record_batch_stream) as ArrowRecordBatchStream)
+    }
+
+    /// Parses a record batch stream coming from positional delete files
+    ///
+    /// Returns a map of data file path to a delete vector
+    async fn parse_positional_deletes_record_batch_stream(
+        stream: ArrowRecordBatchStream,
+    ) -> Result<HashMap<String, RoaringTreemap>> {
         // TODO
 
-        None
+        Ok(HashMap::default())
+    }
+
+    /// Parses record batch streams from individual equality delete files
+    ///
+    /// Returns an unbound Predicate for each batch stream
+    async fn parse_equality_deletes_record_batch_stream(
+        streams: ArrowRecordBatchStream,
+    ) -> Result<Predicate> {
+        // TODO
+
+        Ok(AlwaysTrue)
+    }
+
+    /// Builds eq delete predicate for the provided task.
+    ///
+    /// Must await on load_deletes before calling this.
+    pub(crate) async fn build_delete_predicate_for_task(
+        &self,
+        file_scan_task: &FileScanTask,
+    ) -> Result<Option<BoundPredicate>> {
+        // * Filter the task's deletes into just the Equality deletes
+        // * Retrieve the unbound predicate for each from self.state.equality_deletes
+        // * Logical-AND them all together to get a single combined `Predicate`
+        // * Bind the predicate to the task's schema to get a `BoundPredicate`
+
+        let mut combined_predicate = AlwaysTrue;
+        for delete in &file_scan_task.deletes {
+            if !is_equality_delete(delete) {
+                continue;
+            }
+
+            let predicate = {
+                let state = self.state.read().unwrap();
+
+                let Some(predicate) = state.equality_deletes.get(&delete.file_path) else {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        format!(
+                            "Missing predicate for equality delete file '{}'",
+                            delete.file_path
+                        ),
+                    ));
+                };
+
+                predicate.clone()
+            };
+
+            combined_predicate = combined_predicate.and(predicate.await);
+        }
+
+        if combined_predicate == AlwaysTrue {
+            return Ok(None);
+        }
+
+        // TODO: handle case-insensitive case
+        let bound_predicate = combined_predicate.bind(file_scan_task.schema.clone(), false)?;
+        Ok(Some(bound_predicate))
+    }
+
+    /// Retrieve a delete vector for the data file associated with a given file scan task
+    ///
+    /// Should only be called after awaiting on load_deletes. Takes the vector to avoid a
+    /// clone since each item is specific to a single data file and won't need to be used again
+    pub(crate) fn get_delete_vector_for_task(
+        &self,
+        file_scan_task: &FileScanTask,
+    ) -> Option<RoaringTreemap> {
+        self.state
+            .write()
+            .unwrap()
+            .delete_vectors
+            .remove(file_scan_task.data_file_path())
+    }
+}
+
+pub(crate) fn is_equality_delete(f: &FileScanTaskDeleteFile) -> bool {
+    matches!(f.file_type, DataContentType::EqualityDeletes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use arrow_array::{Int64Array, RecordBatch, StringArray};
+    use arrow_schema::Schema as ArrowSchema;
+    use parquet::arrow::{ArrowWriter, PARQUET_FIELD_ID_META_KEY};
+    use parquet::basic::Compression;
+    use parquet::file::properties::WriterProperties;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::spec::{DataFileFormat, Schema};
+
+    type ArrowSchemaRef = Arc<ArrowSchema>;
+
+    const FIELD_ID_POSITIONAL_DELETE_FILE_PATH: u64 = 2147483546;
+    const FIELD_ID_POSITIONAL_DELETE_POS: u64 = 2147483545;
+
+    #[tokio::test]
+    async fn test_delete_file_manager_load_deletes() {
+        // Note that with the delete file parsing not yet in place, all we can test here is that
+        // the call to the loader does not fail.
+        let delete_file_manager = DeleteFileManager::new();
+
+        let tmp_dir = TempDir::new().unwrap();
+        let table_location = tmp_dir.path();
+        let file_io = FileIO::from_path(table_location.as_os_str().to_str().unwrap())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let file_scan_tasks = setup(table_location);
+
+        delete_file_manager
+            .load_deletes(&file_scan_tasks[0].deletes, file_io, 5)
+            .await
+            .unwrap();
+    }
+
+    fn setup(table_location: &Path) -> Vec<FileScanTask> {
+        let data_file_schema = Arc::new(Schema::builder().build().unwrap());
+        let positional_delete_schema = create_pos_del_schema();
+
+        let file_path_values = vec![format!("{}/1.parquet", table_location.to_str().unwrap()); 8];
+        let pos_values = vec![0, 1, 3, 5, 6, 8, 1022, 1023];
+
+        let file_path_col = Arc::new(StringArray::from_iter_values(file_path_values));
+        let pos_col = Arc::new(Int64Array::from_iter_values(pos_values));
+
+        let props = WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build();
+
+        for n in 1..=3 {
+            let positional_deletes_to_write =
+                RecordBatch::try_new(positional_delete_schema.clone(), vec![
+                    file_path_col.clone(),
+                    pos_col.clone(),
+                ])
+                .unwrap();
+
+            let file = File::create(format!(
+                "{}/pos-del-{}.parquet",
+                table_location.to_str().unwrap(),
+                n
+            ))
+            .unwrap();
+            let mut writer = ArrowWriter::try_new(
+                file,
+                positional_deletes_to_write.schema(),
+                Some(props.clone()),
+            )
+            .unwrap();
+
+            writer
+                .write(&positional_deletes_to_write)
+                .expect("Writing batch");
+
+            // writer must be closed to write footer
+            writer.close().unwrap();
+        }
+
+        let pos_del_1 = FileScanTaskDeleteFile {
+            file_path: format!("{}/pos-del-1.parquet", table_location.to_str().unwrap()),
+            file_type: DataContentType::PositionDeletes,
+            partition_spec_id: 0,
+        };
+
+        let pos_del_2 = FileScanTaskDeleteFile {
+            file_path: format!("{}/pos-del-2.parquet", table_location.to_str().unwrap()),
+            file_type: DataContentType::PositionDeletes,
+            partition_spec_id: 0,
+        };
+
+        let pos_del_3 = FileScanTaskDeleteFile {
+            file_path: format!("{}/pos-del-3.parquet", table_location.to_str().unwrap()),
+            file_type: DataContentType::PositionDeletes,
+            partition_spec_id: 0,
+        };
+
+        let file_scan_tasks = vec![
+            FileScanTask {
+                start: 0,
+                length: 0,
+                record_count: None,
+                data_file_path: "".to_string(),
+                data_file_content: DataContentType::Data,
+                data_file_format: DataFileFormat::Parquet,
+                schema: data_file_schema.clone(),
+                project_field_ids: vec![],
+                predicate: None,
+                deletes: vec![pos_del_1, pos_del_2.clone()],
+            },
+            FileScanTask {
+                start: 0,
+                length: 0,
+                record_count: None,
+                data_file_path: "".to_string(),
+                data_file_content: DataContentType::Data,
+                data_file_format: DataFileFormat::Parquet,
+                schema: data_file_schema.clone(),
+                project_field_ids: vec![],
+                predicate: None,
+                deletes: vec![pos_del_2, pos_del_3],
+            },
+        ];
+
+        file_scan_tasks
+    }
+
+    fn create_pos_del_schema() -> ArrowSchemaRef {
+        let fields = vec![
+            arrow_schema::Field::new("file_path", arrow_schema::DataType::Utf8, false)
+                .with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    FIELD_ID_POSITIONAL_DELETE_FILE_PATH.to_string(),
+                )])),
+            arrow_schema::Field::new("pos", arrow_schema::DataType::Int64, false).with_metadata(
+                HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    FIELD_ID_POSITIONAL_DELETE_POS.to_string(),
+                )]),
+            ),
+        ];
+        Arc::new(arrow_schema::Schema::new(fields))
     }
 }

--- a/crates/iceberg/src/arrow/delete_file_manager.rs
+++ b/crates/iceberg/src/arrow/delete_file_manager.rs
@@ -19,10 +19,11 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::ops::BitAndAssign;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::task::{Context, Poll};
 
 use futures::channel::oneshot;
+use futures::future::join_all;
 use futures::{StreamExt, TryStreamExt};
 use roaring::RoaringTreemap;
 
@@ -41,11 +42,21 @@ use crate::{Error, ErrorKind, Result};
 // state that can be awaited upon to get te EQ deletes. That way we can check to see if
 // a load of each Eq delete file is already in progress and avoid starting another one.
 #[derive(Debug, Clone)]
-struct EqDelFuture {}
+struct EqDelFuture {
+    result: OnceLock<Predicate>,
+}
 
 impl EqDelFuture {
     pub fn new() -> (oneshot::Sender<Predicate>, Self) {
-        todo!()
+        let (tx, rx) = oneshot::channel();
+        let result = OnceLock::new();
+
+        crate::runtime::spawn({
+            let result = result.clone();
+            async move { result.set(rx.await.unwrap()) }
+        });
+
+        (tx, Self { result })
     }
 }
 
@@ -53,7 +64,10 @@ impl Future for EqDelFuture {
     type Output = Predicate;
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        todo!()
+        match self.result.get() {
+            None => Poll::Pending,
+            Some(predicate) => Poll::Ready(predicate.clone()),
+        }
     }
 }
 
@@ -188,6 +202,16 @@ impl DeleteFileManager {
             .try_buffer_unordered(concurrency_limit_data_files)
             .try_collect::<Vec<_>>()
             .await?;
+
+        // wait for all in-progress EQ deletes from other tasks
+        let _ = join_all(results.iter().filter_map(|i| {
+            if let ParsedDeleteFileContext::InProgEqDel(fut) = i {
+                Some(fut.clone())
+            } else {
+                None
+            }
+        }))
+        .await;
 
         let merged_delete_vectors = results
             .into_iter()

--- a/crates/iceberg/src/arrow/mod.rs
+++ b/crates/iceberg/src/arrow/mod.rs
@@ -19,6 +19,7 @@
 
 mod schema;
 pub use schema::*;
+pub(crate) mod delete_file_manager;
 mod reader;
 pub(crate) mod record_batch_projector;
 pub(crate) mod record_batch_transformer;

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -407,9 +407,11 @@ impl ArrowReader {
                     current_idx += run_length;
                 }
 
-                // `skip` all consecutive deleted rows
+                // `skip` all consecutive deleted rows in the current row group
                 let mut run_length = 0;
-                while next_deleted_row_idx == current_idx {
+                while next_deleted_row_idx == current_idx
+                    && next_deleted_row_idx < next_page_base_idx
+                {
                     run_length += 1;
                     current_idx += 1;
                     positional_deletes.remove(next_deleted_row_idx);
@@ -417,6 +419,7 @@ impl ArrowReader {
                     next_deleted_row_idx = match positional_deletes.min() {
                         Some(next_deleted_row_idx) => next_deleted_row_idx,
                         _ => {
+                            // conclude the selection and break if this was the last positional delete
                             results.push(RowSelector::skip(run_length));
                             break 'outer;
                         }
@@ -425,6 +428,7 @@ impl ArrowReader {
                 results.push(RowSelector::skip(run_length));
             }
 
+            // break if this was the final selected row group
             if let Some(selected_row_groups) = selected_row_groups {
                 if selected_row_groups_idx == selected_row_groups.len() {
                     break;
@@ -1532,35 +1536,85 @@ message schema {
 
         let selected_row_groups = Some(vec![1, 3]);
 
+        /* cases to cover:
+           * {skip|select} {first|intermediate|last} {one row|multiple rows} in
+             {first|imtermediate|last} {skipped|selected} row group
+           * row group selection disabled
+        */
+
         let positional_deletes = RoaringTreemap::from_iter(&[
-            1,    // in skipped row group 0, should be ignored
-            3,    // in skipped row group 0, should be ignored
-            4,    // in skipped row group 0, should be ignored
-            5,    // in skipped row group 0, should be ignored
-            1002, // solitary row in selected row group 1
-            1010, // run of 5 rows in selected row group 1
-            1011, 1012, 1013, 1014, 1600, // should ignore, in skipped row group 2
-            2100, // single row in selected row group 3,
+            1, // in skipped rg 0, should be ignored
+            3, // run of three consecutive items in skipped rg0
+            4, 5, 998, // two consecutive items at end of skipped rg0
+            999, 1000, // solitary row at start of selected rg1 (1, 9)
+            1010, // run of 3 rows in selected rg1
+            1011, 1012, // (3, 485)
+            1498, // run of two items at end of selected rg1
+            1499, 1500, // run of two items at start of skipped rg2
+            1501, 1600, // should ignore, in skipped rg2
+            1999, // single row at end of skipped rg2
+            2000, // run of two items at start of selected rg3
+            2001, // (4, 98)
+            2100, // single row in selected row group 3 (1, 99)
             2200, // run of 3 consecutive rows in selected row group 3
-            2201, 2202,
+            2201, 2202, // (3, 796)
+            2999, // single item at end of selected rg3 (1)
+            3000, // single item at start of skipped rg4
         ]);
 
+        // using selected row groups 1 and 3
         let result = ArrowReader::build_deletes_row_selection(
             &row_groups_metadata,
             &selected_row_groups,
+            positional_deletes.clone(),
+        )
+        .unwrap();
+
+        let expected = RowSelection::from(vec![
+            RowSelector::skip(1),
+            RowSelector::select(9),
+            RowSelector::skip(3),
+            RowSelector::select(485),
+            RowSelector::skip(4),
+            RowSelector::select(98),
+            RowSelector::skip(1),
+            RowSelector::select(99),
+            RowSelector::skip(3),
+            RowSelector::select(796),
+            RowSelector::skip(1),
+        ]);
+
+        assert_eq!(result, expected);
+
+        // selecting all row groups
+        let result = ArrowReader::build_deletes_row_selection(
+            &row_groups_metadata,
+            &None,
             positional_deletes,
         )
         .unwrap();
 
         let expected = RowSelection::from(vec![
-            RowSelector::select(2),
+            RowSelector::select(1),
             RowSelector::skip(1),
-            RowSelector::select(7),
-            RowSelector::skip(5),
-            RowSelector::select(100),
+            RowSelector::select(1),
+            RowSelector::skip(3),
+            RowSelector::select(992),
+            RowSelector::skip(3),
+            RowSelector::select(9),
+            RowSelector::skip(3),
+            RowSelector::select(485),
+            RowSelector::skip(4),
+            RowSelector::select(98),
+            RowSelector::skip(1),
+            RowSelector::select(398),
+            RowSelector::skip(3),
+            RowSelector::select(98),
             RowSelector::skip(1),
             RowSelector::select(99),
             RowSelector::skip(3),
+            RowSelector::select(796),
+            RowSelector::skip(2),
         ]);
 
         assert_eq!(result, expected);

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -39,6 +39,7 @@ use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask, PARQUET_FI
 use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use parquet::schema::types::{SchemaDescriptor, Type as ParquetType};
 
+use crate::arrow::delete_file_manager::DeleteFileManager;
 use crate::arrow::record_batch_transformer::RecordBatchTransformer;
 use crate::arrow::{arrow_schema_to_schema, get_arrow_datum};
 use crate::error::Result;
@@ -145,6 +146,7 @@ impl ArrowReader {
                     file_io,
                     row_group_filtering_enabled,
                     row_selection_enabled,
+                    concurrency_limit_data_files,
                 )
             })
             .map_err(|err| {
@@ -162,30 +164,24 @@ impl ArrowReader {
         file_io: FileIO,
         row_group_filtering_enabled: bool,
         row_selection_enabled: bool,
+        concurrency_limit_data_files: usize,
     ) -> Result<ArrowRecordBatchStream> {
-        // TODO: add support for delete files
-        if !task.deletes.is_empty() {
-            return Err(Error::new(
-                ErrorKind::FeatureUnsupported,
-                "Delete files are not yet supported",
-            ));
-        }
+        let should_load_page_index =
+            (row_selection_enabled && task.predicate.is_some()) || !task.deletes.is_empty();
 
-        // Get the metadata for the Parquet file we need to read and build
-        // a reader for the data within
-        let parquet_file = file_io.new_input(&task.data_file_path)?;
-        let (parquet_metadata, parquet_reader) =
-            try_join!(parquet_file.metadata(), parquet_file.reader())?;
-        let parquet_file_reader = ArrowFileReader::new(parquet_metadata, parquet_reader);
-
-        let should_load_page_index = row_selection_enabled && task.predicate.is_some();
-
-        // Start creating the record batch stream, which wraps the parquet file reader
-        let mut record_batch_stream_builder = ParquetRecordBatchStreamBuilder::new_with_options(
-            parquet_file_reader,
-            ArrowReaderOptions::new().with_page_index(should_load_page_index),
-        )
-        .await?;
+        // concurrently retrieve delete files and create RecordBatchStreamBuilder
+        let (delete_file_manager, mut record_batch_stream_builder) = try_join!(
+            DeleteFileManager::load_deletes(
+                task.deletes.clone(),
+                file_io.clone(),
+                concurrency_limit_data_files
+            ),
+            Self::create_parquet_record_batch_stream_builder(
+                &task.data_file_path,
+                file_io.clone(),
+                should_load_page_index,
+            )
+        )?;
 
         // Create a projection mask for the batch stream to select which columns in the
         // Parquet file that we want in the response
@@ -197,7 +193,7 @@ impl ArrowReader {
         )?;
         record_batch_stream_builder = record_batch_stream_builder.with_projection(projection_mask);
 
-        // RecordBatchTransformer performs any required transformations on the RecordBatches
+        // RecordBatchTransformer performs any transformations required on the RecordBatches
         // that come back from the file, such as type promotion, default column insertion
         // and column re-ordering
         let mut record_batch_transformer =
@@ -207,49 +203,102 @@ impl ArrowReader {
             record_batch_stream_builder = record_batch_stream_builder.with_batch_size(batch_size);
         }
 
-        if let Some(predicate) = &task.predicate {
+        let delete_predicate = delete_file_manager.build_delete_predicate(task.schema.clone())?;
+
+        // In addition to the optional predicate supplied in the `FileScanTask`,
+        // we also have an optional predicate resulting from equality delete files.
+        // If both are present, we logical-AND them together to form a single filter
+        // predicate that we can pass to the `RecordBatchStreamBuilder`.
+        let final_predicate = match (&task.predicate, delete_predicate) {
+            (None, None) => None,
+            (Some(predicate), None) => Some(predicate.clone()),
+            (None, Some(ref predicate)) => Some(predicate.clone()),
+            (Some(filter_predicate), Some(delete_predicate)) => {
+                Some(filter_predicate.clone().and(delete_predicate))
+            }
+        };
+
+        // There are two possible sources both for potential lists of selected RowGroup indices,
+        // and for `RowSelection`s.
+        // Selected RowGroup index lists can come from two sources:
+        //   * When there are equality delete files that are applicable;
+        //   * When there is a scan predicate and row_group_filtering_enabled = true.
+        // `RowSelection`s can be created in either or both of the following cases:
+        //   * When there are positional delete files that are applicable;
+        //   * When there is a scan predicate and row_selection_enabled = true
+        // Note that, in the former case we only perform row group filtering when
+        // there is a scan predicate AND row_group_filtering_enabled = true,
+        // but we perform row selection filtering if there are applicable
+        // equality delete files OR (there is a scan predicate AND row_selection_enabled),
+        // since the only implemented method of applying positional deletes is
+        // by using a `RowSelection`.
+        let mut selected_row_group_indices = None;
+        let mut row_selection = None;
+
+        if let Some(predicate) = final_predicate {
             let (iceberg_field_ids, field_id_map) = Self::build_field_id_set_and_map(
                 record_batch_stream_builder.parquet_schema(),
-                predicate,
+                &predicate,
             )?;
 
             let row_filter = Self::get_row_filter(
-                predicate,
+                &predicate,
                 record_batch_stream_builder.parquet_schema(),
                 &iceberg_field_ids,
                 &field_id_map,
             )?;
             record_batch_stream_builder = record_batch_stream_builder.with_row_filter(row_filter);
 
-            let mut selected_row_groups = None;
             if row_group_filtering_enabled {
                 let result = Self::get_selected_row_group_indices(
-                    predicate,
+                    &predicate,
                     record_batch_stream_builder.metadata(),
                     &field_id_map,
                     &task.schema,
                 )?;
 
-                selected_row_groups = Some(result);
+                selected_row_group_indices = Some(result);
             }
 
             if row_selection_enabled {
-                let row_selection = Self::get_row_selection(
-                    predicate,
+                row_selection = Some(Self::get_row_selection_for_filter_predicate(
+                    &predicate,
                     record_batch_stream_builder.metadata(),
-                    &selected_row_groups,
+                    &selected_row_group_indices,
                     &field_id_map,
                     &task.schema,
-                )?;
-
-                record_batch_stream_builder =
-                    record_batch_stream_builder.with_row_selection(row_selection);
+                )?);
             }
+        }
 
-            if let Some(selected_row_groups) = selected_row_groups {
-                record_batch_stream_builder =
-                    record_batch_stream_builder.with_row_groups(selected_row_groups);
-            }
+        let positional_delete_indexes =
+            delete_file_manager.get_positional_delete_indexes_for_data_file(&task.data_file_path);
+
+        if let Some(positional_delete_indexes) = positional_delete_indexes {
+            let delete_row_selection = Self::build_deletes_row_selection(
+                record_batch_stream_builder.metadata(),
+                &selected_row_group_indices,
+                &positional_delete_indexes,
+            )?;
+
+            // merge the row selection from the delete files with the row selection
+            // from the filter predicate, if there is one from the filter predicate
+            row_selection = match row_selection {
+                None => Some(delete_row_selection),
+                Some(filter_row_selection) => {
+                    Some(filter_row_selection.intersection(&delete_row_selection))
+                }
+            };
+        }
+
+        if let Some(row_selection) = row_selection {
+            record_batch_stream_builder =
+                record_batch_stream_builder.with_row_selection(row_selection);
+        }
+
+        if let Some(selected_row_group_indices) = selected_row_group_indices {
+            record_batch_stream_builder =
+                record_batch_stream_builder.with_row_groups(selected_row_group_indices);
         }
 
         // Build the batch stream and send all the RecordBatches that it generates
@@ -263,6 +312,43 @@ impl ArrowReader {
                 });
 
         Ok(Box::pin(record_batch_stream) as ArrowRecordBatchStream)
+    }
+
+    async fn create_parquet_record_batch_stream_builder(
+        data_file_path: &str,
+        file_io: FileIO,
+        should_load_page_index: bool,
+    ) -> Result<ParquetRecordBatchStreamBuilder<ArrowFileReader<impl FileRead + Sized>>> {
+        // Get the metadata for the Parquet file we need to read and build
+        // a reader for the data within
+        let parquet_file = file_io.new_input(data_file_path)?;
+        let (parquet_metadata, parquet_reader) =
+            try_join!(parquet_file.metadata(), parquet_file.reader())?;
+        let parquet_file_reader = ArrowFileReader::new(parquet_metadata, parquet_reader);
+
+        // Create the record batch stream builder, which wraps the parquet file reader
+        let record_batch_stream_builder = ParquetRecordBatchStreamBuilder::new_with_options(
+            parquet_file_reader,
+            ArrowReaderOptions::new().with_page_index(should_load_page_index),
+        )
+        .await?;
+        Ok(record_batch_stream_builder)
+    }
+
+    /// computes a `RowSelection` from positional delete indices.
+    ///
+    /// Using the Parquet page index, we build a `RowSelection` that rejects rows that are indicated
+    /// as having been deleted by a positional delete, taking into account any row groups that have
+    /// been skipped entirely by the filter predicate
+    #[allow(unused)]
+    fn build_deletes_row_selection(
+        parquet_metadata: &Arc<ParquetMetaData>,
+        selected_row_groups: &Option<Vec<usize>>,
+        positional_deletes: &[usize],
+    ) -> Result<RowSelection> {
+        // TODO
+
+        Ok(RowSelection::default())
     }
 
     fn build_field_id_set_and_map(
@@ -475,7 +561,7 @@ impl ArrowReader {
         Ok(results)
     }
 
-    fn get_row_selection(
+    fn get_row_selection_for_filter_predicate(
         predicate: &BoundPredicate,
         parquet_metadata: &Arc<ParquetMetaData>,
         selected_row_groups: &Option<Vec<usize>>,

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -33,7 +33,9 @@ use bytes::Bytes;
 use fnv::FnvHashSet;
 use futures::future::BoxFuture;
 use futures::{try_join, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
-use parquet::arrow::arrow_reader::{ArrowPredicateFn, ArrowReaderOptions, RowFilter, RowSelection};
+use parquet::arrow::arrow_reader::{
+    ArrowPredicateFn, ArrowReaderOptions, RowFilter, RowSelection, RowSelector,
+};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask, PARQUET_FIELD_ID_META_KEY};
 use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader, RowGroupMetaData};
@@ -341,15 +343,98 @@ impl ArrowReader {
     /// Using the Parquet page index, we build a `RowSelection` that rejects rows that are indicated
     /// as having been deleted by a positional delete, taking into account any row groups that have
     /// been skipped entirely by the filter predicate
-    #[allow(unused)]
     fn build_deletes_row_selection(
         row_group_metadata: &[RowGroupMetaData],
         selected_row_groups: &Option<Vec<usize>>,
         mut positional_deletes: RoaringTreemap,
     ) -> Result<RowSelection> {
-        // TODO
+        let mut results: Vec<RowSelector> = Vec::new();
+        let mut selected_row_groups_idx = 0;
+        let mut current_page_base_idx: u64 = 0;
 
-        Ok(RowSelection::default())
+        'outer: for (idx, row_group_metadata) in row_group_metadata.iter().enumerate() {
+            let page_num_rows = row_group_metadata.num_rows() as u64;
+            let next_page_base_idx = current_page_base_idx + page_num_rows;
+
+            // if row group selection is enabled,
+            if let Some(selected_row_groups) = selected_row_groups {
+                // if we've consumed all the selected row groups, we're done
+                if selected_row_groups_idx == selected_row_groups.len() {
+                    break;
+                }
+
+                if idx == selected_row_groups[selected_row_groups_idx] {
+                    // we're in a selected row group. Increment selected_row_groups_idx
+                    // so that next time around the for loop we're looking for the next
+                    // selected row group
+                    selected_row_groups_idx += 1;
+                } else {
+                    // remove any positional deletes from the skipped page so that
+                    // `positional.deletes.min()` can be used
+                    positional_deletes.remove_range(current_page_base_idx..next_page_base_idx);
+
+                    // still increment the current page base index but then skip to the next row group
+                    // in the file
+                    current_page_base_idx += page_num_rows;
+                    continue;
+                }
+            }
+
+            let mut next_deleted_row_idx = match positional_deletes.min() {
+                Some(next_deleted_row_idx) => {
+                    // if the index of the next deleted row is beyond this page, skip to the next page
+                    if next_deleted_row_idx >= next_page_base_idx {
+                        continue;
+                    }
+
+                    next_deleted_row_idx
+                }
+
+                // If there are no more pos deletes, stop building row selections and return what we
+                // have. NB this depends on behavior of ParquetRecordBatchReader that appears to be
+                // undocumented (not that I can find!): if there are no further RowSelections
+                // then everything else is assumed to be selected.
+                // see https://github.com/apache/arrow-rs/blob/c245a45efef9d9453f121587365e56d53c39d28f/parquet/src/arrow/arrow_reader/mod.rs#L703
+                _ => break,
+            };
+
+            let mut current_idx = current_page_base_idx;
+            while next_deleted_row_idx < next_page_base_idx {
+                // `select` all rows that precede the next delete index
+                if current_idx < next_deleted_row_idx {
+                    let run_length = next_deleted_row_idx - current_idx;
+                    results.push(RowSelector::select(run_length as usize));
+                    current_idx += run_length;
+                }
+
+                // `skip` all consecutive deleted rows
+                let mut run_length = 0;
+                while next_deleted_row_idx == current_idx {
+                    run_length += 1;
+                    current_idx += 1;
+                    positional_deletes.remove(next_deleted_row_idx);
+
+                    next_deleted_row_idx = match positional_deletes.min() {
+                        Some(next_deleted_row_idx) => next_deleted_row_idx,
+                        _ => {
+                            results.push(RowSelector::skip(run_length));
+                            break 'outer;
+                        }
+                    };
+                }
+                results.push(RowSelector::skip(run_length));
+            }
+
+            if let Some(selected_row_groups) = selected_row_groups {
+                if selected_row_groups_idx == selected_row_groups.len() {
+                    break;
+                }
+            }
+
+            current_page_base_idx += page_num_rows;
+        }
+
+        Ok(results.into())
     }
 
     fn build_field_id_set_and_map(
@@ -1255,9 +1340,12 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
+    use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
     use parquet::arrow::ProjectionMask;
+    use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
     use parquet::schema::parser::parse_message_type;
-    use parquet::schema::types::SchemaDescriptor;
+    use parquet::schema::types::{SchemaDescPtr, SchemaDescriptor};
+    use roaring::RoaringTreemap;
 
     use crate::arrow::reader::{CollectFieldIdVisitor, PARQUET_FIELD_ID_META_KEY};
     use crate::arrow::ArrowReader;
@@ -1422,5 +1510,96 @@ message schema {
             ArrowReader::get_arrow_projection_mask(&[1], &schema, &parquet_schema, &arrow_schema)
                 .expect("Some ProjectionMask");
         assert_eq!(mask, ProjectionMask::leaves(&parquet_schema, vec![0]));
+    }
+
+    #[test]
+    fn test_build_deletes_row_selection() {
+        let schema_descr = get_test_schema_descr();
+
+        let mut columns = vec![];
+        for ptr in schema_descr.columns() {
+            let column = ColumnChunkMetaData::builder(ptr.clone()).build().unwrap();
+            columns.push(column);
+        }
+
+        let row_groups_metadata = vec![
+            build_test_row_group_meta(schema_descr.clone(), columns.clone(), 1000, 0),
+            build_test_row_group_meta(schema_descr.clone(), columns.clone(), 500, 1),
+            build_test_row_group_meta(schema_descr.clone(), columns.clone(), 500, 2),
+            build_test_row_group_meta(schema_descr.clone(), columns.clone(), 1000, 3),
+            build_test_row_group_meta(schema_descr.clone(), columns.clone(), 500, 4),
+        ];
+
+        let selected_row_groups = Some(vec![1, 3]);
+
+        let positional_deletes = RoaringTreemap::from_iter(&[
+            1,    // in skipped row group 0, should be ignored
+            3,    // in skipped row group 0, should be ignored
+            4,    // in skipped row group 0, should be ignored
+            5,    // in skipped row group 0, should be ignored
+            1002, // solitary row in selected row group 1
+            1010, // run of 5 rows in selected row group 1
+            1011, 1012, 1013, 1014, 1600, // should ignore, in skipped row group 2
+            2100, // single row in selected row group 3,
+            2200, // run of 3 consecutive rows in selected row group 3
+            2201, 2202,
+        ]);
+
+        let result = ArrowReader::build_deletes_row_selection(
+            &row_groups_metadata,
+            &selected_row_groups,
+            positional_deletes,
+        )
+        .unwrap();
+
+        let expected = RowSelection::from(vec![
+            RowSelector::select(2),
+            RowSelector::skip(1),
+            RowSelector::select(7),
+            RowSelector::skip(5),
+            RowSelector::select(100),
+            RowSelector::skip(1),
+            RowSelector::select(99),
+            RowSelector::skip(3),
+        ]);
+
+        assert_eq!(result, expected);
+    }
+
+    fn build_test_row_group_meta(
+        schema_descr: SchemaDescPtr,
+        columns: Vec<ColumnChunkMetaData>,
+        num_rows: i64,
+        ordinal: i16,
+    ) -> RowGroupMetaData {
+        RowGroupMetaData::builder(schema_descr.clone())
+            .set_num_rows(num_rows)
+            .set_total_byte_size(2000)
+            .set_column_metadata(columns)
+            .set_ordinal(ordinal)
+            .build()
+            .unwrap()
+    }
+
+    fn get_test_schema_descr() -> SchemaDescPtr {
+        use parquet::schema::types::Type as SchemaType;
+
+        let schema = SchemaType::group_type_builder("schema")
+            .with_fields(vec![
+                Arc::new(
+                    SchemaType::primitive_type_builder("a", parquet::basic::Type::INT32)
+                        .build()
+                        .unwrap(),
+                ),
+                Arc::new(
+                    SchemaType::primitive_type_builder("b", parquet::basic::Type::INT32)
+                        .build()
+                        .unwrap(),
+                ),
+            ])
+            .build()
+            .unwrap();
+
+        Arc::new(SchemaDescriptor::new(Arc::new(schema)))
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -63,6 +63,7 @@ pub struct ArrowReaderBuilder {
     concurrency_limit_data_files: usize,
     row_group_filtering_enabled: bool,
     row_selection_enabled: bool,
+    delete_file_support_enabled: bool,
 }
 
 impl ArrowReaderBuilder {
@@ -76,6 +77,7 @@ impl ArrowReaderBuilder {
             concurrency_limit_data_files: num_cpus,
             row_group_filtering_enabled: true,
             row_selection_enabled: false,
+            delete_file_support_enabled: false,
         }
     }
 
@@ -104,14 +106,22 @@ impl ArrowReaderBuilder {
         self
     }
 
+    /// Determines whether to enable delete file support.
+    pub fn with_delete_file_support_enabled(mut self, delete_file_support_enabled: bool) -> Self {
+        self.delete_file_support_enabled = delete_file_support_enabled;
+        self
+    }
+
     /// Build the ArrowReader.
     pub fn build(self) -> ArrowReader {
         ArrowReader {
             batch_size: self.batch_size,
+            delete_file_manager: DeleteFileManager::new(),
             file_io: self.file_io,
             concurrency_limit_data_files: self.concurrency_limit_data_files,
             row_group_filtering_enabled: self.row_group_filtering_enabled,
             row_selection_enabled: self.row_selection_enabled,
+            delete_file_support_enabled: self.delete_file_support_enabled,
         }
     }
 }
@@ -121,12 +131,14 @@ impl ArrowReaderBuilder {
 pub struct ArrowReader {
     batch_size: Option<usize>,
     file_io: FileIO,
+    delete_file_manager: DeleteFileManager,
 
     /// the maximum number of data files that can be fetched at the same time
     concurrency_limit_data_files: usize,
 
     row_group_filtering_enabled: bool,
     row_selection_enabled: bool,
+    delete_file_support_enabled: bool,
 }
 
 impl ArrowReader {
@@ -134,22 +146,27 @@ impl ArrowReader {
     /// Returns a stream of Arrow RecordBatches containing the data from the files
     pub async fn read(self, tasks: FileScanTaskStream) -> Result<ArrowRecordBatchStream> {
         let file_io = self.file_io.clone();
+        let delete_file_manager = self.delete_file_manager.clone();
         let batch_size = self.batch_size;
         let concurrency_limit_data_files = self.concurrency_limit_data_files;
         let row_group_filtering_enabled = self.row_group_filtering_enabled;
         let row_selection_enabled = self.row_selection_enabled;
+        let delete_file_support_enabled = self.delete_file_support_enabled;
 
         let stream = tasks
             .map_ok(move |task| {
                 let file_io = file_io.clone();
+                let delete_file_manager = delete_file_manager.clone();
 
                 Self::process_file_scan_task(
                     task,
                     batch_size,
                     file_io,
+                    delete_file_manager,
                     row_group_filtering_enabled,
                     row_selection_enabled,
                     concurrency_limit_data_files,
+                    delete_file_support_enabled,
                 )
             })
             .map_err(|err| {
@@ -161,23 +178,37 @@ impl ArrowReader {
         Ok(Box::pin(stream) as ArrowRecordBatchStream)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_file_scan_task(
         task: FileScanTask,
         batch_size: Option<usize>,
         file_io: FileIO,
+        delete_file_manager: DeleteFileManager,
         row_group_filtering_enabled: bool,
         row_selection_enabled: bool,
         concurrency_limit_data_files: usize,
+        delete_file_support_enabled: bool,
     ) -> Result<ArrowRecordBatchStream> {
+        if !delete_file_support_enabled && !task.deletes.is_empty() {
+            return Err(Error::new(
+                ErrorKind::FeatureUnsupported,
+                "Delete file support is not enabled",
+            ));
+        }
+
         let should_load_page_index =
             (row_selection_enabled && task.predicate.is_some()) || !task.deletes.is_empty();
 
         // concurrently retrieve delete files and create RecordBatchStreamBuilder
-        let (delete_file_manager, mut record_batch_stream_builder) = try_join!(
-            DeleteFileManager::load_deletes(
-                task.deletes.clone(),
+        let (_, mut record_batch_stream_builder) = try_join!(
+            delete_file_manager.load_deletes(
+                if delete_file_support_enabled {
+                    &task.deletes
+                } else {
+                    &[]
+                },
                 file_io.clone(),
-                concurrency_limit_data_files
+                concurrency_limit_data_files,
             ),
             Self::create_parquet_record_batch_stream_builder(
                 &task.data_file_path,
@@ -206,7 +237,9 @@ impl ArrowReader {
             record_batch_stream_builder = record_batch_stream_builder.with_batch_size(batch_size);
         }
 
-        let delete_predicate = delete_file_manager.build_delete_predicate(task.schema.clone())?;
+        let delete_predicate = delete_file_manager
+            .build_delete_predicate_for_task(&task)
+            .await?;
 
         // In addition to the optional predicate supplied in the `FileScanTask`,
         // we also have an optional predicate resulting from equality delete files.
@@ -274,14 +307,13 @@ impl ArrowReader {
             }
         }
 
-        let positional_delete_indexes =
-            delete_file_manager.get_positional_delete_indexes_for_data_file(&task.data_file_path);
+        let positional_delete_indexes = delete_file_manager.get_delete_vector_for_task(&task);
 
         if let Some(positional_delete_indexes) = positional_delete_indexes {
             let delete_row_selection = Self::build_deletes_row_selection(
                 record_batch_stream_builder.metadata().row_groups(),
                 &selected_row_group_indices,
-                positional_delete_indexes,
+                positional_delete_indexes.clone(),
             )?;
 
             // merge the row selection from the delete files with the row selection
@@ -317,7 +349,7 @@ impl ArrowReader {
         Ok(Box::pin(record_batch_stream) as ArrowRecordBatchStream)
     }
 
-    async fn create_parquet_record_batch_stream_builder(
+    pub(crate) async fn create_parquet_record_batch_stream_builder(
         data_file_path: &str,
         file_io: FileIO,
         should_load_page_index: bool,
@@ -1305,7 +1337,7 @@ impl<'a> BoundPredicateVisitor for PredicateConverter<'a> {
 /// - `metadata_size_hint`: Provide a hint as to the size of the parquet file's footer.
 /// - `preload_column_index`: Load the Column Index  as part of [`Self::get_metadata`].
 /// - `preload_offset_index`: Load the Offset Index as part of [`Self::get_metadata`].
-struct ArrowFileReader<R: FileRead> {
+pub(crate) struct ArrowFileReader<R: FileRead> {
     meta: FileMetadata,
     r: R,
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -202,11 +202,7 @@ impl ArrowReader {
         // concurrently retrieve delete files and create RecordBatchStreamBuilder
         let (_, mut record_batch_stream_builder) = try_join!(
             delete_file_manager.load_deletes(
-                if delete_file_support_enabled {
-                    &task.deletes
-                } else {
-                    &[]
-                },
+                &task.deletes,
                 file_io.clone(),
                 concurrency_limit_data_files,
             ),

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -36,8 +36,9 @@ use futures::{try_join, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use parquet::arrow::arrow_reader::{ArrowPredicateFn, ArrowReaderOptions, RowFilter, RowSelection};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask, PARQUET_FIELD_ID_META_KEY};
-use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
+use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader, RowGroupMetaData};
 use parquet::schema::types::{SchemaDescriptor, Type as ParquetType};
+use roaring::RoaringTreemap;
 
 use crate::arrow::delete_file_manager::DeleteFileManager;
 use crate::arrow::record_batch_transformer::RecordBatchTransformer;
@@ -276,9 +277,9 @@ impl ArrowReader {
 
         if let Some(positional_delete_indexes) = positional_delete_indexes {
             let delete_row_selection = Self::build_deletes_row_selection(
-                record_batch_stream_builder.metadata(),
+                record_batch_stream_builder.metadata().row_groups(),
                 &selected_row_group_indices,
-                &positional_delete_indexes,
+                positional_delete_indexes,
             )?;
 
             // merge the row selection from the delete files with the row selection
@@ -342,9 +343,9 @@ impl ArrowReader {
     /// been skipped entirely by the filter predicate
     #[allow(unused)]
     fn build_deletes_row_selection(
-        parquet_metadata: &Arc<ParquetMetaData>,
+        row_group_metadata: &[RowGroupMetaData],
         selected_row_groups: &Option<Vec<usize>>,
-        positional_deletes: &[usize],
+        mut positional_deletes: RoaringTreemap,
     ) -> Result<RowSelection> {
         // TODO
 

--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -724,6 +724,12 @@ pub enum BoundPredicate {
     Set(SetExpression<BoundReference>),
 }
 
+impl BoundPredicate {
+    pub(crate) fn and(self, other: BoundPredicate) -> BoundPredicate {
+        BoundPredicate::And(LogicalExpression::new([Box::new(self), Box::new(other)]))
+    }
+}
+
 impl Display for BoundPredicate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/iceberg/src/scan.rs
+++ b/crates/iceberg/src/scan.rs
@@ -375,12 +375,7 @@ impl TableScan {
         // used to stream the results back to the caller
         let (file_scan_task_tx, file_scan_task_rx) = channel(concurrency_limit_manifest_entries);
 
-        let delete_file_idx_and_tx: Option<(DeleteFileIndex, Sender<DeleteFileContext>)> =
-            if self.delete_file_processing_enabled {
-                Some(DeleteFileIndex::new())
-            } else {
-                None
-            };
+        let (delete_file_idx, delete_file_tx) = DeleteFileIndex::new();
 
         let manifest_list = self.plan_context.get_manifest_list().await?;
 
@@ -390,9 +385,8 @@ impl TableScan {
         let manifest_file_contexts = self.plan_context.build_manifest_file_contexts(
             manifest_list,
             manifest_entry_data_ctx_tx,
-            delete_file_idx_and_tx.as_ref().map(|(delete_file_idx, _)| {
-                (delete_file_idx.clone(), manifest_entry_delete_ctx_tx)
-            }),
+            delete_file_idx.clone(),
+            manifest_entry_delete_ctx_tx,
         )?;
 
         let mut channel_for_manifest_error = file_scan_task_tx.clone();
@@ -411,34 +405,30 @@ impl TableScan {
         });
 
         let mut channel_for_data_manifest_entry_error = file_scan_task_tx.clone();
+        let mut channel_for_delete_manifest_entry_error = file_scan_task_tx.clone();
 
-        if let Some((_, delete_file_tx)) = delete_file_idx_and_tx {
-            let mut channel_for_delete_manifest_entry_error = file_scan_task_tx.clone();
+        // Process the delete file [`ManifestEntry`] stream in parallel
+        spawn(async move {
+            let result = manifest_entry_delete_ctx_rx
+                .map(|me_ctx| Ok((me_ctx, delete_file_tx.clone())))
+                .try_for_each_concurrent(
+                    concurrency_limit_manifest_entries,
+                    |(manifest_entry_context, tx)| async move {
+                        spawn(async move {
+                            Self::process_delete_manifest_entry(manifest_entry_context, tx).await
+                        })
+                        .await
+                    },
+                )
+                .await;
 
-            // Process the delete file [`ManifestEntry`] stream in parallel
-            spawn(async move {
-                let result = manifest_entry_delete_ctx_rx
-                    .map(|me_ctx| Ok((me_ctx, delete_file_tx.clone())))
-                    .try_for_each_concurrent(
-                        concurrency_limit_manifest_entries,
-                        |(manifest_entry_context, tx)| async move {
-                            spawn(async move {
-                                Self::process_delete_manifest_entry(manifest_entry_context, tx)
-                                    .await
-                            })
-                            .await
-                        },
-                    )
+            if let Err(error) = result {
+                let _ = channel_for_delete_manifest_entry_error
+                    .send(Err(error))
                     .await;
-
-                if let Err(error) = result {
-                    let _ = channel_for_delete_manifest_entry_error
-                        .send(Err(error))
-                        .await;
-                }
-            })
-            .await;
-        }
+            }
+        })
+        .await;
 
         // Process the data file [`ManifestEntry`] stream in parallel
         spawn(async move {
@@ -460,7 +450,7 @@ impl TableScan {
             }
         });
 
-        return Ok(file_scan_task_rx.boxed());
+        Ok(file_scan_task_rx.boxed())
     }
 
     /// Returns an [`ArrowRecordBatchStream`].
@@ -468,7 +458,8 @@ impl TableScan {
         let mut arrow_reader_builder = ArrowReaderBuilder::new(self.file_io.clone())
             .with_data_file_concurrency_limit(self.concurrency_limit_data_files)
             .with_row_group_filtering_enabled(self.row_group_filtering_enabled)
-            .with_row_selection_enabled(self.row_selection_enabled);
+            .with_row_selection_enabled(self.row_selection_enabled)
+            .with_delete_file_support_enabled(self.delete_file_processing_enabled);
 
         if let Some(batch_size) = self.batch_size {
             arrow_reader_builder = arrow_reader_builder.with_batch_size(batch_size);
@@ -608,7 +599,7 @@ struct ManifestFileContext {
     object_cache: Arc<ObjectCache>,
     snapshot_schema: SchemaRef,
     expression_evaluator_cache: Arc<ExpressionEvaluatorCache>,
-    delete_file_index: Option<DeleteFileIndex>,
+    delete_file_index: DeleteFileIndex,
 }
 
 /// Wraps a [`ManifestEntryRef`] alongside the objects that are needed
@@ -621,7 +612,7 @@ struct ManifestEntryContext {
     bound_predicates: Option<Arc<BoundPredicates>>,
     partition_spec_id: i32,
     snapshot_schema: SchemaRef,
-    delete_file_index: Option<DeleteFileIndex>,
+    delete_file_index: DeleteFileIndex,
 }
 
 impl ManifestFileContext {
@@ -668,16 +659,13 @@ impl ManifestEntryContext {
     /// consume this `ManifestEntryContext`, returning a `FileScanTask`
     /// created from it
     async fn into_file_scan_task(self) -> Result<FileScanTask> {
-        let deletes = if let Some(delete_file_index) = self.delete_file_index {
-            delete_file_index
-                .get_deletes_for_data_file(
-                    self.manifest_entry.data_file(),
-                    self.manifest_entry.sequence_number(),
-                )
-                .await?
-        } else {
-            vec![]
-        };
+        let deletes = self
+            .delete_file_index
+            .get_deletes_for_data_file(
+                self.manifest_entry.data_file(),
+                self.manifest_entry.sequence_number(),
+            )
+            .await?;
 
         Ok(FileScanTask {
             start: 0,
@@ -732,7 +720,8 @@ impl PlanContext {
         &self,
         manifest_list: Arc<ManifestList>,
         tx_data: Sender<ManifestEntryContext>,
-        delete_file_idx_and_tx: Option<(DeleteFileIndex, Sender<ManifestEntryContext>)>,
+        delete_file_idx: DeleteFileIndex,
+        delete_file_tx: Sender<ManifestEntryContext>,
     ) -> Result<Box<impl Iterator<Item = Result<ManifestFileContext>>>> {
         let manifest_files = manifest_list.entries().iter();
 
@@ -740,16 +729,10 @@ impl PlanContext {
         let mut filtered_mfcs = vec![];
 
         for manifest_file in manifest_files {
-            let (delete_file_idx, tx) = if manifest_file.content == ManifestContentType::Deletes {
-                let Some((delete_file_idx, tx)) = delete_file_idx_and_tx.as_ref() else {
-                    continue;
-                };
-                (Some(delete_file_idx.clone()), tx.clone())
+            let tx = if manifest_file.content == ManifestContentType::Deletes {
+                delete_file_tx.clone()
             } else {
-                (
-                    delete_file_idx_and_tx.as_ref().map(|x| x.0.clone()),
-                    tx_data.clone(),
-                )
+                tx_data.clone()
             };
 
             let partition_bound_predicate = if self.predicate.is_some() {
@@ -777,7 +760,7 @@ impl PlanContext {
                 manifest_file,
                 partition_bound_predicate,
                 tx,
-                delete_file_idx,
+                delete_file_idx.clone(),
             );
 
             filtered_mfcs.push(Ok(mfc));
@@ -791,7 +774,7 @@ impl PlanContext {
         manifest_file: &ManifestFile,
         partition_filter: Option<Arc<BoundPredicate>>,
         sender: Sender<ManifestEntryContext>,
-        delete_file_index: Option<DeleteFileIndex>,
+        delete_file_index: DeleteFileIndex,
     ) -> ManifestFileContext {
         let bound_predicates =
             if let (Some(ref partition_bound_predicate), Some(snapshot_bound_predicate)) =
@@ -1003,23 +986,18 @@ impl ExpressionEvaluatorCache {
                     ErrorKind::Unexpected,
                     "ManifestEvaluatorCache RwLock was poisoned",
                 )
-            })
-            .unwrap()
+            })?
             .insert(
                 spec_id,
                 Arc::new(ExpressionEvaluator::new(partition_filter.clone())),
             );
 
-        let read = self
-            .0
-            .read()
-            .map_err(|_| {
-                Error::new(
-                    ErrorKind::Unexpected,
-                    "ManifestEvaluatorCache RwLock was poisoned",
-                )
-            })
-            .unwrap();
+        let read = self.0.read().map_err(|_| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "ManifestEvaluatorCache RwLock was poisoned",
+            )
+        })?;
 
         Ok(read.get(&spec_id).unwrap().clone())
     }

--- a/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
+++ b/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
@@ -25,7 +25,7 @@ use iceberg_catalog_rest::RestCatalog;
 use crate::get_shared_containers;
 
 #[tokio::test]
-async fn test_read_table_with_positional_deletes() {
+async fn test_read_table_with_positional_deletes_with_delete_support_disabled() {
     let fixture = get_shared_containers();
     let rest_catalog = RestCatalog::new(fixture.catalog_config.clone());
 
@@ -39,7 +39,7 @@ async fn test_read_table_with_positional_deletes() {
 
     let scan = table
         .scan()
-        .with_delete_file_processing_enabled(true)
+        .with_delete_file_processing_enabled(false)
         .build()
         .unwrap();
     println!("{:?}", scan);
@@ -53,21 +53,16 @@ async fn test_read_table_with_positional_deletes() {
         .unwrap();
     println!("{:?}", plan);
 
-    // Scan plan phase should include delete files in file plan
-    // when with_delete_file_processing_enabled == true
+    // Scan plan phase stills include delete files in file plan
+    // when with_delete_file_processing_enabled == false. We instead
+    // fail at the read phase after this.
     assert_eq!(plan[0].deletes.len(), 2);
 
-    // 😱 If we don't support positional deletes, we should fail when we try to read a table that
-    // has positional deletes. The table has 12 rows, and 2 are deleted, see provision.py
+    // with delete_file_processing_enabled == false, we should fail when we 
+    // try to read a table that has positional deletes.
     let result = scan.to_arrow().await.unwrap().try_collect::<Vec<_>>().await;
 
     assert!(result.is_err_and(|e| e.kind() == FeatureUnsupported));
-
-    // When we get support for it:
-    // let batch_stream = scan.to_arrow().await.unwrap();
-    // let batches: Vec<_> = batch_stream.try_collect().await.is_err();
-    // let num_rows: usize = batches.iter().map(|v| v.num_rows()).sum();
-    // assert_eq!(num_rows, 10);
 }
 
 #[tokio::test]

--- a/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
+++ b/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
@@ -58,7 +58,7 @@ async fn test_read_table_with_positional_deletes_with_delete_support_disabled() 
     // fail at the read phase after this.
     assert_eq!(plan[0].deletes.len(), 2);
 
-    // with delete_file_processing_enabled == false, we should fail when we 
+    // with delete_file_processing_enabled == false, we should fail when we
     // try to read a table that has positional deletes.
     let result = scan.to_arrow().await.unwrap().try_collect::<Vec<_>>().await;
 

--- a/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
+++ b/crates/integration_tests/tests/shared_tests/read_positional_deletes.rs
@@ -69,3 +69,43 @@ async fn test_read_table_with_positional_deletes() {
     // let num_rows: usize = batches.iter().map(|v| v.num_rows()).sum();
     // assert_eq!(num_rows, 10);
 }
+
+#[tokio::test]
+async fn test_read_table_with_positional_deletes_with_delete_support_enabled() {
+    let fixture = get_shared_containers();
+    let rest_catalog = RestCatalog::new(fixture.catalog_config.clone());
+
+    let table = rest_catalog
+        .load_table(
+            &TableIdent::from_strs(["default", "test_positional_merge_on_read_double_deletes"])
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let scan = table
+        .scan()
+        .with_delete_file_processing_enabled(true)
+        .build()
+        .unwrap();
+    println!("{:?}", scan);
+
+    let plan: Vec<_> = scan
+        .plan_files()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    println!("{:?}", plan);
+
+    // Scan plan phase should include delete files in file plan
+    // when with_delete_file_processing_enabled == true
+    assert_eq!(plan[0].deletes.len(), 2);
+
+    // we should see two rows deleted, returning 10 rows instead of 12
+    let batch_stream = scan.to_arrow().await.unwrap();
+    let batches: Vec<_> = batch_stream.try_collect().await.unwrap();
+    let num_rows: usize = batches.iter().map(|v| v.num_rows()).sum();
+    assert_eq!(num_rows, 10);
+}


### PR DESCRIPTION
Continues the series of scan delete file support PRs.

* Adds parsing of equality delete files into `DeleteFileManager`
* Tests WIP, to follow

Builds on top of https://github.com/apache/iceberg-rust/pull/1011, https://github.com/apache/iceberg-rust/pull/982, https://github.com/apache/iceberg-rust/pull/951 and https://github.com/apache/iceberg-rust/pull/950 and should be merged after them.

Issue: https://github.com/apache/iceberg-rust/issues/630