### PR TITLE
Add support for custom credential loader for S3 FileIO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,6 +3535,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "regex",
+ "reqsign",
  "reqwest",
  "roaring",
  "rust_decimal",

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -17,13 +17,12 @@
 
 //! This module contains the iceberg REST catalog implementation.
 
-use std::any::{Any, TypeId};
+use std::any::Any;
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use async_trait::async_trait;
-use iceberg::io::FileIO;
+use iceberg::io::{self, FileIO};
 use iceberg::table::Table;
 use iceberg::{
     Catalog, Error, ErrorKind, Namespace, NamespaceIdent, Result, TableCommit, TableCreation,
@@ -243,7 +242,7 @@ pub struct RestCatalog {
     user_config: RestCatalogConfig,
     ctx: OnceCell<RestContext>,
     /// Extensions for the FileIOBuilder.
-    file_io_extensions: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+    file_io_extensions: io::Extensions,
 }
 
 impl RestCatalog {
@@ -252,14 +251,13 @@ impl RestCatalog {
         Self {
             user_config: config,
             ctx: OnceCell::new(),
-            file_io_extensions: HashMap::default(),
+            file_io_extensions: io::Extensions::default(),
         }
     }
 
     /// Add an extension to the file IO builder.
     pub fn with_file_io_extension<T: Any + Send + Sync>(mut self, ext: T) -> Self {
-        self.file_io_extensions
-            .insert(TypeId::of::<T>(), Arc::new(ext));
+        self.file_io_extensions.add(ext);
         self
     }
 

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -17,8 +17,10 @@
 
 //! This module contains the iceberg REST catalog implementation.
 
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use iceberg::io::FileIO;
@@ -240,6 +242,8 @@ pub struct RestCatalog {
     /// It's could be different from the config fetched from the server and used at runtime.
     user_config: RestCatalogConfig,
     ctx: OnceCell<RestContext>,
+    /// Extensions for the FileIOBuilder.
+    file_io_extensions: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
 }
 
 impl RestCatalog {
@@ -248,7 +252,15 @@ impl RestCatalog {
         Self {
             user_config: config,
             ctx: OnceCell::new(),
+            file_io_extensions: HashMap::default(),
         }
+    }
+
+    /// Add an extension to the file IO builder.
+    pub fn with_file_io_extension<T: Any + Send + Sync>(mut self, ext: T) -> Self {
+        self.file_io_extensions
+            .insert(TypeId::of::<T>(), Arc::new(ext));
+        self
     }
 
     /// Gets the [`RestContext`] from the catalog.
@@ -307,7 +319,10 @@ impl RestCatalog {
         };
 
         let file_io = match warehouse_path.or(metadata_location) {
-            Some(url) => FileIO::from_path(url)?.with_props(props).build()?,
+            Some(url) => FileIO::from_path(url)?
+                .with_props(props)
+                .with_extensions(self.file_io_extensions.clone())
+                .build()?,
             None => {
                 return Err(Error::new(
                     ErrorKind::Unexpected,

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -37,7 +37,7 @@ storage-fs = ["opendal/services-fs"]
 storage-gcs = ["opendal/services-gcs"]
 storage-memory = ["opendal/services-memory"]
 storage-oss = ["opendal/services-oss"]
-storage-s3 = ["opendal/services-s3"]
+storage-s3 = ["opendal/services-s3", "reqsign"]
 
 async-std = ["dep:async-std"]
 tokio = ["tokio/rt-multi-thread"]
@@ -76,6 +76,7 @@ ordered-float = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 rand = { workspace = true }
 reqwest = { workspace = true }
+reqsign = { version = "0.16.3", optional = true, default-features = false }
 roaring = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true }

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -230,6 +230,15 @@ impl FileIOBuilder {
         self
     }
 
+    /// Adds multiple extensions to the file IO builder.
+    pub fn with_extensions(
+        mut self,
+        extensions: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+    ) -> Self {
+        self.extensions.extend(extensions);
+        self
+    }
+
     /// Fetch an extension from the file IO builder.
     pub fn extension<T>(&self) -> Option<Arc<T>>
     where T: 'static + Send + Sync + Clone {

--- a/crates/iceberg/src/io/storage_s3.rs
+++ b/crates/iceberg/src/io/storage_s3.rs
@@ -16,9 +16,13 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use async_trait::async_trait;
 use opendal::services::S3Config;
 use opendal::{Configurator, Operator};
+use reqsign::{AwsCredential, AwsCredentialLoad};
+use reqwest::Client;
 use url::Url;
 
 use crate::io::is_truthy;
@@ -151,7 +155,11 @@ pub(crate) fn s3_config_parse(mut m: HashMap<String, String>) -> Result<S3Config
 }
 
 /// Build new opendal operator from give path.
-pub(crate) fn s3_config_build(cfg: &S3Config, path: &str) -> Result<Operator> {
+pub(crate) fn s3_config_build(
+    cfg: &S3Config,
+    customized_credential_load: &Option<CustomAwsCredentialLoader>,
+    path: &str,
+) -> Result<Operator> {
     let url = Url::parse(path)?;
     let bucket = url.host_str().ok_or_else(|| {
         Error::new(
@@ -160,11 +168,49 @@ pub(crate) fn s3_config_build(cfg: &S3Config, path: &str) -> Result<Operator> {
         )
     })?;
 
-    let builder = cfg
+    let mut builder = cfg
         .clone()
         .into_builder()
         // Set bucket name.
         .bucket(bucket);
 
+    if let Some(customized_credential_load) = customized_credential_load {
+        builder = builder
+            .customized_credential_load(customized_credential_load.clone().into_opendal_loader());
+    }
+
     Ok(Operator::new(builder)?.finish())
+}
+
+/// Custom AWS credential loader.
+/// This can be used to load credentials from a custom source, such as the AWS SDK.
+///
+/// This should be set as an extension on `FileIOBuilder`.
+#[derive(Clone)]
+pub struct CustomAwsCredentialLoader(Arc<dyn AwsCredentialLoad>);
+
+impl std::fmt::Debug for CustomAwsCredentialLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CustomAwsCredentialLoader")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CustomAwsCredentialLoader {
+    /// Create a new custom AWS credential loader.
+    pub fn new(loader: Arc<dyn AwsCredentialLoad>) -> Self {
+        Self(loader)
+    }
+
+    /// Convert this loader into an opendal compatible loader for customized AWS credentials.
+    pub fn into_opendal_loader(self) -> Box<dyn AwsCredentialLoad> {
+        Box::new(self)
+    }
+}
+
+#[async_trait]
+impl AwsCredentialLoad for CustomAwsCredentialLoader {
+    async fn load_credential(&self, client: Client) -> anyhow::Result<Option<AwsCredential>> {
+        self.0.load_credential(client).await
+    }
 }

--- a/crates/iceberg/src/io/storage_s3.rs
+++ b/crates/iceberg/src/io/storage_s3.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use opendal::services::S3Config;
 use opendal::{Configurator, Operator};
-use reqsign::{AwsCredential, AwsCredentialLoad};
+pub use reqsign::{AwsCredential, AwsCredentialLoad};
 use reqwest::Client;
 use url::Url;
 

--- a/crates/iceberg/tests/file_io_s3_test.rs
+++ b/crates/iceberg/tests/file_io_s3_test.rs
@@ -18,7 +18,7 @@
 //! Integration tests for FileIO S3.
 #[cfg(all(test, feature = "storage-s3"))]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{IpAddr, SocketAddr};
     use std::sync::{Arc, RwLock};
 
     use async_trait::async_trait;
@@ -55,9 +55,7 @@ mod tests {
     async fn get_file_io() -> FileIO {
         set_up();
 
-        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
-        let docker_compose = guard.as_ref().unwrap();
-        let container_ip = docker_compose.get_container_ip("minio");
+        let container_ip = get_container_ip("minio");
         let minio_socket_addr = SocketAddr::new(container_ip, MINIO_PORT);
 
         FileIOBuilder::new("s3")
@@ -69,6 +67,12 @@ mod tests {
             ])
             .build()
             .unwrap()
+    }
+
+    fn get_container_ip(service_name: &str) -> IpAddr {
+        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
+        let docker_compose = guard.as_ref().unwrap();
+        docker_compose.get_container_ip(service_name)
     }
 
     #[tokio::test]
@@ -197,10 +201,7 @@ mod tests {
         let custom_loader = CustomAwsCredentialLoader::new(Arc::new(mock_loader));
 
         // Get container info for endpoint
-        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
-        let docker_compose = guard.as_ref().unwrap();
-        let container_ip = docker_compose.get_container_ip("minio");
-        drop(guard);
+        let container_ip = get_container_ip("minio");
         let minio_socket_addr = SocketAddr::new(container_ip, MINIO_PORT);
 
         // Build FileIO with custom credential loader
@@ -229,10 +230,7 @@ mod tests {
         let custom_loader = CustomAwsCredentialLoader::new(Arc::new(mock_loader));
 
         // Get container info for endpoint
-        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
-        let docker_compose = guard.as_ref().unwrap();
-        let container_ip = docker_compose.get_container_ip("minio");
-        drop(guard);
+        let container_ip = get_container_ip("minio");
         let minio_socket_addr = SocketAddr::new(container_ip, MINIO_PORT);
 
         // Build FileIO with custom credential loader

--- a/crates/iceberg/tests/file_io_s3_test.rs
+++ b/crates/iceberg/tests/file_io_s3_test.rs
@@ -19,14 +19,18 @@
 #[cfg(all(test, feature = "storage-s3"))]
 mod tests {
     use std::net::SocketAddr;
-    use std::sync::RwLock;
+    use std::sync::{Arc, RwLock};
 
+    use async_trait::async_trait;
     use ctor::{ctor, dtor};
     use iceberg::io::{
-        FileIO, FileIOBuilder, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY,
+        CustomAwsCredentialLoader, FileIO, FileIOBuilder, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION,
+        S3_SECRET_ACCESS_KEY,
     };
     use iceberg_test_utils::docker::DockerCompose;
     use iceberg_test_utils::{normalize_test_name, set_up};
+    use reqsign::{AwsCredential, AwsCredentialLoad};
+    use reqwest::Client;
 
     const MINIO_PORT: u16 = 9000;
     static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
@@ -98,6 +102,160 @@ mod tests {
         {
             let buffer = input_file.read().await.unwrap();
             assert_eq!(buffer, "test_input".as_bytes());
+        }
+    }
+
+    // Mock credential loader for testing
+    struct MockCredentialLoader {
+        credential: Option<AwsCredential>,
+    }
+
+    impl MockCredentialLoader {
+        fn new(credential: Option<AwsCredential>) -> Self {
+            Self { credential }
+        }
+
+        fn new_minio() -> Self {
+            Self::new(Some(AwsCredential {
+                access_key_id: "admin".to_string(),
+                secret_access_key: "password".to_string(),
+                session_token: None,
+                expires_in: None,
+            }))
+        }
+    }
+
+    #[async_trait]
+    impl AwsCredentialLoad for MockCredentialLoader {
+        async fn load_credential(&self, _client: Client) -> anyhow::Result<Option<AwsCredential>> {
+            Ok(self.credential.clone())
+        }
+    }
+
+    #[test]
+    fn test_file_io_builder_extension_system() {
+        // Test adding and retrieving extensions
+        let test_string = "test_extension_value".to_string();
+        let builder = FileIOBuilder::new_fs_io().with_extension(test_string.clone());
+
+        // Test retrieving the extension
+        let extension: Option<Arc<String>> = builder.extension();
+        assert!(extension.is_some());
+        assert_eq!(*extension.unwrap(), test_string);
+
+        // Test that non-existent extension returns None
+        let non_existent: Option<Arc<i32>> = builder.extension();
+        assert!(non_existent.is_none());
+    }
+
+    #[test]
+    fn test_file_io_builder_multiple_extensions() {
+        // Test adding multiple different types of extensions
+        let test_string = "test_value".to_string();
+        let test_number = 42i32;
+
+        let builder = FileIOBuilder::new_fs_io()
+            .with_extension(test_string.clone())
+            .with_extension(test_number);
+
+        // Retrieve both extensions
+        let string_ext: Option<Arc<String>> = builder.extension();
+        let number_ext: Option<Arc<i32>> = builder.extension();
+
+        assert!(string_ext.is_some());
+        assert!(number_ext.is_some());
+        assert_eq!(*string_ext.unwrap(), test_string);
+        assert_eq!(*number_ext.unwrap(), test_number);
+    }
+
+    #[test]
+    fn test_custom_aws_credential_loader_instantiation() {
+        // Test creating CustomAwsCredentialLoader with mock loader
+        let mock_loader = MockCredentialLoader::new_minio();
+        let custom_loader = CustomAwsCredentialLoader::new(Arc::new(mock_loader));
+
+        // Test that the loader can be used in FileIOBuilder
+        let builder = FileIOBuilder::new("s3")
+            .with_extension(custom_loader.clone())
+            .with_props(vec![
+                (S3_ENDPOINT, "http://localhost:9000".to_string()),
+                ("bucket", "test-bucket".to_string()),
+                (S3_REGION, "us-east-1".to_string()),
+            ]);
+
+        // Verify the extension was stored
+        let retrieved_loader: Option<Arc<CustomAwsCredentialLoader>> = builder.extension();
+        assert!(retrieved_loader.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_s3_with_custom_credential_loader_integration() {
+        let _file_io = get_file_io().await;
+
+        // Create a mock credential loader
+        let mock_loader = MockCredentialLoader::new_minio();
+        let custom_loader = CustomAwsCredentialLoader::new(Arc::new(mock_loader));
+
+        // Get container info for endpoint
+        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
+        let docker_compose = guard.as_ref().unwrap();
+        let container_ip = docker_compose.get_container_ip("minio");
+        drop(guard);
+        let minio_socket_addr = SocketAddr::new(container_ip, MINIO_PORT);
+
+        // Build FileIO with custom credential loader
+        let file_io_with_custom_creds = FileIOBuilder::new("s3")
+            .with_extension(custom_loader)
+            .with_props(vec![
+                (S3_ENDPOINT, format!("http://{}", minio_socket_addr)),
+                (S3_REGION, "us-east-1".to_string()),
+            ])
+            .build()
+            .unwrap();
+
+        // Test that the FileIO was built successfully with the custom loader
+        match file_io_with_custom_creds.exists("s3://bucket1/any").await {
+            Ok(_) => {}
+            Err(e) => panic!("Failed to check existence of bucket: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_s3_with_custom_credential_loader_integration_failure() {
+        let _file_io = get_file_io().await;
+
+        // Create a mock credential loader with no credentials
+        let mock_loader = MockCredentialLoader::new(None);
+        let custom_loader = CustomAwsCredentialLoader::new(Arc::new(mock_loader));
+
+        // Get container info for endpoint
+        let guard = DOCKER_COMPOSE_ENV.read().unwrap();
+        let docker_compose = guard.as_ref().unwrap();
+        let container_ip = docker_compose.get_container_ip("minio");
+        drop(guard);
+        let minio_socket_addr = SocketAddr::new(container_ip, MINIO_PORT);
+
+        // Build FileIO with custom credential loader
+        let file_io_with_custom_creds = FileIOBuilder::new("s3")
+            .with_extension(custom_loader)
+            .with_props(vec![
+                (S3_ENDPOINT, format!("http://{}", minio_socket_addr)),
+                (S3_REGION, "us-east-1".to_string()),
+            ])
+            .build()
+            .unwrap();
+
+        // Test that the FileIO was built successfully with the custom loader
+        match file_io_with_custom_creds.exists("s3://bucket1/any").await {
+            Ok(_) => panic!(
+                "Expected error, but got Ok - the credential loader should fail to provide valid credentials"
+            ),
+            Err(e) => {
+                assert!(
+                    e.to_string()
+                        .contains("no valid credential found and anonymous access is not allowed")
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1527

## What changes are included in this PR?

Adds the ability to provide custom extensions to the `FileIOBuilder`. Currently the only supported extension is `CustomAwsCredentialLoader` which is a newtype around [`AwsCredentialLoad`](https://docs.rs/reqsign/0.16.3/reqsign/trait.AwsCredentialLoad.html), which is what OpenDAL expects.

I've added extensions to the `RestCatalog` as well, and when its constructing `FileIO` for table operations, passes along any defined extensions into the `FileIOBuilder`, which then get passed into the underlying OpenDAL constructors.

## Are these changes tested?

Yes, tests added in `crates/iceberg/tests/file_io_s3_test.rs` that verify the extension is working.