### PR TITLE
Finish Adding Default Implementations for V1→V2

### DIFF
--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -432,4 +432,154 @@ mod tests {
 
         assert_eq!(actual_data_file[0].content, DataContentType::Data)
     }
+
+    #[test]
+    fn test_manifest_entry_v1_to_v2_projection() {
+        use crate::spec::manifest::_serde::{DataFileSerde, ManifestEntryV1};
+        use crate::spec::{Literal, RawLiteral, Struct, StructType};
+
+        let partition = RawLiteral::try_from(
+            Literal::Struct(Struct::empty()),
+            &Type::Struct(StructType::new(vec![])),
+        )
+        .unwrap();
+
+        // Create a V1 manifest entry struct (lacks V2 sequence number fields)
+        let v1_entry = ManifestEntryV1 {
+            status: 1, // Added
+            snapshot_id: 12345,
+            data_file: DataFileSerde {
+                content: 0, // DataFileSerde is shared between V1/V2
+                file_path: "test/path.parquet".to_string(),
+                file_format: "PARQUET".to_string(),
+                partition: partition,
+                record_count: 100,
+                file_size_in_bytes: 1024,
+                block_size_in_bytes: Some(0), // V1 includes this field
+                column_sizes: None,
+                value_counts: None,
+                null_value_counts: None,
+                nan_value_counts: None,
+                lower_bounds: None,
+                upper_bounds: None,
+                key_metadata: None,
+                split_offsets: None,
+                equality_ids: None, // Will be converted to empty vec
+                sort_order_id: None,
+                first_row_id: None,
+                referenced_data_file: None,
+                content_offset: None,
+                content_size_in_bytes: None,
+            },
+        };
+
+        // Test the explicit V1→V2 conversion logic in ManifestEntryV1::try_into()
+        let v2_entry = v1_entry
+            .try_into(
+                0, // partition_spec_id
+                &StructType::new(vec![]),
+                &schema(),
+            )
+            .unwrap();
+
+        // Verify that V1→V2 conversion adds the missing V2 sequence number fields
+        assert_eq!(
+            v2_entry.sequence_number,
+            Some(0),
+            "ManifestEntryV1::try_into() should set sequence_number to 0"
+        );
+        assert_eq!(
+            v2_entry.file_sequence_number,
+            Some(0),
+            "ManifestEntryV1::try_into() should set file_sequence_number to 0"
+        );
+        assert_eq!(
+            v2_entry.snapshot_id,
+            Some(12345),
+            "snapshot_id should be preserved during conversion"
+        );
+
+        // Verify that DataFileSerde conversion applies V2 defaults
+        assert_eq!(
+            v2_entry.data_file.content,
+            DataContentType::Data,
+            "DataFileSerde should convert content 0 to DataContentType::Data"
+        );
+        assert_eq!(
+            v2_entry.data_file.equality_ids,
+            Vec::<i32>::new(),
+            "DataFileSerde should convert None equality_ids to empty vec"
+        );
+
+        // Verify other fields are preserved during conversion
+        assert_eq!(v2_entry.data_file.file_path, "test/path.parquet");
+        assert_eq!(v2_entry.data_file.record_count, 100);
+        assert_eq!(v2_entry.data_file.file_size_in_bytes, 1024);
+    }
+
+    #[test]
+    fn test_data_file_serde_v1_field_defaults() {
+        use crate::spec::manifest::_serde::DataFileSerde;
+        use crate::spec::{Literal, RawLiteral, Struct, StructType};
+
+        let partition = RawLiteral::try_from(
+            Literal::Struct(Struct::empty()),
+            &Type::Struct(StructType::new(vec![])),
+        )
+        .unwrap();
+
+        // Create a DataFileSerde that simulates V1 deserialization behavior
+        // (missing V2 fields would be None due to #[serde(default)])
+        let v1_style_data_file = DataFileSerde {
+            content: 0, // V1 doesn't have this field, defaults to 0 via #[serde(default)]
+            file_path: "test/data.parquet".to_string(),
+            file_format: "PARQUET".to_string(),
+            partition: partition,
+            record_count: 500,
+            file_size_in_bytes: 2048,
+            block_size_in_bytes: Some(1024), // V1 includes this field, V2 skips it
+            column_sizes: None,
+            value_counts: None,
+            null_value_counts: None,
+            nan_value_counts: None,
+            lower_bounds: None,
+            upper_bounds: None,
+            key_metadata: None,
+            split_offsets: None,
+            equality_ids: None, // V1 doesn't have this field, defaults to None via #[serde(default)]
+            sort_order_id: None,
+            first_row_id: None,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        };
+
+        // Test the DataFileSerde::try_into() conversion that handles V1 field defaults
+        let data_file = v1_style_data_file
+            .try_into(
+                0, // partition_spec_id
+                &StructType::new(vec![]),
+                &schema(),
+            )
+            .unwrap();
+
+        // Verify that DataFileSerde::try_into() applies correct defaults for missing V2 fields
+        assert_eq!(
+            data_file.content,
+            DataContentType::Data,
+            "content 0 should convert to DataContentType::Data"
+        );
+        assert_eq!(
+            data_file.equality_ids,
+            Vec::<i32>::new(),
+            "None equality_ids should convert to empty vec via unwrap_or_default()"
+        );
+
+        // Verify other fields are handled correctly during conversion
+        assert_eq!(data_file.file_path, "test/data.parquet");
+        assert_eq!(data_file.file_format, DataFileFormat::Parquet);
+        assert_eq!(data_file.record_count, 500);
+        assert_eq!(data_file.file_size_in_bytes, 2048);
+        assert_eq!(data_file.partition_spec_id, 0);
+    }
 }

--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -452,7 +452,7 @@ mod tests {
                 content: 0, // DataFileSerde is shared between V1/V2
                 file_path: "test/path.parquet".to_string(),
                 file_format: "PARQUET".to_string(),
-                partition: partition,
+                partition,
                 record_count: 100,
                 file_size_in_bytes: 1024,
                 block_size_in_bytes: Some(0), // V1 includes this field
@@ -534,7 +534,7 @@ mod tests {
             content: 0, // V1 doesn't have this field, defaults to 0 via #[serde(default)]
             file_path: "test/data.parquet".to_string(),
             file_format: "PARQUET".to_string(),
-            partition: partition,
+            partition,
             record_count: 500,
             file_size_in_bytes: 2048,
             block_size_in_bytes: Some(1024), // V1 includes this field, V2 skips it

--- a/crates/iceberg/src/spec/manifest/data_file.rs
+++ b/crates/iceberg/src/spec/manifest/data_file.rs
@@ -359,6 +359,12 @@ impl TryFrom<i32> for DataContentType {
     }
 }
 
+impl Default for DataContentType {
+    fn default() -> Self {
+        DataContentType::Data // Default 0 for V1 compatibility
+    }
+}
+
 /// Format of this data.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, SerializeDisplay, DeserializeFromStr)]
 pub enum DataFileFormat {
@@ -397,5 +403,19 @@ impl std::fmt::Display for DataFileFormat {
             DataFileFormat::Parquet => write!(f, "parquet"),
             DataFileFormat::Puffin => write!(f, "puffin"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::spec::DataContentType;
+    #[test]
+    fn test_data_content_type_default() {
+        assert_eq!(DataContentType::default(), DataContentType::Data);
+    }
+
+    #[test]
+    fn test_data_content_type_default_value() {
+        assert_eq!(DataContentType::default() as i32, 0);
     }
 }

--- a/crates/iceberg/src/spec/manifest/data_file.rs
+++ b/crates/iceberg/src/spec/manifest/data_file.rs
@@ -333,9 +333,10 @@ pub fn read_data_files_from_avro<R: Read>(
 
 /// Type of content stored by the data file: data, equality deletes, or
 /// position deletes (all v1 files are data files)
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Default)]
 pub enum DataContentType {
     /// value: 0
+    #[default]
     Data = 0,
     /// value: 1
     PositionDeletes = 1,
@@ -356,12 +357,6 @@ impl TryFrom<i32> for DataContentType {
                 format!("data content type {} is invalid", v),
             )),
         }
-    }
-}
-
-impl Default for DataContentType {
-    fn default() -> Self {
-        DataContentType::Data // Default 0 for V1 compatibility
     }
 }
 

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -600,9 +600,10 @@ impl ManifestFile {
 }
 
 /// The type of files tracked by the manifest, either data or delete files; Data(0) for all v1 manifests
-#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash, Default)]
 pub enum ManifestContentType {
     /// The manifest content is data.
+    #[default]
     Data = 0,
     /// The manifest content is deletes.
     Deletes = 1,
@@ -647,12 +648,6 @@ impl TryFrom<i32> for ManifestContentType {
                 ),
             )),
         }
-    }
-}
-
-impl Default for ManifestContentType {
-    fn default() -> Self {
-        ManifestContentType::Data // Default 0 for V1 compatibility
     }
 }
 
@@ -1377,7 +1372,7 @@ mod test {
     #[test]
     fn test_manifest_file_v1_to_v2_projection() {
         use crate::spec::manifest_list::_serde::ManifestFileV1;
-        
+
         // Create a V1 manifest file object (without V2 fields)
         let v1_manifest = ManifestFileV1 {
             manifest_path: "/test/manifest.avro".to_string(),
@@ -1398,10 +1393,20 @@ mod test {
         let v2_manifest: ManifestFile = v1_manifest.try_into().unwrap();
 
         // Verify V1→V2 projection defaults are applied correctly
-        assert_eq!(v2_manifest.content, ManifestContentType::Data, "V1 manifest content should default to Data (0)");
-        assert_eq!(v2_manifest.sequence_number, 0, "V1 manifest sequence_number should default to 0");
-        assert_eq!(v2_manifest.min_sequence_number, 0, "V1 manifest min_sequence_number should default to 0");
-        
+        assert_eq!(
+            v2_manifest.content,
+            ManifestContentType::Data,
+            "V1 manifest content should default to Data (0)"
+        );
+        assert_eq!(
+            v2_manifest.sequence_number, 0,
+            "V1 manifest sequence_number should default to 0"
+        );
+        assert_eq!(
+            v2_manifest.min_sequence_number, 0,
+            "V1 manifest min_sequence_number should default to 0"
+        );
+
         // Verify other fields are preserved correctly
         assert_eq!(v2_manifest.manifest_path, "/test/manifest.avro");
         assert_eq!(v2_manifest.manifest_length, 5806);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1576

## What changes are included in this PR?

This PR implements `Default` trait implementations for `DataContentType` and `ManifestContentType` to enable proper V1→V2 manifest projection as specified in the Apache Iceberg format specification. As part of solving ManifestList projection, I did a full audit of ManifestData, ManifestList, ManifestEntry and Snapshot files. All five file types are now covered for V1 to V2 projection.

 ## Changes Made
- Added `Default` for `DataContentType`**: Returns `DataContentType::Data` (value 0) for V1 compatibility
- Added `Default` for `ManifestContentType`**: Returns `ManifestContentType::Data` (value 0) for V1 compatibility

## Are these changes tested?
- ManifestFile V1→V2 projection test**: Validates `ManifestFileV1::try_into()` properly sets defaults for missing V2 fields
- ManifestEntry V1→V2 projection test**: Validates `ManifestEntryV1::try_into()` correctly applies sequence number defaults
- DataFile V1→V2 projection test**: Validates `DataFileSerde::try_into()` handles V1 field defaults correctly
- Snapshot V1→V2 projection tests**: Two tests covering both scenarios (with/without optional summary field)