### PR TITLE
ci: Don't dismiss stale review to make contribution easier

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,7 +40,7 @@ github:
 
       required_pull_request_reviews:
         required_approving_review_count: 1
-        dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
 
       required_linear_history: true
   del_branch_on_merge: true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

I made this change to avoid dismissing stale reviews to make contributions easier.

iceberg is quite active, and we nearly have conflicts every day. It can be a pain for contributors to get approved, especially after resolving conflicts—they then have to wait for reviewers to give another approval.

I think we can make it clear that trivial changes like resolving merge conflicts are allowed, but adding other code changes aren't. We can just add this to the docs so it’s easier for everyone.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->