### PR TITLE
Add ADLS storage support

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -30,8 +30,9 @@ repository = { workspace = true }
 
 [features]
 default = ["storage-memory", "storage-fs", "storage-s3", "tokio"]
-storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs"]
+storage-all = ["storage-memory", "storage-fs", "storage-s3", "storage-gcs", "storage-azdls"]
 
+storage-azdls = ["opendal/services-azdls"]
 storage-fs = ["opendal/services-fs"]
 storage-gcs = ["opendal/services-gcs"]
 storage-memory = ["opendal/services-memory"]

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -35,12 +35,13 @@ use crate::{Error, ErrorKind, Result};
 ///
 /// Supported storages:
 ///
-/// | Storage            | Feature Flag     | Schemes    |
-/// |--------------------|-------------------|------------|
-/// | Local file system  | `storage-fs`      | `file`     |
-/// | Memory             | `storage-memory`  | `memory`   |
-/// | S3                 | `storage-s3`      | `s3`, `s3a`|
-/// | GCS                | `storage-gcs`     | `gs`, `gcs`|
+/// | Storage            | Feature Flag      | Schemes         |
+/// |--------------------|-------------------|-----------------|
+/// | Local file system  | `storage-fs`      | `file`          |
+/// | Memory             | `storage-memory`  | `memory`        |
+/// | S3                 | `storage-s3`      | `s3`, `s3a`     |
+/// | GCS                | `storage-gcs`     | `gs`, `gcs`     |
+/// | Azure Datalake     | `storage-azdls`   | `adfs`, `adfss` |
 #[derive(Clone, Debug)]
 pub struct FileIO {
     builder: FileIOBuilder,

--- a/crates/iceberg/src/io/mod.rs
+++ b/crates/iceberg/src/io/mod.rs
@@ -67,32 +67,36 @@
 //! - `new_output`: Create output file for writing.
 
 mod file_io;
-pub use file_io::*;
-
 mod storage;
-#[cfg(feature = "storage-memory")]
-mod storage_memory;
-#[cfg(feature = "storage-memory")]
-use storage_memory::*;
-#[cfg(feature = "storage-s3")]
-mod storage_s3;
-#[cfg(feature = "storage-s3")]
-pub use storage_s3::*;
+
+pub use file_io::*;
 pub(crate) mod object_cache;
+
+#[cfg(feature = "storage-azdls")]
+mod storage_azdls;
 #[cfg(feature = "storage-fs")]
 mod storage_fs;
+#[cfg(feature = "storage-gcs")]
+mod storage_gcs;
+#[cfg(feature = "storage-memory")]
+mod storage_memory;
+#[cfg(feature = "storage-oss")]
+mod storage_oss;
+#[cfg(feature = "storage-s3")]
+mod storage_s3;
 
+#[cfg(feature = "storage-azdls")]
+pub use storage_azdls::*;
 #[cfg(feature = "storage-fs")]
 use storage_fs::*;
 #[cfg(feature = "storage-gcs")]
-mod storage_gcs;
-#[cfg(feature = "storage-gcs")]
 pub use storage_gcs::*;
-
-#[cfg(feature = "storage-oss")]
-mod storage_oss;
+#[cfg(feature = "storage-memory")]
+use storage_memory::*;
 #[cfg(feature = "storage-oss")]
 pub use storage_oss::*;
+#[cfg(feature = "storage-s3")]
+pub use storage_s3::*;
 
 pub(crate) fn is_truthy(value: &str) -> bool {
     ["true", "t", "1", "on"].contains(&value.to_lowercase().as_str())

--- a/crates/iceberg/src/io/storage_azdls.rs
+++ b/crates/iceberg/src/io/storage_azdls.rs
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+
+use opendal::Configurator;
+use opendal::services::AzdlsConfig;
+use url::Url;
+
+use crate::{Error, ErrorKind, Result};
+
+/// A connection string.
+///
+/// This could be used to use FileIO with any adls-compatible object storage
+/// service that has a different endpoint (like Azurite).
+///
+/// Note, this string is parsed first, and any other passed adls.* properties
+/// will override values from the connection string.
+const ADLS_CONNECTION_STRING: &str = "adls.connection-string";
+
+/// The account that you want to connect to.
+pub const ADLS_ACCOUNT_NAME: &str = "adls.account-name";
+
+/// The key to authentication against the account.
+pub const ADLS_ACCOUNT_KEY: &str = "adls.account-key";
+
+/// The shared access signature.
+pub const ADLS_SAS_TOKEN: &str = "adls.sas-token";
+
+/// The tenant-id.
+pub const ADLS_TENANT_ID: &str = "adls.tenant-id";
+
+/// The client-id.
+pub const ADLS_CLIENT_ID: &str = "adls.client-id";
+
+/// The client-secret.
+pub const ADLS_CLIENT_SECRET: &str = "adls.client-secret";
+
+/// Parses adls.* prefixed configuration properties.
+pub(crate) fn azdls_config_parse(mut m: HashMap<String, String>) -> Result<AzdlsConfig> {
+    let mut cfg = AzdlsConfig::default();
+
+    if let Some(_conn_str) = m.remove(ADLS_CONNECTION_STRING) {
+        return Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "Azdls: connection string currently not supported",
+        ));
+    }
+
+    if let Some(account_name) = m.remove(ADLS_ACCOUNT_NAME) {
+        cfg.account_name = Some(account_name);
+    }
+
+    if let Some(account_key) = m.remove(ADLS_ACCOUNT_KEY) {
+        cfg.account_key = Some(account_key);
+    }
+
+    if let Some(sas_token) = m.remove(ADLS_SAS_TOKEN) {
+        cfg.sas_token = Some(sas_token);
+    }
+
+    if let Some(tenant_id) = m.remove(ADLS_TENANT_ID) {
+        cfg.tenant_id = Some(tenant_id);
+    }
+
+    if let Some(client_id) = m.remove(ADLS_CLIENT_ID) {
+        cfg.client_id = Some(client_id);
+    }
+
+    if let Some(client_secret) = m.remove(ADLS_CLIENT_SECRET) {
+        cfg.client_secret = Some(client_secret);
+    }
+
+    Ok(cfg)
+}
+
+pub(crate) fn azdls_config_build(cfg: &AzdlsConfig, path: &str) -> Result<opendal::Operator> {
+    let url = Url::parse(path)?;
+
+    // This is ok to be empty, OpenDAL will use the default filesystem.
+    let filesystem = url.username();
+
+    let builder = cfg.clone().into_builder().filesystem(filesystem);
+
+    Ok(opendal::Operator::new(builder)?.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services::AzdlsConfig;
+
+    use crate::io::{azdls_config_build, azdls_config_parse};
+
+    #[test]
+    fn test_azdls_config_parse() {
+        let mut m = std::collections::HashMap::new();
+        m.insert(super::ADLS_ACCOUNT_NAME.to_string(), "test".to_string());
+        m.insert(super::ADLS_ACCOUNT_KEY.to_string(), "secret".to_string());
+
+        let config = azdls_config_parse(m).unwrap();
+
+        assert_eq!(config.account_name, Some("test".to_string()));
+        assert_eq!(config.account_key, Some("secret".to_string()));
+    }
+
+    #[test]
+    fn test_azdls_config_build() {
+        let mut config = AzdlsConfig::default();
+        config.endpoint = Some("https://myaccount.dfs.core.windows.net".to_string());
+
+        let path = "abfss://myfs@myaccount.dfs.core.windows.net/mydir/myfile.parquet";
+
+        let op = azdls_config_build(&config, path).unwrap();
+        assert_eq!(op.info().name(), "myfs");
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1360.

## What changes are included in this PR?

This PR adds an integration for the Azure Datalake storage service. It mainly adds parsing logic for configuration properties. The finished config struct is simply passed down to OpenDAL.
It also creates a new `Storage::Azdls` enum variant based on OpenDAL's existing `Scheme::Azdls` enum variant. It then fits the parsing logic into the existing framework to build the storage integration from an `io::FileIOBuilder`.

---

Note, OpenDAL has only [recently added](https://github.com/apache/opendal/pull/6205) configuration fields for more secure authentication properties. This PR is built on an unreleased version of OpenDAL.
In addition, I have another [OpenDAL PR](https://github.com/apache/opendal/pull/6212) pending to add ADLS connection string support.
I suggest to wait for at least the first PR to be released. In its current form, OpenDAL only supports basic auth via directly passed credentials. But I'm also happy to adapt the changes to support what is already out.

For the time being, I'll keep the PR in draft until we either have a new OpenDAL release, or we take the decision to release what is already out.

## Are these changes tested?

I added minor unit tests to validate the configuration property parsing logic.

I decided not to add integration tests because
 1. ADLS is not S3-compatible which means that we can't reuse our Minio setup
 2. the Azure-specific alternative to local testing - Azurite - doesn't support ADLS

I have yet to test it in a functioning environment.