### PR TITLE
refactor(arrow): Rename parameter in delete_filter for clarity

### DIFF
--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -82,12 +82,12 @@ impl DeleteFilter {
     /// Retrieve a delete vector for a data file
     pub(crate) fn get_delete_vector_for_path(
         &self,
-        delete_file_path: &str,
+        data_file_path: &str,
     ) -> Option<Arc<Mutex<DeleteVector>>> {
         self.state
             .read()
             .ok()
-            .and_then(|st| st.delete_vectors.get(delete_file_path).cloned())
+            .and_then(|st| st.delete_vectors.get(data_file_path).cloned())
     }
 
     pub(crate) fn try_start_eq_del_load(&self, file_path: &str) -> Option<Arc<Notify>> {


### PR DESCRIPTION
The parameter `delete_file_path` in `get_delete_vector_for_path` was misleading because the function expects a data file path, not a delete file path. Renaming it to `data_file_path` accurately reflects its usage.