### PR TITLE
[WIP] feat(catalog): Add drop namespace doumentation

### DIFF
--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -878,6 +878,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_drop_parent_namespace_also_drop_children() {
+        let catalog = new_memory_catalog();
+        let namespace_ident = NamespaceIdent::new("abc".into());
+        create_namespace(&catalog, &namespace_ident).await;
+
+        let child_namespace_ident =
+            NamespaceIdent::from_vec(vec!["abc".to_string(), "def".to_string()]).unwrap();
+        create_namespace(&catalog, &child_namespace_ident).await;
+
+        catalog.drop_namespace(&namespace_ident).await.unwrap();
+
+        assert!(!catalog.namespace_exists(&namespace_ident).await.unwrap());
+        assert!(!catalog
+            .namespace_exists(&child_namespace_ident)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
     async fn test_drop_nested_namespace() {
         let catalog = new_memory_catalog();
         let namespace_ident_a = NamespaceIdent::new("a".into());

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -68,6 +68,10 @@ pub trait Catalog: Debug + Sync + Send {
     ) -> Result<()>;
 
     /// Drop a namespace from the catalog, or returns error if it doesn't exist.
+    ///
+    /// If a parent namespace gets dropped, all its children namespaces will be dropped as well.
+    /// This function doesn't provide transaction guarantee, which means it's possible to have parent namespace deleted with children namespaces still left.
+    /// This function is idempotent, and could be retried infinitely.
     async fn drop_namespace(&self, namespace: &NamespaceIdent) -> Result<()>;
 
     /// List tables from namespace.


### PR DESCRIPTION
## What changes are included in this PR?

This PR adds documentation on `drop_namespace` behavior, which I think unclear.
The behavior referenced to memory catalog and s3 table catalog.

## Are these changes tested?

No real code change, just add documentation and test cases to verify the behavior.