### PR TITLE
Split sqllogictests into different schedule

### DIFF
--- a/crates/sqllogictest/testdata/schedules/df_basic_queries.toml
+++ b/crates/sqllogictest/testdata/schedules/df_basic_queries.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/basic_queries.slt"

--- a/crates/sqllogictest/testdata/schedules/df_binary_predicate_pushdown.toml
+++ b/crates/sqllogictest/testdata/schedules/df_binary_predicate_pushdown.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/binary_predicate_pushdown.slt"

--- a/crates/sqllogictest/testdata/schedules/df_create_table.toml
+++ b/crates/sqllogictest/testdata/schedules/df_create_table.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/create_table.slt"

--- a/crates/sqllogictest/testdata/schedules/df_drop_table.toml
+++ b/crates/sqllogictest/testdata/schedules/df_drop_table.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/drop_table.slt"

--- a/crates/sqllogictest/testdata/schedules/df_insert_and_like.toml
+++ b/crates/sqllogictest/testdata/schedules/df_insert_and_like.toml
@@ -20,32 +20,8 @@ df = { type = "datafusion" }
 
 [[steps]]
 engine = "df"
-slt = "df_test/show_tables.slt"
-
-[[steps]]
-engine = "df"
-slt = "df_test/create_table.slt"
-
-[[steps]]
-engine = "df"
 slt = "df_test/insert_into.slt"
 
 [[steps]]
 engine = "df"
-slt = "df_test/scan_all_types.slt"
-
-[[steps]]
-engine = "df"
-slt = "df_test/basic_queries.slt"
-
-[[steps]]
-engine = "df"
-slt = "df_test/binary_predicate_pushdown.slt"
-
-[[steps]]
-engine = "df"
 slt = "df_test/like_predicate_pushdown.slt"
-
-[[steps]]
-engine = "df"
-slt = "df_test/drop_table.slt"

--- a/crates/sqllogictest/testdata/schedules/df_scan_all_types.toml
+++ b/crates/sqllogictest/testdata/schedules/df_scan_all_types.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/scan_all_types.slt"

--- a/crates/sqllogictest/testdata/schedules/df_show_tables.toml
+++ b/crates/sqllogictest/testdata/schedules/df_show_tables.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/show_tables.slt"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2084 .

## What changes are included in this PR?

Split sqllogictests into different schedules to run in parallel.

## Are these changes tested?

Yes, ci.