### PR TITLE
Memory catalog

### DIFF
--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -1812,7 +1812,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             format!(
-                "TableAlreadyExists => Cannot create table {:? }. Table already exists.",
+                "TableAlreadyExists => Cannot create table {:?}. Table already exists.",
                 &dst_table_ident
             ),
         );

--- a/crates/catalog/memory/src/catalog.rs
+++ b/crates/catalog/memory/src/catalog.rs
@@ -70,6 +70,17 @@ impl MemoryCatalog {
             .file_io(self.file_io.clone())
             .build()
     }
+
+    async fn write_metadata(
+        &self,
+        metadata: &TableMetadata,
+        metadata_location: &str,
+    ) -> Result<()> {
+        self.file_io
+            .new_output(metadata_location)?
+            .write(serde_json::to_vec(metadata)?.into())
+            .await
+    }
 }
 
 #[async_trait]
@@ -221,10 +232,7 @@ impl Catalog for MemoryCatalog {
             Uuid::new_v4()
         );
 
-        self.file_io
-            .new_output(&metadata_location)?
-            .write(serde_json::to_vec(&metadata)?.into())
-            .await?;
+        self.write_metadata(&metadata, &metadata_location).await?;
 
         root_namespace_state.insert_new_table(&table_ident, metadata_location.clone())?;
 

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -379,18 +379,21 @@ impl MetadataLocation {
                 format!("Invalid metadata file name format: {}", file_name),
             ))?;
 
-        let version = version.parse::<i32>().map_err(|_| {
-            Error::new(
-                ErrorKind::Unexpected,
-                format!("Metadata version not a number: {}", version),
-            )
-        })?;
-        if version < 0 {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                format!("Negative metadata version: {}", version),
-            ));
-        }
+        let version = version
+            .parse::<i32>()
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "Metadata version not a number").with_source(e)
+            })
+            .and_then(|v| {
+                if v < 0 {
+                    Err(Error::new(
+                        ErrorKind::Unexpected,
+                        format!("Negative metadata version: {}", version),
+                    ))
+                } else {
+                    Ok(v)
+                }
+            })?;
 
         Ok((version, Uuid::parse_str(id)?))
     }

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -16,9 +16,12 @@
 // under the License.
 
 use std::collections::{hash_map, HashMap};
+use std::fmt::Display;
+use std::str::FromStr;
 
 use iceberg::{Error, ErrorKind, NamespaceIdent, Result, TableIdent};
 use itertools::Itertools;
+use uuid::Uuid;
 
 // Represents the state of a namespace
 #[derive(Debug, Clone, Default)]
@@ -28,7 +31,7 @@ pub(crate) struct NamespaceState {
     // Namespaces nested inside this namespace
     namespaces: HashMap<String, NamespaceState>,
     // Mapping of tables to metadata locations in this namespace
-    table_metadata_locations: HashMap<String, String>,
+    table_metadata_locations: HashMap<String, MetadataLocation>,
 }
 
 fn no_such_namespace_err<T>(namespace_ident: &NamespaceIdent) -> Result<T> {
@@ -253,7 +256,10 @@ impl NamespaceState {
     }
 
     // Returns the metadata location of the given table or an error if doesn't exist
-    pub(crate) fn get_existing_table_location(&self, table_ident: &TableIdent) -> Result<&String> {
+    pub(crate) fn get_existing_table_location(
+        &self,
+        table_ident: &TableIdent,
+    ) -> Result<&MetadataLocation> {
         let namespace = self.get_namespace(table_ident.namespace())?;
 
         match namespace.table_metadata_locations.get(table_ident.name()) {
@@ -266,7 +272,7 @@ impl NamespaceState {
     pub(crate) fn insert_new_table(
         &mut self,
         table_ident: &TableIdent,
-        metadata_location: String,
+        location: MetadataLocation,
     ) -> Result<()> {
         let namespace = self.get_mut_namespace(table_ident.namespace())?;
 
@@ -276,7 +282,7 @@ impl NamespaceState {
         {
             hash_map::Entry::Occupied(_) => table_already_exists_err(table_ident),
             hash_map::Entry::Vacant(entry) => {
-                let _ = entry.insert(metadata_location);
+                let _ = entry.insert(location);
 
                 Ok(())
             }
@@ -284,7 +290,10 @@ impl NamespaceState {
     }
 
     // Removes the given table or returns an error if doesn't exist
-    pub(crate) fn remove_existing_table(&mut self, table_ident: &TableIdent) -> Result<String> {
+    pub(crate) fn remove_existing_table(
+        &mut self,
+        table_ident: &TableIdent,
+    ) -> Result<MetadataLocation> {
         let namespace = self.get_mut_namespace(table_ident.namespace())?;
 
         match namespace
@@ -300,18 +309,196 @@ impl NamespaceState {
     pub(crate) fn update_table(
         &mut self,
         table_ident: &TableIdent,
-        new_metadata_location: String,
+        new_location: MetadataLocation,
     ) -> Result<()> {
         let namespace = self.get_mut_namespace(table_ident.namespace())?;
 
         let _ = namespace
             .table_metadata_locations
-            .insert(table_ident.name().to_string(), new_metadata_location)
+            .insert(table_ident.name().to_string(), new_location)
             .ok_or(Error::new(
                 ErrorKind::Unexpected,
                 format!("No such table: {:?}", table_ident),
             ))?;
 
         Ok(())
+    }
+}
+
+/// Represents a location of the format: `<prefix>/metadata/<version>-<uuid>.metadata.json`
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct MetadataLocation {
+    prefix: String,
+    version: i32,
+    id: Uuid,
+}
+
+impl MetadataLocation {
+    /// Creates a completely new metadata location starting at version 0.
+    /// Only used for creating a new table. For updates, see `with_next_version`.
+    pub(crate) fn new(prefix: &str) -> Self {
+        Self {
+            prefix: prefix.to_string(),
+            version: 0,
+            id: Uuid::new_v4(),
+        }
+    }
+
+    /// Creates a new metadata location for an updated metadata file.
+    pub(crate) fn with_next_version(&self) -> Self {
+        Self {
+            prefix: self.prefix.clone(),
+            version: self.version + 1,
+            id: Uuid::new_v4(),
+        }
+    }
+
+    fn parse_metadata_path_prefix(path: &str) -> Result<String> {
+        let prefix = path.strip_suffix("/metadata").ok_or(Error::new(
+            ErrorKind::Unexpected,
+            format!(
+                "Metadata location not under \"/metadata\" subdirectory: {}",
+                path
+            ),
+        ))?;
+
+        Ok(prefix.to_string())
+    }
+
+    /// Parses a file name of the format `<version>-<uuid>.metadata.json`.
+    fn parse_file_name(file_name: &str) -> Result<(i32, Uuid)> {
+        let (version, id) = file_name
+            .strip_suffix(".metadata.json")
+            .ok_or(Error::new(
+                ErrorKind::Unexpected,
+                format!("Invalid metadata file ending: {}", file_name),
+            ))?
+            .split_once('-')
+            .ok_or(Error::new(
+                ErrorKind::Unexpected,
+                format!("Invalid metadata file name format: {}", file_name),
+            ))?;
+
+        Ok((version.parse::<i32>()?, Uuid::parse_str(id)?))
+    }
+}
+
+impl Display for MetadataLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/metadata/{}-{}.metadata.json",
+            self.prefix, self.version, self.id
+        )
+    }
+}
+
+impl FromStr for MetadataLocation {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let (path, file_name) = s.rsplit_once('/').ok_or(Error::new(
+            ErrorKind::Unexpected,
+            format!("Invalid metadata location: {}", s),
+        ))?;
+
+        let prefix = Self::parse_metadata_path_prefix(path)?;
+        let (version, id) = Self::parse_file_name(file_name)?;
+
+        Ok(MetadataLocation {
+            prefix,
+            version,
+            id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use uuid::Uuid;
+
+    use super::MetadataLocation;
+
+    #[test]
+    fn test_metadata_location_from_string() {
+        let test_cases = vec![
+            // No prefix
+            ("/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Ok(MetadataLocation{
+                prefix: "".to_string(),
+                version: 1234567,
+                id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+            })),
+            // Some prefix
+            ("/abc/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Ok(MetadataLocation{
+                prefix: "/abc".to_string(),
+                version: 1234567,
+                id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+            })),
+            // Longer prefix
+            ("/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Ok(MetadataLocation{
+                prefix: "/abc/def".to_string(),
+                version: 1234567,
+                id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+            })),
+            // Prefix with special characters
+            ("https://127.0.0.1/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Ok(MetadataLocation{
+                prefix: "https://127.0.0.1".to_string(),
+                version: 1234567,
+                id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+            })),
+            // Another id
+            ("/abc/metadata/1234567-81056704-ce5b-41c4-bb83-eb6408081af6.metadata.json", Ok(MetadataLocation{
+                prefix: "/abc".to_string(),
+                version: 1234567,
+                id: Uuid::from_str("81056704-ce5b-41c4-bb83-eb6408081af6").unwrap(),
+            })),
+            // Version 0
+            ("/abc/metadata/0-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Ok(MetadataLocation{
+                prefix: "/abc".to_string(),
+                version: 0,
+                id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+            })),
+            // Negative version
+            ("/metadata/-123-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Err("".to_string())),
+            // Invalid uuid
+            ("/metadata/1234567-no-valid-id.metadata.json", Err("".to_string())),
+            // Non-numeric version
+            ("/metadata/noversion-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Err("".to_string())),
+            // No /metadata subdirectory
+            ("/wrongsubdir/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json", Err("".to_string())),
+            // No .metadata.json suffix
+            ("/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata", Err("".to_string())),
+            ("/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.wrong.file", Err("".to_string())),
+        ];
+
+        for (input, expected) in test_cases {
+            match MetadataLocation::from_str(input) {
+                Ok(metadata_location) => {
+                    assert!(expected.is_ok());
+                    assert_eq!(metadata_location, expected.unwrap());
+                }
+                Err(_) => assert!(expected.is_err()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_metadata_location_with_next_version() {
+        let test_cases = vec![
+            MetadataLocation::new("/abc"),
+            MetadataLocation::from_str(
+                "/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
+            )
+            .unwrap(),
+        ];
+
+        for input in test_cases {
+            let next = input.with_next_version();
+            assert_eq!(next.prefix, input.prefix);
+            assert_eq!(next.version, input.version + 1);
+            assert_ne!(next.id, input.id);
+        }
     }
 }

--- a/crates/catalog/memory/src/namespace_state.rs
+++ b/crates/catalog/memory/src/namespace_state.rs
@@ -295,4 +295,23 @@ impl NamespaceState {
             Some(metadata_location) => Ok(metadata_location),
         }
     }
+
+    /// Updates the metadata location of the given table or returns an error if doesn't exist
+    pub(crate) fn update_table(
+        &mut self,
+        table_ident: &TableIdent,
+        new_metadata_location: String,
+    ) -> Result<()> {
+        let namespace = self.get_mut_namespace(table_ident.namespace())?;
+
+        let _ = namespace
+            .table_metadata_locations
+            .insert(table_ident.name().to_string(), new_metadata_location)
+            .ok_or(Error::new(
+                ErrorKind::Unexpected,
+                format!("No such table: {:?}", table_ident),
+            ))?;
+
+        Ok(())
+    }
 }

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -283,6 +283,12 @@ define_from_err!(
 );
 
 define_from_err!(
+    core::num::ParseIntError,
+    ErrorKind::Unexpected,
+    "parsing integer from string"
+);
+
+define_from_err!(
     std::array::TryFromSliceError,
     ErrorKind::DataInvalid,
     "failed to convert byte slice to array"


### PR DESCRIPTION
This is a copy of https://github.com/apache/iceberg-rust/pull/1290. Reopened here for reference.

## Which issue does this PR close?
Relates to https://github.com/apache/iceberg-rust/issues/700

This is a first attempt at implementing the commit path for the `MemoryCatalog`. Happy about any feedback!

## What changes are included in this PR?

This PR implements the `MemoryCatalog::update_table` method. It also adds a `MetadataLocation` struct to avoid some re-validations of the location format.
I'm very open to removing the `MetadataLocation` or moving it's addition to a separate PR.

## Are these changes tested?

So far, I've included unit tests to verify
- whether a table update that was committed via the `MemoryCatalog` can be observed in the updated table
- that in the case of two competing updates, the later commit fails if it has conflicting requirements
- that an update fails if the table isn't known to the catalog
- parsing logic of the `MetadataLocation`