### PR TITLE
fix: incorrectly added  statement could cause deadlock

### DIFF
--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -429,8 +429,7 @@ impl TableScan {
                         .send(Err(error))
                         .await;
                 }
-            })
-            .await;
+            });
         }
 
         // Process the data file [`ManifestEntry`] stream in parallel


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1305.

## What changes are included in this PR?

Remove incorrect `await`.

## Are these changes tested?

All existing tests pass. Integ test that reads positional deletes in https://github.com/apache/iceberg-rust/pull/1011 no longer deadlocks with this fix.
