### PR TITLE
feat(sqllogictest): support dynamic catalog configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "enum-ordinalize",
  "env_logger",
  "iceberg",
+ "iceberg-catalog-loader",
  "iceberg-datafusion",
  "indicatif",
  "libtest-mimic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ http = "1.2"
 iceberg = { version = "0.8.0", path = "./crates/iceberg" }
 iceberg-catalog-glue = { version = "0.8.0", path = "./crates/catalog/glue" }
 iceberg-catalog-hms = { version = "0.8.0", path = "./crates/catalog/hms" }
+iceberg-catalog-loader = { version = "0.8.0", path = "./crates/catalog/loader" }
 iceberg-catalog-rest = { version = "0.8.0", path = "./crates/catalog/rest" }
 iceberg-catalog-s3tables = { version = "0.8.0", path = "./crates/catalog/s3tables" }
 iceberg-catalog-sql = { version = "0.8.0", path = "./crates/catalog/sql" }

--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -32,6 +32,7 @@ datafusion-sqllogictest = { workspace = true }
 enum-ordinalize = { workspace = true }
 env_logger = { workspace = true }
 iceberg = { workspace = true }
+iceberg-catalog-loader = { workspace = true }
 iceberg-datafusion = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }

--- a/crates/sqllogictest/src/schedule.rs
+++ b/crates/sqllogictest/src/schedule.rs
@@ -204,4 +204,31 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_parse_engines_with_catalog_config() {
+        let toml_content = r#"
+            [engines]
+            df = { type = "datafusion", catalog_type = "memory" }
+        "#;
+
+        let table: TomlTable = toml::from_str(toml_content).unwrap();
+        let result = Schedule::parse_engines(&table).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_parse_engines_default_catalog() {
+        let toml_content = r#"
+            [engines]
+            df = { type = "datafusion" }
+        "#;
+
+        let table: TomlTable = toml::from_str(toml_content).unwrap();
+        let result = Schedule::parse_engines(&table).await;
+
+        // Should default to memory catalog
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1780

## What changes are included in this PR?

This PR adds support for configuring the catalog type dynamically per engine in sqllogictest schedule files.

### Changes:
- Add `catalog_type` and `catalog_properties` fields to engine configuration
- Support `memory` catalog (default) and all catalog types from `iceberg-catalog-loader` (rest, glue, hms, sql, s3tables)
- Add `iceberg-catalog-loader` dependency to the workspace

### Example configuration:

```toml
[engines]
df = { type = "datafusion", catalog_type = "rest", catalog_properties = { uri = "http://localhost:8181" } }

[[steps]]
engine = "df"
slt = "test.slt"
```

If no `catalog_type` is specified, defaults to memory catalog for backward compatibility.

## Are these changes tested?

Yes, unit tests added for:
- Engine loading with default catalog
- Engine loading with explicit memory catalog configuration

Note: pr body updated after maintainer's review and feedbacks