### PR TITLE
fix 0.5.x release `cargo publish`

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -18,14 +18,10 @@
 name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
-  push:
-    tags:
-      - "*"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/release_python.yml"
+  workflow_run:
+    workflows: ["Publish"] # Trigger this workflow after the "publish.yml" workflow completes
+    types:
+      - completed
   workflow_dispatch:
 
 env:
@@ -39,8 +35,16 @@ permissions:
   contents: read
 
 jobs:
+  check-cargo-publish:
+    runs-on: ubuntu-latest
+    # Only run if the triggering workflow succeeded OR if manually triggered
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - run: echo 'The Publish workflow passed or was manually triggered'
+
   sdist:
     runs-on: ubuntu-latest
+    needs: [check-cargo-publish]
     steps:
       - uses: actions/checkout@v4
       - uses: PyO3/maturin-action@v1
@@ -56,6 +60,7 @@ jobs:
 
   wheels:
     runs-on: "${{ matrix.os }}"
+    needs: [check-cargo-publish]
     strategy:
       matrix:
         include:
@@ -94,8 +99,8 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to Pypi
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
-    # Only publish to PyPi if the tag is not a pre-release
-    if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
+    # Only publish to PyPi if the tag is not a pre-release OR if manually triggered
+    if: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')) || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,7 +3499,6 @@ dependencies = [
  "expect-test",
  "fnv",
  "futures",
- "iceberg-catalog-memory",
  "iceberg_test_utils",
  "itertools 0.13.0",
  "moka",

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -90,7 +90,6 @@ zstd = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 expect-test = { workspace = true }
-iceberg-catalog-memory = { workspace = true }
 iceberg_test_utils = { path = "../test_utils", features = ["tests"] }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->
This PR removes `iceberg-catalog-memory` as a dev-dependency of `crates/iceberg`. The dependency is not used and caused `cargo publish` to fail during the 0.5.0 release (See https://github.com/apache/iceberg-rust/issues/1325#issuecomment-2910782152)

This PR also changes `.github/workflows/release_python.yml` to depend on `publish.yml` since we only want to publish `pyiceberg-core` to pypi after the crates are successfully published. 

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->