### PR TITLE
feat: Enable zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "strum_macros 0.27.2",
  "thiserror 2.0.16",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rust-version = "1.87"
 
 [workspace.dependencies]
 anyhow = "1.0.72"
-apache-avro = "0.20"
+apache-avro = { version = "0.20", features = ["zstandard"] }
 array-init = "2"
 arrow-arith = { version = "55.1" }
 arrow-array = { version = "55.1" }
@@ -125,4 +125,4 @@ url = "2.5.4"
 uuid = { version = "1.18", features = ["v7"] }
 volo = "0.10.6"
 volo-thrift = "0.10.8"
-zstd = "0.13.2"
+zstd = "0.13.3"


### PR DESCRIPTION
In Iceberg we allow Avro metadata to be compressed using zstandard. To also support this in Iceberg Rust we need to enable the zstandard feature:

https://github.com/apache/avro-rs/blob/main/avro/README.md#installing-the-library

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->