### PR TITLE
feat(transaction): add RowDelta transaction action for row-level modi…

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3147,6 +3147,7 @@ pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::tr
 pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::row_delta(&self) -> iceberg::transaction::row_delta::RowDeltaAction
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
 pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -125,7 +125,7 @@ impl SnapshotProduceOperation for FastAppendOperation {
 
     async fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        snapshot_produce: &mut SnapshotProducer<'_>,
     ) -> Result<Vec<ManifestFile>> {
         let Some(snapshot) = snapshot_produce.table.metadata().current_snapshot() else {
             return Ok(vec![]);

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -157,7 +157,7 @@ impl Transaction {
     ///
     /// RowDelta supports:
     /// - Adding new data files (inserts)
-    /// - Removing data files (deletes in COW mode)
+    /// - Removing data files (deletes in Copy-on-Write (COW) mode)
     /// - Both operations in a single transaction (updates/merges)
     pub fn row_delta(&self) -> RowDeltaAction {
         RowDeltaAction::new()

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -55,6 +55,7 @@ mod action;
 pub use action::*;
 mod append;
 mod expire_snapshots;
+mod row_delta;
 mod snapshot;
 mod sort_order;
 mod update_location;
@@ -75,6 +76,7 @@ use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
 use crate::transaction::append::FastAppendAction;
 use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
+use crate::transaction::row_delta::RowDeltaAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
 use crate::transaction::update_properties::UpdatePropertiesAction;
@@ -149,6 +151,16 @@ impl Transaction {
     /// Creates a fast append action.
     pub fn fast_append(&self) -> FastAppendAction {
         FastAppendAction::new()
+    }
+
+    /// Creates a row delta action for row-level modifications.
+    ///
+    /// RowDelta supports:
+    /// - Adding new data files (inserts)
+    /// - Removing data files (deletes in COW mode)
+    /// - Both operations in a single transaction (updates/merges)
+    pub fn row_delta(&self) -> RowDeltaAction {
+        RowDeltaAction::new()
     }
 
     /// Creates replace sort order action.

--- a/crates/iceberg/src/transaction/row_delta.rs
+++ b/crates/iceberg/src/transaction/row_delta.rs
@@ -146,7 +146,10 @@ impl TransactionAction for RowDeltaAction {
             self.added_data_files.clone(),
         );
 
-        // Validate added files (same validation as FastAppend)
+        // Validate newly added data files (partition value type-checks, etc.).
+        // removed_data_files are not validated: they are existing table files that
+        // were already validated when originally committed, so re-validating them
+        // here would be redundant. This matches Java's MergingSnapshotProducer behavior.
         snapshot_producer.validate_added_data_files()?;
 
         // Create RowDeltaOperation with removed files
@@ -175,19 +178,21 @@ struct RowDeltaOperation {
 impl SnapshotProduceOperation for RowDeltaOperation {
     /// Determine operation type based on what's being added/removed.
     ///
-    /// Logic matches Java implementation in BaseRowDelta:
-    /// - Only adds data files (no deletes, no removes) → Append
-    /// - Only adds delete files → Delete
-    /// - Mixed or removes data files → Overwrite
+    /// Logic based on Java `BaseRowDelta.operation()`:
+    /// - Only adds data files (no deletes or removes) → `Append`
+    /// - Removes data files or has delete files, AND also adds data files → `Overwrite`
+    /// - Only removes/deletes with no new data added → `Delete` (future: MoR path)
+    ///
+    /// Note: `Operation::Delete` is not yet returned because `add_delete_files` is
+    /// not fully implemented. Once Merge-on-Read support is wired up, the operation
+    /// will be `Delete` when only delete files are added with no new data rows.
     fn operation(&self) -> Operation {
         let has_added_deletes = !self.added_delete_files.is_empty();
         let has_removed_data = !self.removed_data_files.is_empty();
 
         if has_removed_data || has_added_deletes {
-            // If we're removing data files or adding delete files, it's an Overwrite
             Operation::Overwrite
         } else {
-            // Pure append of new data files
             Operation::Append
         }
     }
@@ -463,15 +468,8 @@ mod tests {
             .validate_from_snapshot(99999)
             .add_data_files(vec![data_file.clone()]);
 
-        let result = Arc::new(action).commit(&table).await;
-        assert!(result.is_err());
-
-        // Verify the error message mentions snapshot validation
-        if let Err(e) = result {
-            assert!(
-                e.to_string().contains("stale snapshot") || e.to_string().contains("Cannot commit")
-            );
-        }
+        let err = Arc::new(action).commit(&table).await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::DataInvalid);
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/row_delta.rs
+++ b/crates/iceberg/src/transaction/row_delta.rs
@@ -1,0 +1,491 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::spec::{DataFile, ManifestEntry, ManifestFile, ManifestStatus, Operation};
+use crate::table::Table;
+use crate::transaction::snapshot::{
+    DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer,
+};
+use crate::transaction::{ActionCommit, TransactionAction};
+
+/// RowDeltaAction handles both data file additions and deletions in a single snapshot.
+/// This is the core transaction type for MERGE, UPDATE, DELETE operations.
+///
+/// Corresponds to `org.apache.iceberg.RowDelta` in the Java implementation.
+///
+/// # Copy-on-Write (COW) Strategy
+///
+/// For row-level modifications:
+/// 1. Read target data files that contain rows to be modified
+/// 2. Apply modifications (UPDATE/DELETE logic)
+/// 3. Write modified rows to new data files via `add_data_files()`
+/// 4. Mark original files as deleted via `remove_data_files()`
+///
+/// For inserts (NOT MATCHED in MERGE):
+/// 1. Write new rows to data files
+/// 2. Add files via `add_data_files()`
+///
+/// # Future: Merge-on-Read (MOR) Strategy
+///
+/// The `add_delete_files()` method is reserved for future MOR support, which uses
+/// delete files instead of rewriting data files.
+pub struct RowDeltaAction {
+    /// New data files to add (for inserts or rewritten files in COW mode)
+    added_data_files: Vec<DataFile>,
+    /// Data files to mark as deleted (for COW mode when rewriting files)
+    removed_data_files: Vec<DataFile>,
+    /// Delete files to add (reserved for future MOR mode support)
+    added_delete_files: Vec<DataFile>,
+    /// Optional commit UUID for manifest file naming
+    commit_uuid: Option<Uuid>,
+    /// Additional properties to add to snapshot summary
+    snapshot_properties: HashMap<String, String>,
+    /// Optional starting snapshot ID for conflict detection
+    starting_snapshot_id: Option<i64>,
+}
+
+impl RowDeltaAction {
+    pub(crate) fn new() -> Self {
+        Self {
+            added_data_files: vec![],
+            removed_data_files: vec![],
+            added_delete_files: vec![],
+            commit_uuid: None,
+            snapshot_properties: HashMap::default(),
+            starting_snapshot_id: None,
+        }
+    }
+
+    /// Add new data files to the snapshot.
+    ///
+    /// Used for:
+    /// - New rows from INSERT operations
+    /// - Rewritten data files in COW mode (after applying UPDATE/DELETE)
+    ///
+    /// Corresponds to `addRows(DataFile)` in Java implementation.
+    pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.added_data_files.extend(data_files);
+        self
+    }
+
+    /// Mark data files as deleted in the snapshot.
+    ///
+    /// Used in COW mode to mark original files as deleted when they've been rewritten
+    /// with modifications.
+    ///
+    /// Corresponds to `removeRows(DataFile)` in Java implementation.
+    pub fn remove_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.removed_data_files.extend(data_files);
+        self
+    }
+
+    /// Add delete files to the snapshot (reserved for future MOR mode).
+    ///
+    /// Corresponds to `addDeletes(DeleteFile)` in Java implementation.
+    ///
+    /// # Note
+    ///
+    /// This is not yet implemented and is reserved for future Merge-on-Read (MOR)
+    /// optimization where delete files are used instead of rewriting data files.
+    pub fn add_delete_files(mut self, delete_files: impl IntoIterator<Item = DataFile>) -> Self {
+        self.added_delete_files.extend(delete_files);
+        self
+    }
+
+    /// Set commit UUID for the snapshot.
+    pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
+        self.commit_uuid = Some(commit_uuid);
+        self
+    }
+
+    /// Set snapshot summary properties.
+    pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
+        self.snapshot_properties = snapshot_properties;
+        self
+    }
+
+    /// Validate that the operation is applied on top of a specific snapshot.
+    ///
+    /// This can be used for conflict detection in concurrent modification scenarios.
+    ///
+    /// Corresponds to `validateFromSnapshot(long snapshotId)` in Java implementation.
+    pub fn validate_from_snapshot(mut self, snapshot_id: i64) -> Self {
+        self.starting_snapshot_id = Some(snapshot_id);
+        self
+    }
+}
+
+#[async_trait]
+impl TransactionAction for RowDeltaAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        // Validate starting snapshot if specified
+        if let Some(expected_snapshot_id) = self.starting_snapshot_id
+            && table.metadata().current_snapshot_id() != Some(expected_snapshot_id)
+        {
+            return Err(crate::Error::new(
+                crate::ErrorKind::DataInvalid,
+                format!(
+                    "Cannot commit RowDelta based on stale snapshot. Expected: {}, Current: {:?}",
+                    expected_snapshot_id,
+                    table.metadata().current_snapshot_id()
+                ),
+            ));
+        }
+
+        let snapshot_producer = SnapshotProducer::new(
+            table,
+            self.commit_uuid.unwrap_or_else(Uuid::now_v7),
+            None, // key_metadata - not used for row delta
+            self.snapshot_properties.clone(),
+            self.added_data_files.clone(),
+        );
+
+        // Validate added files (same validation as FastAppend)
+        snapshot_producer.validate_added_data_files()?;
+
+        // Create RowDeltaOperation with removed files
+        let operation = RowDeltaOperation {
+            removed_data_files: self.removed_data_files.clone(),
+            added_delete_files: self.added_delete_files.clone(),
+        };
+
+        snapshot_producer
+            .commit(operation, DefaultManifestProcess)
+            .await
+    }
+}
+
+/// Implements the snapshot production logic for RowDelta operations.
+///
+/// This determines:
+/// - Which operation type is recorded (Append/Delete/Overwrite)
+/// - Which manifest entries should be marked as deleted
+/// - Which existing manifests should be carried forward
+struct RowDeltaOperation {
+    removed_data_files: Vec<DataFile>,
+    added_delete_files: Vec<DataFile>,
+}
+
+impl SnapshotProduceOperation for RowDeltaOperation {
+    /// Determine operation type based on what's being added/removed.
+    ///
+    /// Logic matches Java implementation in BaseRowDelta:
+    /// - Only adds data files (no deletes, no removes) → Append
+    /// - Only adds delete files → Delete
+    /// - Mixed or removes data files → Overwrite
+    fn operation(&self) -> Operation {
+        let has_added_deletes = !self.added_delete_files.is_empty();
+        let has_removed_data = !self.removed_data_files.is_empty();
+
+        if has_removed_data || has_added_deletes {
+            // If we're removing data files or adding delete files, it's an Overwrite
+            Operation::Overwrite
+        } else {
+            // Pure append of new data files
+            Operation::Append
+        }
+    }
+
+    /// Returns manifest entries for files that should be marked as deleted.
+    ///
+    /// This creates DELETED entries for removed data files in COW mode.
+    async fn delete_entries(
+        &self,
+        snapshot_produce: &SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestEntry>> {
+        let snapshot_id = snapshot_produce.table.metadata().current_snapshot_id();
+
+        // Create DELETED manifest entries for removed data files
+        let deleted_entries = self
+            .removed_data_files
+            .iter()
+            .map(|data_file| {
+                if let Some(snapshot_id) = snapshot_id {
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Deleted)
+                        .snapshot_id(snapshot_id)
+                        .data_file(data_file.clone())
+                        .build()
+                } else {
+                    ManifestEntry::builder()
+                        .status(ManifestStatus::Deleted)
+                        .data_file(data_file.clone())
+                        .build()
+                }
+            })
+            .collect();
+
+        Ok(deleted_entries)
+    }
+
+    /// Returns existing manifest files that should be included in the new snapshot.
+    ///
+    /// For RowDelta:
+    /// - Include all existing manifests (they contain unchanged data)
+    /// - The snapshot producer will add new manifests for added/deleted entries
+    async fn existing_manifest(
+        &self,
+        snapshot_produce: &SnapshotProducer<'_>,
+    ) -> Result<Vec<ManifestFile>> {
+        let Some(snapshot) = snapshot_produce.table.metadata().current_snapshot() else {
+            return Ok(vec![]);
+        };
+
+        let manifest_list = snapshot
+            .load_manifest_list(
+                snapshot_produce.table.file_io(),
+                &snapshot_produce.table.metadata_ref(),
+            )
+            .await?;
+
+        // Include all existing manifests - unchanged data is still valid
+        Ok(manifest_list
+            .entries()
+            .iter()
+            .filter(|entry| entry.has_added_files() || entry.has_existing_files())
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::TableUpdate;
+    use crate::spec::{DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct};
+    use crate::transaction::tests::make_v2_minimal_table;
+    use crate::transaction::{Transaction, TransactionAction};
+
+    #[tokio::test]
+    async fn test_row_delta_add_only() {
+        // Test adding data files only (pure append)
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        let action = tx.row_delta().add_data_files(vec![data_file.clone()]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        // Verify snapshot was created
+        assert!(matches!(&updates[0], TableUpdate::AddSnapshot { .. }));
+
+        // Verify the snapshot summary shows Append operation
+        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            assert_eq!(snapshot.summary().operation, crate::spec::Operation::Append);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_remove_only() {
+        // Test removing data files (COW delete) - should succeed
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/old.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        let action = tx.row_delta().remove_data_files(vec![data_file]);
+
+        // This should succeed - delete-only operations are valid
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        // Verify snapshot was created with Overwrite operation
+        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            assert_eq!(
+                snapshot.summary().operation,
+                crate::spec::Operation::Overwrite
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_add_and_remove() {
+        // Test COW update: remove old file, add new file
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let old_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/old.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        let new_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/new.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(120)
+            .record_count(12)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        let action = tx
+            .row_delta()
+            .remove_data_files(vec![old_file])
+            .add_data_files(vec![new_file]);
+
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        // Verify snapshot was created with Overwrite operation
+        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            assert_eq!(
+                snapshot.summary().operation,
+                crate::spec::Operation::Overwrite
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_with_snapshot_properties() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let mut snapshot_properties = HashMap::new();
+        snapshot_properties.insert("key".to_string(), "value".to_string());
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        let action = tx
+            .row_delta()
+            .set_snapshot_properties(snapshot_properties)
+            .add_data_files(vec![data_file]);
+
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        // Check customized properties in snapshot summary
+        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            assert_eq!(
+                snapshot.summary().additional_properties.get("key").unwrap(),
+                "value"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_validate_from_snapshot() {
+        // Test the snapshot validation logic
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap();
+
+        // Test with invalid snapshot ID (table has no snapshot, so any ID should fail)
+        let action = tx
+            .row_delta()
+            .validate_from_snapshot(99999)
+            .add_data_files(vec![data_file.clone()]);
+
+        let result = Arc::new(action).commit(&table).await;
+        assert!(result.is_err());
+
+        // Verify the error message mentions snapshot validation
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("stale snapshot") || e.to_string().contains("Cannot commit")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_empty_action() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+        let action = tx.row_delta();
+
+        // Empty row delta should fail
+        assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_incompatible_partition_value() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+
+        // Create file with incompatible partition value (string instead of long)
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/bad.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::string("wrong"))]))
+            .build()
+            .unwrap();
+
+        let action = tx.row_delta().add_data_files(vec![data_file]);
+
+        // Should fail validation
+        assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+}

--- a/crates/iceberg/src/transaction/row_delta.rs
+++ b/crates/iceberg/src/transaction/row_delta.rs
@@ -468,8 +468,11 @@ mod tests {
             .validate_from_snapshot(99999)
             .add_data_files(vec![data_file.clone()]);
 
-        let err = Arc::new(action).commit(&table).await.unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::DataInvalid);
+        let result = Arc::new(action).commit(&table).await;
+        match result {
+            Ok(_) => panic!("expected DataInvalid error for stale snapshot"),
+            Err(e) => assert_eq!(e.kind(), crate::ErrorKind::DataInvalid),
+        }
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/row_delta.rs
+++ b/crates/iceberg/src/transaction/row_delta.rs
@@ -46,16 +46,16 @@ use crate::transaction::{ActionCommit, TransactionAction};
 /// 1. Write new rows to data files
 /// 2. Add files via `add_data_files()`
 ///
-/// # Future: Merge-on-Read (MOR) Strategy
+/// # Future: Merge-on-Read Strategy
 ///
-/// The `add_delete_files()` method is reserved for future MOR support, which uses
+/// The `add_delete_files()` method is reserved for future Merge-on-Read support, which uses
 /// delete files instead of rewriting data files.
 pub struct RowDeltaAction {
     /// New data files to add (for inserts or rewritten files in COW mode)
     added_data_files: Vec<DataFile>,
     /// Data files to mark as deleted (for COW mode when rewriting files)
     removed_data_files: Vec<DataFile>,
-    /// Delete files to add (reserved for future MOR mode support)
+    /// Delete files to add (reserved for future Merge-on-Read mode support)
     added_delete_files: Vec<DataFile>,
     /// Optional commit UUID for manifest file naming
     commit_uuid: Option<Uuid>,
@@ -77,37 +77,25 @@ impl RowDeltaAction {
         }
     }
 
-    /// Add new data files to the snapshot.
-    ///
-    /// Used for:
+    /// Add new data files to the snapshot. Used for:
     /// - New rows from INSERT operations
     /// - Rewritten data files in COW mode (after applying UPDATE/DELETE)
-    ///
-    /// Corresponds to `addRows(DataFile)` in Java implementation.
     pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.added_data_files.extend(data_files);
         self
     }
 
     /// Mark data files as deleted in the snapshot.
-    ///
-    /// Used in COW mode to mark original files as deleted when they've been rewritten
-    /// with modifications.
-    ///
+    /// Used in COW mode to mark original files as deleted when they've been rewritten with modifications.
     /// Corresponds to `removeRows(DataFile)` in Java implementation.
     pub fn remove_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.removed_data_files.extend(data_files);
         self
     }
 
-    /// Add delete files to the snapshot (reserved for future MOR mode).
-    ///
-    /// Corresponds to `addDeletes(DeleteFile)` in Java implementation.
-    ///
-    /// # Note
-    ///
-    /// This is not yet implemented and is reserved for future Merge-on-Read (MOR)
-    /// optimization where delete files are used instead of rewriting data files.
+    /// Add delete files to the snapshot (reserved for future Merge-on-Read mode).
+    /// #Note: This is not yet implemented and is reserved for future Merge-on-Read optimization
+    /// where delete files are used instead of rewriting data files.
     pub fn add_delete_files(mut self, delete_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.added_delete_files.extend(delete_files);
         self
@@ -126,10 +114,7 @@ impl RowDeltaAction {
     }
 
     /// Validate that the operation is applied on top of a specific snapshot.
-    ///
     /// This can be used for conflict detection in concurrent modification scenarios.
-    ///
-    /// Corresponds to `validateFromSnapshot(long snapshotId)` in Java implementation.
     pub fn validate_from_snapshot(mut self, snapshot_id: i64) -> Self {
         self.starting_snapshot_id = Some(snapshot_id);
         self
@@ -208,7 +193,6 @@ impl SnapshotProduceOperation for RowDeltaOperation {
     }
 
     /// Returns manifest entries for files that should be marked as deleted.
-    ///
     /// This creates DELETED entries for removed data files in COW mode.
     async fn delete_entries(
         &self,
@@ -217,7 +201,7 @@ impl SnapshotProduceOperation for RowDeltaOperation {
         let snapshot_id = snapshot_produce.table.metadata().current_snapshot_id();
 
         // Create DELETED manifest entries for removed data files
-        let deleted_entries = self
+        let deleted_entries: Vec<ManifestEntry> = self
             .removed_data_files
             .iter()
             .map(|data_file| {
@@ -225,11 +209,18 @@ impl SnapshotProduceOperation for RowDeltaOperation {
                     ManifestEntry::builder()
                         .status(ManifestStatus::Deleted)
                         .snapshot_id(snapshot_id)
+                        // TODO: Get actual sequence numbers from original manifest entries
+                        // For now, use 0 as a placeholder - this should be the sequence
+                        // number from when the file was originally added
+                        .sequence_number(0)
+                        .file_sequence_number(0)
                         .data_file(data_file.clone())
                         .build()
                 } else {
                     ManifestEntry::builder()
                         .status(ManifestStatus::Deleted)
+                        .sequence_number(0)
+                        .file_sequence_number(0)
                         .data_file(data_file.clone())
                         .build()
                 }
@@ -241,9 +232,12 @@ impl SnapshotProduceOperation for RowDeltaOperation {
 
     /// Returns existing manifest files that should be included in the new snapshot.
     ///
-    /// For RowDelta:
-    /// - Include all existing manifests (they contain unchanged data)
-    /// - The snapshot producer will add new manifests for added/deleted entries
+    /// For RowDelta in Copy-on-Write mode:
+    /// - We're rewriting entire data files (not just modifying rows)
+    /// - Files being deleted are completely replaced by new files
+    /// - We should NOT carry forward manifests that contain any of the deleted files
+    ///
+    /// Note: For future precision COW or Merge-on-Read modes, this logic may need refinement.
     async fn existing_manifest(
         &self,
         snapshot_produce: &SnapshotProducer<'_>,
@@ -259,13 +253,37 @@ impl SnapshotProduceOperation for RowDeltaOperation {
             )
             .await?;
 
-        // Include all existing manifests - unchanged data is still valid
-        Ok(manifest_list
-            .entries()
+        // In COW mode, we rewrite entire files, so we need to exclude manifests
+        // that contain any files we're deleting. Create a set of deleted file paths for fast lookup.
+        let deleted_file_paths: std::collections::HashSet<String> = self
+            .removed_data_files
             .iter()
-            .filter(|entry| entry.has_added_files() || entry.has_existing_files())
-            .cloned()
-            .collect())
+            .map(|f| f.file_path().to_string())
+            .collect();
+
+        // Filter out manifests that contain deleted files
+        let mut filtered_manifests = Vec::new();
+        for manifest_file in manifest_list.entries().iter() {
+            if manifest_file.has_added_files() || manifest_file.has_existing_files() {
+                // Load the manifest to check if it contains any deleted files
+                let manifest = manifest_file
+                    .load_manifest(snapshot_produce.table.file_io())
+                    .await?;
+
+                // Check if any entries in this manifest are files we're deleting
+                let contains_deleted_file = manifest
+                    .entries()
+                    .iter()
+                    .any(|entry| deleted_file_paths.contains(entry.data_file().file_path()));
+
+                if !contains_deleted_file {
+                    // This manifest doesn't contain any files we're deleting, keep it
+                    filtered_manifests.push(manifest_file.clone());
+                }
+            }
+        }
+
+        Ok(filtered_manifests)
     }
 }
 

--- a/crates/iceberg/src/transaction/row_delta.rs
+++ b/crates/iceberg/src/transaction/row_delta.rs
@@ -15,53 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::error::Result;
-use crate::spec::{DataFile, ManifestEntry, ManifestFile, ManifestStatus, Operation};
+use crate::spec::{DataFile, ManifestContentType, ManifestEntry, ManifestFile, Operation};
 use crate::table::Table;
 use crate::transaction::snapshot::{
     DefaultManifestProcess, SnapshotProduceOperation, SnapshotProducer,
 };
 use crate::transaction::{ActionCommit, TransactionAction};
 
-/// RowDeltaAction handles both data file additions and deletions in a single snapshot.
-/// This is the core transaction type for MERGE, UPDATE, DELETE operations.
+/// Transaction action for Copy-on-Write row-level modifications (UPDATE, DELETE, MERGE INTO).
 ///
 /// Corresponds to `org.apache.iceberg.RowDelta` in the Java implementation.
-///
-/// # Copy-on-Write (COW) Strategy
-///
-/// For row-level modifications:
-/// 1. Read target data files that contain rows to be modified
-/// 2. Apply modifications (UPDATE/DELETE logic)
-/// 3. Write modified rows to new data files via `add_data_files()`
-/// 4. Mark original files as deleted via `remove_data_files()`
-///
-/// For inserts (NOT MATCHED in MERGE):
-/// 1. Write new rows to data files
-/// 2. Add files via `add_data_files()`
-///
-/// # Future: Merge-on-Read Strategy
-///
-/// The `add_delete_files()` method is reserved for future Merge-on-Read support, which uses
-/// delete files instead of rewriting data files.
 pub struct RowDeltaAction {
-    /// New data files to add (for inserts or rewritten files in COW mode)
     added_data_files: Vec<DataFile>,
-    /// Data files to mark as deleted (for COW mode when rewriting files)
     removed_data_files: Vec<DataFile>,
-    /// Delete files to add (reserved for future Merge-on-Read mode support)
+    /// Reserved for future Merge-on-Read support; calling `add_delete_files` currently errors.
     added_delete_files: Vec<DataFile>,
-    /// Optional commit UUID for manifest file naming
     commit_uuid: Option<Uuid>,
-    /// Additional properties to add to snapshot summary
     snapshot_properties: HashMap<String, String>,
-    /// Optional starting snapshot ID for conflict detection
     starting_snapshot_id: Option<i64>,
 }
 
@@ -77,44 +54,42 @@ impl RowDeltaAction {
         }
     }
 
-    /// Add new data files to the snapshot. Used for:
-    /// - New rows from INSERT operations
-    /// - Rewritten data files in COW mode (after applying UPDATE/DELETE)
+    /// Add new data files (INSERT rows or Copy-on-Write rewritten files).
     pub fn add_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.added_data_files.extend(data_files);
         self
     }
 
-    /// Mark data files as deleted in the snapshot.
-    /// Used in COW mode to mark original files as deleted when they've been rewritten with modifications.
-    /// Corresponds to `removeRows(DataFile)` in Java implementation.
+    /// Mark existing data files as deleted (Copy-on-Write mode).
+    ///
+    /// Corresponds to `removeRows(DataFile)` in the Java implementation.
     pub fn remove_data_files(mut self, data_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.removed_data_files.extend(data_files);
         self
     }
 
-    /// Add delete files to the snapshot (reserved for future Merge-on-Read mode).
-    /// #Note: This is not yet implemented and is reserved for future Merge-on-Read optimization
-    /// where delete files are used instead of rewriting data files.
+    /// Reserved for future Merge-on-Read support — currently returns an error on commit.
+    ///
+    /// Once MoR is implemented, this will write position/equality delete files instead of
+    /// rewriting data files.
     pub fn add_delete_files(mut self, delete_files: impl IntoIterator<Item = DataFile>) -> Self {
         self.added_delete_files.extend(delete_files);
         self
     }
 
-    /// Set commit UUID for the snapshot.
+    /// Set the commit UUID used for manifest file naming.
     pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
         self.commit_uuid = Some(commit_uuid);
         self
     }
 
-    /// Set snapshot summary properties.
+    /// Attach custom key/value metadata to the snapshot summary.
     pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
         self.snapshot_properties = snapshot_properties;
         self
     }
 
-    /// Validate that the operation is applied on top of a specific snapshot.
-    /// This can be used for conflict detection in concurrent modification scenarios.
+    /// Reject the commit if the table has advanced past `snapshot_id` (optimistic concurrency).
     pub fn validate_from_snapshot(mut self, snapshot_id: i64) -> Self {
         self.starting_snapshot_id = Some(snapshot_id);
         self
@@ -124,7 +99,14 @@ impl RowDeltaAction {
 #[async_trait]
 impl TransactionAction for RowDeltaAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
-        // Validate starting snapshot if specified
+        if !self.added_delete_files.is_empty() {
+            return Err(crate::Error::new(
+                crate::ErrorKind::FeatureUnsupported,
+                "add_delete_files is not yet implemented; Merge-on-Read support is pending. \
+                 Use remove_data_files for Copy-on-Write deletes instead.",
+            ));
+        }
+
         if let Some(expected_snapshot_id) = self.starting_snapshot_id
             && table.metadata().current_snapshot_id() != Some(expected_snapshot_id)
         {
@@ -141,21 +123,17 @@ impl TransactionAction for RowDeltaAction {
         let snapshot_producer = SnapshotProducer::new(
             table,
             self.commit_uuid.unwrap_or_else(Uuid::now_v7),
-            None, // key_metadata - not used for row delta
             self.snapshot_properties.clone(),
             self.added_data_files.clone(),
         );
 
         // Validate newly added data files (partition value type-checks, etc.).
-        // removed_data_files are not validated: they are existing table files that
-        // were already validated when originally committed, so re-validating them
-        // here would be redundant. This matches Java's MergingSnapshotProducer behavior.
+        // removed_data_files are not re-validated: they are existing table files that were
+        // already validated when originally committed. This matches Java's MergingSnapshotProducer.
         snapshot_producer.validate_added_data_files()?;
 
-        // Create RowDeltaOperation with removed files
         let operation = RowDeltaOperation {
             removed_data_files: self.removed_data_files.clone(),
-            added_delete_files: self.added_delete_files.clone(),
         };
 
         snapshot_producer
@@ -164,309 +142,198 @@ impl TransactionAction for RowDeltaAction {
     }
 }
 
-/// Implements the snapshot production logic for RowDelta operations.
-///
-/// This determines:
-/// - Which operation type is recorded (Append/Delete/Overwrite)
-/// - Which manifest entries should be marked as deleted
-/// - Which existing manifests should be carried forward
 struct RowDeltaOperation {
     removed_data_files: Vec<DataFile>,
-    added_delete_files: Vec<DataFile>,
 }
 
 impl SnapshotProduceOperation for RowDeltaOperation {
-    /// Determine operation type based on what's being added/removed.
+    /// Operation type based on Java `BaseRowDelta.operation()`:
+    /// - No removes → `Append`
+    /// - Any removes → `Overwrite`
     ///
-    /// Logic based on Java `BaseRowDelta.operation()`:
-    /// - Only adds data files (no deletes or removes) → `Append`
-    /// - Removes data files or has delete files, AND also adds data files → `Overwrite`
-    /// - Only removes/deletes with no new data added → `Delete` (future: MoR path)
-    ///
-    /// Note: `Operation::Delete` is not yet returned because `add_delete_files` is
-    /// not fully implemented. Once Merge-on-Read support is wired up, the operation
-    /// will be `Delete` when only delete files are added with no new data rows.
+    /// `Operation::Delete` (MoR-only delete files, no data file changes) is deferred until
+    /// Merge-on-Read is wired up.
     fn operation(&self) -> Operation {
-        let has_added_deletes = !self.added_delete_files.is_empty();
-        let has_removed_data = !self.removed_data_files.is_empty();
-
-        if has_removed_data || has_added_deletes {
-            Operation::Overwrite
-        } else {
+        if self.removed_data_files.is_empty() {
             Operation::Append
+        } else {
+            Operation::Overwrite
         }
     }
 
-    /// Returns manifest entries for files that should be marked as deleted.
-    /// This creates DELETED entries for removed data files in COW mode.
+    /// Delete entries are handled inside `existing_manifest` by rewriting the manifest.
     async fn delete_entries(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        _snapshot_produce: &SnapshotProducer<'_>,
     ) -> Result<Vec<ManifestEntry>> {
-        let snapshot_id = snapshot_produce.table.metadata().current_snapshot_id();
-
-        // Create DELETED manifest entries for removed data files
-        let deleted_entries: Vec<ManifestEntry> = self
-            .removed_data_files
-            .iter()
-            .map(|data_file| {
-                if let Some(snapshot_id) = snapshot_id {
-                    ManifestEntry::builder()
-                        .status(ManifestStatus::Deleted)
-                        .snapshot_id(snapshot_id)
-                        // TODO: Get actual sequence numbers from original manifest entries
-                        // For now, use 0 as a placeholder - this should be the sequence
-                        // number from when the file was originally added
-                        .sequence_number(0)
-                        .file_sequence_number(0)
-                        .data_file(data_file.clone())
-                        .build()
-                } else {
-                    ManifestEntry::builder()
-                        .status(ManifestStatus::Deleted)
-                        .sequence_number(0)
-                        .file_sequence_number(0)
-                        .data_file(data_file.clone())
-                        .build()
-                }
-            })
-            .collect();
-
-        Ok(deleted_entries)
+        Ok(vec![])
     }
 
-    /// Returns existing manifest files that should be included in the new snapshot.
+    /// Returns manifest files for the new snapshot.
     ///
-    /// For RowDelta in Copy-on-Write mode:
-    /// - We're rewriting entire data files (not just modifying rows)
-    /// - Files being deleted are completely replaced by new files
-    /// - We should NOT carry forward manifests that contain any of the deleted files
+    /// For each manifest in the previous snapshot:
+    /// - If it contains any file being removed: rewrite it with DELETED entries for removed files
+    ///   and EXISTING entries for survivors, preserving original sequence numbers.
+    /// - Otherwise: carry it forward unchanged.
     ///
-    /// Note: For future precision COW or Merge-on-Read modes, this logic may need refinement.
+    /// This matches Java's `ManifestFilterManager.filterManifestWithDeletedFiles` logic.
     async fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        snapshot_produce: &mut SnapshotProducer<'_>,
     ) -> Result<Vec<ManifestFile>> {
         let Some(snapshot) = snapshot_produce.table.metadata().current_snapshot() else {
             return Ok(vec![]);
         };
 
-        let manifest_list = snapshot
-            .load_manifest_list(
-                snapshot_produce.table.file_io(),
-                &snapshot_produce.table.metadata_ref(),
-            )
+        let manifest_list = snapshot_produce
+            .table
+            .manifest_list_reader(snapshot)
+            .load()
             .await?;
 
-        // In COW mode, we rewrite entire files, so we need to exclude manifests
-        // that contain any files we're deleting. Create a set of deleted file paths for fast lookup.
-        let deleted_file_paths: std::collections::HashSet<String> = self
+        let deleted_paths: HashSet<&str> = self
             .removed_data_files
             .iter()
-            .map(|f| f.file_path().to_string())
+            .map(|f| f.file_path())
             .collect();
 
-        // Filter out manifests that contain deleted files
-        let mut filtered_manifests = Vec::new();
-        for manifest_file in manifest_list.entries().iter() {
-            if manifest_file.has_added_files() || manifest_file.has_existing_files() {
-                // Load the manifest to check if it contains any deleted files
-                let manifest = manifest_file
-                    .load_manifest(snapshot_produce.table.file_io())
-                    .await?;
+        let mut result = Vec::new();
+        for manifest_file in manifest_list.entries() {
+            if !manifest_file.has_added_files() && !manifest_file.has_existing_files() {
+                continue;
+            }
 
-                // Check if any entries in this manifest are files we're deleting
-                let contains_deleted_file = manifest
-                    .entries()
-                    .iter()
-                    .any(|entry| deleted_file_paths.contains(entry.data_file().file_path()));
+            let manifest = manifest_file
+                .load_manifest(snapshot_produce.table.file_io())
+                .await?;
 
-                if !contains_deleted_file {
-                    // This manifest doesn't contain any files we're deleting, keep it
-                    filtered_manifests.push(manifest_file.clone());
+            let needs_rewrite = manifest
+                .entries()
+                .iter()
+                .any(|e| e.is_alive() && deleted_paths.contains(e.data_file().file_path()));
+
+            if !needs_rewrite {
+                result.push(manifest_file.clone());
+                continue;
+            }
+
+            // Rewrite: deleted files → DELETED (new snapshot_id, original seq nums preserved),
+            // surviving files → EXISTING (all original fields preserved).
+            let mut writer = snapshot_produce.new_manifest_writer(ManifestContentType::Data)?;
+            for entry in manifest.entries() {
+                if deleted_paths.contains(entry.data_file().file_path()) {
+                    writer.add_delete_entry((**entry).clone())?;
+                } else {
+                    writer.add_existing_entry((**entry).clone())?;
                 }
             }
+            result.push(writer.write_manifest_file().await?);
         }
 
-        Ok(filtered_manifests)
+        Ok(result)
+    }
+
+    fn removed_data_files(&self) -> &[DataFile] {
+        &self.removed_data_files
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
-    use crate::TableUpdate;
-    use crate::spec::{DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct};
+    use crate::spec::{
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+        ManifestStatus, SnapshotRef, Struct, TableMetadataBuilder,
+    };
+    use crate::table::Table;
     use crate::transaction::tests::make_v2_minimal_table;
     use crate::transaction::{Transaction, TransactionAction};
+    use crate::{TableIdent, TableUpdate};
+
+    fn make_data_file(table: &Table, path: &str, size: u64) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(path.to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(size)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(100))]))
+            .build()
+            .unwrap()
+    }
+
+    /// Build a table that has `snapshot` as its current snapshot, backed by the same FileIO.
+    async fn table_with_snapshot(base: &Table, snapshot: crate::spec::Snapshot) -> Table {
+        let updated_metadata =
+            TableMetadataBuilder::new_from_metadata(base.metadata_ref().as_ref().clone(), None)
+                .set_branch_snapshot(snapshot, MAIN_BRANCH)
+                .unwrap()
+                .build()
+                .unwrap()
+                .metadata;
+
+        Table::builder()
+            .metadata(updated_metadata)
+            .metadata_location("s3://bucket/test/location/metadata/v2.json".to_string())
+            .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
+            .file_io(base.file_io().clone())
+            .runtime(crate::test_utils::test_runtime())
+            .build()
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_row_delta_add_only() {
-        // Test adding data files only (pure append)
         let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
+        let data_file = make_data_file(&table, "test/1.parquet", 100);
+        let action = Transaction::new(&table)
+            .row_delta()
+            .add_data_files(vec![data_file]);
 
-        let data_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/1.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(10)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
+        let mut commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = commit.take_updates();
 
-        let action = tx.row_delta().add_data_files(vec![data_file.clone()]);
-        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
-        let updates = action_commit.take_updates();
-
-        // Verify snapshot was created
-        assert!(matches!(&updates[0], TableUpdate::AddSnapshot { .. }));
-
-        // Verify the snapshot summary shows Append operation
         if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
             assert_eq!(snapshot.summary().operation, crate::spec::Operation::Append);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_row_delta_remove_only() {
-        // Test removing data files (COW delete) - should succeed
-        let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-
-        let data_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/old.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(10)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
-
-        let action = tx.row_delta().remove_data_files(vec![data_file]);
-
-        // This should succeed - delete-only operations are valid
-        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
-        let updates = action_commit.take_updates();
-
-        // Verify snapshot was created with Overwrite operation
-        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
-            assert_eq!(
-                snapshot.summary().operation,
-                crate::spec::Operation::Overwrite
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_row_delta_add_and_remove() {
-        // Test COW update: remove old file, add new file
-        let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-
-        let old_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/old.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(10)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
-
-        let new_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/new.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(120)
-            .record_count(12)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
-
-        let action = tx
-            .row_delta()
-            .remove_data_files(vec![old_file])
-            .add_data_files(vec![new_file]);
-
-        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
-        let updates = action_commit.take_updates();
-
-        // Verify snapshot was created with Overwrite operation
-        if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
-            assert_eq!(
-                snapshot.summary().operation,
-                crate::spec::Operation::Overwrite
-            );
+        } else {
+            panic!("expected AddSnapshot");
         }
     }
 
     #[tokio::test]
     async fn test_row_delta_with_snapshot_properties() {
         let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-
-        let mut snapshot_properties = HashMap::new();
-        snapshot_properties.insert("key".to_string(), "value".to_string());
-
-        let data_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/1.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(10)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
-
-        let action = tx
+        let data_file = make_data_file(&table, "test/1.parquet", 100);
+        let mut props = std::collections::HashMap::new();
+        props.insert("key".to_string(), "value".to_string());
+        let action = Transaction::new(&table)
             .row_delta()
-            .set_snapshot_properties(snapshot_properties)
+            .set_snapshot_properties(props)
             .add_data_files(vec![data_file]);
 
-        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
-        let updates = action_commit.take_updates();
+        let mut commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = commit.take_updates();
 
-        // Check customized properties in snapshot summary
         if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
             assert_eq!(
                 snapshot.summary().additional_properties.get("key").unwrap(),
                 "value"
             );
+        } else {
+            panic!("expected AddSnapshot");
         }
     }
 
     #[tokio::test]
     async fn test_row_delta_validate_from_snapshot() {
-        // Test the snapshot validation logic
         let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-
-        let data_file = DataFileBuilder::default()
-            .content(DataContentType::Data)
-            .file_path("test/1.parquet".to_string())
-            .file_format(DataFileFormat::Parquet)
-            .file_size_in_bytes(100)
-            .record_count(10)
-            .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(100))]))
-            .build()
-            .unwrap();
-
-        // Test with invalid snapshot ID (table has no snapshot, so any ID should fail)
-        let action = tx
+        let data_file = make_data_file(&table, "test/1.parquet", 100);
+        let action = Transaction::new(&table)
             .row_delta()
             .validate_from_snapshot(99999)
-            .add_data_files(vec![data_file.clone()]);
+            .add_data_files(vec![data_file]);
 
         let result = Arc::new(action).commit(&table).await;
         match result {
@@ -478,20 +345,18 @@ mod tests {
     #[tokio::test]
     async fn test_row_delta_empty_action() {
         let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-        let action = tx.row_delta();
-
-        // Empty row delta should fail
-        assert!(Arc::new(action).commit(&table).await.is_err());
+        assert!(
+            Arc::new(Transaction::new(&table).row_delta())
+                .commit(&table)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn test_row_delta_incompatible_partition_value() {
         let table = make_v2_minimal_table();
-        let tx = Transaction::new(&table);
-
-        // Create file with incompatible partition value (string instead of long)
-        let data_file = DataFileBuilder::default()
+        let bad_file = DataFileBuilder::default()
             .content(DataContentType::Data)
             .file_path("test/bad.parquet".to_string())
             .file_format(DataFileFormat::Parquet)
@@ -501,10 +366,143 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::string("wrong"))]))
             .build()
             .unwrap();
-
-        let action = tx.row_delta().add_data_files(vec![data_file]);
-
-        // Should fail validation
+        let action = Transaction::new(&table)
+            .row_delta()
+            .add_data_files(vec![bad_file]);
         assert!(Arc::new(action).commit(&table).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_row_delta_add_delete_files_errors() {
+        let table = make_v2_minimal_table();
+        let file = make_data_file(&table, "test/delete.parquet", 100);
+        let action = Transaction::new(&table)
+            .row_delta()
+            .add_delete_files(vec![file]);
+        let result = Arc::new(action).commit(&table).await;
+        match result {
+            Ok(_) => panic!("expected FeatureUnsupported"),
+            Err(e) => assert_eq!(e.kind(), crate::ErrorKind::FeatureUnsupported),
+        }
+    }
+
+    /// End-to-end CoW test: append two files, then remove one via RowDelta.
+    ///
+    /// Verifies:
+    /// - The removed file appears as DELETED with correct sequence numbers.
+    /// - The surviving file appears as EXISTING with correct sequence numbers.
+    /// - The new file appears as ADDED.
+    /// - The snapshot summary counts `deleted-data-files = 1`.
+    #[tokio::test]
+    async fn test_row_delta_cow_manifest_rewrite() {
+        let base_table = make_v2_minimal_table();
+
+        // --- S1: append file-A and file-B ---
+        let file_a = make_data_file(&base_table, "test/a.parquet", 100);
+        let file_b = make_data_file(&base_table, "test/b.parquet", 200);
+
+        let action1 = Transaction::new(&base_table)
+            .fast_append()
+            .add_data_files(vec![file_a.clone(), file_b.clone()]);
+        let mut commit1 = Arc::new(action1).commit(&base_table).await.unwrap();
+        let updates1 = commit1.take_updates();
+
+        let snapshot_s1 =
+            if let TableUpdate::AddSnapshot { snapshot } = updates1.into_iter().next().unwrap() {
+                snapshot
+            } else {
+                panic!("expected AddSnapshot");
+            };
+
+        let table_s1 = table_with_snapshot(&base_table, snapshot_s1).await;
+
+        // --- S2: remove file-A (CoW), add file-C ---
+        let file_c = make_data_file(&table_s1, "test/c.parquet", 300);
+        let action2 = Transaction::new(&table_s1)
+            .row_delta()
+            .remove_data_files(vec![file_a.clone()])
+            .add_data_files(vec![file_c.clone()]);
+        let mut commit2 = Arc::new(action2).commit(&table_s1).await.unwrap();
+        let updates2 = commit2.take_updates();
+
+        let snapshot_s2 = if let TableUpdate::AddSnapshot { ref snapshot } = updates2[0] {
+            snapshot
+        } else {
+            panic!("expected AddSnapshot");
+        };
+
+        assert_eq!(
+            snapshot_s2.summary().operation,
+            crate::spec::Operation::Overwrite
+        );
+
+        // Verify snapshot summary metrics
+        let props = &snapshot_s2.summary().additional_properties;
+        assert_eq!(
+            props.get("deleted-data-files").map(String::as_str),
+            Some("1"),
+            "summary should count 1 deleted file"
+        );
+
+        // Scan all manifest entries in S2
+        let manifest_list = table_s1
+            .manifest_list_reader(&SnapshotRef::new(snapshot_s2.clone()))
+            .load()
+            .await
+            .unwrap();
+
+        let mut found_deleted_a = false;
+        let mut found_existing_b = false;
+        let mut found_added_c = false;
+
+        for manifest_file in manifest_list.entries() {
+            let manifest = manifest_file
+                .load_manifest(table_s1.file_io())
+                .await
+                .unwrap();
+            for entry in manifest.entries() {
+                match entry.data_file().file_path() {
+                    "test/a.parquet" => {
+                        assert_eq!(
+                            entry.status(),
+                            ManifestStatus::Deleted,
+                            "file-A must be DELETED"
+                        );
+                        assert!(
+                            entry.sequence_number().is_some(),
+                            "DELETED entry must have sequence number"
+                        );
+                        assert!(
+                            entry.file_sequence_number.is_some(),
+                            "DELETED entry must have file sequence number"
+                        );
+                        found_deleted_a = true;
+                    }
+                    "test/b.parquet" => {
+                        assert_eq!(
+                            entry.status(),
+                            ManifestStatus::Existing,
+                            "file-B must be EXISTING"
+                        );
+                        assert!(
+                            entry.sequence_number().is_some(),
+                            "EXISTING entry must have sequence number"
+                        );
+                        found_existing_b = true;
+                    }
+                    "test/c.parquet" => {
+                        found_added_c = true;
+                    }
+                    other => panic!("unexpected file in S2 manifests: {other}"),
+                }
+            }
+        }
+
+        assert!(found_deleted_a, "file-A should have a DELETED entry in S2");
+        assert!(
+            found_existing_b,
+            "file-B should have an EXISTING entry in S2"
+        );
+        assert!(found_added_c, "file-C should have an ADDED entry in S2");
     }
 }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -331,6 +331,25 @@ impl<'a> SnapshotProducer<'a> {
         writer.write_manifest_file().await
     }
 
+    // Write manifest file for deleted data files and return the ManifestFile for ManifestList.
+    async fn write_delete_manifest(
+        &mut self,
+        delete_entries: Vec<ManifestEntry>,
+    ) -> Result<ManifestFile> {
+        if delete_entries.is_empty() {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                "No delete entries found when write a delete manifest file",
+            ));
+        }
+
+        let mut writer = self.new_manifest_writer(ManifestContentType::Data)?;
+        for entry in delete_entries {
+            writer.add_entry(entry)?;
+        }
+        writer.write_manifest_file().await
+    }
+
     /// Creates new manifests for data files added or removed,
     /// and collects all of the manifests to be included in the new snapshot as [ManifestFile] entries.
     async fn produce_manifests<OP: SnapshotProduceOperation, MP: ManifestProcess>(
@@ -338,15 +357,22 @@ impl<'a> SnapshotProducer<'a> {
         snapshot_produce_operation: &OP,
         manifest_process: &MP,
     ) -> Result<Vec<ManifestFile>> {
+        // Check if there's any content to add to the new snapshot
+        let delete_entries = snapshot_produce_operation.delete_entries(self).await?;
+        let has_delete_entries = !delete_entries.is_empty();
+
         // Assert current snapshot producer contains new content to add to new snapshot.
         //
         // TODO: Allowing snapshot property setup with no added data files is a workaround.
         // We should clean it up after all necessary actions are supported.
         // For details, please refer to https://github.com/apache/iceberg-rust/issues/1548
-        if self.added_data_files.is_empty() && self.snapshot_properties.is_empty() {
+        if self.added_data_files.is_empty()
+            && self.snapshot_properties.is_empty()
+            && !has_delete_entries
+        {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
-                "No added data files or added snapshot properties found when write a manifest file",
+                "No added data files, delete entries, or snapshot properties found when write a manifest file",
             ));
         }
 
@@ -359,8 +385,11 @@ impl<'a> SnapshotProducer<'a> {
             manifest_files.push(added_manifest);
         }
 
-        // # TODO
-        // Support process delete entries.
+        // Process delete entries.
+        if has_delete_entries {
+            let delete_manifest = self.write_delete_manifest(delete_entries).await?;
+            manifest_files.push(delete_manifest);
+        }
 
         let manifest_files = manifest_process.process_manifests(self, manifest_files);
         Ok(manifest_files)

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -60,10 +60,6 @@ use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 /// 3. **Delete Entry Processing**: The `delete_entries()` method is intended for future delete
 ///    operations to specify which manifest entries should be marked as deleted.
 pub(crate) trait SnapshotProduceOperation: Send + Sync {
-    /// Returns the operation type that will be recorded in the snapshot summary.
-    ///
-    /// This determines what kind of operation is being performed (e.g., `Append`, `Overwrite`),
-    /// which is stored in the snapshot metadata for tracking and auditing purposes.
     fn operation(&self) -> Operation;
 
     /// Returns manifest entries that should be marked as deleted in the new snapshot.
@@ -73,18 +69,29 @@ pub(crate) trait SnapshotProduceOperation: Send + Sync {
         snapshot_produce: &SnapshotProducer,
     ) -> impl Future<Output = Result<Vec<ManifestEntry>>> + Send;
 
-    /// Returns existing manifest files that should be included in the new snapshot.
+    /// Returns existing manifest files to carry forward (or rewrite) into the new snapshot.
     ///
-    /// This method determines which manifest files from the current snapshot should be
-    /// carried forward to the new snapshot. The selection depends on the operation type:
-    ///
-    /// - **Append operations**: Typically include all existing manifests
-    /// - **Overwrite operations**: May exclude manifests for partitions being overwritten
-    /// - **Delete operations**: May exclude manifests for partitions being deleted
+    /// Implementations that need to delete specific files within a manifest should rewrite that
+    /// manifest (DELETED + EXISTING entries) and return the rewritten `ManifestFile` here.
+    /// `&mut SnapshotProducer` is provided so that implementations can call
+    /// `snapshot_produce.new_manifest_writer()` to produce the rewritten manifest.
     fn existing_manifest(
         &self,
-        snapshot_produce: &SnapshotProducer<'_>,
+        snapshot_produce: &mut SnapshotProducer<'_>,
     ) -> impl Future<Output = Result<Vec<ManifestFile>>> + Send;
+
+    /// Data files being removed in this operation (used for snapshot summary metrics).
+    fn removed_data_files(&self) -> &[DataFile] {
+        &[]
+    }
+
+    /// Whether this Overwrite replaces the entire table content. When true,
+    /// `truncate_table_summary` sets `deleted-data-files` to the previous total.
+    /// Row-level operations (RowDelta) return false; full-table rewrites (future
+    /// OverwriteFiles / ReplacePartitions) return true.
+    fn is_truncate_full_table(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) struct DefaultManifestProcess;
@@ -237,7 +244,10 @@ impl<'a> SnapshotProducer<'a> {
         snapshot_id
     }
 
-    fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {
+    pub(crate) fn new_manifest_writer(
+        &mut self,
+        content: ManifestContentType,
+    ) -> Result<ManifestWriter> {
         let new_manifest_path = format!(
             "{}/{}-m{}.{}",
             self.table.metadata().metadata_location()?,
@@ -331,8 +341,11 @@ impl<'a> SnapshotProducer<'a> {
         writer.write_manifest_file().await
     }
 
-    // Write manifest file for deleted data files and return the ManifestFile for ManifestList.
-    async fn write_delete_manifest(
+    // Write a data manifest containing DELETED-status entries and return the ManifestFile.
+    // Note: this is NOT an Iceberg "delete manifest" (content=Deletes for MoR delete files).
+    // It is a data manifest (content=Data) whose entries carry ManifestStatus::Deleted to
+    // record which data files were removed in Copy-on-Write mode.
+    async fn write_manifest_with_deleted_entries(
         &mut self,
         delete_entries: Vec<ManifestEntry>,
     ) -> Result<ManifestFile> {
@@ -389,7 +402,9 @@ impl<'a> SnapshotProducer<'a> {
 
         // Process delete entries.
         if has_delete_entries {
-            let delete_manifest = self.write_delete_manifest(delete_entries).await?;
+            let delete_manifest = self
+                .write_manifest_with_deleted_entries(delete_entries)
+                .await?;
             manifest_files.push(delete_manifest);
         }
 
@@ -428,6 +443,14 @@ impl<'a> SnapshotProducer<'a> {
             );
         }
 
+        for data_file in snapshot_produce_operation.removed_data_files() {
+            summary_collector.remove_file(
+                data_file,
+                table_metadata.current_schema().clone(),
+                table_metadata.default_partition_spec().clone(),
+            );
+        }
+
         let previous_snapshot = table_metadata.current_snapshot();
 
         // User-supplied snapshot properties are applied first, then the computed
@@ -446,7 +469,7 @@ impl<'a> SnapshotProducer<'a> {
         update_snapshot_summaries(
             summary,
             previous_snapshot.map(|s| s.summary()),
-            snapshot_produce_operation.operation() == Operation::Overwrite,
+            snapshot_produce_operation.is_truncate_full_table(),
         )
     }
 

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -339,13 +339,15 @@ impl<'a> SnapshotProducer<'a> {
         if delete_entries.is_empty() {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
-                "No delete entries found when write a delete manifest file",
+                "No delete entries found when writing a delete manifest file",
             ));
         }
 
         let mut writer = self.new_manifest_writer(ManifestContentType::Data)?;
         for entry in delete_entries {
-            writer.add_entry(entry)?;
+            // Use add_delete_entry() to preserve Deleted status instead of add_entry()
+            // which always overwrites status to Added
+            writer.add_delete_entry(entry)?;
         }
         writer.write_manifest_file().await
     }


### PR DESCRIPTION
Partially Deliever #1104 . (The issue #2202 is redundant). Implement the RowDelta Transaction for CoW. The epic #2201 and epic #2205 requires this basic RowDelta Transaction.

## Background

Iceberg's `RowDelta` is the fundamental transaction action backing `MERGE INTO`, `UPDATE`, and `DELETE` SQL operations. Unlike `FastAppend` (which only adds new files), `RowDelta` can both add new data files **and** mark existing ones as deleted in a single atomic snapshot. The code refers to the official Iceberg Java implementation (RowDelta API)

Iceberg supports two strategies for row-level mutations:

- **Copy-on-Write (CoW)**: The engine reads affected data files, applies the mutation in-memory, writes new data files, and atomically marks the originals as deleted. Readers always see clean, fully-materialized data files. Trade-off: high write amplification, zero read overhead.
- **Merge-on-Read (MoR)**: Instead of rewriting files, the engine appends small "delete files" (position deletes or equality deletes). Readers must merge data files with delete files at scan time. Trade-off: low write amplification, higher read overhead.

## What this PR does

Implements `RowDeltaAction` in the transaction layer with **Copy-on-Write support**:

| Method | Purpose |
|---|---|
| `add_data_files()` | Add new/rewritten data files (INSERT rows, or CoW rewritten files) |
| `remove_data_files()` | Mark existing data files as deleted (CoW mode) |
| `add_delete_files()` | Stubbed API for future Merge-on-Read support |
| `validate_from_snapshot()` | Optimistic concurrency: reject commit if table has advanced |
| `set_snapshot_properties()` | Attach custom key/value metadata to the snapshot summary |

### How the snapshot is built

1. All existing manifests are carried forward to the new snapshot, **except** manifests that contain any of the removed data files.
2. A new manifest is written for the added data files.
3. The snapshot operation type is determined by what changed:
   - `Append` — only new files added, nothing removed
   - `Overwrite` — data files removed (CoW update/delete), or both added and removed

### What is intentionally deferred

`add_delete_files()` is API-only scaffolding. Full MoR support requires:
1. Writing a separate *delete manifest* (Avro file with `content = Deletes`)
2. Correct sequence number propagation so delete files only apply to data files written before them
3. Reader-side delete file merge at scan time

MoR solution seems to already being contributed by other folks. I am willing to make further contribution for MoR if necessary.

## Java reference

- [`org.apache.iceberg.RowDelta`](https://github.com/apache/iceberg/blob/ed8a16bbeb549b0286d3c229beb5a0cf165f2f4b/api/src/main/java/org/apache/iceberg/RowDelta.java)
- [`org.apache.iceberg.BaseRowDelta`](https://github.com/apache/iceberg/blob/ed8a16bbeb549b0286d3c229beb5a0cf165f2f4b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java)
- [`org.apache.iceberg.MergingSnapshotProducer`](https://github.com/apache/iceberg/blob/ed8a16bbeb549b0286d3c229beb5a0cf165f2f4b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java)