### PR TITLE
CI(Python): dont use --sdist in maturin build for CI

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           working-directory: "bindings/python"
           command: build
-          args: --out dist --sdist
+          args: --out dist
       - uses: astral-sh/setup-uv@v7
         with:
           version: "0.9.3"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
This PR updates Python bindings CI to avoid `--sdist` in the test build step due to `maturin` regression for 1.12.3+ tracked in https://github.com/PyO3/maturin/issues/3030. We dont pin maturin in CI, so CI installs the latest version. 

`--sdist` is not needed here, removing it also aligns with other `maturin` usage in CI
See https://github.com/search?q=repo%3Aapache%2Ficeberg-rust+%22command%3A+build%22&type=code

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->