### PR TITLE
[ci] fix pypi publishing trigger

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -99,6 +99,8 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to Pypi
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
+    # Only publish to PyPi if the tag is not a pre-release OR if manually triggered
+    if: ${{ (startsWith(github.event.workflow_run.head_branch, 'refs/tags/') && !contains(github.event.workflow_run.head_branch, '-')) || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -99,8 +99,8 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to Pypi
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
-    # Only publish to PyPi if the tag is not a pre-release OR if manually triggered
-    if: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')) || github.event_name == 'workflow_dispatch' }}
+    # Only publish to PyPi if the triggering workflow succeeded OR if manually triggered
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -99,8 +99,6 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to Pypi
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
-    # Only publish to PyPi if the triggering workflow succeeded OR if manually triggered
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     environment:
       name: pypi


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Follow up to #1379. This PR changes the pypi publishing step to trigger on previous workflow's successful run

Also see https://github.com/apache/iceberg-rust/issues/1325#issuecomment-2942634833

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->