### PR TITLE
feat(datafusion): export table provider constructor

### DIFF
--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -80,7 +80,7 @@ impl IcebergTableProvider {
     ///
     /// Loads the table once to get the initial schema, then stores the catalog
     /// reference for future metadata refreshes on each operation.
-    pub(crate) async fn try_new(
+    pub async fn try_new(
         catalog: Arc<dyn Catalog>,
         namespace: NamespaceIdent,
         name: impl Into<String>,


### PR DESCRIPTION
At the moment, the provider is only available through the Iceberg implementation of the DF catalog, which can be inconvenient when using a custom catalog implementation. This patch adds a public builder, allowing external users to create the provider.
