### PR TITLE
[easy] [discussion] Add more error types

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -452,7 +452,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::NotFound,
                 format!(
                     "Table object for database: {} and table: {} does not exist",
                     db_name, table_name
@@ -566,7 +566,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::NotFound,
                 format!(
                     "'Table' object for database: {} and table: {} does not exist",
                     src_db_name, src_table_name

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -33,21 +33,21 @@ pub(crate) struct NamespaceState {
 
 fn no_such_namespace_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::NotFound,
         format!("No such namespace: {:?}", namespace_ident),
     ))
 }
 
 fn no_such_table_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::NotFound,
         format!("No such table: {:?}", table_ident),
     ))
 }
 
 fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::AlreadyExists,
         format!(
             "Cannot create namespace {:?}. Namespace already exists.",
             namespace_ident
@@ -57,7 +57,7 @@ fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T
 
 fn table_already_exists_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::AlreadyExists,
         format!(
             "Cannot create table {:?}. Table already exists.",
             table_ident

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -40,6 +40,17 @@ pub enum ErrorKind {
     ///
     /// The table could be invalid or corrupted.
     DataInvalid,
+
+    /// Iceberg entity already exists.
+    ///
+    /// This error is returned when we try to create an entity (i.e. namespace or table) that already exists.
+    AlreadyExists,
+
+    /// Iceberg entity not found.
+    ///
+    /// This error is returned when we try to access an entity (i.e. namespace or table) that does not exist.
+    NotFound,
+
     /// Iceberg feature is not supported.
     ///
     /// This error is returned when given iceberg feature is not supported.
@@ -59,6 +70,8 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::Unexpected => "Unexpected",
             ErrorKind::DataInvalid => "DataInvalid",
             ErrorKind::FeatureUnsupported => "FeatureUnsupported",
+            ErrorKind::AlreadyExists => "AlreadyExists",
+            ErrorKind::NotFound => "NotFound",
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/iceberg-rust/issues/1249

## What changes are included in this PR?

In this PR, I introduce two new error status: `ALREADY_EXISTS` and `NOT_FOUND`, which I borrowed from grpc status code.
https://grpc.io/docs/guides/status-codes/

I'm willing and happy to discuss more on the error status propagation and error testing; this PR serves as an example to add clearer and detailed error codes.

## Are these changes tested?

I checked with `cargo test` and doesn't find any breakage.