### PR TITLE
[catalog] Add more error types

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -452,7 +452,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::NotFound,
                 format!(
                     "Table object for database: {} and table: {} does not exist",
                     db_name, table_name
@@ -566,7 +566,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::NotFound,
                 format!(
                     "'Table' object for database: {} and table: {} does not exist",
                     src_db_name, src_table_name

--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -452,7 +452,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::NotFound,
+                ErrorKind::TableNotFound,
                 format!(
                     "Table object for database: {} and table: {} does not exist",
                     db_name, table_name
@@ -566,7 +566,7 @@ impl Catalog for GlueCatalog {
 
         match glue_table_output.table() {
             None => Err(Error::new(
-                ErrorKind::NotFound,
+                ErrorKind::TableNotFound,
                 format!(
                     "'Table' object for database: {} and table: {} does not exist",
                     src_db_name, src_table_name

--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -598,7 +598,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => Cannot create namespace {:?}. Namespace already exists.",
+                "AlreadyExists => Cannot create namespace {:?}. Namespace already exists.",
                 &namespace_ident
             )
         );
@@ -667,7 +667,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 NamespaceIdent::new("a".into())
             )
         );
@@ -692,7 +692,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 NamespaceIdent::from_strs(vec!["a", "b"]).unwrap()
             )
         );
@@ -773,7 +773,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             )
         )
@@ -860,7 +860,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             )
         )
@@ -937,7 +937,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             )
         )
@@ -957,7 +957,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             )
         )
@@ -1257,7 +1257,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => Cannot create table {:?}. Table already exists.",
+                "AlreadyExists => Cannot create table {:?}. Table already exists.",
                 &table_ident
             )
         );
@@ -1359,7 +1359,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             ),
         );
@@ -1409,7 +1409,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             ),
         );
@@ -1429,10 +1429,7 @@ mod tests {
                 .await
                 .unwrap_err()
                 .to_string(),
-            format!(
-                "Unexpected => No such table: {:?}",
-                non_existent_table_ident
-            ),
+            format!("NotFound => No such table: {:?}", non_existent_table_ident),
         );
     }
 
@@ -1494,7 +1491,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_namespace_ident
             ),
         );
@@ -1609,7 +1606,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_src_namespace_ident
             ),
         );
@@ -1633,7 +1630,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => No such namespace: {:?}",
+                "NotFound => No such namespace: {:?}",
                 non_existent_dst_namespace_ident
             ),
         );
@@ -1653,7 +1650,7 @@ mod tests {
                 .await
                 .unwrap_err()
                 .to_string(),
-            format!("Unexpected => No such table: {:?}", src_table_ident),
+            format!("NotFound => No such table: {:?}", src_table_ident),
         );
     }
 
@@ -1673,7 +1670,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "Unexpected => Cannot create table {:? }. Table already exists.",
+                "AlreadyExists => Cannot create table {:? }. Table already exists.",
                 &dst_table_ident
             ),
         );

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -33,21 +33,21 @@ pub(crate) struct NamespaceState {
 
 fn no_such_namespace_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::NotFound,
+        ErrorKind::NamespaceNotFound,
         format!("No such namespace: {:?}", namespace_ident),
     ))
 }
 
 fn no_such_table_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::NotFound,
+        ErrorKind::TableNotFound,
         format!("No such table: {:?}", table_ident),
     ))
 }
 
 fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::AlreadyExists,
+        ErrorKind::NamespaceAlreadyExists,
         format!(
             "Cannot create namespace {:?}. Namespace already exists.",
             namespace_ident
@@ -57,7 +57,7 @@ fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T
 
 fn table_already_exists_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::AlreadyExists,
+        ErrorKind::TableAlreadyExists,
         format!(
             "Cannot create table {:?}. Table already exists.",
             table_ident

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -33,21 +33,21 @@ pub(crate) struct NamespaceState {
 
 fn no_such_namespace_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::NotFound,
         format!("No such namespace: {:?}", namespace_ident),
     ))
 }
 
 fn no_such_table_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::NotFound,
         format!("No such table: {:?}", table_ident),
     ))
 }
 
 fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::AlreadyExists,
         format!(
             "Cannot create namespace {:?}. Namespace already exists.",
             namespace_ident
@@ -57,7 +57,7 @@ fn namespace_already_exists_err<T>(namespace_ident: &NamespaceIdent) -> Result<T
 
 fn table_already_exists_err<T>(table_ident: &TableIdent) -> Result<T> {
     Err(Error::new(
-        ErrorKind::Unexpected,
+        ErrorKind::AlreadyExists,
         format!(
             "Cannot create table {:?}. Table already exists.",
             table_ident

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -40,6 +40,17 @@ pub enum ErrorKind {
     ///
     /// The table could be invalid or corrupted.
     DataInvalid,
+
+    /// Iceberg entity already exists.
+    ///
+    /// This error is returned when we try to create an entity (i.e. namespace or table) that already exists.
+    AlreadyExists,
+
+    /// Iceberg entity not found.
+    ///
+    /// This error is returned when we try to access an entity (i.e. namespace or table) that does not exist.
+    NotFound,
+
     /// Iceberg feature is not supported.
     ///
     /// This error is returned when given iceberg feature is not supported.
@@ -59,6 +70,8 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::Unexpected => "Unexpected",
             ErrorKind::DataInvalid => "DataInvalid",
             ErrorKind::FeatureUnsupported => "FeatureUnsupported",
+            ErrorKind::AlreadyExists => "AlreadyExists",
+            ErrorKind::NotFound => "NotFound",
         }
     }
 }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -41,15 +41,17 @@ pub enum ErrorKind {
     /// The table could be invalid or corrupted.
     DataInvalid,
 
-    /// Iceberg entity already exists.
-    ///
-    /// This error is returned when we try to create an entity (i.e. namespace or table) that already exists.
-    AlreadyExists,
+    /// Iceberg namespace already exists at creation.
+    NamespaceAlreadyExists,
 
-    /// Iceberg entity not found.
-    ///
-    /// This error is returned when we try to access an entity (i.e. namespace or table) that does not exist.
-    NotFound,
+    /// Iceberg table already exists at creation.
+    TableAlreadyExists,
+
+    /// Iceberg namespace already exists at creation.
+    NamespaceNotFound,
+
+    /// Iceberg table already exists at creation.
+    TableNotFound,
 
     /// Iceberg feature is not supported.
     ///
@@ -70,8 +72,10 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::Unexpected => "Unexpected",
             ErrorKind::DataInvalid => "DataInvalid",
             ErrorKind::FeatureUnsupported => "FeatureUnsupported",
-            ErrorKind::AlreadyExists => "AlreadyExists",
-            ErrorKind::NotFound => "NotFound",
+            ErrorKind::TableAlreadyExists => "TableAlreadyExists",
+            ErrorKind::TableNotFound => "TableNotFound",
+            ErrorKind::NamespaceAlreadyExists => "NamespaceAlreadyExists",
+            ErrorKind::NamespaceNotFound => "NamespaceNotFound",
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/iceberg-rust/issues/1249

## What changes are included in this PR?

As discussed in https://github.com/apache/iceberg-rust/issues/1038#issuecomment-2833199052 and suggested by @Xuanwo at https://github.com/apache/iceberg-rust/issues/1038#issuecomment-2833258633, I redo my old [PR](https://github.com/apache/iceberg-rust/pull/1250), to add namespace / table error kind.

Next steps:
1. Have an initial version for retry in rest catalog, meanwhile we should expose retry mechanism;
2. Have a retry layer for all catalog types, which shouldn't lead to any behavior change.

## Are these changes tested?

I checked with `cargo test` and doesn't find any breakage.