### PR TITLE
Remove wildcard pattern in exhaustive enums

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -169,7 +169,7 @@ impl SchemaVisitor for GlueSchemaBuilder {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
                     format!("Conversion from {p:?} is not supported"),
-                ))
+                ));
             }
             PrimitiveType::Time | PrimitiveType::String | PrimitiveType::Uuid => {
                 "string".to_string()

--- a/crates/catalog/hms/src/schema.rs
+++ b/crates/catalog/hms/src/schema.rs
@@ -126,7 +126,7 @@ impl SchemaVisitor for HiveSchemaBuilder {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
                     format!("Conversion from {p:?} is not supported"),
-                ))
+                ));
             }
             PrimitiveType::Time | PrimitiveType::String | PrimitiveType::Uuid => {
                 "string".to_string()


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1924.

## What changes are included in this PR?

- For match expression on `PrimitiveType`, removes wildcard and explicitly handles all enum variants.
- Removes support of `PrimititveType::TimestampzNs` for HMS and Glue.
   - Hive/HMS does not support timezone aware timestamps, per [Hive docs](https://cwiki.apache.org/confluence/display/hive/languagemanual+types#LanguageManualTypes-TimestampstimestampTimestamps).
   - Glue uses the Hive type system so it should also be disabled for Glue.


## Are these changes tested?

Tested with existing test suite