### PR TITLE
infra: use apache/hive:4.0.0 as hive Dockerfile base image

### DIFF
--- a/crates/catalog/hms/testdata/hms_catalog/Dockerfile
+++ b/crates/catalog/hms/testdata/hms_catalog/Dockerfile
@@ -13,24 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM openjdk:8-jre-slim AS build
-
-ARG BUILDPLATFORM
-
-RUN apt-get update -qq && apt-get -qq -y install curl
-
-ENV AWSSDK_VERSION=2.20.18
-ENV HADOOP_VERSION=3.1.0
-
-RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar -Lo /tmp/aws-java-sdk-bundle-1.11.271.jar
-RUN curl https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar -Lo /tmp/hadoop-aws-${HADOOP_VERSION}.jar
-
-
 FROM apache/hive:3.1.3
 
 ENV AWSSDK_VERSION=2.20.18
 ENV HADOOP_VERSION=3.1.0
 
-COPY --from=build /tmp/hadoop-aws-${HADOOP_VERSION}.jar /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar
-COPY --from=build /tmp/aws-java-sdk-bundle-1.11.271.jar /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar
+USER root
+
+RUN apt-get update -qq && apt-get -qq -y install curl && \
+    curl https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar -Lo /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar && \
+    curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar -Lo /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+
+USER hive


### PR DESCRIPTION
## What changes are included in this PR?

We had some failures in the Pyiceberg repo with the hive docker file here: https://github.com/apache/iceberg-python/pull/2697, so I'm porting this over here.

The HMS test Dockerfile was using a deprecated `openjdk:8-jre-slim` base image that has very **recently** been removed from Docker Hub, causing build failures:

```
#7 ERROR: docker.io/library/openjdk:8-jre-slim: not found
```

Simplified the Dockerfile to use apache/hive:3.1.3 as the base image directly, also eliminating the multi-stage build pattern. Which removes the dependency on a deprecated OpenJDK image and will use what's included in hive, and maintains the same functionality for HMS integration tests.

Inspired by [](https://github.com/trinodb/docker-images/blob/master/testing/hive4.0-hive/Dockerfile)<https://github.com/trinodb/docker-images/blob/master/testing/hive4.0-hive/Dockerfile>
