### PR TITLE
chore: expose field id mapping from schema

### DIFF
--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -410,8 +410,13 @@ impl Schema {
     }
 
     /// Return A HashMap matching field ids to field names.
-    pub(crate) fn field_id_to_name_map(&self) -> &HashMap<i32, String> {
+    pub fn field_id_to_name_map(&self) -> &HashMap<i32, String> {
         &self.id_to_name
+    }
+
+    /// Return a hashmap matching field ids to nested fields.
+    pub fn field_id_to_fields(&self) -> &HashMap<i32, NestedFieldRef> {
+        &self.id_to_field
     }
 }
 


### PR DESCRIPTION
## What changes are included in this PR?

Motivation:
- I would like to leverage naming mapping, to compensate the issue that table metadata reassigns field id on creation.
- Name mapping requires (1) field id; (2) field name; (3) children values; all these information could be fetched from `Schema`, but could be a lot easier and performant if we could expose (1) field id -> field name; (2) field id -> field mapping.

## Are these changes tested?

N/A, trivial visibility change, no functional change