### PR TITLE
ci: Use taplo to replace cargo-sort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,6 @@ jobs:
       - name: Cargo clippy
         run: make check-clippy
 
-      - name: Install cargo-sort
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-sort@1.0.9
-      - name: Cargo sort
-        run: cargo sort -c -w
-
       - name: Install cargo-machete
         uses: taiki-e/install-action@v2
         with:

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+include = ["Cargo.toml", "**/*.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = true
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 80
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '  '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = true
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,25 +16,25 @@
 # under the License.
 
 [workspace]
-resolver = "2"
-members = [
-    "crates/catalog/*",
-    "crates/examples",
-    "crates/iceberg",
-    "crates/integration_tests",
-    "crates/integrations/*",
-    "crates/sqllogictest",
-    "crates/test_utils",
-]
 exclude = ["bindings/python"]
+members = [
+  "crates/catalog/*",
+  "crates/examples",
+  "crates/iceberg",
+  "crates/integration_tests",
+  "crates/integrations/*",
+  "crates/sqllogictest",
+  "crates/test_utils",
+]
+resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
 edition = "2021"
 homepage = "https://rust.iceberg.apache.org/"
+version = "0.4.0"
 
-repository = "https://github.com/apache/iceberg-rust"
 license = "Apache-2.0"
+repository = "https://github.com/apache/iceberg-rust"
 # Check the MSRV policy in README.md before changing this
 rust-version = "1.84"
 
@@ -50,8 +50,8 @@ arrow-ord = { version = "54.2.0" }
 arrow-schema = { version = "54.2.0" }
 arrow-select = { version = "54.2.0" }
 arrow-string = { version = "54.2.0" }
-async-trait = "0.1.86"
 async-std = "1.12"
+async-trait = "0.1.86"
 aws-config = "1"
 aws-sdk-glue = "1.39"
 bimap = "0.6"
@@ -62,11 +62,14 @@ ctor = "0.2.8"
 datafusion = "45"
 derive_builder = "0.20"
 env_logger = "0.11.0"
+expect-test = "1"
 fnv = "1.0.7"
 futures = "0.3"
+hive_metastore = "0.1"
+http = "1.1"
 iceberg = { version = "0.4.0", path = "./crates/iceberg" }
-iceberg-catalog-rest = { version = "0.4.0", path = "./crates/catalog/rest" }
 iceberg-catalog-memory = { version = "0.4.0", path = "./crates/catalog/memory" }
+iceberg-catalog-rest = { version = "0.4.0", path = "./crates/catalog/rest" }
 iceberg-datafusion = { version = "0.4.0", path = "./crates/integrations/datafusion" }
 itertools = "0.13"
 log = "0.4.22"
@@ -78,8 +81,8 @@ opendal = "0.53.0"
 ordered-float = "4"
 parquet = "54.2.0"
 pilota = "0.11.2"
-pretty_assertions = "1.4"
 port_scanner = "0.1.5"
+pretty_assertions = "1.4"
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = { version = "0.12.2", default-features = false, features = ["json"] }
@@ -92,14 +95,11 @@ serde_json = "1.0.138"
 serde_repr = "0.1.16"
 serde_with = "3.4"
 tempfile = "3.18"
+tera = "1"
 thrift = "0.17.0"
 tokio = { version = "1.44", default-features = false }
 typed-builder = "0.20"
 url = "2.5.4"
 uuid = { version = "1.14", features = ["v7"] }
 volo-thrift = "0.10"
-hive_metastore = "0.1"
-tera = "1"
 zstd = "0.13.2"
-expect-test = "1"
-http = "1.1"

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,6 @@ check-fmt:
 check-clippy:
 	cargo  clippy --all-targets --all-features --workspace -- -D warnings
 
-install-cargo-sort:
-	cargo install cargo-sort@1.0.9
-
-cargo-sort: install-cargo-sort
-	cargo sort -c -w
-
 install-cargo-machete:
 	cargo install cargo-machete@0.7.0
 
@@ -47,7 +41,7 @@ fix-toml: install-taplo-cli
 check-toml: install-taplo-cli
 	taplo check
 
-check: check-fmt check-clippy cargo-sort check-toml cargo-machete
+check: check-fmt check-clippy check-toml cargo-machete
 
 doc-test:
 	cargo test --no-fail-fast --doc --all-features --workspace

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,21 +16,21 @@
 # under the License.
 
 [package]
-name = "pyiceberg_core_rust"
-version = "0.4.0"
 edition = "2021"
 homepage = "https://rust.iceberg.apache.org"
+name = "pyiceberg_core_rust"
 rust-version = "1.84"
+version = "0.4.0"
 # This crate is used to build python bindings, we don't want to publish it
 publish = false
 
-license = "Apache-2.0"
 keywords = ["iceberg"]
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
+arrow = { version = "54.1.0", features = ["pyarrow", "chrono-tz"] }
 iceberg = { path = "../../crates/iceberg" }
 pyo3 = { version = "0.23.3", features = ["extension-module", "abi3-py39"] }
-arrow = { version = "54.1.0", features = ["pyarrow", "chrono-tz"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -16,14 +16,10 @@
 # under the License.
 
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
+requires = ["maturin>=1.0,<2.0"]
 
 [project]
-name = "pyiceberg-core"
-version = "0.4.0"
-readme = "project-description.md"
-requires-python = "~=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -34,11 +30,15 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
+name = "pyiceberg-core"
+readme = "project-description.md"
+requires-python = "~=3.9"
+version = "0.4.0"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
-python-source = "python"
 module-name = "pyiceberg_core.pyiceberg_core_rust"
+python-source = "python"
 
 [tool.ruff.lint]
 ignore = ["F403", "F405"]
@@ -47,6 +47,6 @@ ignore = ["F403", "F405"]
 dependencies = ["maturin>=1.0,<2.0", "pytest>=8.3.2", "pyarrow>=17.0.0"]
 
 [tool.hatch.envs.dev.scripts]
-develop = "maturin develop"
 build = "maturin build --out dist --sdist"
+develop = "maturin develop"
 test = "pytest"

--- a/crates/catalog/glue/Cargo.toml
+++ b/crates/catalog/glue/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-glue"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-glue"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Glue Catalog Support"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "glue", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/catalog/hms/Cargo.toml
+++ b/crates/catalog/hms/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-hms"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-hms"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Hive Metastore Catalog Support"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "hive", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/catalog/memory/Cargo.toml
+++ b/crates/catalog/memory/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-memory"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-memory"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Rust Memory Catalog API"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "memory", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-rest"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-rest"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Rust REST API"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "rest", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 # async-trait = { workspace = true }

--- a/crates/catalog/s3tables/Cargo.toml
+++ b/crates/catalog/s3tables/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-s3tables"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-s3tables"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Rust S3Tables Catalog"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "sql", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -16,17 +16,17 @@
 # under the License.
 
 [package]
-name = "iceberg-catalog-sql"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-catalog-sql"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Rust Sql Catalog"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "sql", "catalog"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -16,13 +16,13 @@
 # under the License.
 
 [package]
-name = "iceberg-examples"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-repository = { workspace = true }
 license = { workspace = true }
+name = "iceberg-examples"
+repository = { workspace = true }
 rust-version = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 iceberg = { workspace = true }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -16,26 +16,26 @@
 # under the License.
 
 [package]
-name = "iceberg"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg"
 rust-version = { workspace = true }
+version = { workspace = true }
 
 categories = ["database"]
 description = "Apache Iceberg Rust implementation"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [features]
 default = ["storage-memory", "storage-fs", "storage-s3", "tokio"]
 storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs"]
 
-storage-memory = ["opendal/services-memory"]
 storage-fs = ["opendal/services-fs"]
-storage-s3 = ["opendal/services-s3"]
 storage-gcs = ["opendal/services-gcs"]
+storage-memory = ["opendal/services-memory"]
+storage-s3 = ["opendal/services-s3"]
 
 async-std = ["dep:async-std"]
 tokio = ["tokio/rt-multi-thread"]

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -16,13 +16,13 @@
 # under the License.
 
 [package]
-name = "iceberg-integration-tests"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-repository = { workspace = true }
 license = { workspace = true }
+name = "iceberg-integration-tests"
+repository = { workspace = true }
 rust-version = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -16,10 +16,10 @@
 # under the License.
 
 [package]
-name = "iceberg-datafusion"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg-datafusion"
+version = { workspace = true }
 # kept the same as DataFusion's MSRV
 # https://github.com/apache/datafusion?tab=readme-ov-file#rust-version-compatibility-policy
 # https://github.com/apache/datafusion/blob/main/Cargo.toml#L68
@@ -27,9 +27,9 @@ rust-version = "1.82"
 
 categories = ["database"]
 description = "Apache Iceberg DataFusion Integration"
-repository = { workspace = true }
-license = { workspace = true }
 keywords = ["iceberg", "integrations", "datafusion"]
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -16,13 +16,13 @@
 # under the License.
 
 [package]
-name = "sqllogictest"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-repository = { workspace = true }
 license = { workspace = true }
+name = "sqllogictest"
+repository = { workspace = true }
 rust-version = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -16,14 +16,14 @@
 # under the License.
 
 [package]
-name = "iceberg_test_utils"
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+name = "iceberg_test_utils"
 rust-version = { workspace = true }
+version = { workspace = true }
 
-repository = { workspace = true }
 license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 env_logger = { workspace = true }

--- a/website/book.toml
+++ b/website/book.toml
@@ -23,8 +23,8 @@ src = "src"
 title = "Iceberg Rust"
 
 [output.html]
-git-repository-url = "https://github.com/apache/iceberg-rust"
-git-repository-icon = "fa-github"
-edit-url-template = "https://github.com/apache/iceberg-rust/edit/main/website/{path}"
 cname = "rust.iceberg.apache.org"
+edit-url-template = "https://github.com/apache/iceberg-rust/edit/main/website/{path}"
+git-repository-icon = "fa-github"
+git-repository-url = "https://github.com/apache/iceberg-rust"
 no-section-label = true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

## What changes are included in this PR?

Use taplo to replace cargo-sort entirely. taplo covers all features that cargo-sort have.

## Are these changes tested?

Better toml handling.