### PR TITLE
feat(memory): Implement update_table for MemoryCatalog

### DIFF
--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -262,6 +262,26 @@ impl NamespaceState {
         }
     }
 
+    // Updates the metadata location of the given table or throws an error if it doesn't exist
+    pub(crate) fn update_existing_table_location(
+        &mut self,
+        table_ident: &TableIdent,
+        new_metadata_location: String,
+    ) -> Result<()> {
+        let namespace = self.get_mut_namespace(table_ident.namespace())?;
+        if !namespace
+            .table_metadata_locations
+            .contains_key(table_ident.name())
+        {
+            return no_such_table_err(table_ident);
+        }
+        namespace
+            .table_metadata_locations
+            .insert(table_ident.name().to_string(), new_metadata_location);
+
+        Ok(())
+    }
+
     // Inserts the given table or returns an error if it already exists
     pub(crate) fn insert_new_table(
         &mut self,

--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -194,6 +194,11 @@ impl TableMetadataBuilder {
         )
     }
 
+    /// Returns whether or not the builder is tracking any changes
+    pub fn has_changes(&self) -> bool {
+        !self.changes.is_empty()
+    }
+
     /// Changes uuid of table metadata.
     pub fn assign_uuid(mut self, uuid: Uuid) -> Self {
         if self.metadata.table_uuid != uuid {


### PR DESCRIPTION
My initial motivation was to work on #1322, but for that the MemoryCatalog needs to support update_table, so this is that implementation, verified with a few basic tests. 

There's more tests to add to actually complete #1322, but I wanted to add those in a separate PR. There's also some missing categories of tests (e.g. failed and successful requirements, concurrent updates, etc) that can be added on top of this.

This is my first PR in the project (and Rust as well) so looking forward to pointers.

cc: @jonathanc-n @liurenjie1024 @Xuanwo @CTTY I think you all have context.