### PR TITLE
Rename `pyiceberg_core` to `pyiceberg-core`

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -95,7 +95,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/pyiceberg_core
+      url: https://pypi.org/p/pyiceberg-core
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -109,7 +109,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/pyiceberg_core
+      url: https://test.pypi.org/p/pyiceberg-core
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/bindings/python/project-description.md
+++ b/bindings/python/project-description.md
@@ -24,5 +24,5 @@ This project is used to build an iceberg-rust powered core for pyiceberg, and in
 Install via PyPI:
 
 ```
-pip install pyiceberg_core
+pip install pyiceberg-core
 ```

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "pyiceberg_core"
+name = "pyiceberg-core"
 version = "0.4.0"
 readme = "project-description.md"
 requires-python = "~=3.9"


### PR DESCRIPTION
## What changes are included in this PR?

When I go to:

https://pypi.org/project/pyiceberg_core/

It redirects to:

https://pypi.org/project/pyiceberg-core/

We also install `pyiceberg-core` in PyIceberg, so I think pypi automatically replaces the underscore with a dash.


<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->