### PR TITLE
chore: Add manifest metadata accessor

### DIFF
--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -99,6 +99,11 @@ impl Manifest {
         &self.entries
     }
 
+    /// Get metadata.
+    pub fn metadata(&self) -> &ManifestMetadata {
+        &self.metadata
+    }
+
     /// Consume this Manifest, returning its constituent parts
     pub fn into_parts(self) -> (Vec<ManifestEntryRef>, ManifestMetadata) {
         let Self { entries, metadata } = self;


### PR DESCRIPTION
## What changes are included in this PR?

An easy change, I need to access manifest metadata without `into_parts` and re-organize.

## Are these changes tested?

An easy no-op change.