### PR TITLE
use RecordBatchTransformerBuilder instead of RecordBatchTransformer

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -792,7 +792,8 @@ mod test {
         let projected_iceberg_field_ids = [1, 2, 3];
 
         let mut transformer =
-            RecordBatchTransformer::build(snapshot_schema, &projected_iceberg_field_ids);
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
 
         let file_schema = Arc::new(ArrowSchema::new(vec![
             simple_field("id", DataType::Int32, false, "1"),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
This should fix CI, currently broken with
```
795 |             RecordBatchTransformer::build(snapshot_schema, &projected_iceberg_field_ids);
    |                                     ^^^^^ function or associated item not found in `RecordBatchTransformer`
```

Likely due to merge conflict between https://github.com/apache/iceberg-rust/pull/1847/files#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cR637 and https://github.com/apache/iceberg-rust/pull/1821/files#diff-640415fbb0b37eac6f774eff524fb364c4e54c02da3a3c0e355af5caa941007cR149

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->