### PR TITLE
ci(python): fix bindings wheel install glob in CI

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --reinstall dist/pyiceberg_core_rust-*.whl
+          uv pip install --reinstall dist/pyiceberg_core*.whl
       - name: Run tests
         working-directory: "bindings/python"
         shell: bash


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Update the wheel install pattern in the Python bindings CI test job to match the actual wheel artifact name from maturin (pyiceberg_core_rust-*.whl).

Found this in #2164's CI 

Tested this locally
```
➜ uvx maturin build --out dist --sdist
...
➜  ll dist                                                     
total 94592
-rw-r--r--@ 1 kevinliu  staff   648K Feb 22 18:22 pyiceberg_core-0.8.0.tar.gz
-rw-r--r--@ 1 kevinliu  staff    45M Feb 22 18:23 pyiceberg_core_rust-0.8.0-cp310-abi3-macosx_11_0_arm64.whl
```

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->