### PR TITLE
Try infer file io scheme from metadata location ahead of warehouse path

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -316,7 +316,7 @@ impl RestCatalog {
             None => None,
         };
 
-        let file_io = match warehouse_path.or(metadata_location) {
+        let file_io = match metadata_location.or(warehouse_path) {
             Some(url) => FileIO::from_path(url)?
                 .with_props(props)
                 .with_extensions(self.file_io_extensions.clone())


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1589

## What changes are included in this PR?

As S3Tables REST endpoint accept `warehouse` only in ARN format,
Current code logic will infer file io scheme through `warehouse_path` in ARN format as `arn` which is wrong and unable to be processed.

Changed the code logic to try infer file io scheme with `metadata_location` before `warehouse_path`,
This makes file io scheme infer as `s3` correctly.

## Are these changes tested?

Test only in `load_table` path for rest catalog implementation