### PR TITLE
feat(datafusion): Add Boolean predicate pushdown support

### DIFF
--- a/crates/sqllogictest/src/engine/datafusion.rs
+++ b/crates/sqllogictest/src/engine/datafusion.rs
@@ -96,7 +96,6 @@ impl DataFusionEngine {
         // Create partitioned test table (unpartitioned tables are now created via SQL)
         Self::create_partitioned_table(&catalog, &namespace).await?;
         Self::create_binary_table(&catalog, &namespace).await?;
-        Self::create_boolean_table(&catalog, &namespace).await?;
 
         Ok(Arc::new(
             IcebergCatalogProvider::try_new(Arc::new(catalog)).await?,
@@ -156,34 +155,6 @@ impl DataFusionEngine {
                 namespace,
                 TableCreation::builder()
                     .name("test_binary_table".to_string())
-                    .schema(schema)
-                    .build(),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Create a test table with boolean type column
-    /// Used for testing boolean predicate pushdown
-    /// TODO: this can be removed when we support CREATE TABLE
-    async fn create_boolean_table(
-        catalog: &impl Catalog,
-        namespace: &NamespaceIdent,
-    ) -> anyhow::Result<()> {
-        let schema = Schema::builder()
-            .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "is_active", Type::Primitive(PrimitiveType::Boolean)).into(),
-                NestedField::optional(3, "description", Type::Primitive(PrimitiveType::String)).into(),
-            ])
-            .build()?;
-
-        catalog
-            .create_table(
-                namespace,
-                TableCreation::builder()
-                    .name("test_boolean_table".to_string())
                     .schema(schema)
                     .build(),
             )

--- a/crates/sqllogictest/testdata/slts/df_test/boolean_predicate_pushdown.slt
+++ b/crates/sqllogictest/testdata/slts/df_test/boolean_predicate_pushdown.slt
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Create test table with boolean column
+statement ok
+CREATE TABLE default.default.test_boolean_table (id INT NOT NULL, is_active BOOLEAN, description STRING)
+
 # Insert test data into test_boolean_table
 statement ok
 INSERT INTO default.default.test_boolean_table VALUES
@@ -120,3 +124,7 @@ SELECT * FROM default.default.test_boolean_table WHERE is_active IS NOT NULL
 3 true Premium member
 4 false Trial expired
 5 true Verified account
+
+# Clean up: Drop the test table
+statement ok
+DROP TABLE default.default.test_boolean_table

--- a/crates/sqllogictest/testdata/slts/df_test/show_tables.slt
+++ b/crates/sqllogictest/testdata/slts/df_test/show_tables.slt
@@ -28,9 +28,6 @@ datafusion information_schema views VIEW
 default default test_binary_table BASE TABLE
 default default test_binary_table$manifests BASE TABLE
 default default test_binary_table$snapshots BASE TABLE
-default default test_boolean_table BASE TABLE
-default default test_boolean_table$manifests BASE TABLE
-default default test_boolean_table$snapshots BASE TABLE
 default default test_partitioned_table BASE TABLE
 default default test_partitioned_table$manifests BASE TABLE
 default default test_partitioned_table$snapshots BASE TABLE


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

This commit adds comprehensive support for pushing down Boolean predicates to the Iceberg table scan layer, improving query performance by filtering data at the storage level.

Changes:
- Enhanced expr_to_predicate.rs to handle boolean column expressions:
  * Bare boolean columns in filters (e.g., WHERE is_active) are converted to column = true predicates
  * NOT of boolean columns (e.g., WHERE NOT is_active) are converted to column = false predicates
  * Added Boolean scalar value to Datum conversion
- Added comprehensive sqllogictest (boolean_predicate_pushdown.slt) with:
  * Tests for is_active = true/false with EXPLAIN verification
  * Tests for is_active != true with EXPLAIN verification
  * Tests for combined predicates (AND/OR)
  * Tests for IS NULL/IS NOT NULL on boolean columns
- Created test_boolean_table in engine setup for testing
- Updated test schedule and show_tables baseline

All tests verify that predicates are successfully pushed down to IcebergTableScan, not just executed in FilterExec.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->