### PR TITLE
feat: check schema capability when adding parquet files

### DIFF
--- a/crates/iceberg/src/arrow/mod.rs
+++ b/crates/iceberg/src/arrow/mod.rs
@@ -28,6 +28,7 @@ pub mod delete_file_loader;
 pub(crate) mod delete_filter;
 
 mod reader;
+pub(crate) use reader::apply_name_mapping_to_arrow_schema;
 /// RecordBatch projection utilities
 pub mod record_batch_projector;
 pub(crate) mod record_batch_transformer;

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1025,7 +1025,7 @@ fn build_fallback_field_id_map(parquet_schema: &SchemaDescriptor) -> HashMap<i32
 ///
 /// # Returns
 /// Arrow schema with field IDs assigned based on name mapping
-fn apply_name_mapping_to_arrow_schema(
+pub(crate) fn apply_name_mapping_to_arrow_schema(
     arrow_schema: ArrowSchemaRef,
     name_mapping: &NameMapping,
 ) -> Result<Arc<ArrowSchema>> {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1030 

## What changes are included in this PR?

Adds schema compatibility validation when converting existing parquet files to data files
via `parquet_files_to_data_files`.

## Are these changes tested?

Yes, tests are passing locally