### PR TITLE
feat: Add `refresh` to get get updated `TableMetadata`

### DIFF
--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -19,8 +19,6 @@
 
 use std::sync::Arc;
 
-use futures::TryFutureExt;
-
 use crate::arrow::ArrowReaderBuilder;
 use crate::inspect::MetadataTable;
 use crate::io::object_cache::ObjectCache;
@@ -30,18 +28,18 @@ use crate::spec::{TableMetadata, TableMetadataRef};
 use crate::{Catalog, Error, ErrorKind, Result, TableIdent};
 
 /// Builder to create table scan.
-pub struct TableBuilder<'a> {
+pub struct TableBuilder {
     file_io: Option<FileIO>,
     metadata_location: Option<String>,
     metadata: Option<TableMetadataRef>,
     identifier: Option<TableIdent>,
-    catalog: Option<&'a dyn Catalog>,
+    catalog: Option<Arc<dyn Catalog>>,
     readonly: bool,
     disable_cache: bool,
     cache_size_bytes: Option<u64>,
 }
 
-impl<'a> TableBuilder<'a> {
+impl TableBuilder {
     pub(crate) fn new() -> Self {
         Self {
             file_io: None,
@@ -80,7 +78,7 @@ impl<'a> TableBuilder<'a> {
     }
 
     /// required - passes in the reference to the Catalog to use for the Table
-    pub fn catalog(mut self, catalog: &'a dyn Catalog) -> Self {
+    pub fn catalog(mut self, catalog: Arc<dyn Catalog>) -> Self {
         self.catalog = Some(catalog);
         self
     }
@@ -171,19 +169,19 @@ impl<'a> TableBuilder<'a> {
 
 /// Table represents a table in the catalog.
 #[derive(Debug, Clone)]
-pub struct Table<'a> {
+pub struct Table {
     file_io: FileIO,
     metadata_location: Option<String>,
     metadata: TableMetadataRef,
     identifier: TableIdent,
-    catalog: &'a dyn Catalog,
+    catalog: Arc<dyn Catalog>,
     readonly: bool,
     object_cache: Arc<ObjectCache>,
 }
 
-impl <'a> Table<'a> {
+impl Table {
     /// Returns a TableBuilder to build a table
-    pub fn builder<'b>() -> TableBuilder<'a> {
+    pub fn builder<'b>() -> TableBuilder {
         TableBuilder::new()
     }
 

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -37,14 +37,14 @@ use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdat
 
 /// Table transaction.
 pub struct Transaction<'a> {
-    table: &'a mut Table<'a>,
+    table: &'a Table,
     updates: Vec<TableUpdate>,
     requirements: Vec<TableRequirement>,
 }
 
 impl<'a> Transaction<'a> {
     /// Creates a new transaction.
-    pub fn new(table: &'a mut Table) -> Self {
+    pub fn new(table: &'a Table) -> Self {
         Self {
             table,
             updates: vec![],
@@ -127,14 +127,12 @@ impl<'a> Transaction<'a> {
     }
 
     /// Creates a fast append action.
-    pub async fn fast_append(
+    pub fn fast_append(
         self,
         commit_uuid: Option<Uuid>,
         key_metadata: Vec<u8>,
     ) -> Result<FastAppendAction<'a>> {
         let snapshot_id = self.generate_unique_snapshot_id();
-        let _ = self.table.refresh().await?;
-        
         FastAppendAction::new(
             self,
             snapshot_id,

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -37,14 +37,14 @@ use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdat
 
 /// Table transaction.
 pub struct Transaction<'a> {
-    table: &'a Table,
+    table: &'a mut Table<'a>,
     updates: Vec<TableUpdate>,
     requirements: Vec<TableRequirement>,
 }
 
 impl<'a> Transaction<'a> {
     /// Creates a new transaction.
-    pub fn new(table: &'a Table) -> Self {
+    pub fn new(table: &'a mut Table) -> Self {
         Self {
             table,
             updates: vec![],
@@ -127,12 +127,14 @@ impl<'a> Transaction<'a> {
     }
 
     /// Creates a fast append action.
-    pub fn fast_append(
+    pub async fn fast_append(
         self,
         commit_uuid: Option<Uuid>,
         key_metadata: Vec<u8>,
     ) -> Result<FastAppendAction<'a>> {
         let snapshot_id = self.generate_unique_snapshot_id();
+        let _ = self.table.refresh().await?;
+        
         FastAppendAction::new(
             self,
             snapshot_id,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Mentioned [here](https://github.com/apache/iceberg-rust/issues/964)

## What changes are included in this PR?

Added basic conflict detection. The current idea is that before commit we can use catalog to refresh the table state before commit to compare with the base metadata.