### PR TITLE
feat: set snapshot summary property in append action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,7 +3712,7 @@ dependencies = [
  "iceberg-catalog-rest",
  "iceberg-datafusion",
  "iceberg_test_utils",
- "ordered-float 4.6.0",
+ "ordered-float 2.10.1",
  "parquet",
  "tokio",
  "uuid",

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -122,6 +122,15 @@ impl<'a> SnapshotProduceAction<'a> {
         Ok(())
     }
 
+    /// Set snapshot summary properties.
+    pub fn set_snapshot_properties(
+        &mut self,
+        snapshot_properties: HashMap<String, String>,
+    ) -> Result<&mut Self> {
+        self.snapshot_properties = snapshot_properties;
+        Ok(self)
+    }
+
     /// Add data files to the snapshot.
     pub fn add_data_files(
         &mut self,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1329

## What changes are included in this PR?

This PR tries to do the same thing as reverted [PR](https://github.com/apache/iceberg-rust/pull/1336), which adds capability to set snapshot summary properties. 
Followup on thread: https://github.com/apache/iceberg-rust/pull/1336#issuecomment-2915765649, in this PR I took a different way, which expose interfaces within fast append action.

## Are these changes tested?

Yes, I add new unit tests.