### PR TITLE
chore: Add assertion for empty data files for append action

### DIFF
--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -29,7 +29,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum ErrorKind {
     /// The operation was rejected because the system is not in a state required for the operation’s execution.
-    FailedPrecondition,
+    PreconditionFailed,
 
     /// Iceberg don't know what happened here, and no actions other than
     /// just returning it back. For example, iceberg returns an internal
@@ -79,7 +79,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::TableNotFound => "TableNotFound",
             ErrorKind::NamespaceAlreadyExists => "NamespaceAlreadyExists",
             ErrorKind::NamespaceNotFound => "NamespaceNotFound",
-            ErrorKind::FailedPrecondition => "FailedPrecondition",
+            ErrorKind::PreconditionFailed => "PreconditionFailed",
         }
     }
 }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -28,6 +28,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
+    /// Function receives an invalid argument, which iceberg library cannot handle.
+    InvalidArgument,
+
     /// Iceberg don't know what happened here, and no actions other than
     /// just returning it back. For example, iceberg returns an internal
     /// service error.
@@ -76,6 +79,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::TableNotFound => "TableNotFound",
             ErrorKind::NamespaceAlreadyExists => "NamespaceAlreadyExists",
             ErrorKind::NamespaceNotFound => "NamespaceNotFound",
+            ErrorKind::InvalidArgument => "InvalidArgument",
         }
     }
 }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -28,8 +28,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// Function receives an invalid argument, which iceberg library cannot handle.
-    InvalidArgument,
+    /// The operation was rejected because the system is not in a state required for the operation’s execution.
+    FailedPrecondition,
 
     /// Iceberg don't know what happened here, and no actions other than
     /// just returning it back. For example, iceberg returns an internal
@@ -79,7 +79,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::TableNotFound => "TableNotFound",
             ErrorKind::NamespaceAlreadyExists => "NamespaceAlreadyExists",
             ErrorKind::NamespaceNotFound => "NamespaceNotFound",
-            ErrorKind::InvalidArgument => "InvalidArgument",
+            ErrorKind::FailedPrecondition => "FailedPrecondition",
         }
     }
 }

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -224,7 +224,8 @@ mod tests {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
         let mut action = tx.fast_append(None, vec![]).unwrap();
-        assert!(action.add_data_files(vec![]).is_err());
+        action.add_data_files(vec![]).unwrap();
+        assert!(action.apply().await.is_err());
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -220,6 +220,14 @@ mod tests {
     use crate::{TableRequirement, TableUpdate};
 
     #[tokio::test]
+    async fn test_empty_data_append_action() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+        let mut action = tx.fast_append(None, vec![]).unwrap();
+        assert!(action.add_data_files(vec![]).is_err());
+    }
+
+    #[tokio::test]
     async fn test_fast_append_action() {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -129,13 +129,6 @@ impl<'a> SnapshotProduceAction<'a> {
         data_files: impl IntoIterator<Item = DataFile>,
     ) -> Result<&mut Self> {
         let data_files: Vec<DataFile> = data_files.into_iter().collect();
-        if data_files.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidArgument,
-                "No data files were provided when adding data files to snapshot",
-            ));
-        }
-
         for data_file in &data_files {
             if data_file.content_type() != crate::spec::DataContentType::Data {
                 return Err(Error::new(
@@ -181,7 +174,7 @@ impl<'a> SnapshotProduceAction<'a> {
         let added_data_files = std::mem::take(&mut self.added_data_files);
         if added_data_files.is_empty() {
             return Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::FailedPrecondition,
                 "No added data files found when write a manifest file",
             ));
         }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -129,6 +129,13 @@ impl<'a> SnapshotProduceAction<'a> {
         data_files: impl IntoIterator<Item = DataFile>,
     ) -> Result<&mut Self> {
         let data_files: Vec<DataFile> = data_files.into_iter().collect();
+        if data_files.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                "Doesn't add any data files when fast append",
+            ));
+        }
+
         for data_file in &data_files {
             if data_file.content_type() != crate::spec::DataContentType::Data {
                 return Err(Error::new(
@@ -172,6 +179,13 @@ impl<'a> SnapshotProduceAction<'a> {
     // Write manifest file for added data files and return the ManifestFile for ManifestList.
     async fn write_added_manifest(&mut self) -> Result<ManifestFile> {
         let added_data_files = std::mem::take(&mut self.added_data_files);
+        if added_data_files.is_empty() {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "No added data files found when write a manifest file",
+            ));
+        }
+
         let snapshot_id = self.snapshot_id;
         let format_version = self.tx.current_table.metadata().format_version();
         let manifest_entries = added_data_files.into_iter().map(|data_file| {

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -174,7 +174,7 @@ impl<'a> SnapshotProduceAction<'a> {
         let added_data_files = std::mem::take(&mut self.added_data_files);
         if added_data_files.is_empty() {
             return Err(Error::new(
-                ErrorKind::FailedPrecondition,
+                ErrorKind::PreconditionFailed,
                 "No added data files found when write a manifest file",
             ));
         }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -132,7 +132,7 @@ impl<'a> SnapshotProduceAction<'a> {
         if data_files.is_empty() {
             return Err(Error::new(
                 ErrorKind::InvalidArgument,
-                "Doesn't add any data files when fast append",
+                "No data files were provided when adding data files to snapshot",
             ));
         }
 


### PR DESCRIPTION
## What changes are included in this PR?

The general usage to append data files is
```rust
let mut action = txn.fast_append(/*commit_uuid=*/ None, /*key_metadata=*/ vec![])?;
action.add_data_files(new_data_files)?;
let txn = action.apply().await?;
let table = txn.commit(catalog).await?
```
I found if ` new_data_files` is empty by accident, a new manifest file will still be created and tracked by manifest list file, which doesn't make sense to me (let me if team thinks it's a valid and ideal use case).

In this PR, I did a few changes:
- Add a new invalid argument error code;
- Add assertion to fail empty data files append, and empty action commit use cases.

## Are these changes tested?

Existing unit tests pass, and add a validation test for invalid data file append.