### PR TITLE
feat(writer): Make LocationGenerator partition-aware

### DIFF
--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -176,6 +176,23 @@ impl PartitionSpec {
     }
 }
 
+/// todo doc
+pub struct PartitionKey {
+    /// The partition spec that contains the partition fields.
+    spec: PartitionSpec,
+    /// The schema to which the partition spec is bound.
+    schema: SchemaRef,
+    /// Partition fields' values in struct.
+    data: Struct,
+}
+
+impl PartitionKey {
+    /// Generates a partition path based on the partition values.
+    pub fn to_path(&self) -> String {
+        self.spec.partition_to_path(&self.data, self.schema.clone())
+    }
+}
+
 /// Reference to [`UnboundPartitionSpec`].
 pub type UnboundPartitionSpecRef = Arc<UnboundPartitionSpec>;
 /// Unbound partition field can be built without a schema and later bound to a schema.

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -177,6 +177,7 @@ impl PartitionSpec {
 }
 
 /// todo doc
+#[derive(Clone, Debug)]
 pub struct PartitionKey {
     /// The partition spec that contains the partition fields.
     spec: PartitionSpec,
@@ -191,6 +192,11 @@ impl PartitionKey {
     pub fn to_path(&self) -> String {
         self.spec.partition_to_path(&self.data, self.schema.clone())
     }
+}
+
+/// todo doc
+pub fn partition_key_is_none(partition_key: Option<&PartitionKey>) -> bool {
+    partition_key.is_none_or(|pk| pk.spec.is_unpartitioned())
 }
 
 /// Reference to [`UnboundPartitionSpec`].

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -176,7 +176,8 @@ impl PartitionSpec {
     }
 }
 
-/// todo doc
+/// A partition key represents a specific partition in a table, containing the partition spec,
+/// schema, and the actual partition values.
 #[derive(Clone, Debug)]
 pub struct PartitionKey {
     /// The partition spec that contains the partition fields.
@@ -188,15 +189,23 @@ pub struct PartitionKey {
 }
 
 impl PartitionKey {
+    /// Creates a new partition key with the given spec, schema, and data.
+    pub fn new(spec: PartitionSpec, schema: SchemaRef, data: Struct) -> Self {
+        Self { spec, schema, data }
+    }
+
     /// Generates a partition path based on the partition values.
     pub fn to_path(&self) -> String {
         self.spec.partition_to_path(&self.data, self.schema.clone())
     }
 }
 
-/// todo doc
+/// Checks if a partition key is effectively none.
 pub fn partition_key_is_none(partition_key: Option<&PartitionKey>) -> bool {
-    partition_key.is_none_or(|pk| pk.spec.is_unpartitioned())
+    match partition_key {
+        None => true,
+        Some(pk) => pk.spec.is_unpartitioned(),
+    }
 }
 
 /// Reference to [`UnboundPartitionSpec`].

--- a/crates/iceberg/src/writer/base_writer/data_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/data_file_writer.rs
@@ -144,6 +144,7 @@ mod test {
         let pw = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(schema),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,
@@ -221,6 +222,7 @@ mod test {
         let parquet_writer_builder = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(schema.clone()),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -404,6 +404,7 @@ mod test {
         let pb = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(delete_schema),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,
@@ -569,6 +570,7 @@ mod test {
         let pb = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(delete_schema),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -36,6 +36,8 @@ pub trait LocationGenerator: Clone + Send + 'static {
     ///
     /// An absolute path that includes the partition path, e.g.,
     /// "/table/data/id=1/name=alice/part-00000.parquet"
+    /// or non-partitioned path:
+    /// "/table/data/part-00000.parquet"
     fn generate_location(&self, partition_key: Option<PartitionKey>, file_name: &str) -> String;
 }
 

--- a/crates/iceberg/src/writer/file_writer/rolling_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/rolling_writer.rs
@@ -200,6 +200,7 @@ mod tests {
         let parquet_writer_builder = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(schema),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,
@@ -259,6 +260,7 @@ mod tests {
         let parquet_writer_builder = ParquetWriterBuilder::new(
             WriterProperties::builder().build(),
             Arc::new(schema),
+            None,
             file_io.clone(),
             location_gen,
             file_name_gen,

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -163,6 +163,8 @@
 //! async fn main() -> Result<()> {
 //!     // Build your file IO.
 //!     use iceberg::NamespaceIdent;
+//!     use iceberg::spec::{Literal, PartitionKey, Struct};
+//! 
 //!     let file_io = FileIOBuilder::new("memory").build()?;
 //!     // Connect to a catalog.
 //!     let catalog = MemoryCatalog::new(file_io, None);
@@ -173,6 +175,11 @@
 //!     let table = catalog
 //!         .load_table(&TableIdent::from_strs(["hello", "world"])?)
 //!         .await?;
+//!     let partition_key = PartitionKey::new(
+//!         table.metadata().default_partition_spec().as_ref().clone(),
+//!         table.metadata().current_schema().clone(),
+//!         Struct::from_iter(vec![Some(Literal::int("seattle"))]),
+//!     );
 //!     let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
 //!     let file_name_generator = DefaultFileNameGenerator::new(
 //!         "test".to_string(),
@@ -256,7 +263,7 @@ mod tests {
     use crate::io::FileIO;
     use crate::spec::{DataFile, DataFileFormat};
 
-    // This function is used to guarantee the trait can be used as a object safe trait.
+    // This function is used to guarantee the trait can be used as an object safe trait.
     async fn _guarantee_object_safe(mut w: Box<dyn IcebergWriter>) {
         let _ = w
             .write(RecordBatch::new_empty(Schema::empty().into()))

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -78,6 +78,7 @@
 //!     let parquet_writer_builder = ParquetWriterBuilder::new(
 //!         WriterProperties::default(),
 //!         table.metadata().current_schema().clone(),
+//!         None,
 //!         table.file_io().clone(),
 //!         location_generator.clone(),
 //!         file_name_generator.clone(),
@@ -183,6 +184,7 @@
 //!     let parquet_writer_builder = ParquetWriterBuilder::new(
 //!         WriterProperties::default(),
 //!         table.metadata().current_schema().clone(),
+//!         None,
 //!         table.file_io().clone(),
 //!         location_generator.clone(),
 //!         file_name_generator.clone(),

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -164,7 +164,7 @@
 //!     // Build your file IO.
 //!     use iceberg::NamespaceIdent;
 //!     use iceberg::spec::{Literal, PartitionKey, Struct};
-//! 
+//!
 //!     let file_io = FileIOBuilder::new("memory").build()?;
 //!     // Connect to a catalog.
 //!     let catalog = MemoryCatalog::new(file_io, None);

--- a/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
@@ -74,6 +74,7 @@ async fn test_append_data_file() {
     let parquet_writer_builder = ParquetWriterBuilder::new(
         WriterProperties::default(),
         table.metadata().current_schema().clone(),
+        None,
         table.file_io().clone(),
         location_generator.clone(),
         file_name_generator.clone(),

--- a/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
@@ -89,6 +89,7 @@ async fn test_append_partition_data_file() {
     let parquet_writer_builder = ParquetWriterBuilder::new(
         WriterProperties::default(),
         table.metadata().current_schema().clone(),
+        None,
         table.file_io().clone(),
         location_generator.clone(),
         file_name_generator.clone(),

--- a/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
@@ -73,6 +73,7 @@ async fn test_append_data_file_conflict() {
     let parquet_writer_builder = ParquetWriterBuilder::new(
         WriterProperties::default(),
         table.metadata().current_schema().clone(),
+        None,
         table.file_io().clone(),
         location_generator.clone(),
         file_name_generator.clone(),

--- a/crates/integration_tests/tests/shared_tests/scan_all_type.rs
+++ b/crates/integration_tests/tests/shared_tests/scan_all_type.rs
@@ -155,6 +155,7 @@ async fn test_scan_all_type() {
     let parquet_writer_builder = ParquetWriterBuilder::new(
         WriterProperties::default(),
         table.metadata().current_schema().clone(),
+        None,
         table.file_io().clone(),
         location_generator.clone(),
         file_name_generator.clone(),

--- a/crates/integrations/datafusion/src/physical_plan/write.rs
+++ b/crates/integrations/datafusion/src/physical_plan/write.rs
@@ -235,6 +235,7 @@ impl ExecutionPlan for IcebergWriteExec {
         let parquet_file_writer_builder = ParquetWriterBuilder::new_with_match_mode(
             WriterProperties::default(),
             self.table.metadata().current_schema().clone(),
+            None,
             FieldMatchMode::Name,
             self.table.file_io().clone(),
             DefaultLocationGenerator::new(self.table.metadata().clone())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1624 

## What changes are included in this PR?
- Added `PartitionKey` to hold necessary partition-related info for path generation
- [BREAKING] Changed `LocationGenerator::generate_location` to accept an optional partition key
- [BREAKING] Have `ParquetWriter` take in an `Option<PartitionKey>`
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?
Added ut
<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->