### PR TITLE
fix: doc typo for `Schema.name_by_field_id()`

### DIFF
--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -381,7 +381,7 @@ impl Schema {
         self.name_to_id.get(name).copied()
     }
 
-    /// Get field id by full name.
+    /// Get full name by field id.
     pub fn name_by_field_id(&self, field_id: i32) -> Option<&str> {
         self.id_to_name.get(&field_id).map(String::as_str)
     }


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## What changes are included in this PR?

This PR is to fix a typo in function `Schema.name_by_field_id()` doc string.

## Are these changes tested?

Yes