### PR TITLE
chore: minor update to manifest sanity check error message

### DIFF
--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -171,7 +171,8 @@ impl ManifestWriter {
                     return Err(Error::new(
                         ErrorKind::DataInvalid,
                         format!(
-                            "Content type of entry {:?} should have DataContentType::Data",
+                            "Date file at path {} with manifest content type `data`, should have DataContentType `Data`, but has `{:?}`",
+                            data_file.file_path(),
                             data_file.content
                         ),
                     ));
@@ -183,7 +184,11 @@ impl ManifestWriter {
                 {
                     return Err(Error::new(
                     ErrorKind::DataInvalid,
-                    format!("Content type of entry {:?} should have DataContentType::EqualityDeletes or DataContentType::PositionDeletes", data_file.content),
+                    format!(
+                        "Date file at path {} with manifest content type `deletes`, should have DataContentType `Data`, but has `{:?}`",
+                        data_file.file_path(),
+                        data_file.content
+                    ),
                 ));
                 }
             }


### PR DESCRIPTION
## What changes are included in this PR?

This is the error message I get on my end:
```sh
Error: DataInvalid => Content type of entry PositionDeletes should have DataContentType::Data
```
At first sight, I have no idea what this means, until I read the sanity check code.

In this PR, I updated the error message for manifest write sanity check to provide more context:
- What's the manifest content file
- What's the filepath, this is useful for devs to directly understand what's the data file having issues
- What's the expected and actual data content type

## Are these changes tested?

No-op change