### PR TITLE
fix: MemoryCatalog to return absolute NamespaceIdents

### DIFF
--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -166,9 +166,9 @@ impl Catalog for MemoryCatalog {
                     .map(|name| {
                         let mut names = parent_namespace_ident.iter().cloned().collect::<Vec<_>>();
                         names.push(name.to_string());
-                        NamespaceIdent::from_vec(names).unwrap()
+                        NamespaceIdent::from_vec(names)
                     })
-                    .collect_vec();
+                    .collect::<Result<Vec<_>>>()?;
 
                 Ok(namespaces)
             }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1969.

## What changes are included in this PR?

The change makes `list_namespaces(parent)` return an absolute namespace identifier instead of a relative.

## Are these changes tested?

The associated unit tests are updated with the same behaviour as SqlCatalog.
