### PR TITLE
feat: `rustls-tls` and `rustls-native-roots` feature flags

### DIFF
--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -28,6 +28,13 @@ keywords = ["iceberg", "rest", "catalog"]
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+rustls-tls = ["reqwest/rustls-tls", "iceberg/rustls-tls"]
+rustls-tls-native-roots = [
+  "reqwest/rustls-tls-native-roots",
+  "iceberg/rustls-tls-native-roots",
+]
+
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -30,6 +30,8 @@ repository = { workspace = true }
 
 [features]
 default = ["storage-memory", "storage-fs", "storage-s3", "tokio"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs"]
 
 storage-fs = ["opendal/services-fs"]


### PR DESCRIPTION
## What changes are included in this PR?

Add `rustls-tls` and `rustls-tls-native-roots"` feature flags for rest catalog & core.
`reqwest` is not directly used in other crates

## Are these changes tested?

No - just pass through a well-tested rustls functionality.