### PR TITLE
feat(transaction): add OverwriteAction with CoW delete support

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3081,6 +3081,7 @@ pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn icebe
 pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::expire_snapshots::ExpireSnapshotsAction
 pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
+pub fn iceberg::transaction::Transaction::overwrite(&self) -> iceberg::transaction::overwrite::OverwriteAction
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -382,6 +382,14 @@ impl ManifestWriter {
         Ok(())
     }
 
+    /// Add a deleted manifest entry, preserving the original sequence numbers.
+    pub(crate) fn add_deleted_entry(&mut self, mut entry: ManifestEntry) -> Result<()> {
+        self.check_data_file(&entry.data_file)?;
+        entry.status = ManifestStatus::Deleted;
+        self.add_entry_inner(entry)?;
+        Ok(())
+    }
+
     /// Add an file as existing manifest entry. The original data and file sequence numbers, snapshot ID,
     /// which were assigned at commit, must be preserved when adding an existing entry.
     pub fn add_existing_file(

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -90,6 +90,7 @@ impl TransactionAction for FastAppendAction {
             self.key_metadata.clone(),
             self.snapshot_properties.clone(),
             self.added_data_files.clone(),
+            vec![],
         );
 
         // validate added files

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -55,6 +55,7 @@ mod action;
 pub use action::*;
 mod append;
 mod expire_snapshots;
+mod overwrite;
 mod snapshot;
 mod sort_order;
 mod update_location;
@@ -75,6 +76,7 @@ use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
 use crate::transaction::append::FastAppendAction;
 use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
+use crate::transaction::overwrite::OverwriteAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
 use crate::transaction::update_properties::UpdatePropertiesAction;
@@ -149,6 +151,11 @@ impl Transaction {
     /// Creates a fast append action.
     pub fn fast_append(&self) -> FastAppendAction {
         FastAppendAction::new()
+    }
+
+    /// Creates an overwrite action.
+    pub fn overwrite(&self) -> OverwriteAction {
+        OverwriteAction::new()
     }
 
     /// Creates replace sort order action.

--- a/crates/iceberg/src/transaction/overwrite.rs
+++ b/crates/iceberg/src/transaction/overwrite.rs
@@ -423,7 +423,9 @@ mod tests {
         let original_file1 = test_data_file("test/original1.parquet", spec_id);
         let original_file2 = test_data_file("test/original2.parquet", spec_id);
         let tx = Transaction::new(&table);
-        let action = tx.fast_append().add_data_files(vec![original_file1.clone(), original_file2.clone()]);
+        let action = tx
+            .fast_append()
+            .add_data_files(vec![original_file1.clone(), original_file2.clone()]);
         let tx = action.apply(tx).unwrap();
         let table = tx.commit(&catalog).await.unwrap();
 

--- a/crates/iceberg/src/transaction/overwrite.rs
+++ b/crates/iceberg/src/transaction/overwrite.rs
@@ -420,9 +420,10 @@ mod tests {
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
         let spec_id = table.metadata().default_partition_spec_id();
 
-        let original_file = test_data_file("test/original.parquet", spec_id);
+        let original_file1 = test_data_file("test/original1.parquet", spec_id);
+        let original_file2 = test_data_file("test/original2.parquet", spec_id);
         let tx = Transaction::new(&table);
-        let action = tx.fast_append().add_data_files(vec![original_file.clone()]);
+        let action = tx.fast_append().add_data_files(vec![original_file1.clone(), original_file2.clone()]);
         let tx = action.apply(tx).unwrap();
         let table = tx.commit(&catalog).await.unwrap();
 
@@ -435,7 +436,7 @@ mod tests {
         let action = tx
             .overwrite()
             .add_data_files(vec![replacement_file.clone()])
-            .delete_data_files(vec![original_file.clone()]);
+            .delete_data_files(vec![original_file1.clone(), original_file2.clone()]);
         let tx = action.apply(tx).unwrap();
         let table = tx.commit(&catalog).await.unwrap();
 
@@ -454,13 +455,15 @@ mod tests {
             }
         }
 
-        assert!(
-            all_entries
-                .iter()
-                .any(|(status, path)| *status == ManifestStatus::Deleted
-                    && path == "test/original.parquet"),
-            "Original file should be marked as Deleted, entries: {all_entries:?}",
-        );
+        for original_file in ["test/original1.parquet", "test/original2.parquet"] {
+            assert!(
+                all_entries
+                    .iter()
+                    .any(|(status, path)| *status == ManifestStatus::Deleted
+                        && path == original_file),
+                "Original file {original_file} should be marked as Deleted, entries: {all_entries:?}",
+            );
+        }
 
         assert!(
             all_entries
@@ -477,7 +480,7 @@ mod tests {
                 .additional_properties
                 .get("deleted-data-files")
                 .map(|s| s.as_str()),
-            Some("1")
+            Some("2")
         );
         assert_eq!(
             snapshot
@@ -485,7 +488,7 @@ mod tests {
                 .additional_properties
                 .get("deleted-records")
                 .map(|s| s.as_str()),
-            Some("1")
+            Some("2")
         );
 
         // Step 3: Fast append after overwrite — delete-only manifest must survive.
@@ -510,12 +513,14 @@ mod tests {
         }
 
         // The deleted entry must still be present after fast_append.
-        assert!(
-            all_entries
-                .iter()
-                .any(|(status, path)| *status == ManifestStatus::Deleted
-                    && path == "test/original.parquet"),
-            "Deleted entry should survive fast_append, entries: {all_entries:?}",
-        );
+        for original_file in ["test/original1.parquet", "test/original2.parquet"] {
+            assert!(
+                all_entries
+                    .iter()
+                    .any(|(status, path)| *status == ManifestStatus::Deleted
+                        && path == original_file),
+                "Deleted entry should survive fast_append, entries: {all_entries:?}",
+            );
+        }
     }
 }

--- a/crates/iceberg/src/transaction/overwrite.rs
+++ b/crates/iceberg/src/transaction/overwrite.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::error::Result;
 use crate::spec::{
-    DataFile, FormatVersion, ManifestContentType, ManifestEntry, ManifestFile,
+    DataFile, FormatVersion, Manifest, ManifestContentType, ManifestEntry, ManifestFile,
     ManifestWriterBuilder, Operation,
 };
 use crate::table::Table;
@@ -208,7 +208,7 @@ impl OverwriteOperation {
         &self,
         snapshot_produce: &SnapshotProducer<'_>,
         manifest_file: &ManifestFile,
-        manifest: &crate::spec::Manifest,
+        manifest: &Manifest,
     ) -> Result<ManifestFile> {
         let table = snapshot_produce.table;
 
@@ -259,14 +259,14 @@ mod tests {
     use std::sync::Arc;
 
     use crate::spec::{
-        DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestStatus,
-        Operation, SnapshotRef, Struct,
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+        ManifestStatus, Operation, SnapshotRef, Struct,
     };
     use crate::transaction::tests::make_v2_minimal_table;
     use crate::transaction::{Transaction, TransactionAction};
     use crate::{TableRequirement, TableUpdate};
 
-    fn test_data_file(path: &str, partition_spec_id: i32) -> crate::spec::DataFile {
+    fn test_data_file(path: &str, partition_spec_id: i32) -> DataFile {
         DataFileBuilder::default()
             .content(DataContentType::Data)
             .file_path(path.to_string())

--- a/crates/iceberg/src/transaction/overwrite.rs
+++ b/crates/iceberg/src/transaction/overwrite.rs
@@ -1,0 +1,521 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::spec::{
+    DataFile, FormatVersion, ManifestContentType, ManifestEntry, ManifestFile,
+    ManifestWriterBuilder, Operation,
+};
+use crate::table::Table;
+use crate::transaction::snapshot::{
+    DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer,
+};
+use crate::transaction::{ActionCommit, TransactionAction};
+
+/// OverwriteAction is a transaction action for overwriting data files in the table.
+///
+/// Creates a snapshot with `Operation::Overwrite` semantics — adds new data files and
+/// optionally removes existing data files by rewriting affected manifests with those
+/// entries marked as `ManifestStatus::Deleted`.
+pub struct OverwriteAction {
+    check_duplicate: bool,
+    commit_uuid: Option<Uuid>,
+    key_metadata: Option<Vec<u8>>,
+    snapshot_properties: HashMap<String, String>,
+    added_data_files: Vec<DataFile>,
+    deleted_data_files: Vec<DataFile>,
+}
+
+impl OverwriteAction {
+    pub(crate) fn new() -> Self {
+        Self {
+            check_duplicate: true,
+            commit_uuid: None,
+            key_metadata: None,
+            snapshot_properties: HashMap::default(),
+            added_data_files: vec![],
+            deleted_data_files: vec![],
+        }
+    }
+
+    /// Set whether to check duplicate files.
+    pub fn with_check_duplicate(mut self, v: bool) -> Self {
+        self.check_duplicate = v;
+        self
+    }
+
+    /// Add data files to the snapshot.
+    pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.added_data_files.extend(data_files);
+        self
+    }
+
+    /// Specify data files to be removed from the table in this overwrite.
+    pub fn delete_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.deleted_data_files.extend(data_files);
+        self
+    }
+
+    /// Set commit UUID for the snapshot.
+    pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
+        self.commit_uuid = Some(commit_uuid);
+        self
+    }
+
+    /// Set key metadata for manifest files.
+    pub fn set_key_metadata(mut self, key_metadata: Vec<u8>) -> Self {
+        self.key_metadata = Some(key_metadata);
+        self
+    }
+
+    /// Set snapshot summary properties.
+    pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
+        self.snapshot_properties = snapshot_properties;
+        self
+    }
+}
+
+#[async_trait]
+impl TransactionAction for OverwriteAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        let snapshot_producer = SnapshotProducer::new(
+            table,
+            self.commit_uuid.unwrap_or_else(Uuid::now_v7),
+            self.key_metadata.clone(),
+            self.snapshot_properties.clone(),
+            self.added_data_files.clone(),
+            self.deleted_data_files.clone(),
+        );
+
+        snapshot_producer.validate_added_data_files()?;
+
+        if self.check_duplicate {
+            snapshot_producer.validate_duplicate_files().await?;
+        }
+
+        let deleted_file_paths: HashSet<String> = self
+            .deleted_data_files
+            .iter()
+            .map(|f| f.file_path.clone())
+            .collect();
+
+        let snapshot_id = snapshot_producer.snapshot_id();
+        snapshot_producer
+            .commit(
+                OverwriteOperation {
+                    deleted_file_paths,
+                    snapshot_id,
+                },
+                DefaultManifestProcess,
+            )
+            .await
+    }
+}
+
+struct OverwriteOperation {
+    deleted_file_paths: HashSet<String>,
+    snapshot_id: i64,
+}
+
+impl SnapshotProduceOperation for OverwriteOperation {
+    fn operation(&self) -> Operation {
+        Operation::Overwrite
+    }
+
+    async fn delete_entries(
+        &self,
+        _snapshot_produce: &SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestEntry>> {
+        Ok(vec![])
+    }
+
+    async fn existing_manifest(
+        &self,
+        snapshot_produce: &SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestFile>> {
+        let Some(snapshot) = snapshot_produce.table.metadata().current_snapshot() else {
+            return Ok(vec![]);
+        };
+
+        let manifest_list = snapshot_produce
+            .table
+            .manifest_list_reader(snapshot)
+            .load()
+            .await?;
+
+        if self.deleted_file_paths.is_empty() {
+            return Ok(manifest_list
+                .entries()
+                .iter()
+                .filter(|entry| entry.has_added_files() || entry.has_existing_files())
+                .cloned()
+                .collect());
+        }
+
+        let mut result = Vec::new();
+
+        for manifest_file in manifest_list.entries() {
+            if !manifest_file.has_added_files() && !manifest_file.has_existing_files() {
+                continue;
+            }
+
+            let manifest = manifest_file
+                .load_manifest(snapshot_produce.table.file_io())
+                .await?;
+
+            let has_deletes = manifest.entries().iter().any(|entry| {
+                entry.is_alive() && self.deleted_file_paths.contains(entry.file_path())
+            });
+
+            if has_deletes {
+                let rewritten = self
+                    .rewrite_manifest(snapshot_produce, manifest_file, &manifest)
+                    .await?;
+                result.push(rewritten);
+            } else {
+                result.push(manifest_file.clone());
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl OverwriteOperation {
+    /// Rewrite a manifest, marking entries whose file paths are in `deleted_file_paths`
+    /// as `ManifestStatus::Deleted`.
+    async fn rewrite_manifest(
+        &self,
+        snapshot_produce: &SnapshotProducer<'_>,
+        manifest_file: &ManifestFile,
+        manifest: &crate::spec::Manifest,
+    ) -> Result<ManifestFile> {
+        let table = snapshot_produce.table;
+
+        let new_manifest_path = format!(
+            "{}/metadata/{}-m-overwrite.avro",
+            table.metadata().location(),
+            Uuid::now_v7(),
+        );
+        let output_file = table.file_io().new_output(&new_manifest_path)?;
+        let builder = ManifestWriterBuilder::new(
+            output_file,
+            Some(self.snapshot_id),
+            manifest_file.key_metadata.clone(),
+            table.metadata().current_schema().clone(),
+            table.metadata().default_partition_spec().as_ref().clone(),
+        );
+
+        let mut writer = match table.metadata().format_version() {
+            FormatVersion::V1 => builder.build_v1(),
+            FormatVersion::V2 => match manifest_file.content {
+                ManifestContentType::Data => builder.build_v2_data(),
+                ManifestContentType::Deletes => builder.build_v2_deletes(),
+            },
+            FormatVersion::V3 => match manifest_file.content {
+                ManifestContentType::Data => builder.build_v3_data(),
+                ManifestContentType::Deletes => builder.build_v3_deletes(),
+            },
+        };
+
+        for entry in manifest.entries() {
+            if entry.is_alive() && self.deleted_file_paths.contains(entry.file_path()) {
+                let mut deleted: ManifestEntry = (**entry).clone();
+                deleted.snapshot_id = Some(self.snapshot_id);
+                writer.add_deleted_entry(deleted)?;
+            } else {
+                let cloned: ManifestEntry = (**entry).clone();
+                writer.add_existing_entry(cloned)?;
+            }
+        }
+
+        writer.write_manifest_file().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::spec::{
+        DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestStatus,
+        Operation, SnapshotRef, Struct,
+    };
+    use crate::transaction::tests::make_v2_minimal_table;
+    use crate::transaction::{Transaction, TransactionAction};
+    use crate::{TableRequirement, TableUpdate};
+
+    fn test_data_file(path: &str, partition_spec_id: i32) -> crate::spec::DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(partition_spec_id)
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_empty_data_overwrite_action() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+        let action = tx.overwrite().add_data_files(vec![]);
+        assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_snapshot_properties() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let mut snapshot_properties = HashMap::new();
+        snapshot_properties.insert("key".to_string(), "val".to_string());
+
+        let data_file = test_data_file(
+            "test/1.parquet",
+            table.metadata().default_partition_spec_id(),
+        );
+
+        let action = tx
+            .overwrite()
+            .set_snapshot_properties(snapshot_properties)
+            .add_data_files(vec![data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            snapshot
+        } else {
+            unreachable!()
+        };
+        assert_eq!(
+            new_snapshot
+                .summary()
+                .additional_properties
+                .get("key")
+                .unwrap(),
+            "val"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_incompatible_partition_value() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/3.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::string("test"))]))
+            .build()
+            .unwrap();
+
+        let action = tx.overwrite().add_data_files(vec![data_file]);
+        assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_basic() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let data_file = test_data_file(
+            "test/3.parquet",
+            table.metadata().default_partition_spec_id(),
+        );
+
+        let action = tx.overwrite().add_data_files(vec![data_file.clone()]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+        let requirements = action_commit.take_requirements();
+
+        assert!(
+            matches!((&updates[0],&updates[1]), (TableUpdate::AddSnapshot { snapshot },TableUpdate::SetSnapshotRef { reference,ref_name }) if snapshot.snapshot_id() == reference.snapshot_id && ref_name == MAIN_BRANCH)
+        );
+
+        assert_eq!(
+            vec![
+                TableRequirement::UuidMatch {
+                    uuid: table.metadata().uuid()
+                },
+                TableRequirement::RefSnapshotIdMatch {
+                    r#ref: MAIN_BRANCH.to_string(),
+                    snapshot_id: table.metadata().current_snapshot_id
+                }
+            ],
+            requirements
+        );
+
+        let new_snapshot: SnapshotRef = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            SnapshotRef::new(snapshot.clone())
+        } else {
+            unreachable!()
+        };
+        assert_eq!(new_snapshot.summary().operation, Operation::Overwrite);
+
+        let manifest_list = table
+            .manifest_list_reader(&new_snapshot)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(1, manifest_list.entries().len());
+        assert_eq!(
+            manifest_list.entries()[0].sequence_number,
+            new_snapshot.sequence_number()
+        );
+
+        let manifest = manifest_list.entries()[0]
+            .load_manifest(table.file_io())
+            .await
+            .unwrap();
+        assert_eq!(1, manifest.entries().len());
+        assert_eq!(
+            new_snapshot.sequence_number(),
+            manifest.entries()[0]
+                .sequence_number()
+                .expect("Inherit sequence number by load manifest")
+        );
+        assert_eq!(
+            new_snapshot.snapshot_id(),
+            manifest.entries()[0].snapshot_id().unwrap()
+        );
+        assert_eq!(data_file, *manifest.entries()[0].data_file());
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_with_deleted_files() {
+        use crate::memory::tests::new_memory_catalog;
+        use crate::transaction::ApplyTransactionAction;
+        use crate::transaction::tests::make_v3_minimal_table_in_catalog;
+
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let spec_id = table.metadata().default_partition_spec_id();
+
+        let original_file = test_data_file("test/original.parquet", spec_id);
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(vec![original_file.clone()]);
+        let tx = action.apply(tx).unwrap();
+        let table = tx.commit(&catalog).await.unwrap();
+
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
+        assert_eq!(1, manifest_list.entries().len());
+
+        let replacement_file = test_data_file("test/replacement.parquet", spec_id);
+        let tx = Transaction::new(&table);
+        let action = tx
+            .overwrite()
+            .add_data_files(vec![replacement_file.clone()])
+            .delete_data_files(vec![original_file.clone()]);
+        let tx = action.apply(tx).unwrap();
+        let table = tx.commit(&catalog).await.unwrap();
+
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        assert_eq!(snapshot.summary().operation, Operation::Overwrite);
+
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
+
+        assert_eq!(2, manifest_list.entries().len());
+
+        let mut all_entries = vec![];
+        for manifest_file in manifest_list.entries() {
+            let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                all_entries.push((entry.status(), entry.file_path().to_string()));
+            }
+        }
+
+        assert!(
+            all_entries
+                .iter()
+                .any(|(status, path)| *status == ManifestStatus::Deleted
+                    && path == "test/original.parquet"),
+            "Original file should be marked as Deleted, entries: {all_entries:?}",
+        );
+
+        assert!(
+            all_entries
+                .iter()
+                .any(|(status, path)| *status == ManifestStatus::Added
+                    && path == "test/replacement.parquet"),
+            "Replacement file should be marked as Added, entries: {all_entries:?}",
+        );
+
+        // Verify snapshot summary reports the deleted file.
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("deleted-data-files")
+                .map(|s| s.as_str()),
+            Some("1")
+        );
+        assert_eq!(
+            snapshot
+                .summary()
+                .additional_properties
+                .get("deleted-records")
+                .map(|s| s.as_str()),
+            Some("1")
+        );
+
+        // Step 3: Fast append after overwrite — delete-only manifest must survive.
+        let appended_file = test_data_file("test/appended.parquet", spec_id);
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(vec![appended_file.clone()]);
+        let tx = action.apply(tx).unwrap();
+        let table = tx.commit(&catalog).await.unwrap();
+
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
+
+        // 3 manifests: rewritten (deleted entry), overwrite added, fast_append added.
+        assert_eq!(3, manifest_list.entries().len());
+
+        let mut all_entries = vec![];
+        for manifest_file in manifest_list.entries() {
+            let manifest = manifest_file.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                all_entries.push((entry.status(), entry.file_path().to_string()));
+            }
+        }
+
+        // The deleted entry must still be present after fast_append.
+        assert!(
+            all_entries
+                .iter()
+                .any(|(status, path)| *status == ManifestStatus::Deleted
+                    && path == "test/original.parquet"),
+            "Deleted entry should survive fast_append, entries: {all_entries:?}",
+        );
+    }
+}

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -355,7 +355,13 @@ impl<'a> SnapshotProducer<'a> {
         // TODO: Allowing snapshot property setup with no added data files is a workaround.
         // We should clean it up after all necessary actions are supported.
         // For details, please refer to https://github.com/apache/iceberg-rust/issues/1548
-        if self.added_data_files.is_empty() && self.snapshot_properties.is_empty() {
+        //
+        // A delete-only overwrite (no added files, no properties, but with deleted files) is
+        // valid per the Iceberg spec — the existing manifests are rewritten with deleted entries.
+        if self.added_data_files.is_empty()
+            && self.snapshot_properties.is_empty()
+            && self.deleted_data_files.is_empty()
+        {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
                 "No added data files or added snapshot properties found when write a manifest file",

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -116,6 +116,7 @@ pub(crate) struct SnapshotProducer<'a> {
     key_metadata: Option<Vec<u8>>,
     snapshot_properties: HashMap<String, String>,
     added_data_files: Vec<DataFile>,
+    deleted_data_files: Vec<DataFile>,
     // A counter used to generate unique manifest file names.
     // It starts from 0 and increments for each new manifest file.
     // Note: This counter is limited to the range of (0..u64::MAX).
@@ -123,12 +124,17 @@ pub(crate) struct SnapshotProducer<'a> {
 }
 
 impl<'a> SnapshotProducer<'a> {
+    pub(crate) fn snapshot_id(&self) -> i64 {
+        self.snapshot_id
+    }
+
     pub(crate) fn new(
         table: &'a Table,
         commit_uuid: Uuid,
         key_metadata: Option<Vec<u8>>,
         snapshot_properties: HashMap<String, String>,
         added_data_files: Vec<DataFile>,
+        deleted_data_files: Vec<DataFile>,
     ) -> Self {
         Self {
             table,
@@ -137,6 +143,7 @@ impl<'a> SnapshotProducer<'a> {
             key_metadata,
             snapshot_properties,
             added_data_files,
+            deleted_data_files,
             manifest_counter: (0..),
         }
     }
@@ -396,6 +403,14 @@ impl<'a> SnapshotProducer<'a> {
 
         for data_file in &self.added_data_files {
             summary_collector.add_file(
+                data_file,
+                table_metadata.current_schema().clone(),
+                table_metadata.default_partition_spec().clone(),
+            );
+        }
+
+        for data_file in &self.deleted_data_files {
+            summary_collector.remove_file(
                 data_file,
                 table_metadata.current_schema().clone(),
                 table_metadata.default_partition_spec().clone(),


### PR DESCRIPTION
## Which issue does this PR close?

Part of #2186 

This is the first in a series of PRs working toward full Copy-on-Write (CoW) and Merge-on-Read (MoR) support. CoW comes first because it provides the foundation that MoR eventually depends on. This PR delivers complete CoW overwrite semantics. Subsequent PRs will add `RowDeltaAction` for writing position/equality delete files (MoR write path), scan-side delete file reconciliation (MoR read path), and compaction.

Adds `OverwriteAction`, a new `TransactionAction` that produces snapshots with `Operation::Overwrite` semantics. It adds new data files and optionally removes existing data files by rewriting affected manifests with entries marked as `ManifestStatus::Deleted`.

Supporting changes:

- `ManifestWriter::add_deleted_entry()`--the existing `add_entry()` unconditionally sets status to `Added`; there was no way to write deleted entries
- `SnapshotProducer::snapshot_id()` getter--needed to stamp the snapshot ID on deleted manifest entries
- `FastAppendAction::existing_manifest()` now preserves delete-only manifests so that deleted entries produced by `OverwriteAction` survive subsequent appends

## Are these changes tested?

5 new unit tests in `transaction::overwrite::tests`:

- `test_empty_data_overwrite_action`--error on empty file list
- `test_overwrite_snapshot_properties`--custom properties flow to snapshot summary
- `test_overwrite_incompatible_partition_value`--rejects mismatched partition types
- `test_overwrite_basic`--verifies updates, requirements, operation type, manifest structure, sequence numbers
- `test_overwrite_with_deleted_files`--end-to-end: append via catalog, overwrite with deletes via catalog, verify original file is `Deleted` and replacement is `Added`