### PR TITLE
[WIP] Sync manifest entry schema

### DIFF
--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -347,6 +347,9 @@ mod tests {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -371,6 +374,9 @@ mod tests {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 

--- a/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
@@ -1997,6 +1997,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -2019,6 +2022,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -2077,6 +2083,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
     fn get_test_file_2() -> DataFile {
@@ -2104,6 +2113,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -2132,6 +2144,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -2160,6 +2175,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 }

--- a/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
@@ -582,6 +582,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -604,6 +607,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -626,6 +632,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 
@@ -649,6 +658,9 @@ mod test {
             equality_ids: vec![],
             sort_order_id: None,
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }
     }
 

--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -215,6 +215,9 @@ impl DataFileSerde {
             equality_ids: self.equality_ids.unwrap_or_default(),
             sort_order_id: self.sort_order_id,
             partition_spec_id,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         })
     }
 }
@@ -359,7 +362,10 @@ mod tests {
             split_offsets: vec![4],
             equality_ids: vec![],
             sort_order_id: Some(0),
-            partition_spec_id: 0
+            partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         }];
 
         let mut buffer = Vec::new();

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -215,7 +215,7 @@ mod tests {
                     snapshot_id: None,
                     sequence_number: None,
                     file_sequence_number: None,
-                    data_file: DataFile {content:DataContentType::Data,file_path:"s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),file_format:DataFileFormat::Parquet,partition:Struct::empty(),record_count:1,file_size_in_bytes:5442,column_sizes:HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),value_counts:HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),null_value_counts:HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),nan_value_counts:HashMap::new(),lower_bounds:HashMap::new(),upper_bounds:HashMap::new(),key_metadata:None,split_offsets:vec![4],equality_ids:Vec::new(),sort_order_id:None, partition_spec_id: 0 }
+                    data_file: DataFile {content:DataContentType::Data,file_path:"s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),file_format:DataFileFormat::Parquet,partition:Struct::empty(),record_count:1,file_size_in_bytes:5442,column_sizes:HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),value_counts:HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),null_value_counts:HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),nan_value_counts:HashMap::new(),lower_bounds:HashMap::new(),upper_bounds:HashMap::new(),key_metadata:None,split_offsets:vec![4],equality_ids:Vec::new(),sort_order_id:None, partition_spec_id: 0,referenced_data_file: None,content_offset: None,content_size_in_bytes: None }
                 }
             ];
 
@@ -396,7 +396,10 @@ mod tests {
                     split_offsets: vec![4],
                     equality_ids: vec![],
                     sort_order_id: None,
-                    partition_spec_id: 0
+                    partition_spec_id: 0,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
                 },
             }];
 
@@ -489,7 +492,10 @@ mod tests {
                     split_offsets: vec![4],
                     equality_ids: vec![],
                     sort_order_id: Some(0),
-                    partition_spec_id: 0
+                    partition_spec_id: 0,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
                 }
             }];
 
@@ -593,7 +599,10 @@ mod tests {
                         split_offsets: vec![4],
                         equality_ids: vec![],
                         sort_order_id: Some(0),
-                        partition_spec_id: 0
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
                     },
                 }
             ];
@@ -697,7 +706,10 @@ mod tests {
                     split_offsets: vec![4],
                     equality_ids: vec![],
                     sort_order_id: None,
-                    partition_spec_id: 0
+                    partition_spec_id: 0,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
                 },
             }];
 
@@ -784,7 +796,10 @@ mod tests {
                     split_offsets: vec![4],
                     equality_ids: vec![],
                     sort_order_id: None,
-                    partition_spec_id: 0
+                    partition_spec_id: 0,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
                 },
             })],
         };
@@ -834,6 +849,40 @@ mod tests {
             format_version: FormatVersion::V2,
         };
         let entries = vec![
+            ManifestEntry {
+                status: ManifestStatus::Added,
+                snapshot_id: None,
+                sequence_number: None,
+                file_sequence_number: None,
+                data_file: DataFile {
+                    content: DataContentType::Data,
+                    file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                    file_format: DataFileFormat::Parquet,
+                    partition: Struct::from_iter(
+                        vec![
+                            Some(Literal::int(2021)),
+                            Some(Literal::float(1.0)),
+                            Some(Literal::double(2.0)),
+                        ]
+                    ),
+                    record_count: 1,
+                    file_size_in_bytes: 5442,
+                    column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
+                    value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
+                    null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
+                    nan_value_counts: HashMap::new(),
+                    lower_bounds: HashMap::new(),
+                    upper_bounds: HashMap::new(),
+                    key_metadata: None,
+                    split_offsets: vec![4],
+                    equality_ids: Vec::new(),
+                    sort_order_id: None,
+                    partition_spec_id: 0,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
+                }
+            },
                 ManifestEntry {
                     status: ManifestStatus::Added,
                     snapshot_id: None,
@@ -845,9 +894,9 @@ mod tests {
                         file_format: DataFileFormat::Parquet,
                         partition: Struct::from_iter(
                             vec![
-                                Some(Literal::int(2021)),
-                                Some(Literal::float(1.0)),
-                                Some(Literal::double(2.0)),
+                                Some(Literal::int(1111)),
+                                Some(Literal::float(15.5)),
+                                Some(Literal::double(25.5)),
                             ]
                         ),
                         record_count: 1,
@@ -862,103 +911,81 @@ mod tests {
                         split_offsets: vec![4],
                         equality_ids: Vec::new(),
                         sort_order_id: None,
-                        partition_spec_id: 0
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
                     }
                 },
-                    ManifestEntry {
-                        status: ManifestStatus::Added,
-                        snapshot_id: None,
-                        sequence_number: None,
-                        file_sequence_number: None,
-                        data_file: DataFile {
-                            content: DataContentType::Data,
-                            file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
-                            file_format: DataFileFormat::Parquet,
-                            partition: Struct::from_iter(
-                                vec![
-                                    Some(Literal::int(1111)),
-                                    Some(Literal::float(15.5)),
-                                    Some(Literal::double(25.5)),
-                                ]
-                            ),
-                            record_count: 1,
-                            file_size_in_bytes: 5442,
-                            column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
-                            value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
-                            null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
-                            nan_value_counts: HashMap::new(),
-                            lower_bounds: HashMap::new(),
-                            upper_bounds: HashMap::new(),
-                            key_metadata: None,
-                            split_offsets: vec![4],
-                            equality_ids: Vec::new(),
-                            sort_order_id: None,
-                            partition_spec_id: 0
-                        }
-                    },
-                    ManifestEntry {
-                        status: ManifestStatus::Added,
-                        snapshot_id: None,
-                        sequence_number: None,
-                        file_sequence_number: None,
-                        data_file: DataFile {
-                            content: DataContentType::Data,
-                            file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
-                            file_format: DataFileFormat::Parquet,
-                            partition: Struct::from_iter(
-                                vec![
-                                    Some(Literal::int(1211)),
-                                    Some(Literal::float(f32::NAN)),
-                                    Some(Literal::double(1.0)),
-                                ]
-                            ),
-                            record_count: 1,
-                            file_size_in_bytes: 5442,
-                            column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
-                            value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
-                            null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
-                            nan_value_counts: HashMap::new(),
-                            lower_bounds: HashMap::new(),
-                            upper_bounds: HashMap::new(),
-                            key_metadata: None,
-                            split_offsets: vec![4],
-                            equality_ids: Vec::new(),
-                            sort_order_id: None,
-                            partition_spec_id: 0
-                        }
-                    },
-                    ManifestEntry {
-                        status: ManifestStatus::Added,
-                        snapshot_id: None,
-                        sequence_number: None,
-                        file_sequence_number: None,
-                        data_file: DataFile {
-                            content: DataContentType::Data,
-                            file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
-                            file_format: DataFileFormat::Parquet,
-                            partition: Struct::from_iter(
-                                vec![
-                                    Some(Literal::int(1111)),
-                                    None,
-                                    Some(Literal::double(11.0)),
-                                ]
-                            ),
-                            record_count: 1,
-                            file_size_in_bytes: 5442,
-                            column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
-                            value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
-                            null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
-                            nan_value_counts: HashMap::new(),
-                            lower_bounds: HashMap::new(),
-                            upper_bounds: HashMap::new(),
-                            key_metadata: None,
-                            split_offsets: vec![4],
-                            equality_ids: Vec::new(),
-                            sort_order_id: None,
-                            partition_spec_id: 0
-                        }
-                    },
-            ];
+                ManifestEntry {
+                    status: ManifestStatus::Added,
+                    snapshot_id: None,
+                    sequence_number: None,
+                    file_sequence_number: None,
+                    data_file: DataFile {
+                        content: DataContentType::Data,
+                        file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                        file_format: DataFileFormat::Parquet,
+                        partition: Struct::from_iter(
+                            vec![
+                                Some(Literal::int(1211)),
+                                Some(Literal::float(f32::NAN)),
+                                Some(Literal::double(1.0)),
+                            ]
+                        ),
+                        record_count: 1,
+                        file_size_in_bytes: 5442,
+                        column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
+                        value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
+                        null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
+                        nan_value_counts: HashMap::new(),
+                        lower_bounds: HashMap::new(),
+                        upper_bounds: HashMap::new(),
+                        key_metadata: None,
+                        split_offsets: vec![4],
+                        equality_ids: Vec::new(),
+                        sort_order_id: None,
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
+                    }
+                },
+                ManifestEntry {
+                    status: ManifestStatus::Added,
+                    snapshot_id: None,
+                    sequence_number: None,
+                    file_sequence_number: None,
+                    data_file: DataFile {
+                        content: DataContentType::Data,
+                        file_path: "s3a://icebergdata/demo/s1/t1/data/00000-0-ba56fbfa-f2ff-40c9-bb27-565ad6dc2be8-00000.parquet".to_string(),
+                        file_format: DataFileFormat::Parquet,
+                        partition: Struct::from_iter(
+                            vec![
+                                Some(Literal::int(1111)),
+                                None,
+                                Some(Literal::double(11.0)),
+                            ]
+                        ),
+                        record_count: 1,
+                        file_size_in_bytes: 5442,
+                        column_sizes: HashMap::from([(0,73),(6,34),(2,73),(7,61),(3,61),(5,62),(9,79),(10,73),(1,61),(4,73),(8,73)]),
+                        value_counts: HashMap::from([(4,1),(5,1),(2,1),(0,1),(3,1),(6,1),(8,1),(1,1),(10,1),(7,1),(9,1)]),
+                        null_value_counts: HashMap::from([(1,0),(6,0),(2,0),(8,0),(0,0),(3,0),(5,0),(9,0),(7,0),(4,0),(10,0)]),
+                        nan_value_counts: HashMap::new(),
+                        lower_bounds: HashMap::new(),
+                        upper_bounds: HashMap::new(),
+                        key_metadata: None,
+                        split_offsets: vec![4],
+                        equality_ids: Vec::new(),
+                        sort_order_id: None,
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
+                    }
+                },
+        ];
 
         // write manifest to file
         let tmp_dir = TempDir::new().unwrap();

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -542,7 +542,10 @@ mod tests {
                         split_offsets: vec![4],
                         equality_ids: Vec::new(),
                         sort_order_id: None,
-                        partition_spec_id: 0
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
                     },
                 },
                 ManifestEntry {
@@ -567,7 +570,10 @@ mod tests {
                         split_offsets: vec![4],
                         equality_ids: Vec::new(),
                         sort_order_id: None,
-                        partition_spec_id: 0
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
                     },
                 },
                 ManifestEntry {
@@ -592,7 +598,10 @@ mod tests {
                         split_offsets: vec![4],
                         equality_ids: Vec::new(),
                         sort_order_id: None,
-                        partition_spec_id: 0
+                        partition_spec_id: 0,
+                        referenced_data_file: None,
+                        content_offset: None,
+                        content_size_in_bytes: None,
                     },
                 },
             ];

--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -769,6 +769,9 @@ mod tests {
             equality_ids: vec![],
             sort_order_id: Some(0),
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         };
 
         let file2 = DataFile {
@@ -797,6 +800,9 @@ mod tests {
             equality_ids: vec![],
             sort_order_id: Some(0),
             partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
         };
 
         collector.add_file(&file1, schema.clone(), partition_spec.clone());
@@ -901,6 +907,9 @@ mod tests {
                 equality_ids: vec![],
                 sort_order_id: None,
                 partition_spec_id: 0,
+                referenced_data_file: None,
+                content_offset: None,
+                content_size_in_bytes: None,
             },
             schema.clone(),
             partition_spec.clone(),
@@ -925,6 +934,9 @@ mod tests {
                 equality_ids: vec![],
                 sort_order_id: None,
                 partition_spec_id: 0,
+                referenced_data_file: None,
+                content_offset: None,
+                content_size_in_bytes: None,
             },
             schema.clone(),
             partition_spec.clone(),
@@ -975,6 +987,9 @@ mod tests {
                 equality_ids: vec![],
                 sort_order_id: None,
                 partition_spec_id: 0,
+                referenced_data_file: None,
+                content_offset: None,
+                content_size_in_bytes: None,
             },
             schema.clone(),
             partition_spec.clone(),


### PR DESCRIPTION
## Which issue does this PR close?

This PR sync up with upstream iceberg spec on deletion vector related fields.
Reference PR: https://github.com/apache/iceberg/pull/11240
Reference file: https://github.com/apache/iceberg/blob/main/format/spec.md#manifests

Context:
I'm working on iceberg related projects in my company, one of the features I'm working on is deletion vector.
Because there's no existing rust support for it, I need to do some of the work my own (i.e. deletion vector read and write).

My philosophy is to reduce discrepancy with upstream is:
- Avoid touching existing code unless unavoidable, and collaborate with open community if possible;
- For deletion vector issue, I could make no other changes and keep puffin write/read completely change on my end;
- The schema change in this PR is something hard to work-around. :(

I personally think the schema change alone (without actual deletion vector feature implementation) make sense, because it's a sync-up from iceberg spec sync (which has already been acknowledged by the community), as the [PR](https://github.com/apache/iceberg/pull/11240).

## Are these changes tested?

This PR is a no-op change, I confirm I could build + link with no problem.