### PR TITLE
ci: allows nightly to run on workflow dispatch

### DIFF
--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   set-version:
+    if: github.repository == 'apache/iceberg-rust' || github.event_name == 'workflow_dispatch' # Run on schedule for apache repo, or on manual dispatch from any repo
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.set-ts.outputs.TIMESTAMP }}
@@ -37,7 +38,6 @@ jobs:
 
   sdist:
     needs: set-version
-    if: github.repository == 'apache/iceberg-rust' # Only run for apache repo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,7 +62,6 @@ jobs:
 
   wheels:
     needs: set-version
-    if: github.repository == 'apache/iceberg-rust' # Only run for apache repo
     runs-on: "${{ matrix.os }}"
     strategy:
       max-parallel: 15
@@ -114,6 +113,7 @@ jobs:
           path: bindings/python/dist
 
   testpypi-publish:
+    if: github.repository == 'apache/iceberg-rust' # Only run for apache repo
     needs: [sdist, wheels]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Allows `.github/workflows/release_python_nightly.yml` to run on workflow dispatch
Only publish if run from the apache repo 
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?
Yes ran on fork repo 
https://github.com/kevinjqliu/iceberg-rust/actions/runs/23812542547

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->