### PR TITLE
feat: Public accessors for `last_column_id` and `last_partition_id`

### DIFF
--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -234,6 +234,7 @@ impl TableMetadata {
     }
 
     /// Returns the last partition_id
+    #[inline]
     pub fn last_partition_id(&self) -> i32 {
         self.last_partition_id
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -227,6 +227,17 @@ impl TableMetadata {
         }
     }
 
+    /// Returns the last column id.
+    #[inline]
+    pub fn last_column_id(&self) -> i32 {
+        self.last_column_id
+    }
+
+    /// Returns the last partition_id
+    pub fn last_partition_id(&self) -> i32 {
+        self.last_partition_id
+    }
+
     /// Returns last updated time.
     #[inline]
     pub fn last_updated_timestamp(&self) -> Result<DateTime<Utc>> {


### PR DESCRIPTION
We are currently missing public accessors for `last_column_id` and `last_partition_id` as part of `TableMetadata`.