### PR TITLE
chore: introduce `nightly` feature flag to provide error backtrace

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -41,6 +41,8 @@ storage-s3 = ["opendal/services-s3"]
 async-std = ["dep:async-std"]
 tokio = ["tokio/rt-multi-thread"]
 
+nightly = []
+
 [dependencies]
 anyhow = { workspace = true }
 apache-avro = { workspace = true }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -211,6 +211,13 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source.as_ref().map(|v| v.as_ref())
     }
+
+    #[cfg(feature = "nightly")]
+    fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+        if self.backtrace.status() == BacktraceStatus::Captured {
+            request.provide_ref::<Backtrace>(&self.backtrace);
+        }
+    }
 }
 
 impl Error {

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -51,6 +51,7 @@
 //! }
 //! ```
 
+#![cfg_attr(feature = "nightly", feature(error_generic_member_access))]
 #![deny(missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
## What changes are included in this PR?

In nightly toolchain, there's an unstable feature `error_generic_member_access` which allows  accessing the error to extract additional information. A common convention is to `provide` error backtrace here.

This PR introduces a new non-default feature named `nightly` to `iceberg` crate. When it's enabled, we will provide the backtrace if it's captured in `iceberg::Error`.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->