### PR TITLE
feat: add support for wasm targets

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -198,7 +198,8 @@ impl GlueCatalog {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for GlueCatalog {
     /// List namespaces from glue catalog.
     ///

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -210,7 +210,8 @@ impl HmsCatalog {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for HmsCatalog {
     /// HMS doesn't support nested namespaces.
     ///

--- a/crates/catalog/loader/src/lib.rs
+++ b/crates/catalog/loader/src/lib.rs
@@ -41,7 +41,8 @@ pub fn supported_types() -> Vec<&'static str> {
     CATALOG_REGISTRY.iter().map(|(k, _)| *k).collect()
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait BoxedCatalogBuilder {
     async fn load(
         self: Box<Self>,
@@ -50,7 +51,8 @@ pub trait BoxedCatalogBuilder {
     ) -> Result<Arc<dyn Catalog>>;
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<T: CatalogBuilder + 'static> BoxedCatalogBuilder for T {
     async fn load(
         self: Box<Self>,

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -435,7 +435,8 @@ impl RestCatalog {
 
 /// All requests and expected responses are derived from the REST catalog API spec:
 /// https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for RestCatalog {
     async fn list_namespaces(
         &self,

--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -191,7 +191,8 @@ impl S3TablesCatalog {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for S3TablesCatalog {
     /// List namespaces from s3tables catalog.
     ///

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -218,7 +218,8 @@ impl SqlCatalog {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for SqlCatalog {
     async fn list_namespaces(
         &self,

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -40,7 +40,7 @@ storage-oss = ["opendal/services-oss"]
 storage-s3 = ["opendal/services-s3", "reqsign"]
 
 smol = ["dep:smol"]
-tokio = ["tokio/rt-multi-thread"]
+tokio = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -74,8 +74,8 @@ opendal = { workspace = true }
 ordered-float = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 rand = { workspace = true }
-reqwest = { workspace = true }
 reqsign = { version = "0.16.3", optional = true, default-features = false }
+reqwest = { workspace = true }
 roaring = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true }
@@ -87,7 +87,6 @@ serde_with = { workspace = true }
 smol = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thrift = { workspace = true }
-tokio = { workspace = true, optional = false, features = ["sync"] }
 typed-builder = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
@@ -103,6 +102,15 @@ rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
 tera = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, optional = false, features = [
+  "rt-multi-thread",
+  "sync",
+] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { workspace = true, optional = false, features = ["rt", "sync"] }
 
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version

--- a/crates/iceberg/src/arrow/delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/delete_file_loader.rs
@@ -28,7 +28,8 @@ use crate::{Error, ErrorKind, Result};
 
 /// Delete File Loader
 #[allow(unused)]
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait DeleteFileLoader {
     /// Read the delete file referred to in the task
     ///
@@ -96,7 +97,8 @@ impl BasicDeleteFileLoader {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl DeleteFileLoader for BasicDeleteFileLoader {
     async fn read_delete_file(
         &self,

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -140,7 +140,8 @@ impl MemoryCatalog {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Catalog for MemoryCatalog {
     /// List namespaces inside the catalog.
     async fn list_namespaces(

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -47,7 +47,8 @@ use crate::table::Table;
 use crate::{Error, ErrorKind, Result};
 
 /// The catalog API for Iceberg Rust.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(test, automock)]
 pub trait Catalog: Debug + Sync + Send {
     /// List namespaces inside the catalog.

--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -60,7 +60,7 @@ impl DeleteFileIndex {
         let state = Arc::new(RwLock::new(DeleteFileIndexState::Populating(
             notify.clone(),
         )));
-        let delete_file_stream = rx.boxed();
+        let delete_file_stream = Box::pin(rx);
 
         spawn({
             let state = state.clone();

--- a/crates/iceberg/src/future_util.rs
+++ b/crates/iceberg/src/future_util.rs
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! A module for `futures`-related utilities.
+//!
+//! The primary purpose of this module is to provide a type alias to maintain
+//! compatibility between WebAssembly (WASM) and native targets.
+//!
+//! `BoxedStream` is defined as a different type depending on the compilation target:
+//! - **Native environments (`not(target_arch = "wasm32")`)**: Uses `futures::stream::BoxStream`.
+//!   This stream implements the `Send` trait, allowing it to be safely sent across threads.
+//! - **WASM environments (`target_arch = "wasm32"`)**: Uses `futures::stream::LocalBoxStream`.
+//!   Since WASM is typically a single-threaded environment, `LocalBoxStream`, which is `!Send`,
+//!   is the appropriate choice.
+//!
+//! This conditional compilation allows for seamless support of various platforms
+//! while maintaining a single codebase.
+
+/// BoxedStream is the type alias of [`futures::stream::BoxStream`].
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxedStream<'a, T> = futures::stream::BoxStream<'a, T>;
+#[cfg(target_arch = "wasm32")]
+/// BoxedStream is the type alias of [`futures::stream::LocalBoxStream`].
+pub type BoxedStream<'a, T> = futures::stream::LocalBoxStream<'a, T>;

--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -24,7 +24,7 @@ use arrow_array::builder::{
 };
 use arrow_array::types::{Int32Type, Int64Type};
 use arrow_schema::{DataType, Field, Fields};
-use futures::{StreamExt, stream};
+use futures::stream;
 
 use crate::Result;
 use crate::arrow::schema_to_arrow_schema;
@@ -212,7 +212,7 @@ impl<'a> ManifestsTable<'a> {
             Arc::new(deleted_delete_files_count.finish()),
             Arc::new(partition_summaries.finish()),
         ])?;
-        Ok(stream::iter(vec![Ok(batch)]).boxed())
+        Ok(Box::pin(stream::iter(vec![Ok(batch)])))
     }
 
     fn partition_summary_builder(&self) -> Result<GenericListBuilder<i32, StructBuilder>> {

--- a/crates/iceberg/src/inspect/snapshots.rs
+++ b/crates/iceberg/src/inspect/snapshots.rs
@@ -22,7 +22,7 @@ use arrow_array::RecordBatch;
 use arrow_array::builder::{MapBuilder, MapFieldNames, PrimitiveBuilder, StringBuilder};
 use arrow_array::types::{Int64Type, TimestampMicrosecondType};
 use arrow_schema::{DataType, Field};
-use futures::{StreamExt, stream};
+use futures::stream;
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 
 use crate::Result;
@@ -130,7 +130,7 @@ impl<'a> SnapshotsTable<'a> {
             Arc::new(summary.finish()),
         ])?;
 
-        Ok(stream::iter(vec![Ok(batch)]).boxed())
+        Ok(Box::pin(stream::iter(vec![Ok(batch)])))
     }
 }
 

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -295,7 +295,8 @@ pub struct FileMetadata {
 ///
 /// It's possible for us to remove the async_trait, but we need to figure
 /// out how to handle the object safety.
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait FileRead: Send + Sync + Unpin + 'static {
     /// Read file content with given range.
     ///
@@ -303,7 +304,8 @@ pub trait FileRead: Send + Sync + Unpin + 'static {
     async fn read(&self, range: Range<u64>) -> crate::Result<Bytes>;
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl FileRead for opendal::Reader {
     async fn read(&self, range: Range<u64>) -> crate::Result<Bytes> {
         Ok(opendal::Reader::read(self, range).await?.to_bytes())
@@ -365,7 +367,8 @@ impl InputFile {
 ///
 /// It's possible for us to remove the async_trait, but we need to figure
 /// out how to handle the object safety.
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait FileWrite: Send + Unpin + 'static {
     /// Write bytes to file.
     ///
@@ -378,7 +381,8 @@ pub trait FileWrite: Send + Unpin + 'static {
     async fn close(&mut self) -> crate::Result<()>;
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl FileWrite for opendal::Writer {
     async fn write(&mut self, bs: Bytes) -> crate::Result<()> {
         Ok(opendal::Writer::write(self, bs).await?)
@@ -390,7 +394,8 @@ impl FileWrite for opendal::Writer {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl FileWrite for Box<dyn FileWrite> {
     async fn write(&mut self, bs: Bytes) -> crate::Result<()> {
         self.as_mut().write(bs).await

--- a/crates/iceberg/src/io/storage_s3.rs
+++ b/crates/iceberg/src/io/storage_s3.rs
@@ -208,7 +208,8 @@ impl CustomAwsCredentialLoader {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl AwsCredentialLoad for CustomAwsCredentialLoader {
     async fn load_credential(&self, client: Client) -> anyhow::Result<Option<AwsCredential>> {
         self.0.load_credential(client).await

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -91,6 +91,7 @@ mod runtime;
 
 pub mod arrow;
 pub(crate) mod delete_file_index;
+pub mod future_util;
 pub mod test_utils;
 mod utils;
 pub mod writer;

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -15,15 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::expr::BoundPredicate;
+use crate::future_util::BoxedStream;
 use crate::spec::{DataContentType, DataFileFormat, ManifestEntryRef, Schema, SchemaRef};
 
 /// A stream of [`FileScanTask`].
-pub type FileScanTaskStream = BoxStream<'static, Result<FileScanTask>>;
+pub type FileScanTaskStream = BoxedStream<'static, Result<FileScanTask>>;
 
 /// A task to scan part of file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/iceberg/src/transaction/action.rs
+++ b/crates/iceberg/src/transaction/action.rs
@@ -33,7 +33,8 @@ pub(crate) type BoxedTransactionAction = Arc<dyn TransactionAction>;
 /// Implementors of this trait define how a specific action is committed to a table.
 /// Each action is responsible for generating the updates and requirements needed
 /// to modify the table metadata.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub(crate) trait TransactionAction: AsAny + Sync + Send {
     /// Commits this action against the provided table and returns the resulting updates.
     /// NOTE: This function is intended for internal use only and should not be called directly by users.
@@ -120,7 +121,8 @@ mod tests {
 
     struct TestAction;
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransactionAction for TestAction {
         async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
             Ok(ActionCommit::new(

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -81,7 +81,8 @@ impl FastAppendAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for FastAppendAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
         let snapshot_producer = SnapshotProducer::new(

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::future::Future;
 use std::ops::RangeFrom;
 
 use uuid::Uuid;
@@ -38,14 +37,14 @@ const META_ROOT_PATH: &str = "metadata";
 pub(crate) trait SnapshotProduceOperation: Send + Sync {
     fn operation(&self) -> Operation;
     #[allow(unused)]
-    fn delete_entries(
+    async fn delete_entries(
         &self,
         snapshot_produce: &SnapshotProducer,
-    ) -> impl Future<Output = Result<Vec<ManifestEntry>>> + Send;
-    fn existing_manifest(
+    ) -> Result<Vec<ManifestEntry>>;
+    async fn existing_manifest(
         &self,
         snapshot_produce: &SnapshotProducer<'_>,
-    ) -> impl Future<Output = Result<Vec<ManifestFile>>> + Send;
+    ) -> Result<Vec<ManifestFile>>;
 }
 
 pub(crate) struct DefaultManifestProcess;

--- a/crates/iceberg/src/transaction/sort_order.rs
+++ b/crates/iceberg/src/transaction/sort_order.rs
@@ -97,7 +97,8 @@ impl Default for ReplaceSortOrderAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for ReplaceSortOrderAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
         let current_schema = table.metadata().current_schema();

--- a/crates/iceberg/src/transaction/update_location.rs
+++ b/crates/iceberg/src/transaction/update_location.rs
@@ -59,7 +59,8 @@ impl Default for UpdateLocationAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for UpdateLocationAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
         let updates: Vec<TableUpdate>;

--- a/crates/iceberg/src/transaction/update_properties.rs
+++ b/crates/iceberg/src/transaction/update_properties.rs
@@ -80,7 +80,8 @@ impl Default for UpdatePropertiesAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for UpdatePropertiesAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
         if let Some(overlapping_key) = self.removals.iter().find(|k| self.updates.contains_key(*k))

--- a/crates/iceberg/src/transaction/update_statistics.rs
+++ b/crates/iceberg/src/transaction/update_statistics.rs
@@ -74,7 +74,8 @@ impl Default for UpdateStatisticsAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for UpdateStatisticsAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
         let mut updates: Vec<TableUpdate> = vec![];

--- a/crates/iceberg/src/transaction/upgrade_format_version.rs
+++ b/crates/iceberg/src/transaction/upgrade_format_version.rs
@@ -63,7 +63,8 @@ impl Default for UpgradeFormatVersionAction {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransactionAction for UpgradeFormatVersionAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {
         let format_version = self.format_version.ok_or_else(|| {

--- a/crates/iceberg/src/writer/base_writer/data_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/data_file_writer.rs
@@ -44,7 +44,8 @@ impl<B: FileWriterBuilder> DataFileWriterBuilder<B> {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<B: FileWriterBuilder> IcebergWriterBuilder for DataFileWriterBuilder<B> {
     type R = DataFileWriter<B>;
 
@@ -65,7 +66,8 @@ pub struct DataFileWriter<B: FileWriterBuilder> {
     partition_spec_id: i32,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<B: FileWriterBuilder> IcebergWriter for DataFileWriter<B> {
     async fn write(&mut self, batch: RecordBatch) -> Result<()> {
         self.inner_writer.as_mut().unwrap().write(&batch).await

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -109,7 +109,8 @@ impl EqualityDeleteWriterConfig {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<B: FileWriterBuilder> IcebergWriterBuilder for EqualityDeleteFileWriterBuilder<B> {
     type R = EqualityDeleteFileWriter<B>;
 
@@ -134,7 +135,8 @@ pub struct EqualityDeleteFileWriter<B: FileWriterBuilder> {
     partition_spec_id: i32,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<B: FileWriterBuilder> IcebergWriter for EqualityDeleteFileWriter<B> {
     async fn write(&mut self, batch: RecordBatch) -> Result<()> {
         let batch = self.projector.project_batch(batch)?;

--- a/crates/iceberg/src/writer/file_writer/mod.rs
+++ b/crates/iceberg/src/writer/file_writer/mod.rs
@@ -19,6 +19,7 @@
 
 use arrow_array::RecordBatch;
 use futures::Future;
+use opendal::raw::MaybeSend;
 
 use super::CurrentFileStatus;
 use crate::Result;
@@ -44,7 +45,7 @@ pub trait FileWriterBuilder<O = DefaultOutput>: Send + Clone + 'static {
 /// File writer focus on writing record batch to different physical file format.(Such as parquet. orc)
 pub trait FileWriter<O = DefaultOutput>: Send + CurrentFileStatus + 'static {
     /// Write record batch to file.
-    fn write(&mut self, batch: &RecordBatch) -> impl Future<Output = Result<()>> + Send;
+    fn write(&mut self, batch: &RecordBatch) -> impl Future<Output = Result<()>> + MaybeSend;
     /// Close file writer.
-    fn close(self) -> impl Future<Output = Result<O>> + Send;
+    fn close(self) -> impl Future<Output = Result<O>> + MaybeSend;
 }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 use bytes::Bytes;
-use futures::future::BoxFuture;
 use itertools::Itertools;
+use opendal::raw::BoxedFuture;
 use parquet::arrow::AsyncArrowWriter;
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::async_writer::AsyncFileWriter as ArrowAsyncFileWriter;
@@ -659,7 +659,7 @@ impl<W: FileWrite> AsyncFileWriter<W> {
 }
 
 impl<W: FileWrite> ArrowAsyncFileWriter for AsyncFileWriter<W> {
-    fn write(&mut self, bs: Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
+    fn write(&mut self, bs: Bytes) -> BoxedFuture<'_, parquet::errors::Result<()>> {
         Box::pin(async {
             self.0
                 .write(bs)
@@ -668,7 +668,7 @@ impl<W: FileWrite> ArrowAsyncFileWriter for AsyncFileWriter<W> {
         })
     }
 
-    fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
+    fn complete(&mut self) -> BoxedFuture<'_, parquet::errors::Result<()>> {
         Box::pin(async {
             self.0
                 .close()

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -136,7 +136,8 @@
 //!     }
 //! }
 //!
-//! #[async_trait::async_trait]
+//! #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+//! #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 //! impl<B: IcebergWriterBuilder> IcebergWriterBuilder for LatencyRecordWriterBuilder<B> {
 //!     type R = LatencyRecordWriter<B::R>;
 //!
@@ -150,7 +151,8 @@
 //!     inner_writer: W,
 //! }
 //!
-//! #[async_trait::async_trait]
+//! #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+//! #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 //! impl<W: IcebergWriter> IcebergWriter for LatencyRecordWriter<W> {
 //!     async fn write(&mut self, input: RecordBatch) -> Result<()> {
 //!         let start = Instant::now();
@@ -235,7 +237,8 @@ type DefaultInput = RecordBatch;
 type DefaultOutput = Vec<DataFile>;
 
 /// The builder for iceberg writer.
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>:
     Send + Clone + 'static
 {
@@ -246,7 +249,8 @@ pub trait IcebergWriterBuilder<I = DefaultInput, O = DefaultOutput>:
 }
 
 /// The iceberg writer used to write data to iceberg table.
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait IcebergWriter<I = DefaultInput, O = DefaultOutput>: Send + 'static {
     /// Write data to iceberg table.
     async fn write(&mut self, input: I) -> Result<()>;

--- a/crates/integrations/datafusion/src/table/metadata_table.rs
+++ b/crates/integrations/datafusion/src/table/metadata_table.rs
@@ -27,8 +27,8 @@ use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::ExecutionPlan;
 use futures::TryStreamExt;
-use futures::stream::BoxStream;
 use iceberg::arrow::schema_to_arrow_schema;
+use iceberg::future_util::BoxedStream;
 use iceberg::inspect::MetadataTableType;
 use iceberg::table::Table;
 
@@ -74,7 +74,7 @@ impl TableProvider for IcebergMetadataTableProvider {
 }
 
 impl IcebergMetadataTableProvider {
-    pub async fn scan(self) -> DFResult<BoxStream<'static, DFResult<RecordBatch>>> {
+    pub async fn scan(self) -> DFResult<BoxedStream<'static, DFResult<RecordBatch>>> {
         let metadata_table = self.table.inspect();
         let stream = match self.r#type {
             MetadataTableType::Snapshots => metadata_table.snapshots().scan().await,

--- a/crates/sqllogictest/src/engine/datafusion.rs
+++ b/crates/sqllogictest/src/engine/datafusion.rs
@@ -33,7 +33,8 @@ pub struct DataFusionEngine {
     datafusion: DataFusion,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl EngineRunner for DataFusionEngine {
     async fn run_slt_file(&mut self, path: &Path) -> Result<()> {
         let content = std::fs::read_to_string(path)

--- a/crates/sqllogictest/src/engine/mod.rs
+++ b/crates/sqllogictest/src/engine/mod.rs
@@ -27,7 +27,8 @@ use crate::error::Result;
 const KEY_TYPE: &str = "type";
 const TYPE_DATAFUSION: &str = "datafusion";
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait EngineRunner: Sized {
     async fn run_slt_file(&mut self, path: &Path) -> Result<()>;
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1710.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Add support for WASM targets below:

- wasm32-wasip1
- wasm32-wasip2

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Currently there build steps below are passed on my local machine:

- `cargo build --package parquet --target wasm32-wasip1 -p parquet --no-default-features --features tokio`
- `cargo build --package parquet --target wasm32-wasip2 -p parquet --no-default-features --features tokio`

These steps are still in progress:

- [ ] `parquet`'s WASM support (single-thread support): https://github.com/apache/arrow-rs/issues/7612
- [ ] Add support for storage backends --> `OpenDAL`'s WASM support for storage backends
- [ ] Passing tests
