### PR TITLE
fix: Reserved sort order ID cannot contain any fields

### DIFF
--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -511,7 +511,7 @@ impl TableMetadata {
             && !sort_order.fields.is_empty()
         {
             return Err(Error::new(
-                ErrorKind::DataInvalid,
+                ErrorKind::Unexpected,
                 format!(
                     "Sort order ID {} is reserved for unsorted order",
                     SortOrder::UNSORTED_ORDER_ID


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1963.

## What changes are included in this PR?

This change validates that table metadata with reserved sort order ID (0) cannot contain fields associated with it. If this is found, we error out instead of silently parsing arbitrary field values.

## Are these changes tested?

Added the unit test described in the issue and verified that the check is now enforced.