### PR TITLE
[easy] Add comment on non-existent namespace/table at drop

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -67,7 +67,7 @@ pub trait Catalog: Debug + Sync + Send {
         properties: HashMap<String, String>,
     ) -> Result<()>;
 
-    /// Drop a namespace from the catalog.
+    /// Drop a namespace from the catalog, or returns error if it doesn't exist.
     async fn drop_namespace(&self, namespace: &NamespaceIdent) -> Result<()>;
 
     /// List tables from namespace.
@@ -83,7 +83,7 @@ pub trait Catalog: Debug + Sync + Send {
     /// Load table from the catalog.
     async fn load_table(&self, table: &TableIdent) -> Result<Table>;
 
-    /// Drop a table from the catalog.
+    /// Drop a table from the catalog, or returns error if it doesn't exist.
     async fn drop_table(&self, table: &TableIdent) -> Result<()>;
 
     /// Check if a table exists in the catalog.


### PR DESCRIPTION
## What changes are included in this PR?

I added documentation on the behavior when table/namespace to drop doesn't exist, which I think it's important to consolidate for traits.
I reference `MemoryCatalog` for behavior: https://github.com/apache/iceberg-rust/blob/main/crates/catalog/memory/src/catalog.rs

## Are these changes tested?

N/A