### PR TITLE
CI: Fix Nightly PyPi GitHub Action

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -38,14 +38,15 @@ runs:
       env:
         TIMESTAMP: ${{ inputs.timestamp }}
       run: |
-        CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/pyproject.toml')['project']['version'])")
-        NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
-        NEW_VERSION=$NEW_VERSION python -c "
+        CURRENT_VERSION=$(python -c "import toml; print(toml.load('bindings/python/Cargo.toml')['package']['version'])")
+        export NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
+        python -c "
         import toml
         import os
-        config = toml.load('bindings/python/pyproject.toml')
-        config['project']['version'] = os.environ['NEW_VERSION']
-        with open('bindings/python/pyproject.toml', 'w') as f:
+        config = toml.load('bindings/python/Cargo.toml')
+        new_version = os.environ['NEW_VERSION']
+        config['package']['version'] = new_version
+        with open('bindings/python/Cargo.toml', 'w') as f:
             toml.dump(config, f)
-        print(f'Updated version to: {config[\"project\"][\"version\"]}')
+        print(f'Updated version to: {new_version}')
         "


### PR DESCRIPTION
This was broken because we now import the version: https://github.com/apache/iceberg-rust/pull/1380#discussion_r2108118748

The build has been broken for a while: https://github.com/apache/iceberg-rust/actions/workflows/release_python_nightly.yml

Tested locally:

```
➜  iceberg-rust git:(fd-fix-version) ✗ export TIMESTAMP=123
CURRENT_VERSION=$(python3 -c "import toml; print(toml.load('bindings/python/Cargo.toml')['package']['version'])")
export NEW_VERSION="${CURRENT_VERSION}.dev${TIMESTAMP}"
➜  iceberg-rust git:(fd-fix-version) ✗ echo $NEW_VERSION
0.7.0.dev123
➜  iceberg-rust git:(fd-fix-version) ✗ python3 -c "
import toml
import os
config = toml.load('bindings/python/Cargo.toml')
new_version = os.environ['NEW_VERSION']
config['package']['version'] = new_version
with open('bindings/python/Cargo.toml', 'w') as f:
    toml.dump(config, f)
print(f'Updated version to: {new_version}')
"
Updated version to: 0.7.0.dev123
```

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->