### PR TITLE
ci: only use `-Z direct-minimal-versions` for MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/actions/setup-builder
       - name: Generate minimal versions lockfile
         run: |
-          cargo generate-lockfile -Z direct-minimal-versions -Z minimal-versions
+          cargo generate-lockfile -Z direct-minimal-versions
       - name: Setup MSRV Rust toolchain
         uses: ./.github/actions/setup-builder
         with:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Context: https://github.com/apache/iceberg-rust/issues/1195#issuecomment-3262641348
[the docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#minimal-versions) mentions that the feature is not recommended anymore

I've ran an issue with this flag when upgrading datafusion from 47 -> 48. -Z minimal-versions will pull in very old versions of transitive dependencies

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->