### PR TITLE
docs: add `Transaction` example

### DIFF
--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -25,28 +25,25 @@
 //! Below is a basic example using the "fast-append" action:
 //!
 //! ```ignore
+//! use iceberg::transaction::{ApplyTransactionAction, Transaction};
+//! use iceberg::Catalog;
+//!
 //! // Create a transaction.
 //! let tx = Transaction::new(my_table);
 //!
 //! // Create a `FastAppendAction` which will not rewrite or append
 //! // to existing metadata. This will create a new manifest.
-//! let mut action = tx
-//!     .fast_append(None, Vec::new())
-//!     .expect("a transaction can be validated with this input");
+//! let action = tx.fast_append().add_data_files(my_data_files);
 //!
-//! action
-//!     .add_data_files(my_data_files)
-//!     .unwrap();
+//! // Apply the fast-append action to the given transaction, returning
+//! // the newly updated `Transaction`.
+//! let tx = action.apply(tx).unwrap();
 //!
-//! let tx = action
-//!     .apply()
-//!     .await
-//!     .unwrap();
 //!
 //! // End the transaction by committing to an `iceberg::Catalog`
 //! // implementation. This will cause a table update to occur.
 //! let table = tx
-//!     .commit(some_catalog_impl)
+//!     .commit(&some_catalog_impl)
 //!     .await
 //!     .unwrap();
 //! ```


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A, although I can link this to the Write support epic is that is useful?

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Adding additional documentation to the `transaction` module to provide a basic example of the `FastAppendAction` usage.

Other actions are not included at this time.

<details>

<summary> it looks like this </summary>

![image](https://github.com/user-attachments/assets/8f357408-e26a-4216-81b9-4594adf8f7ad)



</details>

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A
