### PR TITLE
chore: upgrade roaring to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4207,7 +4207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5844,9 +5844,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ pretty_assertions = "1.4"
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
-roaring = { version = "0.10.12" }
+roaring = { version = "0.11" }
 rust_decimal = "1.37.1"
 serde = { version = "1.0.210", features = ["rc"] }
 serde_bytes = "0.11.15"


### PR DESCRIPTION
## What changes are included in this PR?

This PR upgrades `roaring` dependency from 0.10 to 0.11.

Motivation:
- Latest roaring v0.11 includes all features described in spec, including `run container` which is only supported in v0.11
  + See v0.11 release notes: https://github.com/RoaringBitmap/roaring-rs/releases
- I do notice iceberg-rust has configured dependabot and triggers on weekly basic, but doesn't seem to upgrade this particular crate for a while
  + The v0.11 was release 6 weeks ago, which I expect to upgrade with no human intervene

I checked there's one version for `roaring`.

## Are these changes tested?

No op change, CI should be enough.