### PR TITLE
fix(iceberg-datafusion): handle timestamp predicates from DF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,6 +3525,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "datafusion",
  "expect-test",
  "futures",

--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -40,5 +40,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }
+chrono = { workspace = true }
 parquet = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
DataFusion sometimes passes dates as string literals, but can also pass timestamp ScalarValues, which need to be converted to predicates correctly in order to enable partition pruning.