### PR TITLE
chore: declare `FileRead` trait to be `Sync`-safe

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -220,7 +220,7 @@ pub struct FileMetadata {
 /// It's possible for us to remove the async_trait, but we need to figure
 /// out how to handle the object safety.
 #[async_trait::async_trait]
-pub trait FileRead: Send + Unpin + 'static {
+pub trait FileRead: Send + Sync + Unpin + 'static {
     /// Read file content with given range.
     ///
     /// TODO: we can support reading non-contiguous bytes in the future.


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1318

## What changes are included in this PR?

Declare `FileRead` trait `Sync`-safe.

## Are these changes tested?

Not a feature change, so existing unit tests.