### PR TITLE
chore: Ignore .zed settings dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 target
 .idea
 .vscode
+.zed
 **/.DS_Store
 dist/*
 **/venv


### PR DESCRIPTION
## Which issue does this PR close?

None

## What changes are included in this PR?

I'm currently using `zed` (it's great, I highly recommend it!). 

I needed to add the following RA settings:

```json
{
  "rust-analyzer": {
    "linkedProjects": ["./Cargo.toml", "./bindings/python/Cargo.toml"]
  }
}
```

This allows RA to work with the Python bindings as well.

I'm going to add `.zed` to the gitignore file so I don't accidentally include it.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->