### PR TITLE
Fix/skip serialize null fields unit tests

### DIFF
--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -856,27 +856,28 @@ mod tests {
 
     #[test]
     fn test_unbound_partition_spec() {
+        // With all optional fields present
         let spec = r#"
-		{
-		"spec-id": 1,
-		"fields": [ {
-			"source-id": 4,
-			"field-id": 1000,
-			"name": "ts_day",
-			"transform": "day"
-			}, {
-			"source-id": 1,
-			"field-id": 1001,
-			"name": "id_bucket",
-			"transform": "bucket[16]"
-			}, {
-			"source-id": 2,
-			"field-id": 1002,
-			"name": "id_truncate",
-			"transform": "truncate[4]"
-			} ]
-		}
-		"#;
+        {
+        "spec-id": 1,
+        "fields": [ {
+            "source-id": 4,
+            "field-id": 1000,
+            "name": "ts_day",
+            "transform": "day"
+            }, {
+            "source-id": 1,
+            "field-id": 1001,
+            "name": "id_bucket",
+            "transform": "bucket[16]"
+            }, {
+            "source-id": 2,
+            "field-id": 1002,
+            "name": "id_truncate",
+            "transform": "truncate[4]"
+            } ]
+        }
+        "#;
 
         let partition_spec: UnboundPartitionSpec = serde_json::from_str(spec).unwrap();
         assert_eq!(Some(1), partition_spec.spec_id);
@@ -896,15 +897,20 @@ mod tests {
         assert_eq!("id_truncate", partition_spec.fields[2].name);
         assert_eq!(Transform::Truncate(4), partition_spec.fields[2].transform);
 
+        let expected: serde_json::Value = serde_json::from_str(spec).unwrap();
+        assert_eq!(serde_json::to_value(&partition_spec).unwrap(), expected);
+
+        // Without optional fields — they must be omitted, not null
         let spec = r#"
-		{
-		"fields": [ {
-			"source-id": 4,
-			"name": "ts_day",
-			"transform": "day"
-			} ]
-		}
-		"#;
+        {
+        "fields": [ {
+            "source-id": 4,
+            "name": "ts_day",
+            "transform": "day"
+            } ]
+        }
+        "#;
+
         let partition_spec: UnboundPartitionSpec = serde_json::from_str(spec).unwrap();
         assert_eq!(None, partition_spec.spec_id);
 
@@ -912,6 +918,9 @@ mod tests {
         assert_eq!(None, partition_spec.fields[0].field_id);
         assert_eq!("ts_day", partition_spec.fields[0].name);
         assert_eq!(Transform::Day, partition_spec.fields[0].transform);
+
+        let expected: serde_json::Value = serde_json::from_str(spec).unwrap();
+        assert_eq!(serde_json::to_value(&partition_spec).unwrap(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2135

## What changes are included in this PR?

Unit tests for https://github.com/apache/iceberg-rust/pull/2136

(But it is based on `jonbjo:fix/skip-serialize-null-fields` from that PR, so it also has those changes.)

## Are these changes tested?

Yes. The [original PR](https://github.com/apache/iceberg-rust/pull/2136) contained the changes, this PR contains those changes and additional unit tests.

### Note about failing Bindings Python CI test:
- I don't think that it is related to my changes
- [This Workflow](https://github.com/apache/iceberg-rust/actions/workflows/bindings_python_ci.yml) seems to be broken for everybody since Feb 20