### PR TITLE
feat: forward vended credentials to file_io config

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -833,11 +833,21 @@ impl Catalog for RestCatalog {
             }
         };
 
-        let config = response
+        let mut config = response
             .config
             .into_iter()
             .chain(self.user_config.props.clone())
-            .collect();
+            .collect::<HashMap<String, String>>();
+
+        if let Some(storage_credentials) = response.storage_credentials {
+            for storage_credential in storage_credentials {
+                if let Some(metadata_location) = &response.metadata_location
+                    && metadata_location.starts_with(&storage_credential.prefix)
+                {
+                    config.extend(storage_credential.config.clone());
+                }
+            }
+        }
 
         let file_io = self
             .load_file_io(response.metadata_location.as_deref(), Some(config))


### PR DESCRIPTION
## Which issue does this PR close?

No issue filled.

## What changes are included in this PR?

This PR is a draft to support credentials vending.

When loading a table, credentials are obtained if the relevant mode is activated, but ignored.

With this PR, if there is credentials available, and the prefix matches the table's metadata location, they are appended to the props of the loaded table.

The advantages of this is that you don't require to give full access (read or write) to the underlying bucket.

It allows to have fined grain permissions on the underlying data.

## Are these changes tested?

It has been tested on GCP Iceberg Catalog with vended credentials enabled, in read mode only.

Write mode will be tested shortly.

See https://docs.cloud.google.com/biglake/docs/blms-rest-catalog for an example of how to use a Biglake Iceberg Catalog.
