### PR TITLE
Infra: Remove GitHub Actions from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,6 @@
 
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-
   # Maintain dependencies for iceberg
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
Removed GitHub Actions dependency update configuration.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Related to https://github.com/apache/iceberg-python/issues/3186

Dont auto update since we now depend on github action being allowlisted by asf-infra first, https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->