### PR TITLE
feat(catalog): Implement update_table for Hive metastore catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ dependencies = [
  "tracing",
  "volo",
  "volo-thrift",
+ "whoami",
 ]
 
 [[package]]
@@ -7505,6 +7506,7 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,4 +131,5 @@ url = "2.5.7"
 uuid = { version = "1.18", features = ["v7"] }
 volo = "0.10.6"
 volo-thrift = "0.10.8"
+whoami = "1.6.1"
 zstd = "0.13.3"

--- a/crates/catalog/hms/Cargo.toml
+++ b/crates/catalog/hms/Cargo.toml
@@ -52,6 +52,7 @@ linkedbytes = { workspace = true }
 metainfo = { workspace = true }
 motore-macros = { workspace = true }
 volo = { workspace = true }
+whoami = "1.6.1"
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/crates/catalog/hms/Cargo.toml
+++ b/crates/catalog/hms/Cargo.toml
@@ -52,7 +52,7 @@ linkedbytes = { workspace = true }
 metainfo = { workspace = true }
 motore-macros = { workspace = true }
 volo = { workspace = true }
-whoami = "1.6.1"
+whoami = { workspace = true }
 
 [dev-dependencies]
 ctor = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

- Addresses update_table for https://github.com/apache/iceberg-rust/issues/1893

## What changes are included in this PR?

update_table for HMS catalog.
The implementation is based on other iceberg implementations, Trino and Hive code bases.

## Are these changes tested?

The existing tests were modified, and extensive manual tests were performed.