### PR TITLE
feat: expand arrow type conversion test

### DIFF
--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -1688,5 +1688,22 @@ mod tests {
             ]));
             assert_eq!(arrow_type, type_to_arrow_type(&iceberg_type).unwrap());
         }
+
+        // test dictionary type
+        {
+            let arrow_type =
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int8));
+            let iceberg_type = Type::Primitive(PrimitiveType::Int);
+            assert_eq!(
+                iceberg_type,
+                arrow_type_to_type(&arrow_type).unwrap(),
+                "Expected dictionary conversion to use the contained value"
+            );
+
+            let arrow_type =
+                DataType::Dictionary(Box::new(DataType::Utf8), Box::new(DataType::Boolean));
+            let iceberg_type = Type::Primitive(PrimitiveType::Boolean);
+            assert_eq!(iceberg_type, arrow_type_to_type(&arrow_type).unwrap());
+        }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Helps https://github.com/apache/iceberg-rust/issues/1277

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

This expands the `test_type_conversion` test with the specific `DataType::Dictionary` type.

Props to @phillipleblanc for this, as I noticed the extra coverage on his PR which I believe is very useful to capture[^1].

[^1]: I was looking to add similar to https://github.com/apache/iceberg-rust/pull/1293, but it was merged just before I pushed the changes :laughing: 

