### PR TITLE
Upgrade opendal to v0.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,10 +4015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4030,6 +4032,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -4742,20 +4759,20 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opendal"
-version = "0.54.1"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
 dependencies = [
  "anyhow",
  "backon",
  "base64 0.22.1",
  "bytes",
- "chrono",
  "crc32c",
  "futures",
  "getrandom 0.2.16",
  "http 1.3.1",
  "http-body 1.0.1",
+ "jiff",
  "log",
  "md-5",
  "percent-encoding",
@@ -4765,6 +4782,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,9 @@ http = "1.2"
 iceberg = { version = "0.7.0", path = "./crates/iceberg" }
 iceberg-catalog-glue = { version = "0.7.0", path = "./crates/catalog/glue" }
 iceberg-catalog-hms = { version = "0.7.0", path = "./crates/catalog/hms" }
-iceberg-catalog-sql = { version = "0.7.0", path = "./crates/catalog/sql" }
 iceberg-catalog-rest = { version = "0.7.0", path = "./crates/catalog/rest" }
 iceberg-catalog-s3tables = { version = "0.7.0", path = "./crates/catalog/s3tables" }
+iceberg-catalog-sql = { version = "0.7.0", path = "./crates/catalog/sql" }
 iceberg-datafusion = { version = "0.7.0", path = "./crates/integrations/datafusion" }
 indicatif = "0.18"
 itertools = "0.13"
@@ -99,7 +99,7 @@ motore-macros = "0.4.3"
 murmur3 = "0.5.2"
 num-bigint = "0.4.6"
 once_cell = "1.20"
-opendal = "0.54.0"
+opendal = "0.55.0"
 ordered-float = "4"
 parquet = "56.2"
 pilota = "0.11.10"


### PR DESCRIPTION
## What changes are included in this PR?

Dependency upgrade is supposed to perform automatically via dependabot, but somehow I didn't see it this weekend.

## Are these changes tested?

Checked with local iceberg unit tests and seem fine.