### PR TITLE
fix(iceberg-catalog-rest): set application/x-www-form-urlencoded content-type header for oauth2 request

### DIFF
--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -158,12 +158,18 @@ impl HttpClient {
                 .map(|(k, v)| (k.as_str(), v.as_str())),
         );
 
-        let auth_req = self
+        let mut auth_req = self
             .request(Method::POST, &self.token_endpoint)
             .form(&params)
             .build()?;
+        // extra headers add content-type application/json header it's necessary to override it with proper type
+        // note that form call doesn't add content-type header if already present
+        auth_req.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
         let auth_url = auth_req.url().clone();
-        let auth_resp = self.execute(auth_req).await?;
+        let auth_resp = self.client.execute(auth_req).await?;
 
         let auth_res: TokenResponse = if auth_resp.status() == StatusCode::OK {
             let text = auth_resp


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

PR solves error when trying to authenticate through oauth2 endpoint.

```
Error: Unexpected, context: { code: 400 Bad Request, operation: auth, url: http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token, json: {"error":"invalid_request","error_description":"Missing form parameter: grant_type"} } => Received unexpected response, source: invalid type: string "invalid_request", expected struct ErrorModel at line 1 column 26

Caused by:
    invalid type: string "invalid_request", expected struct ErrorModel at line 1 column 26
```

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

- override `content-type` header to `application/x-www-form-urlencoded` for oauth2 authenticate requests

## Are these changes tested?

yes:
- tested it manually (through `keycloak`)
- existing tests in repo

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->