### PR TITLE
fix: prioritize delete manifests to prevent scan deadlock

### DIFF
--- a/crates/iceberg/src/scan/context.rs
+++ b/crates/iceberg/src/scan/context.rs
@@ -194,7 +194,17 @@ impl PlanContext {
         delete_file_idx: DeleteFileIndex,
         delete_file_tx: Sender<ManifestEntryContext>,
     ) -> Result<Box<impl Iterator<Item = Result<ManifestFileContext>> + 'static>> {
-        let manifest_files = manifest_list.entries().iter();
+        let mut manifest_files = manifest_list.entries().iter().collect::<Vec<_>>();
+        // Sort manifest files to process delete manifests first.
+        // This avoids a deadlock where the producer blocks on sending data manifest entries
+        // (because the data channel is full) while the delete manifest consumer is waiting
+        // for delete manifest entries (which haven't been produced yet).
+        // By processing delete manifests first, we ensure the delete consumer can finish,
+        // which then allows the data consumer to start draining the data channel.
+        manifest_files.sort_by_key(|m| match m.content {
+            ManifestContentType::Deletes => 0,
+            ManifestContentType::Data => 1,
+        });
 
         // TODO: Ideally we could ditch this intermediate Vec as we return an iterator.
         let mut filtered_mfcs = vec![];


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## What changes are included in this PR?

This change ensures that delete manifests are processed before data manifests during the table scan planning phase.
Previously, if data manifests were processed first and produced enough entries to fill the channel, the producer would block. Since the delete manifest consumer might still be waiting for its entries (which hadn't been produced yet), this could lead to a deadlock. Prioritizing delete manifests ensures the delete consumer can proceed, allowing the data consumer to eventually drain the channel.

## Are these changes tested?

Added a reproduction test case `test_scan_deadlock` to verify the fix.