### PR TITLE
infra: use `toml-cli` to manually set version in github action

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -97,6 +97,8 @@ jobs:
         run: |
           echo "Setting cargo version to: ${{ needs.validate-release-tag.outputs.cargo-version }}"
           toml set Cargo.toml package.version ${{ needs.validate-release-tag.outputs.cargo-version }} > Cargo.toml.tmp
+          # doing this explicitly to avoid issue in Windows where `mv` does not overwrite existing file
+          rm Cargo.toml
           mv Cargo.toml.tmp Cargo.toml
 
       - uses: PyO3/maturin-action@v1
@@ -138,6 +140,8 @@ jobs:
         run: |
           echo "Setting cargo version to: ${{ needs.validate-release-tag.outputs.cargo-version }}"
           toml set Cargo.toml package.version ${{ needs.validate-release-tag.outputs.cargo-version }} > Cargo.toml.tmp
+          # doing this explicitly to avoid issue in Windows where `mv` does not overwrite existing file
+          rm Cargo.toml
           mv Cargo.toml.tmp Cargo.toml
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
See [comment](https://github.com/apache/iceberg-rust/issues/1331#issuecomment-3101114866) for context
Previously used `cargo-edit` but it does not allow setting version from `0.6.0` -> `0.6.0-rc1`.

This PR changes the github action to use `toml-cli` to manually override and set the version in the `binding/python/Cargo.toml` so that we can build pre-release artifacts to push to pypi.

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, similar to https://github.com/apache/iceberg-rust/pull/1449

Pushed this PR as the `main` branch in my fork 
Create a new tag and push to fork to trigger CI
```
git tag "v0.6.0-rc.2" -m "v0.6.0-rc.2"
git push kevinjqliu v0.6.0-rc.2
```
Verify that python artifacts are build correctly with pre-release tag, https://github.com/kevinjqliu/iceberg-rust/actions/runs/16436181005
- downloaded `wheels-sdist`, verified correct version in `PKG-INFO` but not in `Cargo.toml`. I think this is fine
- downloaded `wheels-ubuntu-latest-armv7l` and verified the `METADATA` file
