### PR TITLE
chore: Expose object cache

### DIFF
--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -215,7 +215,7 @@ impl Table {
     }
 
     /// Returns this table's object cache
-    pub(crate) fn object_cache(&self) -> Arc<ObjectCache> {
+    pub fn object_cache(&self) -> Arc<ObjectCache> {
         self.object_cache.clone()
     }
 


### PR DESCRIPTION
## What changes are included in this PR?

object storage cache is introduced at https://github.com/apache/iceberg-rust/pull/512, which seems to be used for (internal) scan only for now.

I did some profiling on [moonlink](https://github.com/Mooncake-Labs/moonlink) CPU, and found loading manifest list takes 23% CPU.
<img width="1848" height="832" alt="image" src="https://github.com/user-attachments/assets/caf5b8e2-9f22-4cd8-9106-b8f77cfc6137" />

So I would like to expose access to object storage and attempt to get manifest list myself.
I think it's beneficial for all accesses requiring manifest and manifest list, which is not confined to only scan workload.

## Are these changes tested?

No-op change, just visibility update.