### PR TITLE
infra: release script, validate proper ICEBERG_VERSION variable

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,6 +25,12 @@ else
 	echo "var is set to '$ICEBERG_VERSION'"
 fi
 
+# Validate version format (e.g., 1.0.0)
+if [[ ! "$ICEBERG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "Error: ICEBERG_VERSION ($ICEBERG_VERSION) must be in the format: <number>.<number>.<number>"
+	exit 1
+fi
+
 # tar source code
 release_version=${ICEBERG_VERSION}
 # rc versions


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Add a check that the input `ICEBERG_VERSION` variable is in the proper format, i.e. `0.8.0`. Otherwise, the source directory and zip file will have the wrong name

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Added these 3 lines:
```
echo "Release version: $release_version"
echo "Git branch: $git_branch"
echo "Source directory: apache-iceberg-rust-$release_version"
```

This PR:
```
➜  iceberg-rust git:(kevinjqliu/validate-version) ✗ ICEBERG_VERSION=rc.1 ./scripts/release.sh  
var is set to 'rc.1'
Error: ICEBERG_VERSION (rc.1) must be in the format: <number>.<number>.<number>
➜  iceberg-rust git:(kevinjqliu/validate-version) ✗ ICEBERG_VERSION=0.8.0 ./scripts/release.sh 
var is set to '0.8.0'
Release version: 0.8.0
Git branch: release-0.8.0-rc.1
Source directory: apache-iceberg-rust-0.8.0
```

main:
```
➜  iceberg-rust git:(kevinjqliu/validate-version) ✗ ICEBERG_VERSION=rc.1 ./scripts/release.sh 
var is set to 'rc.1'
Release version: rc.1
Git branch: release-rc.1-rc.1
Source directory: apache-iceberg-rust-rc.1
➜  iceberg-rust git:(kevinjqliu/validate-version) ✗ ICEBERG_VERSION=0.8.0 ./scripts/release.sh
var is set to '0.8.0'
Release version: 0.8.0
Git branch: release-0.8.0-rc.1
Source directory: apache-iceberg-rust-0.8.0
```