### PR TITLE
[catalog] Fix namespace creation error status

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -403,7 +403,7 @@ impl Catalog for RestCatalog {
                     deserialize_catalog_response::<NamespaceSerde>(http_response).await?;
                 Namespace::try_from(response)
             }
-            StatusCode::NOT_FOUND => Err(Error::new(
+            StatusCode::CONFLICT => Err(Error::new(
                 ErrorKind::Unexpected,
                 "Tried to create a namespace that already exists",
             )),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1247 

## What changes are included in this PR?

According to the [openapi spec](https://github.com/apache/iceberg-rust/issues/1247), already existed error should return 409 (Conflict) status code.

## Are these changes tested?

I checked with cargo test and doesn't find any breakage.