### PR TITLE
Fix moto server port conflict with macOS AirPlay Receiver

### DIFF
--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -435,7 +435,7 @@ mod tests {
     #[tokio::test]
     async fn test_config_with_custom_endpoint() {
         let properties = HashMap::new();
-        let endpoint_url = "http://custom_url:5000";
+        let endpoint_url = "http://custom_url:5001";
 
         let sdk_config = create_sdk_config(&properties, Some(&endpoint_url.to_string())).await;
 

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -47,7 +47,7 @@ mod common {
     pub const DEFAULT_MINIO_PORT: u16 = 9000;
     pub const DEFAULT_REST_CATALOG_PORT: u16 = 8181;
     pub const DEFAULT_HMS_PORT: u16 = 9083;
-    pub const DEFAULT_GLUE_PORT: u16 = 5000;
+    pub const DEFAULT_GLUE_PORT: u16 = 5001;
     pub const DEFAULT_GCS_PORT: u16 = 4443;
 
     /// Returns the MinIO S3-compatible endpoint.

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -137,9 +137,12 @@ services:
     networks:
       iceberg_test:
     ports:
-      - "5000:5000"
+      - "5001:5001"
+    environment:
+      # Use port 5001 instead of default 5000 to avoid conflict with macOS AirPlay Receiver.
+      - MOTO_PORT=5001
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/moto-api/"]
+      test: ["CMD", "curl", "-f", "http://localhost:5001/moto-api/"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
This PR changes the default moto server port from `5000` to `5001`. Port 5000 is used by AirPlay Receiver on MacOS. 

The same was done in pyiceberg: https://github.com/apache/iceberg-python/pull/292

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes locally. I also did a global search for 5000