### PR TITLE
Make `convert_filters_to_predicate` public

### DIFF
--- a/crates/integrations/datafusion/src/physical_plan/mod.rs
+++ b/crates/integrations/datafusion/src/physical_plan/mod.rs
@@ -26,5 +26,6 @@ pub(crate) mod write;
 
 pub(crate) const DATA_FILES_COL_NAME: &str = "data_files";
 
+pub use expr_to_predicate::convert_filters_to_predicate;
 pub use project::project_with_partition;
 pub use scan::IcebergTableScan;


### PR DESCRIPTION
## What changes are included in this PR?

- Make `convert_filters_to_predicate` public in the DataFusion integration to allow external usage of the filter conversion logic.

## Are these changes tested?

- This is a visibility change (`pub use`) and does not introduce new logic. 