### PR TITLE
feat(storage): Add hdfs support via webhdfs

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -30,12 +30,13 @@ keywords = ["iceberg"]
 
 [features]
 default = ["storage-memory", "storage-fs", "storage-s3", "tokio"]
-storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs"]
+storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs", "storage-webhdfs"]
 
 storage-memory = ["opendal/services-memory"]
 storage-fs = ["opendal/services-fs"]
 storage-s3 = ["opendal/services-s3"]
 storage-gcs = ["opendal/services-gcs"]
+storage-webhdfs = ["opendal/services-webhdfs"]
 
 async-std = ["dep:async-std"]
 tokio = ["dep:tokio"]

--- a/crates/iceberg/src/io/mod.rs
+++ b/crates/iceberg/src/io/mod.rs
@@ -81,13 +81,16 @@ pub use storage_s3::*;
 pub(crate) mod object_cache;
 #[cfg(feature = "storage-fs")]
 mod storage_fs;
-
 #[cfg(feature = "storage-fs")]
 use storage_fs::*;
 #[cfg(feature = "storage-gcs")]
 mod storage_gcs;
 #[cfg(feature = "storage-gcs")]
 pub use storage_gcs::*;
+#[cfg(feature = "storage-webhdfs")]
+mod storage_webhdfs;
+#[cfg(feature = "storage-webhdfs")]
+pub use storage_webhdfs::*;
 
 pub(crate) fn is_truthy(value: &str) -> bool {
     ["true", "t", "1", "on"].contains(&value.to_lowercase().as_str())

--- a/crates/iceberg/src/io/storage_webhdfs.rs
+++ b/crates/iceberg/src/io/storage_webhdfs.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+
+use opendal::services::WebhdfsConfig;
+use opendal::{Configurator, Operator};
+
+use crate::io::is_truthy;
+use crate::{Error, ErrorKind, Result};
+
+/// Configure the HDFS host to connect to
+pub const HDSF_HOST: &str = "hdfs.host";
+/// Configure the HDFS part to connect to
+pub const HDSF_PORT: &str = "hdfs.port";
+/// Configure the HDFS username used for connection.
+pub const HDFS_USER: &str = "hdfs.user";
+/// Configure the hdfs to not use the list batch api.
+pub const HDFS_DISABLE_LIST_BATCH: &str = "hdfs.disable_list_batch";
+
+/// Parse iceberg props to hdfs config.
+pub(crate) fn webhdfs_config_parse(mut m: HashMap<String, String>) -> Result<WebhdfsConfig> {
+    let mut cfg = WebhdfsConfig::default();
+
+    let host = if let Some(host) = m.remove(HDSF_HOST) {
+        host
+    } else {
+        return Err(
+            Error::new(ErrorKind::Unexpected, "hdfs.host is required to use HDFS")
+                .with_context("config", format!("{m:?}")),
+        );
+    };
+
+    let port = if let Some(port) = m.remove(HDSF_PORT) {
+        port
+    } else {
+        return Err(
+            Error::new(ErrorKind::Unexpected, "hdfs.port is required to use HDFS")
+                .with_context("config", format!("{m:?}")),
+        );
+    };
+
+    cfg.endpoint = Some(format!("{}:{}", host, port));
+
+    if let Some(user) = m.remove(HDFS_USER) {
+        cfg.user_name = Some(user);
+    };
+    if let Some(disable_list_batch) = m.remove(HDFS_DISABLE_LIST_BATCH) {
+        cfg.disable_list_batch = is_truthy(&disable_list_batch);
+    };
+
+    Ok(cfg)
+}
+
+/// Build new opendal operator from give path.
+pub(crate) fn webhdfs_config_build(cfg: &WebhdfsConfig) -> Result<Operator> {
+    let builder = cfg.clone().into_builder();
+    Ok(Operator::new(builder)?.finish())
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/iceberg-rust/issues/1130

## What changes are included in this PR?

Add webhdfs based hdfs storage support in iceberg-rust.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Webhdfs service itself is tested at opendal side, maybe we can setup related tests in iceberg-rust too.