### PR TITLE
feat: support azure blob storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "uuid",
 ]

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -30,12 +30,13 @@ keywords = ["iceberg"]
 
 [features]
 default = ["storage-memory", "storage-fs", "storage-s3", "tokio"]
-storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs"]
+storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs", "storage-azblob"]
 
 storage-memory = ["opendal/services-memory"]
 storage-fs = ["opendal/services-fs"]
 storage-s3 = ["opendal/services-s3"]
 storage-gcs = ["opendal/services-gcs"]
+storage-azblob = ["opendal/services-azblob"]
 
 async-std = ["dep:async-std"]
 tokio = ["dep:tokio"]

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -41,6 +41,7 @@ use crate::{Error, ErrorKind, Result};
 /// | Memory             | `storage-memory`  | `memory`   |
 /// | S3                 | `storage-s3`      | `s3`, `s3a`|
 /// | GCS                | `storage-gcs`     | `gs`, `gcs`|
+/// | AZBLOB             | `storage-azblob`  | `azblob`   |
 #[derive(Clone, Debug)]
 pub struct FileIO {
     builder: FileIOBuilder,

--- a/crates/iceberg/src/io/mod.rs
+++ b/crates/iceberg/src/io/mod.rs
@@ -89,6 +89,11 @@ mod storage_gcs;
 #[cfg(feature = "storage-gcs")]
 pub use storage_gcs::*;
 
+#[cfg(feature = "storage-azblob")]
+mod storage_azblob;
+#[cfg(feature = "storage-azblob")]
+pub use storage_azblob::*;
+
 fn is_truthy(value: &str) -> bool {
     ["true", "t", "1", "on"].contains(&value.to_lowercase().as_str())
 }

--- a/crates/iceberg/src/io/storage_azblob.rs
+++ b/crates/iceberg/src/io/storage_azblob.rs
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//! Azure blob storage properties
+
+use std::collections::HashMap;
+
+use opendal::services::AzblobConfig;
+use opendal::Operator;
+use url::Url;
+
+use crate::{Error, ErrorKind, Result};
+
+/// Azure blob account name.
+pub const AZBLOB_ACCOUNT_NAME: &str = "azblob.account-name";
+/// Azure blob account key.
+pub const AZBLOB_ACCOUNT_KEY: &str = "azblob.account-key";
+/// Azure blob account endpoint.
+pub const AZBLOB_ENDPOINT: &str = "azblob.endpoint";
+
+/// Parse iceberg properties to [`AzblobConfig`].
+pub(crate) fn azblob_config_parse(mut m: HashMap<String, String>) -> Result<AzblobConfig> {
+    let mut cfg = AzblobConfig::default();
+
+    if let Some(account_name) = m.remove(AZBLOB_ACCOUNT_NAME) {
+        cfg.account_name = Some(account_name);
+    };
+    if let Some(account_key) = m.remove(AZBLOB_ACCOUNT_KEY) {
+        cfg.account_key = Some(account_key);
+    };
+    if let Some(endpoint) = m.remove(AZBLOB_ENDPOINT) {
+        cfg.endpoint = Some(endpoint);
+    };
+
+    Ok(cfg)
+}
+
+/// Build a new OpenDAL [`Operator`] based on a provided [`AzblobConfig`].
+pub(crate) fn azblob_config_build(cfg: &AzblobConfig, path: &str) -> Result<Operator> {
+    let url = Url::parse(path)?;
+    let container = url.host_str().ok_or_else(|| {
+        Error::new(
+            ErrorKind::DataInvalid,
+            format!("Invalid azblob url: {}, container is required", path),
+        )
+    })?;
+
+    let mut cfg = cfg.clone();
+    cfg.container = container.to_string();
+    Ok(Operator::from_config(cfg)?.finish())
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
This PR is similar to the previous one that supported GCS as storage, and it adds support for Azure Blob as storage. The authentication here uses account_name, account_key, and endpoint URL. Connectivity and correctness have already been verified on the RisingWave side, allowing for read and write access to Azure Blob.
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->