### PR TITLE
fix: incorrect storage descriptor when creating tables in GlueCatalog

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -118,7 +118,7 @@ impl SchemaVisitor for GlueSchemaBuilder {
             (ICEBERG_FIELD_ID.to_string(), format!("{}", field.id)),
             (
                 ICEBERG_FIELD_OPTIONAL.to_string(),
-                format!("{}", field.required).to_lowercase(),
+                format!("{}", !field.required).to_lowercase(),
             ),
             (
                 ICEBERG_FIELD_CURRENT.to_string(),

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -151,7 +151,7 @@ pub(crate) fn convert_to_glue_table(
 
     let storage_descriptor = StorageDescriptor::builder()
         .set_columns(Some(glue_schema))
-        .location(&metadata_location)
+        .location(metadata.location().to_string())
         .build();
 
     let mut parameters = HashMap::from([
@@ -345,7 +345,7 @@ mod tests {
 
         let parameters = HashMap::from([
             (ICEBERG_FIELD_ID.to_string(), "1".to_string()),
-            (ICEBERG_FIELD_OPTIONAL.to_string(), "true".to_string()),
+            (ICEBERG_FIELD_OPTIONAL.to_string(), "false".to_string()),
             (ICEBERG_FIELD_CURRENT.to_string(), "true".to_string()),
         ]);
 
@@ -359,7 +359,7 @@ mod tests {
 
         let storage_descriptor = StorageDescriptor::builder()
             .set_columns(Some(vec![column]))
-            .location(&metadata_location)
+            .location(metadata.location())
             .build();
 
         let result =


### PR DESCRIPTION
## Which issue does this PR close?
Fixes two bugs in the `GlueCatalogs` table creation that caused inconsistency with Iceberg core and PyIceberg implementations:
* `StorageDescriptor.Location` incorrectly set to metadata file path instead of table base location
* `iceberg.field.optional` parameter logic inverted - was setting it to field.required instead of !field.required

Iceberg ref:
* location: https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java#L280
* field.optional: https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java#L377

## What changes are included in this PR?

### Location

#### Before:
```
{
  "StorageDescriptor": {
    "Location": "s3://bucket/table/metadata/00000-uuid.metadata.json"
  },
  "Parameters": {
    "metadata_location": "s3://bucket/table/metadata/00000-uuid.metadata.json"
  }
}
```
#### After:
```
{
  "StorageDescriptor": {
    "Location": "s3://bucket/table"
  },
  "Parameters": {
    "metadata_location": "s3://bucket/table/metadata/00000-uuid.metadata.json"
  }
}
```
### Schema (with required field)
#### Rust Schema
```
 NestedField::required(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
```


#### Before:
```
{
    "Name": "foo",
    "Type": "string",
    "Parameters": {
        "iceberg.field.current": "true",
        "iceberg.field.id": "2",
        "iceberg.field.optional": "true" <---
    }
}
```
#### After:
```
{
    "Name": "foo",
    "Type": "string",
    "Parameters": {
        "iceberg.field.current": "true",
        "iceberg.field.id": "2",
        "iceberg.field.optional": "false" <---
    }
}
```

## Are these changes tested?
* Repaired the existing test
* Tested manually with GlueCatalog.