### PR TITLE
fix: chore cargo lock and fix two warning for python bindings

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -541,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1329,7 @@ dependencies = [
  "paste",
  "rand",
  "reqwest",
+ "roaring",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -2559,6 +2566,16 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roaring"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
 
 [[package]]
 name = "rust-ini"

--- a/bindings/python/src/transform.rs
+++ b/bindings/python/src/transform.rs
@@ -75,7 +75,7 @@ fn apply(py: Python, array: PyObject, transform: Transform) -> PyResult<PyObject
 }
 
 pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let this = PyModule::new_bound(py, "transform")?;
+    let this = PyModule::new(py, "transform")?;
 
     this.add_function(wrap_pyfunction!(identity, &this)?)?;
     this.add_function(wrap_pyfunction!(void, &this)?)?;
@@ -87,7 +87,7 @@ pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
     this.add_function(wrap_pyfunction!(truncate, &this)?)?;
 
     m.add_submodule(&this)?;
-    py.import_bound("sys")?
+    py.import("sys")?
         .getattr("modules")?
         .set_item("pyiceberg_core.transform", this)
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This patch chore the cargo.lock and fix the warning for python binding