### PR TITLE
fix: use localhost for Docker integration tests

### DIFF
--- a/crates/iceberg/testdata/file_io_gcs/docker-compose.yaml
+++ b/crates/iceberg/testdata/file_io_gcs/docker-compose.yaml
@@ -18,6 +18,8 @@
 services:
   gcs-server:
     image: fsouza/fake-gcs-server@sha256:36b0116fae5236e8def76ccb07761a9ca323e476f366a5f4bf449cac19deaf2d
+    ports:
+      - 4443:4443
     expose:
       - 4443
     command: --scheme http

--- a/crates/iceberg/testdata/file_io_s3/docker-compose.yaml
+++ b/crates/iceberg/testdata/file_io_s3/docker-compose.yaml
@@ -18,6 +18,8 @@
 services:
   minio:
     image: minio/minio:RELEASE.2024-02-26T09-33-48Z
+    ports:
+      - 9002:9000
     expose:
       - 9000
       - 9001

--- a/crates/iceberg/tests/file_io_gcs_test.rs
+++ b/crates/iceberg/tests/file_io_gcs_test.rs
@@ -53,13 +53,7 @@ mod tests {
     async fn get_file_io_gcs() -> FileIO {
         set_up();
 
-        let ip = DOCKER_COMPOSE_ENV
-            .read()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .get_container_ip("gcs-server");
-        let addr = SocketAddr::new(ip, FAKE_GCS_PORT);
+        let addr = SocketAddr::new("127.0.0.1".parse().unwrap(), FAKE_GCS_PORT);
 
         // A bucket must exist for FileIO
         create_bucket(FAKE_GCS_BUCKET, addr.to_string())

--- a/crates/integration_tests/src/lib.rs
+++ b/crates/integration_tests/src/lib.rs
@@ -23,6 +23,7 @@ use iceberg_test_utils::docker::DockerCompose;
 use iceberg_test_utils::{normalize_test_name, set_up};
 
 const REST_CATALOG_PORT: u16 = 8181;
+const MINIO_PORT: u16 = 9000;
 
 pub struct TestFixture {
     pub _docker_compose: DockerCompose,
@@ -36,21 +37,17 @@ pub fn set_test_fixture(func: &str) -> TestFixture {
         format!("{}/testdata", env!("CARGO_MANIFEST_DIR")),
     );
 
-    // Stop any containers from previous runs and start new ones
     docker_compose.down();
     docker_compose.up();
-
-    let rest_catalog_ip = docker_compose.get_container_ip("rest");
-    let minio_ip = docker_compose.get_container_ip("minio");
 
     let catalog_config = HashMap::from([
         (
             REST_CATALOG_PROP_URI.to_string(),
-            format!("http://{rest_catalog_ip}:{REST_CATALOG_PORT}"),
+            format!("http://127.0.0.1:{REST_CATALOG_PORT}"),
         ),
         (
             S3_ENDPOINT.to_string(),
-            format!("http://{}:{}", minio_ip, 9000),
+            format!("http://127.0.0.1:{MINIO_PORT}"),
         ),
         (S3_ACCESS_KEY_ID.to_string(), "admin".to_string()),
         (S3_SECRET_ACCESS_KEY.to_string(), "password".to_string()),

--- a/crates/integration_tests/testdata/docker-compose.yaml
+++ b/crates/integration_tests/testdata/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
     networks:
       rest_bridge:
     ports:
+      - 9000:9000
       - 9001:9001
     expose:
       - 9001


### PR DESCRIPTION
## Which issue does this PR close?

N/A - fixes test infrastructure issue on macOS.

## What changes are included in this PR?

Docker integration tests use container IPs (172.x.x.x) which aren't routable from the host on macOS with Docker Desktop. Changed to use localhost with published ports instead.

## Are these changes tested?

Yes - all Docker-based tests pass on macOS:
- Integration tests: 7 pass
- GCS file_io: 3 pass
- S3 file_io: 8 pass