### PR TITLE
infra: fix manual trigger for the "release python" github workflow

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -23,10 +23,11 @@ on:
     types:
       - completed
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}-${{ github.event_name }}
-  cancel-in-progress: true
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., v0.4.0 or v0.4.0-rc.1)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -46,12 +47,20 @@ jobs:
       cargo-version: ${{ steps.validate.outputs.cargo-version }}
       is-rc: ${{ steps.validate.outputs.is-rc }}
     steps:
+      - uses: actions/checkout@v6
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+
       - name: Validate release tag format
         id: validate
+        # Use input for workflow_dispatch, otherwise use `workflow_run.head_branch`
         # Note, `workflow_run.head_branch` does not contain `refs/tags/` prefix, just the tag name, i.e. `v0.4.0` or `v0.4.0-rc.1`
         # Valid formats: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc.<release_candidate>
         run: |
-          RELEASE_TAG="${{ github.event.workflow_run.head_branch }}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          else
+            RELEASE_TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
           echo "Validating release tag: $RELEASE_TAG"
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
             echo "❌ Invalid release tag format: $RELEASE_TAG"
@@ -64,6 +73,26 @@ jobs:
           # Strip 'v' prefix for cargo version
           CARGO_VERSION="${RELEASE_TAG#v}"
           echo "Cargo version (without v prefix): $CARGO_VERSION"
+          
+          # For manual triggers, validate that the tag matches the version in Cargo.toml
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Extract base version (without -rc.X suffix) for comparison with Cargo.toml
+            BASE_VERSION="${CARGO_VERSION%-rc.*}"
+            echo "Base version (for Cargo.toml comparison): $BASE_VERSION"
+            
+            # Read version from Cargo.toml and validate it matches
+            CARGO_TOML_VERSION=$(grep '^version = ' bindings/python/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+            echo "Version in bindings/python/Cargo.toml: $CARGO_TOML_VERSION"
+            
+            if [ "$BASE_VERSION" != "$CARGO_TOML_VERSION" ]; then
+              echo "❌ Version mismatch!"
+              echo "   Release tag base version: $BASE_VERSION"
+              echo "   bindings/python/Cargo.toml version: $CARGO_TOML_VERSION"
+              echo "Please ensure the release tag matches the version in Cargo.toml"
+              exit 1
+            fi
+            echo "✅ Version matches bindings/python/Cargo.toml"
+          fi
           
           # Check if this is a release candidate
           if [[ "$RELEASE_TAG" =~ -rc\.[0-9]+$ ]]; then


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2038

This unblocks us to publish python binding to pypi

## What changes are included in this PR?
Need to manually trigger `.github/workflows/release_python.yml` to publish python binding to pypi. 
This PR fixes the manual flow by allowing to specify `RELEASE_TAG` as input. Added an extra validation for the manual workflow to check the version against the library version in `bindings/python/Cargo.toml` 

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->