### PR TITLE
Allowing publishing iceberg-catalog-sql in workflow.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,7 @@ jobs:
           - "crates/catalog/hms"
           - "crates/catalog/memory"
           - "crates/catalog/rest"
-          # sql is not ready for release yet.
-          # - "crates/catalog/sql"
+          - "crates/catalog/sql"
           - "crates/integrations/datafusion"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1460.

## What changes are included in this PR?

Add iceberg-catalog-sql when publishing.

## Are these changes tested?

No, simple github workflow change.