### PR TITLE
fix: Update view version log timestamp for historical accuracy

### DIFF
--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -229,6 +229,12 @@ impl ViewVersionLog {
     pub fn timestamp(&self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }
+
+    /// Update the timestamp of this version log.
+    pub(crate) fn set_timestamp_ms(&mut self, timestamp_ms: i64) -> &mut Self {
+        self.timestamp_ms = timestamp_ms;
+        self
+    }
 }
 
 pub(super) mod _serde {


### PR DESCRIPTION
## What changes are included in this PR?

This change updates the behavior when setting a view version as current. When we set a previously existing view version as current, we now update its log timestamp to the current time rather than reusing the original timestamp of the ViewVersion.

Lets assume the following changes:
1. ViewVersion 1 is added and set active
2. View Version 2 is added and set active
3. View Version 1 is set active.

This resulted in the following `version_log`:
```json
    "version-log": [
        {
            "version-id": 1,
            "timestamp-ms": 1744716416168
        },
        {
            "version-id": 2,
            "timestamp-ms": 1744716449754
        },
        {
            "version-id": 1,
            "timestamp-ms": 1744716416168
        }
    ],
```

Note that the last and first entries have the same timestamp, namely the time stamp of the initial ViewVersion creation.

I believe this is undesired in a history, where we are interested when a certain change became active. It makes sense to use the exact timestamp of the ViewVersion if it was added in the same set of changes, but re-enabling a previously used view version (maybe years ago) should not add a history for this past timestamp.

Java behaviors the same way as rust currently does. @nastra if we agree that we should change the behavior, we should also touch Java.

## Are these changes tested?

Yes