### PR TITLE
Expose puffin blob constructor

### DIFF
--- a/crates/iceberg/src/puffin/blob.rs
+++ b/crates/iceberg/src/puffin/blob.rs
@@ -34,6 +34,25 @@ pub struct Blob {
 }
 
 impl Blob {
+    /// Create a `Blob` object.
+    pub fn new(
+        blob_type: String,
+        fields: Vec<i32>,
+        snapshot_id: i64,
+        sequence_number: i64,
+        data: Vec<u8>,
+        properties: HashMap<String, String>,
+    ) -> Blob {
+        Self {
+            r#type: blob_type,
+            fields,
+            snapshot_id,
+            sequence_number,
+            data,
+            properties,
+        }
+    }
+
     #[inline]
     /// See blob types: https://iceberg.apache.org/puffin-spec/#blob-types
     pub fn blob_type(&self) -> &str {


### PR DESCRIPTION
## Which issue does this PR close?

This PR expose public construction function for puffin blob, as discussed in the linked issue.
The main motivation is: puffin blob is supposed to hold any type, so should be public-ly accessible by developers.

- Closes https://github.com/apache/iceberg-rust/issues/1311

## Are these changes tested?

This PR is a no-op change, I verified compilation passes through on my end.