### PR TITLE
chore: group `arrow*` and `parquet` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,9 @@ updates:
        # For all packages, ignore all patch updates
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      arrow-parquet:
+        applies-to: version-updates
+        patterns:
+          - "arrow*"
+          - "parquet"


### PR DESCRIPTION
## Which issue does this PR close?

None.

## What changes are included in this PR?

Group `arrow*` and `parquet` dependabot updates (https://github.com/apache/iceberg-rust/pulls?q=author%3Aapp%2Fdependabot+arrow).

## Are these changes tested?

No.