### PR TITLE
feat(ci): miri test support for CI

### DIFF
--- a/.github/actions/setup-builder/action.yml
+++ b/.github/actions/setup-builder/action.yml
@@ -35,6 +35,7 @@ runs:
         rustup toolchain install ${RUST_VERSION}
         rustup override set ${RUST_VERSION}
         rustup component add rustfmt clippy
+        rustup component add miri
     - name: Setup Rust toolchain according to rust-toolchain.toml
       shell: bash
       if: ${{ inputs.rust-version == '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,13 @@ jobs:
       - name: Check MSRV
         run: |
           cargo +${{ env.rust_msrv }} check --locked --workspace
+
+  miri:
+    name: Run Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Nightly Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Run Miri
+        run: cargo miri test


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #446.

## What changes are included in this PR?

Adds miri test call to `ci` Github Actions workflow to detect UB.

## Are these changes tested?

I'm unable to run the Github Action from my fork so I've created this PR to see if I can trigger a run on the main repo, prior to merge.