### PR TITLE
fix(catalog/rest): Allow deserialize error with empty response

### DIFF
--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -250,18 +250,21 @@ pub(crate) async fn deserialize_catalog_response<R: DeserializeOwned>(
 }
 
 /// Deserializes a unexpected catalog response into an error.
-///
-/// TODO: Eventually, this function should return an error response that is custom to the error
-/// codes that all endpoints share (400, 404, etc.).
 pub(crate) async fn deserialize_unexpected_catalog_error(response: Response) -> Error {
-    let (status, headers) = (response.status(), response.headers().clone());
+    let err = Error::new(
+        ErrorKind::Unexpected,
+        "Received response with unexpected status code",
+    )
+    .with_context("status", response.status().to_string())
+    .with_context("headers", format!("{:?}", response.headers()));
+
     let bytes = match response.bytes().await {
         Ok(bytes) => bytes,
         Err(err) => return err.into(),
     };
 
-    Error::new(ErrorKind::Unexpected, "Received unexpected response")
-        .with_context("status", status.to_string())
-        .with_context("headers", format!("{:?}", headers))
-        .with_context("json", String::from_utf8_lossy(&bytes))
+    if bytes.is_empty() {
+        return err;
+    }
+    err.with_context("json", String::from_utf8_lossy(&bytes))
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/iceberg-rust/issues/1234

## What changes are included in this PR?

Allow deserialize error with empty response

## Are these changes tested?

Unit tests.