### PR TITLE
fix: Fix mock dependency

### DIFF
--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -67,7 +67,6 @@ expect-test = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-mockall = { workspace = true }
 moka = { version = "0.12.10", features = ["future"] }
 murmur3 = { workspace = true }
 num-bigint = { workspace = true }
@@ -97,6 +96,7 @@ zstd = { workspace = true }
 ctor = { workspace = true }
 expect-test = { workspace = true }
 iceberg_test_utils = { path = "../test_utils", features = ["tests"] }
+mockall = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use _serde::deserialize_snapshot;
 use async_trait::async_trait;
 pub use memory::MemoryCatalog;
+#[cfg(test)]
 use mockall::automock;
 use serde_derive::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
@@ -44,7 +45,7 @@ use crate::{Error, ErrorKind, Result};
 
 /// The catalog API for Iceberg Rust.
 #[async_trait]
-#[automock]
+#[cfg_attr(test, automock)]
 pub trait Catalog: Debug + Sync + Send {
     /// List namespaces inside the catalog.
     async fn list_namespaces(&self, parent: Option<&NamespaceIdent>)


### PR DESCRIPTION
## What changes are included in this PR?

`mockall` dependency is introduced in https://github.com/apache/iceberg-rust/pull/1484, which is used for unit test on retry.
But it's only used in unit tests, but not production code; it should be placed under dev section.
Current implementation unnecessarily increases crate size for production usage.

## Are these changes tested?

N/A, a no-op change, a passed compilation should be enough