### PR TITLE
pyiceberg-core: create even smaller artifacts 

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -41,5 +41,6 @@ tokio = { version = "1.46.1", default-features = false }
 [profile.release]
 codegen-units = 1
 debug = false
-lto = "fat"
+lto = "thin"
+opt-level = "z"
 strip = true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1839

## What changes are included in this PR?
use `lto = "thin", opt-level = "z"`

Tested building the wheel locally on mac. And this is the winning combination. 

Change                  | Wheel Size | Build Time | Notes
------------------------|------------|------------|------------------
fat LTO, opt-level=3 (default)    | 21 MB      | ~3 min     | Original
fat LTO, opt-level=z    | 12 MB      | ~3 min     | 43% smaller
thin LTO, opt-level=z   | 12 MB      | ~1.5 min   | Same size, 2x faster build!
no LTO, opt-level=z     | 13 MB      | ~1 min     | Slightly bigger

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

### Size Reduction
[This branch](https://github.com/apache/iceberg-rust/actions/runs/19285828822) vs [main branch w/ #1841](https://github.com/apache/iceberg-rust/actions/runs/19280546898/attempts/1)

| Name                                           | Old Size | New Size | % Decrease |
|-----------------------------------------------|----------|----------|------------|
| wheels-macos-latest-universal2-apple-darwin  | 44.4 MB  | 23.5 MB  | 47.07%     |
| wheels-ubuntu-latest-aarch64                 | 66.1 MB   | 40.9 MB  | 38.12%     |
| wheels-ubuntu-latest-armv7l                  | 70.5 MB   | 33.1 MB  | 53.05%     |
| wheels-ubuntu-latest-x86_64                  | 23.8 MB| 13 MB  | 45.38%     |
| wheels-windows-latest                        | 25.9 MB  | 12.7 MB  | 45.38%     |
| wheels-sdist                                 | 575 KB   | 574 KB  

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes 
https://github.com/apache/iceberg-rust/actions/runs/19285828822