### PR TITLE
fix(rest): Filter sensitive headers from error logs (#2117)

### DIFF
--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -43,6 +43,8 @@ pub(crate) struct HttpClient {
     extra_headers: HeaderMap,
     /// Extra oauth parameters to be added to each authentication request.
     extra_oauth_params: HashMap<String, String>,
+    /// Whether to disable header redaction in error logs (defaults to false for security).
+    disable_header_redaction: bool,
 }
 
 impl Debug for HttpClient {
@@ -65,6 +67,7 @@ impl HttpClient {
             credential: cfg.credential(),
             extra_headers,
             extra_oauth_params: cfg.extra_oauth_params(),
+            disable_header_redaction: cfg.disable_header_redaction(),
         })
     }
 
@@ -92,6 +95,7 @@ impl HttpClient {
             } else {
                 self.extra_oauth_params
             },
+            disable_header_redaction: cfg.disable_header_redaction(),
         })
     }
 
@@ -258,6 +262,11 @@ impl HttpClient {
         self.authenticate(&mut request).await?;
         self.execute(request).await
     }
+
+    /// Returns whether header redaction is disabled for this client.
+    pub(crate) fn disable_header_redaction(&self) -> bool {
+        self.disable_header_redaction
+    }
 }
 
 /// Deserializes a catalog response into the given [`DeserializedOwned`] type.
@@ -278,14 +287,64 @@ pub(crate) async fn deserialize_catalog_response<R: DeserializeOwned>(
     })
 }
 
+/// Headers that contain sensitive information and should be excluded from logs.
+const SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "set-cookie",
+    "cookie",
+    "x-api-key",
+    "x-auth-token",
+];
+
+/// Returns true if the header name is considered sensitive.
+fn is_sensitive_header(name: &str) -> bool {
+    let name_lower = name.to_lowercase();
+    SENSITIVE_HEADERS.iter().any(|h| name_lower == *h)
+}
+
+/// Redacts sensitive headers and returns a debug-formatted string.
+///
+/// If `disable_redaction` is true, returns all headers without redaction.
+/// Otherwise, replaces sensitive header values with "[REDACTED]".
+fn format_headers_redacted(headers: &HeaderMap, disable_redaction: bool) -> String {
+    if disable_redaction {
+        // Return all headers as-is without redaction
+        let all: HashMap<&str, &str> = headers
+            .iter()
+            .filter_map(|(name, value)| value.to_str().ok().map(|v| (name.as_str(), v)))
+            .collect();
+        return format!("{all:?}");
+    }
+
+    // Redact sensitive headers by replacing their values with "[REDACTED]"
+    let redacted: HashMap<&str, &str> = headers
+        .iter()
+        .filter_map(|(name, value)| {
+            if is_sensitive_header(name.as_str()) {
+                Some((name.as_str(), "[REDACTED]"))
+            } else {
+                value.to_str().ok().map(|v| (name.as_str(), v))
+            }
+        })
+        .collect();
+    format!("{redacted:?}")
+}
+
 /// Deserializes a unexpected catalog response into an error.
-pub(crate) async fn deserialize_unexpected_catalog_error(response: Response) -> Error {
+pub(crate) async fn deserialize_unexpected_catalog_error(
+    response: Response,
+    disable_header_redaction: bool,
+) -> Error {
     let err = Error::new(
         ErrorKind::Unexpected,
         "Received response with unexpected status code",
     )
     .with_context("status", response.status().to_string())
-    .with_context("headers", format!("{:?}", response.headers()));
+    .with_context(
+        "headers",
+        format_headers_redacted(response.headers(), disable_header_redaction),
+    );
 
     let bytes = match response.bytes().await {
         Ok(bytes) => bytes,
@@ -296,4 +355,125 @@ pub(crate) async fn deserialize_unexpected_catalog_error(response: Response) -> 
         return err;
     }
     err.with_context("json", String::from_utf8_lossy(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_headers_redacted_empty() {
+        let headers = HeaderMap::new();
+        let result = format_headers_redacted(&headers, false);
+        assert_eq!(result, "{}");
+    }
+
+    #[test]
+    fn test_format_headers_redacted_non_sensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        headers.insert("x-request-id", "abc123".parse().unwrap());
+
+        let result = format_headers_redacted(&headers, false);
+
+        assert!(result.contains("content-type"));
+        assert!(result.contains("application/json"));
+        assert!(result.contains("x-request-id"));
+        assert!(result.contains("abc123"));
+    }
+
+    #[test]
+    fn test_format_headers_redacted_filters_sensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer secret-token".parse().unwrap());
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let result = format_headers_redacted(&headers, false);
+
+        // Sensitive header should be present but with redacted value
+        assert!(result.contains("authorization"));
+        assert!(result.contains("[REDACTED]"));
+        // Sensitive value should NOT be present
+        assert!(!result.contains("secret-token"));
+        // Non-sensitive header should be present with actual value
+        assert!(result.contains("content-type"));
+        assert!(result.contains("application/json"));
+    }
+
+    #[test]
+    fn test_format_headers_redacted_filters_set_cookie() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "set-cookie",
+            "CF_Authorization=sensitive-session-token; Path=/; Secure;"
+                .parse()
+                .unwrap(),
+        );
+        headers.insert("server", "cloudflare".parse().unwrap());
+
+        let result = format_headers_redacted(&headers, false);
+
+        // Sensitive header should be present but with redacted value
+        assert!(result.contains("set-cookie"));
+        assert!(result.contains("[REDACTED]"));
+        // Sensitive value should NOT be present
+        assert!(!result.contains("sensitive-session-token"));
+        // Non-sensitive header should be present with actual value
+        assert!(result.contains("server"));
+        assert!(result.contains("cloudflare"));
+    }
+
+    #[test]
+    fn test_format_headers_redacted_filters_all_sensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer token".parse().unwrap());
+        headers.insert("proxy-authorization", "Basic creds".parse().unwrap());
+        headers.insert("set-cookie", "session=abc".parse().unwrap());
+        headers.insert("cookie", "session=abc".parse().unwrap());
+        headers.insert("x-api-key", "api-key-123".parse().unwrap());
+        headers.insert("x-auth-token", "auth-token-456".parse().unwrap());
+        headers.insert("x-request-id", "req-123".parse().unwrap());
+
+        let result = format_headers_redacted(&headers, false);
+
+        // All sensitive headers should be present but with redacted values
+        assert!(result.contains("authorization"));
+        assert!(result.contains("proxy-authorization"));
+        assert!(result.contains("set-cookie"));
+        assert!(result.contains("cookie"));
+        assert!(result.contains("x-api-key"));
+        assert!(result.contains("x-auth-token"));
+        assert!(result.contains("[REDACTED]"));
+
+        // Ensure no sensitive values leaked
+        assert!(!result.contains("Bearer token"));
+        assert!(!result.contains("Basic creds"));
+        assert!(!result.contains("session=abc"));
+        assert!(!result.contains("api-key-123"));
+        assert!(!result.contains("auth-token-456"));
+
+        // Non-sensitive header should be present with actual value
+        assert!(result.contains("x-request-id"));
+        assert!(result.contains("req-123"));
+    }
+
+    #[test]
+    fn test_format_headers_with_redaction_disabled() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer secret-token".parse().unwrap());
+        headers.insert("x-api-key", "api-key-123".parse().unwrap());
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let result = format_headers_redacted(&headers, true);
+
+        // When redaction is disabled, all headers and values should be present
+        assert!(result.contains("authorization"));
+        assert!(result.contains("Bearer secret-token"));
+        assert!(result.contains("x-api-key"));
+        assert!(result.contains("api-key-123"));
+        assert!(result.contains("content-type"));
+        assert!(result.contains("application/json"));
+        // [REDACTED] should NOT be present when redaction is disabled
+        assert!(!result.contains("[REDACTED]"));
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2117

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Sensitive headers like Set-Cookie, Authorization, and Cookie were being included in error messages, potentially exposing authentication tokens and session information in logs.

This change replaces sensitive headers with `[REDACTED]` from error context rather than logging their values, preventing credential leakage.

This option can be disabled using `REST_CATALOG_PROP_DISABLE_HEADER_REDACTION=true`

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by unit tests. 