### PR TITLE
fix(views): make timestamp take &self & fix set_current_version_id

### DIFF
--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -226,7 +226,7 @@ impl ViewVersionLog {
     }
 
     /// Returns the last updated timestamp as a DateTime<Utc> with millisecond precision.
-    pub fn timestamp(self) -> Result<DateTime<Utc>> {
+    pub fn timestamp(&self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1099
- Closes #1100

## What changes are included in this PR?

1. fixes set current view version
2. makes ViewVersionLog::timestamp not consume `self`

## Are these changes tested?

1. Added a test which sets current view version to -1
2. doesn't require a test, it's a quality of life improvement

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->