### PR TITLE
chore: define deletion vector type constant

### DIFF
--- a/crates/iceberg/src/puffin/blob.rs
+++ b/crates/iceberg/src/puffin/blob.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 
 /// A serialized form of a "compact" Theta sketch produced by the Apache DataSketches library.
 pub const APACHE_DATASKETCHES_THETA_V1: &str = "apache-datasketches-theta-v1";
+/// A serialized form of a deletion vector.
+pub const DELETION_VECTOR_V1: &str = "deletion-vector-v1";
 
 /// The blob
 #[derive(Debug, PartialEq, Clone)]

--- a/crates/iceberg/src/puffin/mod.rs
+++ b/crates/iceberg/src/puffin/mod.rs
@@ -20,7 +20,7 @@
 #![deny(missing_docs)]
 
 mod blob;
-pub use blob::{Blob, APACHE_DATASKETCHES_THETA_V1};
+pub use blob::{Blob, APACHE_DATASKETCHES_THETA_V1, DELETION_VECTOR_V1};
 
 mod compression;
 pub use compression::CompressionCodec;


### PR DESCRIPTION
## Which issue does this PR close?

This PR adds deletion vector type constant (which is the counterpart for already-defined `APACHE_DATASKETCHES_THETA_V1`).
Reference: https://iceberg.apache.org/puffin-spec/#deletion-vector-v1-blob-type