### PR TITLE
fix: explicitly set Python interpreter in maturin build to prevent using wrong version

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           working-directory: "bindings/python"
           command: build
-          args: --out dist
+          args: --out dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           version: "0.9.3"

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -191,7 +191,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           working-directory: "bindings/python"
           command: build
-          args: --release -o dist
+          args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -101,7 +101,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           working-directory: "bindings/python"
           command: build
-          args: --release -o dist
+          args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2276.
- Related to https://github.com/apache/iceberg-python/issues/3190

## What changes are included in this PR?
Maturin auto-discovers Python interpreters inside manylinux Docker containers and may pick an older version (e.g., 3.8) instead of the intended 3.12. The `actions/setup-python` step only installs Python on the host runner, not inside the container. (This is called by in the [`maturin-action` documentation](https://github.com/PyO3/maturin-action))

Fix by passing `-i python3.12` to `maturin build` in all workflows:
- `bindings_python_ci.yml`
- `release_python.yml`
- `release_python_nightly.yml`

`sdist` commands are unchanged since source distributions don't target a specific interpreter.


<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, tested by manually triggering nightly build https://github.com/apache/iceberg-rust/actions/runs/23450629743

Log for `wheels (ubuntu-latest, x86_64)` shows:
```
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support
🐍 Found CPython 3.12 at /opt/python/cp312-cp312/bin/python
📡 Using build options features from pyproject.toml
...
📦 Built wheel for abi3 Python ≥ 3.10 to dist/pyiceberg_core-0.9.0.dev20260323172059-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```