### PR TITLE
Make `dependencies.py generate` fail on cargo-deny error

### DIFF
--- a/scripts/dependencies.py
+++ b/scripts/dependencies.py
@@ -36,7 +36,7 @@ def check_deps():
     cargo_dirs = DIRS
     for root in cargo_dirs:
         print(f"Checking dependencies of {root}")
-        subprocess.run(["cargo", "deny", "check", "license"], cwd=root)
+        subprocess.run(["cargo", "deny", "check", "license"], cwd=root, check=True)
 
 
 def generate_deps():

--- a/scripts/dependencies.py
+++ b/scripts/dependencies.py
@@ -22,14 +22,13 @@ import os
 
 DIRS = [
     "crates/iceberg",
-
-    "crates/catalog/glue", "crates/catalog/hms",
-    "crates/catalog/memory", "crates/catalog/rest",
+    "crates/catalog/glue",
+    "crates/catalog/hms",
+    "crates/catalog/memory",
+    "crates/catalog/rest",
     "crates/catalog/sql",
-
     "crates/integrations/datafusion",
-    
-    "bindings/python"
+    "bindings/python",
 ]
 
 
@@ -44,12 +43,20 @@ def generate_deps():
     cargo_dirs = DIRS
     for root in cargo_dirs:
         print(f"Generating dependencies {root}")
-        result = subprocess.run(
-            ["cargo", "deny", "list", "-f", "tsv", "-t", "0.6"],
-            cwd=root,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["cargo", "deny", "list", "-f", "tsv", "-t", "0.6"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Failed to run 'cargo deny' in '{root}'. "
+                f"Is it installed?\n\nSTDERR:\n{e.stderr}"
+            ) from e
+
         with open(f"{root}/DEPENDENCIES.rust.tsv", "w") as f:
             f.write(result.stdout)
 
@@ -59,18 +66,17 @@ if __name__ == "__main__":
     parser.set_defaults(func=parser.print_help)
     subparsers = parser.add_subparsers()
 
-    parser_check = subparsers.add_parser('check',
-                                         description="Check dependencies",
-                                         help="Check dependencies")
+    parser_check = subparsers.add_parser(
+        "check", description="Check dependencies", help="Check dependencies"
+    )
     parser_check.set_defaults(func=check_deps)
 
     parser_generate = subparsers.add_parser(
-        'generate',
-        description="Generate dependencies",
-        help="Generate dependencies")
+        "generate", description="Generate dependencies", help="Generate dependencies"
+    )
     parser_generate.set_defaults(func=generate_deps)
 
     args = parser.parse_args()
     arg_dict = dict(vars(args))
-    del arg_dict['func']
+    del arg_dict["func"]
     args.func(**arg_dict)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #1325.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->
`DEPENDENCIES.rust.tsv` files were accidentally removed as part of the 0.5.0 prep PR (#1345). It was added back and updated in the follow up PR (#1363). 

I realized this happened because I did not install `cargo-deny` in my env and the dependency generation script did not error. 

This PR changes generation script (`python3 ./scripts/dependencies.py generate`) to error when the underlying subprocess call (`cargo deny`) errors. 

I also ran `uvx ruff format scripts/dependencies.py` to format the script

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, manually

I was also able to install `cargo-deny` and confirm #1363 changes are all correct
```
cargo install --locked cargo-deny
```
