### PR TITLE
Bump iceberg-rust version to 0.5.0 (Round 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_msrv: "1.84.0"
+  rust_msrv: "1.85.0"
 
 jobs:
   check:
@@ -118,11 +118,11 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
           root-reserve-mb: 10240
           temp-reserve-mb: 10240
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+      - "*"
   workflow_dispatch:
 
 env:
-  rust_msrv: "1.77.1"
+  rust_msrv: "1.85"
 
 jobs:
   publish:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -20,7 +20,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 on:
   push:
     tags:
-      - '*'
+      - "*"
   pull_request:
     branches:
       - main
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 env:
-  rust_msrv: "1.77.1"
+  rust_msrv: "1.85"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -62,33 +62,37 @@ jobs:
           - { os: windows-latest }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
-          - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
+          - {
+              os: ubuntu-latest,
+              target: "aarch64",
+              manylinux: "manylinux_2_28",
+            }
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
-          with:
-            python-version: 3.9
-        - name: Setup Rust toolchain
-          uses: ./.github/actions/setup-builder
-          with:
-            rust-version: ${{ env.rust_msrv }}
-        - uses: PyO3/maturin-action@v1
-          with:
-            target: ${{ matrix.target }}
-            manylinux: ${{ matrix.manylinux || 'auto' }}
-            working-directory: "bindings/python"
-            command: build
-            args: --release -o dist
-        - name: Upload wheels
-          uses: actions/upload-artifact@v4
-          with:
-            name: wheels-${{ matrix.os }}-${{ matrix.target }}
-            path: bindings/python/dist
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{ env.rust_msrv }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+          working-directory: "bindings/python"
+          command: build
+          args: --release -o dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: bindings/python/dist
 
   pypi-publish:
     name: Publish Python 🐍 distribution 📦 to Pypi
-    needs: [ sdist, wheels ]
+    needs: [sdist, wheels]
     runs-on: ubuntu-latest
     # Only publish to PyPi if the tag is not a pre-release
     if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
@@ -98,18 +102,18 @@ jobs:
       url: https://pypi.org/p/pyiceberg-core
 
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: bindings/python/dist
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: bindings/python/dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-      with:
-        skip-existing: true
-        packages-dir: bindings/python/dist
+        with:
+          skip-existing: true
+          packages-dir: bindings/python/dist

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -19,11 +19,11 @@ name: "Nightly PyPI Build"
 
 on:
   schedule:
-    - cron: "0 0 * * *"  # Runs at midnight UTC every day
-  workflow_dispatch:  # Allows manual triggering
+    - cron: "0 0 * * *" # Runs at midnight UTC every day
+  workflow_dispatch: # Allows manual triggering
 
 env:
-  rust_msrv: "1.77.1"
+  rust_msrv: "1.85"
 
 permissions:
   contents: read
@@ -40,12 +40,12 @@ jobs:
 
   sdist:
     needs: set-version
-    if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
+    if: github.repository == 'apache/iceberg-rust' # Only run for apache repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - uses: ./.github/actions/overwrite-package-version  # Overwrite package version with timestamp
+
+      - uses: ./.github/actions/overwrite-package-version # Overwrite package version with timestamp
         with:
           timestamp: ${{ needs.set-version.outputs.TIMESTAMP }}
 
@@ -54,7 +54,7 @@ jobs:
           working-directory: "bindings/python"
           command: sdist
           args: -o dist
-      
+
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
@@ -63,7 +63,7 @@ jobs:
 
   wheels:
     needs: set-version
-    if: github.repository == 'apache/iceberg-rust'  # Only run for apache repo
+    if: github.repository == 'apache/iceberg-rust' # Only run for apache repo
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
@@ -71,40 +71,44 @@ jobs:
           - { os: windows-latest }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
-          - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
+          - {
+              os: ubuntu-latest,
+              target: "aarch64",
+              manylinux: "manylinux_2_28",
+            }
           - { os: ubuntu-latest, target: "armv7l" }
     steps:
-        - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-        - uses: ./.github/actions/overwrite-package-version  # Overwrite package version with timestamp
-          with:
-            timestamp: ${{ needs.set-version.outputs.TIMESTAMP }}
+      - uses: ./.github/actions/overwrite-package-version # Overwrite package version with timestamp
+        with:
+          timestamp: ${{ needs.set-version.outputs.TIMESTAMP }}
 
-        - uses: actions/setup-python@v5
-          with:
-            python-version: 3.9
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
 
-        - name: Setup Rust toolchain
-          uses: ./.github/actions/setup-builder
-          with:
-            rust-version: ${{ env.rust_msrv }}
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{ env.rust_msrv }}
 
-        - uses: PyO3/maturin-action@v1
-          with:
-            target: ${{ matrix.target }}
-            manylinux: ${{ matrix.manylinux || 'auto' }}
-            working-directory: "bindings/python"
-            command: build
-            args: --release -o dist
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+          working-directory: "bindings/python"
+          command: build
+          args: --release -o dist
 
-        - name: Upload wheels
-          uses: actions/upload-artifact@v4
-          with:
-            name: wheels-${{ matrix.os }}-${{ matrix.target }}
-            path: bindings/python/dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: bindings/python/dist
 
   testpypi-publish:
-    needs: [ sdist, wheels ]
+    needs: [sdist, wheels]
     runs-on: ubuntu-latest
 
     environment:
@@ -112,20 +116,20 @@ jobs:
       url: https://test.pypi.org/p/pyiceberg-core
 
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: bindings/python/dist
-    - name: List downloaded artifacts
-      run: ls -R bindings/python/dist
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: true
-        packages-dir: bindings/python/dist
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: bindings/python/dist
+      - name: List downloaded artifacts
+        run: ls -R bindings/python/dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: bindings/python/dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,14 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 homepage = "https://rust.iceberg.apache.org/"
 version = "0.4.0"
 
 license = "Apache-2.0"
 repository = "https://github.com/apache/iceberg-rust"
 # Check the MSRV policy in README.md before changing this
-rust-version = "1.84"
+rust-version = "1.85"
 
 [workspace.dependencies]
 anyhow = "1.0.72"

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "async-trait",
+ "base64",
  "bimap",
  "bytes",
  "chrono",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,10 +16,10 @@
 # under the License.
 
 [package]
-edition = "2021"
+edition = "2024"
 homepage = "https://rust.iceberg.apache.org"
 name = "pyiceberg_core_rust"
-rust-version = "1.84"
+rust-version = "1.85"
 version = "0.4.0"
 # This crate is used to build python bindings, we don't want to publish it
 publish = false

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -29,7 +29,6 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-# async-trait = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -25,8 +25,8 @@ use reqwest::{Client, IntoUrl, Method, Request, RequestBuilder, Response};
 use serde::de::DeserializeOwned;
 use tokio::sync::Mutex;
 
-use crate::types::{ErrorResponse, TokenResponse};
 use crate::RestCatalogConfig;
+use crate::types::{ErrorResponse, TokenResponse};
 
 pub(crate) struct HttpClient {
     client: Client,
@@ -80,14 +80,18 @@ impl HttpClient {
         Ok(HttpClient {
             client: cfg.client().unwrap_or(self.client),
             token: Mutex::new(cfg.token().or_else(|| self.token.into_inner())),
-            token_endpoint: (!cfg.get_token_endpoint().is_empty())
-                .then(|| cfg.get_token_endpoint())
-                .unwrap_or(self.token_endpoint),
+            token_endpoint: if !cfg.get_token_endpoint().is_empty() {
+                cfg.get_token_endpoint()
+            } else {
+                self.token_endpoint
+            },
             credential: cfg.credential().or(self.credential),
             extra_headers,
-            extra_oauth_params: (!cfg.extra_oauth_params().is_empty())
-                .then(|| cfg.extra_oauth_params())
-                .unwrap_or(self.extra_oauth_params),
+            extra_oauth_params: if !cfg.extra_oauth_params().is_empty() {
+                cfg.extra_oauth_params()
+            } else {
+                self.extra_oauth_params
+            },
         })
     }
 

--- a/crates/iceberg/src/delete_vector.rs
+++ b/crates/iceberg/src/delete_vector.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use roaring::RoaringTreemap;
 use roaring::bitmap::Iter;
 use roaring::treemap::BitmapIter;
-use roaring::RoaringTreemap;
 
 #[allow(unused)]
 pub struct DeleteVector {
@@ -61,7 +61,7 @@ impl Iterator for DeleteVectorIterator<'_> {
     type Item = u64;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(ref mut inner) = &mut self.inner {
+        if let Some(inner) = &mut self.inner {
             if let Some(inner_next) = inner.bitmap_iter.next() {
                 return Some(u64::from(inner.high_bits) << 32 | u64::from(inner_next));
             }

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -300,7 +300,7 @@ impl InputFile {
     /// Creates [`FileRead`] for continuous reading.
     ///
     /// For one-time reading, use [`Self::read`] instead.
-    pub async fn reader(&self) -> crate::Result<impl FileRead> {
+    pub async fn reader(&self) -> crate::Result<impl FileRead + use<>> {
         Ok(self.op.reader(&self.path[self.relative_path_pos..]).await?)
     }
 }
@@ -399,13 +399,13 @@ impl OutputFile {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{create_dir_all, File};
+    use std::fs::{File, create_dir_all};
     use std::io::Write;
     use std::path::Path;
 
     use bytes::Bytes;
-    use futures::io::AllowStdIo;
     use futures::AsyncReadExt;
+    use futures::io::AllowStdIo;
     use tempfile::TempDir;
 
     use super::{FileIO, FileIOBuilder};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -20,5 +20,5 @@
 #
 # The channel is exactly same day for our MSRV.
 [toolchain]
-channel = "nightly-2024-11-22"
+channel = "nightly-2025-02-20"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/iceberg-rust/issues/1325

## What changes are included in this PR?

This PR will bump iceberg-rust version to 0.5.0 to get ready for our next release.

Align with our MSRV policy, we bumped our MSRV to 1.85, which released three months ago at 20 February, 2025.

Also, we changed our edition to 2024 (which already covered by MSRV 1.84).

## Are these changes tested?

In CI.