### PR TITLE
fix: Fix compilation failure when only storage-fs feature included

### DIFF
--- a/crates/iceberg/src/io/storage.rs
+++ b/crates/iceberg/src/io/storage.rs
@@ -102,9 +102,9 @@ impl Storage {
             #[cfg(feature = "storage-memory")]
             Storage::Memory(op) => {
                 if let Some(stripped) = path.strip_prefix("memory:/") {
-                    Ok((op.clone(), stripped))
+                    Ok::<_, crate::Error>((op.clone(), stripped))
                 } else {
-                    Ok((op.clone(), &path[1..]))
+                    Ok::<_, crate::Error>((op.clone(), &path[1..]))
                 }
             }
             #[cfg(feature = "storage-fs")]
@@ -112,9 +112,9 @@ impl Storage {
                 let op = super::fs_config_build()?;
 
                 if let Some(stripped) = path.strip_prefix("file:/") {
-                    Ok((op, stripped))
+                    Ok::<_, crate::Error>((op, stripped))
                 } else {
-                    Ok((op, &path[1..]))
+                    Ok::<_, crate::Error>((op, &path[1..]))
                 }
             }
             #[cfg(feature = "storage-s3")]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1303

## What changes are included in this PR?

This PR makes return type `Return<>` explicit.

## Are these changes tested?

I included a reproduction environment on the issue, and verify it compiles with no issue after my fix.