### PR TITLE
fix: safety ci using static check zizmor

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -35,9 +35,11 @@ runs:
 
     - name: Get and update version
       shell: bash
+      env:
+        TIMESTAMP: ${{ inputs.timestamp }}
       run: |
         CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
-        NEW_VERSION="${CURRENT_VERSION}.dev${{ inputs.timestamp }}"
+        NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
         NEW_VERSION=$NEW_VERSION python -c "
         import toml
         import os

--- a/.github/actions/setup-builder/action.yml
+++ b/.github/actions/setup-builder/action.yml
@@ -28,10 +28,12 @@ runs:
     - name: Setup specified Rust toolchain
       shell: bash
       if: ${{ inputs.rust-version != '' }}
+      env:
+        RUST_VERSION: ${{ inputs.rust-version }}
       run: |
-        echo "Installing ${{ inputs.rust-version }}"
-        rustup toolchain install ${{ inputs.rust-version }}
-        rustup override set ${{ inputs.rust-version }}
+        echo "Installing ${RUST_VERSION}"
+        rustup toolchain install ${RUST_VERSION}
+        rustup override set ${RUST_VERSION}
         rustup component add rustfmt clippy
     - name: Setup Rust toolchain according to rust-toolchain.toml
       shell: bash


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

this patch make ci more safety using static check zizmor: to avoid code injection

more: 
- https://github.com/apache/airflow/issues/45408
- https://github.com/astral-sh/ruff/pull/14844

and github actions safety is more and more important:

link: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised