### PR TITLE
feat(iceberg-datafusion): make IcebergTableScan public

### DIFF
--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -21,7 +21,7 @@ pub use catalog::*;
 mod error;
 pub use error::*;
 
-mod physical_plan;
+pub mod physical_plan;
 mod schema;
 pub mod table;
 pub use table::table_provider_factory::IcebergTableProviderFactory;

--- a/crates/integrations/datafusion/src/physical_plan/mod.rs
+++ b/crates/integrations/datafusion/src/physical_plan/mod.rs
@@ -18,3 +18,4 @@
 pub(crate) mod expr_to_predicate;
 pub(crate) mod metadata_scan;
 pub(crate) mod scan;
+pub use scan::IcebergTableScan;

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -39,7 +39,7 @@ use crate::to_datafusion_error;
 /// Manages the scanning process of an Iceberg [`Table`], encapsulating the
 /// necessary details and computed properties required for execution planning.
 #[derive(Debug)]
-pub(crate) struct IcebergTableScan {
+pub struct IcebergTableScan {
     /// A table in the catalog.
     table: Table,
     /// Snapshot of the table to scan.
@@ -77,6 +77,22 @@ impl IcebergTableScan {
             projection,
             predicates,
         }
+    }
+
+    pub fn table(&self) -> &Table {
+        &self.table
+    }
+
+    pub fn snapshot_id(&self) -> Option<i64> {
+        self.snapshot_id
+    }
+
+    pub fn projection(&self) -> Option<&[String]> {
+        self.projection.as_deref()
+    }
+
+    pub fn predicates(&self) -> Option<&Predicate> {
+        self.predicates.as_ref()
     }
 
     /// Computes [`PlanProperties`] used in query optimization.


### PR DESCRIPTION
DataFusion `ExecutionPlan` implementations are generally public, so that they can be inspected and munged by optimization rules.

Our specific use case is to use `IcebergTableProvider` to plan files, and then pass those files (assuming no deletes) to DataFusion`s `ListingTable`.