### PR TITLE
fix: fix batch transform modify schema

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -153,7 +153,14 @@ impl RecordBatchTransformer {
                 )?
             }
             Some(BatchTransform::ModifySchema { target_schema }) => {
-                record_batch.with_schema(target_schema.clone())?
+                let options = RecordBatchOptions::default()
+                    .with_match_field_names(false)
+                    .with_row_count(Some(record_batch.num_rows()));
+                RecordBatch::try_new_with_options(
+                    target_schema.clone(),
+                    record_batch.columns().to_vec(),
+                    &options,
+                )?
             }
             None => {
                 self.batch_transform = Some(Self::generate_batch_transform(


### PR DESCRIPTION
## Which issue does this PR close?

- Previously, we used `record_batch.with_schema(target_schema.clone())` to change the schema name of a record batch, but unfortunately, `with_schema` would check the schema name and throw an error. So I think we should convert the RecordBatch like how `BatchTransform::Modify` does, but keep the same columns.

```rust
    pub fn with_schema(self, schema: SchemaRef) -> Result<Self, ArrowError> {
        if !schema.contains(self.schema.as_ref()) {
            return Err(ArrowError::SchemaError(format!(
                "target schema is not superset of current schema target={schema} current={}",
                self.schema
            )));
        }

        Ok(Self {
            schema,
            columns: self.columns,
            row_count: self.row_count,
        })
    }
```

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->