### PR TITLE
infra: use new `del_branch_on_merge` in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,7 +43,9 @@ github:
         dismiss_stale_reviews: false
 
       required_linear_history: true
-  del_branch_on_merge: true
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
   features:
     wiki: false
     issues: true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->
Previous use of `del_branch_on_merge` 
```
github:
  del_branch_on_merge: true
```
is deprecated, https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#delete-branch-on-merge

New way is to 
```
github:
  pull_requests:
    del_branch_on_merge: true
```
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#pull_requests

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->