### PR TITLE
feat(sqllogictest): Support configuring datafusion catalog in sqllogic…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,6 +3611,7 @@ dependencies = [
  "enum-ordinalize",
  "env_logger",
  "iceberg",
+ "iceberg-catalog-loader",
  "iceberg-datafusion",
  "indicatif",
  "libtest-mimic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ iceberg-catalog-hms = { version = "0.8.0", path = "./crates/catalog/hms" }
 iceberg-catalog-rest = { version = "0.8.0", path = "./crates/catalog/rest" }
 iceberg-catalog-s3tables = { version = "0.8.0", path = "./crates/catalog/s3tables" }
 iceberg-catalog-sql = { version = "0.8.0", path = "./crates/catalog/sql" }
+iceberg-catalog-loader = { version = "0.8.0", path = "./crates/catalog/loader" }
 iceberg-datafusion = { version = "0.8.0", path = "./crates/integrations/datafusion" }
 indicatif = "0.18"
 itertools = "0.13"

--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -32,6 +32,7 @@ datafusion-sqllogictest = { workspace = true }
 enum-ordinalize = { workspace = true }
 env_logger = { workspace = true }
 iceberg = { workspace = true }
+iceberg-catalog-loader = { workspace = true }
 iceberg-datafusion = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }

--- a/crates/sqllogictest/src/engine/mod.rs
+++ b/crates/sqllogictest/src/engine/mod.rs
@@ -140,4 +140,32 @@ mod tests {
         let result = load_engine_runner(config).await;
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_load_datafusion_with_memory_catalog() {
+        let config = EngineConfig::Datafusion {
+            catalog: Some(DatafusionCatalogConfig {
+                catalog_type: "memory".to_string(),
+                props: std::collections::HashMap::from([
+                    ("warehouse".to_string(), "memory://test".to_string()),
+                ]),
+            }),
+        };
+
+        let result = load_engine_runner(config).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_datafusion_with_unsupported_catalog() {
+        let config = EngineConfig::Datafusion {
+            catalog: Some(DatafusionCatalogConfig {
+                catalog_type: "unsupported_catalog".to_string(),
+                props: std::collections::HashMap::new(),
+            }),
+        };
+
+        let result = load_engine_runner(config).await;
+        assert!(result.is_err());
+    }
 }

--- a/crates/sqllogictest/testdata/schedules/df_with_catalog_config.toml
+++ b/crates/sqllogictest/testdata/schedules/df_with_catalog_config.toml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+[engines.df]
+type = "datafusion"
+
+[engines.df.catalog]
+type = "memory"
+
+[engines.df.catalog.props]
+warehouse = "memory://test-warehouse"
+
+[[steps]]
+engine = "df"
+slt = "df_test/show_tables.slt"


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1780 .

## What changes are included in this PR?

Changes:
- Added "memory" catalog to iceberg-catalog-loader
- Added MemoryCatalogBuilder to the catalog registry
- Added test for memory catalog loading
- Updated DataFusionEngine to use dynamic catalog loading 

- Not sure if we want to have a default memory catalog is still used when no config is provided for backward compatible purpose

## Are these changes tested?

Yes, tests have passed locally.