### PR TITLE
feat: Allow reuse http client in rest catalog

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -31,7 +31,7 @@ use itertools::Itertools;
 use reqwest::header::{
     HeaderMap, HeaderName, HeaderValue, {self},
 };
-use reqwest::{Method, StatusCode, Url};
+use reqwest::{Client, Method, StatusCode, Url};
 use tokio::sync::OnceCell;
 use typed_builder::TypedBuilder;
 
@@ -58,6 +58,9 @@ pub struct RestCatalogConfig {
 
     #[builder(default)]
     props: HashMap<String, String>,
+
+    #[builder(default)]
+    client: Option<Client>,
 }
 
 impl RestCatalogConfig {
@@ -104,6 +107,11 @@ impl RestCatalogConfig {
             "tables",
             &table.name,
         ])
+    }
+
+    /// Get the client from the config.
+    pub(crate) fn client(&self) -> Option<Client> {
+        self.client.clone()
     }
 
     /// Get the token from the config.


### PR DESCRIPTION
## Which issue does this PR close?

Creating a reqwest client is not without cost; it involves DNS caching, HTTP connection pooling, and TLS certificate loading. The previous design also made it difficult for users to configure the HTTP client, such as setting custom timeout values or using a globally shared DNS resolver.

This PR addressed this by allowing users to create the client and pass to rest catalog as config.

## What changes are included in this PR?

Allow users to pass a `reqwest::Client` as config.

## Are these changes tested?

Unit tests