### PR TITLE
Change tokio feature

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -38,7 +38,7 @@ storage-s3 = ["opendal/services-s3"]
 storage-gcs = ["opendal/services-gcs"]
 
 async-std = ["dep:async-std"]
-tokio = ["tokio/full"]
+tokio = ["tokio/rt-multi-thread"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -38,7 +38,7 @@ storage-s3 = ["opendal/services-s3"]
 storage-gcs = ["opendal/services-gcs"]
 
 async-std = ["dep:async-std"]
-tokio = ["dep:tokio"]
+tokio = ["tokio/full"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -80,7 +80,7 @@ serde_json = { workspace = true }
 serde_repr = { workspace = true }
 serde_with = { workspace = true }
 thrift = { workspace = true }
-tokio = { workspace = true, optional = true, features = ["sync"] }
+tokio = { workspace = true, optional = false, features = ["sync"] }
 typed-builder = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
## What changes are included in this PR?

Changes tokio dependency, enable `sync` feature only by default, but requires `full` feature when we enable `tokio` cfg. With this change, we can still use tokio's runtime indepdenent utils, while only rely on tokio's runtime when we enable `tokio` cfg.


## Are these changes tested?

CI.