### PR TITLE
feat(playground): Add S3Tables catalog support (#1161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,6 +3396,7 @@ dependencies = [
  "dirs",
  "fs-err",
  "iceberg-catalog-rest",
+ "iceberg-catalog-s3tables",
  "iceberg-datafusion",
  "mimalloc",
  "stacker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ http = "1.1"
 iceberg = { version = "0.4.0", path = "./crates/iceberg" }
 iceberg-catalog-memory = { version = "0.4.0", path = "./crates/catalog/memory" }
 iceberg-catalog-rest = { version = "0.4.0", path = "./crates/catalog/rest" }
+iceberg-catalog-s3tables = { version = "0.4.0", path = "./crates/catalog/s3tables" }
 iceberg-datafusion = { version = "0.4.0", path = "./crates/integrations/datafusion" }
 indicatif = "0.17"
 itertools = "0.13"

--- a/crates/integrations/cli/Cargo.toml
+++ b/crates/integrations/cli/Cargo.toml
@@ -35,6 +35,7 @@ anyhow = {workspace = true}
 iceberg-datafusion = {workspace = true}
 toml = {workspace = true}
 iceberg-catalog-rest = {workspace = true}
+iceberg-catalog-s3tables = {workspace = true}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true}
 dirs = {workspace = true}

--- a/crates/integrations/cli/README.md
+++ b/crates/integrations/cli/README.md
@@ -23,3 +23,64 @@
 Iceberg CLI (`iceberg-cli`) is a small command line utility that runs SQL queries against tables,
 which is backed by the DataFusion engine.
 
+## Supported Catalog Types
+
+The CLI supports the following catalog types:
+
+1. **REST Catalog**: Connect to an Iceberg REST catalog service
+2. **S3Tables Catalog**: Connect to AWS S3Tables service
+
+## Configuration
+
+The CLI uses a configuration file (typically `~/.icebergrc`) to define catalogs. Here's how to configure different catalog types:
+
+### REST Catalog Configuration
+
+```toml
+[[catalogs]]
+name = "local_rest_catalog"
+type = "rest"
+
+[catalogs.config]
+uri = "http://localhost:8181"
+warehouse = "file:///tmp/iceberg_warehouse"
+
+[catalogs.config.props]
+aws_region = "<region>"
+```
+
+### S3Tables Catalog Configuration
+
+```toml
+[[catalogs]]
+name = "s3tables_catalog"
+type = "s3tables"
+
+[catalogs.config]
+endpoint_url = "https://s3tables.<region>.amazonaws.com"
+table_bucket_arn = "arn:aws:s3:<region>:<account>:bucket/<bucket_name>"
+
+[catalogs.config.props]
+aws_region = "<region>"
+"s3.region" = "<region>"
+"s3.access-key-id" = "<access-key-id>"
+"s3.secret-access-key" = "<secret-access-key>"
+"s3.session-token" = "<session-token>"
+profile_name = "<profile>"
+```
+
+## Usage
+
+Once configured, you can use the CLI to query tables from your catalogs:
+
+```bash
+# Start the CLI
+cargo run --package iceberg-cli --bin iceberg-cli
+
+# List tables
+SHOW TABLES;
+
+# Query a table
+SELECT * FROM my_catalog.my_namespace.my_table LIMIT 10;
+```
+


### PR DESCRIPTION
Allow configuring S3Tables catalog type in the playground CLI config.

## Which issue does this PR close?

Closes https://github.com/apache/iceberg-rust/issues/1161

## What changes are included in this PR?

Adds parsing for `type = "s3tables"` in `cli/src/catalog.rs`, handling `table_bucket_arn`, optional `endpoint_url`, and `props`. Instantiates the `S3TablesCatalog` and wraps it for DataFusion integration.

This enables testing S3Tables interactions via the playground using TOML configuration like:

```
[[catalogs]]
name = "s3tables_catalog"
type = "s3tables"

[catalogs.config]
endpoint_url = "https://s3tables.<region>.amazonaws.com"
table_bucket_arn = "arn:aws:s3:<region>:<account>:bucket/<bucket_name>"

[catalogs.config.props]
aws_region = "<region>"
"s3.region" = "<region>"
"s3.access-key-id" = "<access-key-id>"
"s3.secret-access-key" = "<secret-access-key>"
"s3.session-token" = "<session-token>"
profile_name = "<profile>"
```

## Are these changes tested?

Tested locally using both rest and s3tables catalog

```
$ cargo run --package iceberg-cli --bin iceberg-cli

> SHOW TABLES;

> SELECT * FROM my_catalog.my_namespace.my_table LIMIT 10;

```

