### PR TITLE
feat/perf: add insert_range and contains to DeleteVector

### DIFF
--- a/crates/iceberg/src/delete_vector.rs
+++ b/crates/iceberg/src/delete_vector.rs
@@ -46,12 +46,20 @@ impl DeleteVector {
     }
 
     /// Inserts all positions in the range [start, end) into the delete vector.
-    /// If start >= end, this method does nothing and returns 0.
+    /// If start == end, this method does nothing and returns 0.
+    ///
+    /// # Panics
+    ///
+    /// Panics if start > end (a reversed range indicates a bug in the caller).
     ///
     /// Returns the number of newly inserted positions.
     #[allow(unused)]
     pub fn insert_range(&mut self, start: u64, end: u64) -> u64 {
-        if start >= end {
+        assert!(
+            start <= end,
+            "insert_range requires start <= end, got [{start}, {end})"
+        );
+        if start == end {
             return 0;
         }
         self.inner.insert_range(start..end)
@@ -76,6 +84,7 @@ impl DeleteVector {
         Ok(positions.len())
     }
 
+    /// Returns true if the given position is present in the delete vector.
     #[allow(unused)]
     pub fn contains(&self, pos: u64) -> bool {
         self.inner.contains(pos)
@@ -276,10 +285,10 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_range_empty_when_start_greater_than_end() {
+    #[should_panic(expected = "insert_range requires start <= end")]
+    fn test_insert_range_reversed_panics() {
         let mut dv = DeleteVector::default();
-        assert_eq!(dv.insert_range(100, 50), 0);
-        assert_eq!(dv.len(), 0);
+        dv.insert_range(100, 50);
     }
 
     #[test]

--- a/crates/iceberg/src/delete_vector.rs
+++ b/crates/iceberg/src/delete_vector.rs
@@ -77,6 +77,11 @@ impl DeleteVector {
     }
 
     #[allow(unused)]
+    pub fn contains(&self, pos: u64) -> bool {
+        self.inner.contains(pos)
+    }
+
+    #[allow(unused)]
     pub fn len(&self) -> u64 {
         self.inner.len()
     }
@@ -255,12 +260,12 @@ mod tests {
         let inserted = dv.insert_range(start, end);
         assert_eq!(inserted, end - start);
         assert_eq!(dv.len(), end - start);
-        assert!(dv.iter().any(|p| p == start));
-        assert!(dv.iter().any(|p| p == end - 1));
-        assert!(dv.iter().any(|p| p == 1u64 << 32));
-        assert!(dv.iter().any(|p| p == (1u64 << 32) | 0xFFFFFFF0));
-        assert!(!dv.iter().any(|p| p == start - 1));
-        assert!(!dv.iter().any(|p| p == end));
+        assert!(dv.contains(start));
+        assert!(dv.contains(end - 1));
+        assert!(dv.contains(1u64 << 32));
+        assert!(dv.contains((1u64 << 32) | 0xFFFFFFF0));
+        assert!(!dv.contains(start - 1));
+        assert!(!dv.contains(end));
     }
 
     #[test]

--- a/crates/iceberg/src/delete_vector.rs
+++ b/crates/iceberg/src/delete_vector.rs
@@ -45,6 +45,18 @@ impl DeleteVector {
         self.inner.insert(pos)
     }
 
+    /// Inserts all positions in the range [start, end) into the delete vector.
+    /// If start >= end, this method does nothing and returns 0.
+    ///
+    /// Returns the number of newly inserted positions.
+    #[allow(unused)]
+    pub fn insert_range(&mut self, start: u64, end: u64) -> u64 {
+        if start >= end {
+            return 0;
+        }
+        self.inner.insert_range(start..end)
+    }
+
     /// Marks the given `positions` as deleted and returns the number of elements appended.
     ///
     /// The input slice must be strictly ordered in ascending order, and every value must be greater than all existing values already in the set.
@@ -197,5 +209,82 @@ mod tests {
         let positions = vec![1, 3, 5, 5];
         let res = dv.insert_positions(&positions);
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_insert_range_single_key() {
+        let mut dv = DeleteVector::default();
+        assert_eq!(dv.insert_range(10, 20), 10);
+        assert_eq!(dv.len(), 10);
+        for pos in 10..20 {
+            assert!(dv.iter().any(|p| p == pos), "missing {pos}");
+        }
+        assert!(!dv.iter().any(|p| p == 9));
+        assert!(!dv.iter().any(|p| p == 20));
+    }
+
+    #[test]
+    fn test_insert_range_single_position() {
+        let mut dv = DeleteVector::default();
+        assert_eq!(dv.insert_range(42, 43), 1);
+        assert_eq!(dv.len(), 1);
+        assert!(dv.iter().any(|p| p == 42));
+        assert!(!dv.iter().any(|p| p == 41));
+        assert!(!dv.iter().any(|p| p == 43));
+    }
+
+    #[test]
+    fn test_insert_range_across_keys() {
+        let mut dv = DeleteVector::default();
+        let start = (1u64 << 32) - 5;
+        let end = (1u64 << 32) + 5;
+        assert_eq!(dv.insert_range(start, end), 10);
+        assert_eq!(dv.len(), 10);
+        for pos in start..end {
+            assert!(dv.iter().any(|p| p == pos), "missing {pos}");
+        }
+        assert!(!dv.iter().any(|p| p == start - 1));
+        assert!(!dv.iter().any(|p| p == end));
+    }
+
+    #[test]
+    fn test_insert_range_spanning_three_keys() {
+        let mut dv = DeleteVector::default();
+        let start = 0xFFFFFFF0u64;
+        let end = (2u64 << 32) | 0x10;
+        let inserted = dv.insert_range(start, end);
+        assert_eq!(inserted, end - start);
+        assert_eq!(dv.len(), end - start);
+        assert!(dv.iter().any(|p| p == start));
+        assert!(dv.iter().any(|p| p == end - 1));
+        assert!(dv.iter().any(|p| p == 1u64 << 32));
+        assert!(dv.iter().any(|p| p == (1u64 << 32) | 0xFFFFFFF0));
+        assert!(!dv.iter().any(|p| p == start - 1));
+        assert!(!dv.iter().any(|p| p == end));
+    }
+
+    #[test]
+    fn test_insert_range_empty_when_start_equals_end() {
+        let mut dv = DeleteVector::default();
+        assert_eq!(dv.insert_range(100, 100), 0);
+        assert_eq!(dv.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_range_empty_when_start_greater_than_end() {
+        let mut dv = DeleteVector::default();
+        assert_eq!(dv.insert_range(100, 50), 0);
+        assert_eq!(dv.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_range_large_contiguous() {
+        let mut dv = DeleteVector::default();
+        assert_eq!(dv.insert_range(500, 200_500), 200_000);
+        assert_eq!(dv.len(), 200_000);
+        assert!(dv.iter().any(|p| p == 500));
+        assert!(dv.iter().any(|p| p == 200_499));
+        assert!(!dv.iter().any(|p| p == 499));
+        assert!(!dv.iter().any(|p| p == 200_500));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This is the Rust counterpart of the Java optimization in https://github.com/apache/iceberg/pull/15791.

## What changes are included in this PR?

- Add `DeleteVector::insert_range(start, end)` that delegates to `RoaringTreemap::insert_range` for bulk range insertion
- Add `DeleteVector::contains(pos)` for efficient single-position lookups
- Add tests for single-position, cross-key, three-key spanning, empty, reversed, and large contiguous ranges

## Are these changes tested?

Yes, unit tests covering all edge cases listed above are included in `delete_vector::tests`.