### PR TITLE
test: pyiceberg-core, pin datafusion and unpin pyarrow

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -44,7 +44,7 @@ python-source = "python"
 ignore = ["F403", "F405"]
 
 [tool.hatch.envs.dev]
-dependencies = ["maturin>=1.0,<2.0", "pytest>=8.3.2", "pyarrow==16.*", "datafusion==47.*", "pyiceberg[sql-sqlite]>=0.9.1"]
+dependencies = ["maturin>=1.0,<2.0", "pytest>=8.3.2", "datafusion==45.*", "pyiceberg[sql-sqlite,pyarrow]>=0.9.1"]
 
 [tool.hatch.envs.dev.scripts]
 build = "maturin build --out dist --sdist"

--- a/bindings/python/tests/test_datafusion_table_provider.py
+++ b/bindings/python/tests/test_datafusion_table_provider.py
@@ -27,8 +27,8 @@ from pathlib import Path
 import datafusion
 
 assert (
-    datafusion.__version__ >= "47"
-)  # iceberg table provider only works for datafusion >= 47
+    datafusion.__version__ >= "45"
+)  # iceberg table provider only works for datafusion >= 45
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Follow up to #1635
We dont need to pin pyarrow specifically, just grab it from pyiceberg.
Revert datafusion version threshold to 45. Version 45 is the lowest version which will still work. 
The underlying issue for #1635 is with the **newer** versions of datafusion, mainly datafusion 49 due to a breaking change described in #1647

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->