### PR TITLE
ci: Fix python bindings rust code not checked

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -35,8 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check format
+        working-directory: "bindings/python"
         run: cargo fmt --all -- --check
       - name: Check clippy
+        working-directory: "bindings/python"
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   check-python:


### PR DESCRIPTION
## Which issue does this PR close?

None

## What changes are included in this PR?

While reviewing PRs related to the python bindings, I noticed that the code formatting was incorrect and some clippy lints were not being triggered properly.

This happened because we weren't running the checks on the correct path. This PR addresses that issue.

Our Python friends should be happier and feel more at home with Rust now.

## Are these changes tested?

Not needed, it's in CI.