### PR TITLE
[catalog] Expose TableCommit construction to public

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -269,7 +269,7 @@ pub struct TableCreation {
 
 /// TableCommit represents the commit of a table in the catalog.
 #[derive(Debug, TypedBuilder)]
-#[builder(build_method(vis = "pub(crate)"))]
+#[builder(build_method(vis = "pub"))]
 pub struct TableCommit {
     /// The table ident.
     ident: TableIdent,


### PR DESCRIPTION
## What changes are included in this PR?

In this PR, I expose `TableCommit` builder to public, so I could create the instance outside of the crate.

Some context why I need this change:
- I'm working on a filesystem catalog, which reads and writes everything to and from local filesystem;
- This is necessary because: (1) it's beneficial to testing; (2) it's beneficial and easy to setup for our initial customer try out;
- To test the `update_table` function, I need to create a table commit instance.

Alternatives considered:
- Use `std::mem::transmute` to manually hack the object memory, similar to `reinterpret_cast` in C++;
- I could use `Transaction` interface to achieve the same effect, but takes more effort.

Would appreciate if team has any concerns about it.

## Are these changes tested?

N/A, it's a no-op change