### PR TITLE
Add initial AuthManager support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,6 +3612,7 @@ name = "iceberg-catalog-rest"
 version = "0.5.1"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "ctor",
  "http 1.3.1",

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -30,6 +30,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 iceberg = { workspace = true }
@@ -44,6 +45,7 @@ typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+base64 = { workspace = true }
 ctor = { workspace = true }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose;
+
+/// Trait for authentication managers that supply authorization headers.
+#[async_trait]
+pub trait AuthManager: Send + Sync + std::fmt::Debug {
+    /// Return the Authorization header value, or None if not applicable.
+    async fn auth_header(&self) -> Option<String>;
+}
+
+/// An `AuthManager` that performs no authentication.
+#[derive(Debug, Default)]
+pub struct NoopAuthManager;
+
+#[async_trait]
+impl AuthManager for NoopAuthManager {
+    async fn auth_header(&self) -> Option<String> {
+        None
+    }
+}
+
+/// An `AuthManager` for basic authentication.
+#[derive(Debug)]
+pub struct BasicAuthManager {
+    token: String,
+}
+
+impl BasicAuthManager {
+    /// Create a new `BasicAuthManager`.
+    pub fn new(username: &str, password: &str) -> Self {
+        let credentials = format!("{}:{}", username, password);
+        let token = general_purpose::STANDARD.encode(credentials.as_bytes());
+        BasicAuthManager { token }
+    }
+}
+
+#[async_trait]
+impl AuthManager for BasicAuthManager {
+    async fn auth_header(&self) -> Option<String> {
+        Some(format!("Basic {}", self.token))
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?
This adds a definition for an user-selectable AuthManager class. It allows different authentication methods to be used with the REST Catalog.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #1510 

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

- Initial definition of AuthManager class.

## Are these changes tested?

Unit tests.

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->