### PR TITLE
refactor(s3tables): avoid misleading FileIO::from_path

### DIFF
--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -24,7 +24,7 @@ use aws_sdk_s3tables::operation::get_namespace::GetNamespaceOutput;
 use aws_sdk_s3tables::operation::get_table::GetTableOutput;
 use aws_sdk_s3tables::operation::list_tables::ListTablesOutput;
 use aws_sdk_s3tables::types::OpenTableFormat;
-use iceberg::io::FileIO;
+use iceberg::io::{FileIO, FileIOBuilder};
 use iceberg::spec::{TableMetadata, TableMetadataBuilder};
 use iceberg::table::Table;
 use iceberg::{
@@ -70,19 +70,7 @@ impl S3TablesCatalog {
         let aws_config = create_sdk_config(&config.properties, config.endpoint_url.clone()).await;
         let s3tables_client = aws_sdk_s3tables::Client::new(&aws_config);
 
-        // parse bucket name from ARN format like: arn:aws:s3:<region>:<account>:bucket/<bucket_name>
-        let bucket_name = config
-            .table_bucket_arn
-            .rsplit(":bucket/")
-            .next()
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::DataInvalid,
-                    format!("Invalid bucket ARN format: {}", config.table_bucket_arn),
-                )
-            })?;
-
-        let file_io = FileIO::from_path(format!("s3://{}", bucket_name))?
+        let file_io = FileIOBuilder::new("s3")
             .with_props(&config.properties)
             .build()?;
 


### PR DESCRIPTION
The `FileIO::from_path` only validates a s3 url, and finally calls `FileIOBuilder::new(url.scheme())`.

For s3 tables, the table bucket is not a real bucket, and we can't do s3 operations on that. The `FileIO::from_path` here gives a fake impression that the bucket name will be used.

Signed-off-by: xxchan <xxchan22f@gmail.com>

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->