### PR TITLE
fix: build_fallback_field_id_map produces incorrect column indices for schemas with nested types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -3056,6 +3070,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -3361,6 +3376,7 @@ dependencies = [
  "reqwest",
  "roaring",
  "serde",
+ "serde_arrow",
  "serde_bytes",
  "serde_derive",
  "serde_json",
@@ -4128,6 +4144,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "marrow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5240d6977234968ff9ad254bfa73aa397fb51e41dcb22b1eb85835e9295485b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "bytemuck",
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -5894,6 +5925,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrow"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2784e59a0315568e850cb01ddadf458f8c09e28d8cfc4880c2cc08f5dc3444e0"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "bytemuck",
+ "chrono",
+ "half",
+ "marrow",
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6602,7 +6648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -91,6 +91,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
 minijinja = { workspace = true }
+serde_arrow = { version = "0.14", features = ["arrow-58"] }
 
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1112,6 +1112,18 @@ fn build_field_id_map(parquet_schema: &SchemaDescriptor) -> Result<Option<HashMa
 
 /// Build a fallback field ID map for Parquet files without embedded field IDs.
 ///
+/// Returns the number of primitive (leaf) columns in a Parquet type, recursing into groups.
+fn leaf_count(ty: &parquet::schema::types::Type) -> usize {
+    if ty.is_primitive() {
+        1
+    } else {
+        ty.get_fields().iter().map(|f| leaf_count(f)).sum()
+    }
+}
+
+/// Builds a mapping from fallback field IDs to leaf column indices for Parquet files
+/// without embedded field IDs. Returns entries only for primitive top-level fields.
+///
 /// Must use top-level field positions (not leaf column positions) to stay consistent
 /// with `add_fallback_field_ids_to_arrow_schema`, which assigns ordinal IDs to
 /// top-level Arrow fields. Using leaf positions instead would produce wrong indices
@@ -1125,19 +1137,10 @@ fn build_fallback_field_id_map(parquet_schema: &SchemaDescriptor) -> HashMap<i32
 
     for (top_pos, field) in parquet_schema.root_schema().get_fields().iter().enumerate() {
         let field_id = (top_pos + 1) as i32;
-
         if field.is_primitive() {
             column_map.insert(field_id, leaf_idx);
-            leaf_idx += 1;
-        } else {
-            // Advance past all leaves in this group. Count them by checking
-            // how many subsequent leaves share this root index.
-            while leaf_idx < parquet_schema.num_columns()
-                && parquet_schema.get_column_root_idx(leaf_idx) == top_pos
-            {
-                leaf_idx += 1;
-            }
         }
+        leaf_idx += leaf_count(field);
     }
 
     column_map

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1112,32 +1112,22 @@ fn build_field_id_map(parquet_schema: &SchemaDescriptor) -> Result<Option<HashMa
 
 /// Build a fallback field ID map for Parquet files without embedded field IDs.
 ///
-/// Must iterate top-level fields (not leaf columns) to stay consistent with
-/// `add_fallback_field_ids_to_arrow_schema`, which assigns ordinal IDs to
-/// top-level Arrow fields. Iterating leaves instead would produce wrong indices
+/// Must use top-level field positions (not leaf column positions) to stay consistent
+/// with `add_fallback_field_ids_to_arrow_schema`, which assigns ordinal IDs to
+/// top-level Arrow fields. Using leaf positions instead would produce wrong indices
 /// when nested types (struct/list/map) expand into multiple leaf columns.
 ///
 /// Matches iceberg-java's ParquetSchemaUtil.addFallbackIds().
 fn build_fallback_field_id_map(parquet_schema: &SchemaDescriptor) -> HashMap<i32, usize> {
     let mut column_map = HashMap::new();
-    let mut leaf_idx = 0;
 
-    for (top_pos, field) in parquet_schema.root_schema().get_fields().iter().enumerate() {
-        let field_id = (top_pos + 1) as i32;
-
-        if field.is_primitive() {
+    for leaf_idx in 0..parquet_schema.num_columns() {
+        let root_idx = parquet_schema.get_column_root_idx(leaf_idx);
+        // Only map primitive root columns; leaves inside groups (struct/list/map)
+        // don't get fallback IDs since predicates only target root-level primitives.
+        if !parquet_schema.get_column_root(leaf_idx).is_group() {
+            let field_id = (root_idx + 1) as i32;
             column_map.insert(field_id, leaf_idx);
-            leaf_idx += 1;
-        } else {
-            fn count_leaves(tp: &parquet::schema::types::Type) -> usize {
-                match tp {
-                    parquet::schema::types::Type::PrimitiveType { .. } => 1,
-                    parquet::schema::types::Type::GroupType { fields, .. } => {
-                        fields.iter().map(|f| count_leaves(f)).sum()
-                    }
-                }
-            }
-            leaf_idx += count_leaves(field);
         }
     }
 

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -4751,9 +4751,8 @@ message schema {
         assert_eq!(ids, vec![2, 3]);
     }
 
-    /// Regression: predicate on a column after a struct in a migrated file (no field IDs).
-    /// Without the fix, build_fallback_field_id_map maps id's field_id to a leaf inside
-    /// the struct, causing "isn't a root column in Parquet schema".
+    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
+    /// predicate on a column after a struct in a migrated file (no field IDs).
     #[tokio::test]
     async fn test_predicate_on_migrated_file_with_struct() {
         let schema = Arc::new(
@@ -4810,7 +4809,8 @@ message schema {
         read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
     }
 
-    /// Regression: predicate on a column after a list in a migrated file (no field IDs).
+    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
+    /// predicate on a column after a list in a migrated file (no field IDs).
     /// Uses list-of-struct (2+ leaves) because a list of primitives has only 1 leaf,
     /// which coincidentally produces the same mapping as a top-level primitive.
     #[tokio::test]
@@ -4879,7 +4879,8 @@ message schema {
         read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
     }
 
-    /// Regression: predicate on a column after a map in a migrated file (no field IDs).
+    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
+    /// predicate on a column after a map in a migrated file (no field IDs).
     #[tokio::test]
     async fn test_predicate_on_migrated_file_with_map() {
         let schema = Arc::new(

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1100,7 +1100,7 @@ fn build_field_id_map(parquet_schema: &SchemaDescriptor) -> Result<Option<HashMa
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
-                        "Leave column in schema should be primitive type but got {field_type:?}"
+                        "Leaf column in schema should be primitive type but got {field_type:?}"
                     ),
                 ));
             }
@@ -1111,14 +1111,34 @@ fn build_field_id_map(parquet_schema: &SchemaDescriptor) -> Result<Option<HashMa
 }
 
 /// Build a fallback field ID map for Parquet files without embedded field IDs.
-/// Position-based (1, 2, 3, ...) for compatibility with iceberg-java migrations.
+///
+/// Must iterate top-level fields (not leaf columns) to stay consistent with
+/// `add_fallback_field_ids_to_arrow_schema`, which assigns ordinal IDs to
+/// top-level Arrow fields. Iterating leaves instead would produce wrong indices
+/// when nested types (struct/list/map) expand into multiple leaf columns.
+///
+/// Matches iceberg-java's ParquetSchemaUtil.addFallbackIds().
 fn build_fallback_field_id_map(parquet_schema: &SchemaDescriptor) -> HashMap<i32, usize> {
     let mut column_map = HashMap::new();
+    let mut leaf_idx = 0;
 
-    // 1-indexed to match iceberg-java's convention
-    for (idx, _field) in parquet_schema.columns().iter().enumerate() {
-        let field_id = (idx + 1) as i32;
-        column_map.insert(field_id, idx);
+    for (top_pos, field) in parquet_schema.root_schema().get_fields().iter().enumerate() {
+        let field_id = (top_pos + 1) as i32;
+
+        if field.is_primitive() {
+            column_map.insert(field_id, leaf_idx);
+            leaf_idx += 1;
+        } else {
+            fn count_leaves(tp: &parquet::schema::types::Type) -> usize {
+                match tp {
+                    parquet::schema::types::Type::PrimitiveType { .. } => 1,
+                    parquet::schema::types::Type::GroupType { fields, .. } => {
+                        fields.iter().map(|f| count_leaves(f)).sum()
+                    }
+                }
+            }
+            leaf_idx += count_leaves(field);
+        }
     }
 
     column_map
@@ -1409,7 +1429,7 @@ impl PredicateConverter<'_> {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
-                        "Leave column `{}` in predicates isn't a root column in Parquet schema.",
+                        "Leaf column `{}` in predicates isn't a root column in Parquet schema.",
                         reference.field().name
                     ),
                 ));
@@ -1423,7 +1443,7 @@ impl PredicateConverter<'_> {
                 .ok_or(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
-                "Leave column `{}` in predicates cannot be found in the required column indices.",
+                "Leaf column `{}` in predicates cannot be found in the required column indices.",
                 reference.field().name
             ),
                 ))?;
@@ -1957,9 +1977,14 @@ mod tests {
     use std::ops::Range;
     use std::sync::Arc;
 
+    use arrow_array::builder::StringBuilder;
     use arrow_array::cast::AsArray;
-    use arrow_array::{ArrayRef, LargeStringArray, RecordBatch, StringArray};
-    use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
+    use arrow_array::{
+        Array, ArrayRef, Int32Array, LargeStringArray, ListArray, RecordBatch, StringArray,
+        StructArray,
+    };
+    use arrow_buffer::OffsetBuffer;
+    use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
     use futures::TryStreamExt;
     use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
     use parquet::arrow::{ArrowWriter, ProjectionMask};
@@ -4666,5 +4691,268 @@ message schema {
         assert_eq!(result[0], expected_0);
         assert_eq!(result[1], expected_1);
         assert_eq!(result[2], expected_2);
+    }
+
+    /// Helper: write a Parquet file without field IDs containing a nested type column
+    /// followed by an `id` column, then read it with a predicate on `id`.
+    /// This exercises the fallback field ID mapping path that Comet uses.
+    async fn read_migrated_file_with_nested_type_and_predicate(
+        iceberg_schema: SchemaRef,
+        arrow_schema: Arc<ArrowSchema>,
+        batch: RecordBatch,
+    ) {
+        let tmp_dir = TempDir::new().unwrap();
+        let table_location = tmp_dir.path().to_str().unwrap().to_string();
+        let file_path = format!("{table_location}/1.parquet");
+
+        let props = WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build();
+        let file = File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, Some(props)).unwrap();
+        writer.write(&batch).expect("Writing batch");
+        writer.close().unwrap();
+
+        // Fallback field IDs: nested_col=1, id=2
+        let predicate = Reference::new("id").greater_than(Datum::int(1));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs())
+            .with_row_group_filtering_enabled(true)
+            .with_row_selection_enabled(true)
+            .build();
+
+        let tasks = Box::pin(futures::stream::iter(
+            vec![Ok(FileScanTask {
+                file_size_in_bytes: std::fs::metadata(&file_path).unwrap().len(),
+                start: 0,
+                length: 0,
+                record_count: None,
+                data_file_path: file_path,
+                data_file_format: DataFileFormat::Parquet,
+                schema: iceberg_schema.clone(),
+                project_field_ids: vec![2],
+                predicate: Some(predicate.bind(iceberg_schema, true).unwrap()),
+                deletes: vec![],
+                partition: None,
+                partition_spec: None,
+                name_mapping: None,
+                case_sensitive: false,
+            })]
+            .into_iter(),
+        )) as FileScanTaskStream;
+
+        let result = reader
+            .read(tasks)
+            .unwrap()
+            .try_collect::<Vec<RecordBatch>>()
+            .await
+            .unwrap();
+
+        let ids: Vec<i32> = result
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_primitive::<arrow_array::types::Int32Type>()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    /// Regression: predicate on a column after a struct in a migrated file (no field IDs).
+    /// Without the fix, build_fallback_field_id_map maps id's field_id to a leaf inside
+    /// the struct, causing "isn't a root column in Parquet schema".
+    #[tokio::test]
+    async fn test_predicate_on_migrated_file_with_struct() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(
+                        1,
+                        "person",
+                        Type::Struct(crate::spec::StructType::new(vec![
+                            NestedField::required(
+                                3,
+                                "name",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                            NestedField::required(4, "age", Type::Primitive(PrimitiveType::Int))
+                                .into(),
+                        ])),
+                    )
+                    .into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "person",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("name", DataType::Utf8, false),
+                    Field::new("age", DataType::Int32, false),
+                ])),
+                false,
+            ),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        let person_data = Arc::new(StructArray::from(vec![
+            (
+                Arc::new(Field::new("name", DataType::Utf8, false)),
+                Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("age", DataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![30, 25, 40])) as ArrayRef,
+            ),
+        ])) as ArrayRef;
+        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
+
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![person_data, id_data]).unwrap();
+
+        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
+    }
+
+    /// Regression: predicate on a column after a list in a migrated file (no field IDs).
+    /// Uses list-of-struct (2+ leaves) because a list of primitives has only 1 leaf,
+    /// which coincidentally produces the same mapping as a top-level primitive.
+    #[tokio::test]
+    async fn test_predicate_on_migrated_file_with_list() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(
+                        1,
+                        "people",
+                        Type::List(crate::spec::ListType {
+                            element_field: NestedField::required(
+                                3,
+                                "element",
+                                Type::Struct(crate::spec::StructType::new(vec![
+                                    NestedField::required(
+                                        4,
+                                        "name",
+                                        Type::Primitive(PrimitiveType::String),
+                                    )
+                                    .into(),
+                                    NestedField::required(
+                                        5,
+                                        "age",
+                                        Type::Primitive(PrimitiveType::Int),
+                                    )
+                                    .into(),
+                                ])),
+                            )
+                            .into(),
+                        }),
+                    )
+                    .into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let name_field = Arc::new(Field::new("name", DataType::Utf8, false));
+        let age_field = Arc::new(Field::new("age", DataType::Int32, false));
+        let struct_fields = Fields::from(vec![name_field.clone(), age_field.clone()]);
+        let element_field = Field::new("element", DataType::Struct(struct_fields), false);
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new_list("people", element_field, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        // 3 rows, each with a single-element list of struct
+        let names = Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])) as ArrayRef;
+        let ages = Arc::new(Int32Array::from(vec![30, 25, 40])) as ArrayRef;
+        let structs = StructArray::from(vec![(name_field, names), (age_field, ages)]);
+        // One list element per row
+        let offsets = OffsetBuffer::from_lengths([1, 1, 1]);
+        let people_data = Arc::new(ListArray::new(
+            Arc::new(Field::new("element", structs.data_type().clone(), false)),
+            offsets,
+            Arc::new(structs),
+            None,
+        )) as ArrayRef;
+        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
+
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![people_data, id_data]).unwrap();
+
+        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
+    }
+
+    /// Regression: predicate on a column after a map in a migrated file (no field IDs).
+    #[tokio::test]
+    async fn test_predicate_on_migrated_file_with_map() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(
+                        1,
+                        "props",
+                        Type::Map(crate::spec::MapType {
+                            key_field: NestedField::required(
+                                3,
+                                "key",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                            value_field: NestedField::required(
+                                4,
+                                "value",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                        }),
+                    )
+                    .into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new_map(
+                "props",
+                "entries",
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Utf8, false),
+                false,
+                false,
+            ),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        let key_field = Arc::new(Field::new("key", DataType::Utf8, false));
+        let value_field = Arc::new(Field::new("value", DataType::Utf8, false));
+        let mut map_builder =
+            arrow_array::builder::MapBuilder::new(None, StringBuilder::new(), StringBuilder::new())
+                .with_keys_field(key_field)
+                .with_values_field(value_field);
+        map_builder.keys().append_value("k1");
+        map_builder.values().append_value("v1");
+        map_builder.append(true).unwrap();
+        map_builder.keys().append_value("k2");
+        map_builder.values().append_value("v2");
+        map_builder.append(true).unwrap();
+        map_builder.keys().append_value("k3");
+        map_builder.values().append_value("v3");
+        map_builder.append(true).unwrap();
+        let props_data = Arc::new(map_builder.finish()) as ArrayRef;
+        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
+
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![props_data, id_data]).unwrap();
+
+        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1976,14 +1976,9 @@ mod tests {
     use std::ops::Range;
     use std::sync::Arc;
 
-    use arrow_array::builder::StringBuilder;
     use arrow_array::cast::AsArray;
-    use arrow_array::{
-        Array, ArrayRef, Int32Array, LargeStringArray, ListArray, RecordBatch, StringArray,
-        StructArray,
-    };
-    use arrow_buffer::OffsetBuffer;
-    use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
+    use arrow_array::{ArrayRef, LargeStringArray, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
     use futures::TryStreamExt;
     use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
     use parquet::arrow::{ArrowWriter, ProjectionMask};
@@ -4692,14 +4687,147 @@ message schema {
         assert_eq!(result[2], expected_2);
     }
 
-    /// Helper: write a Parquet file without field IDs containing a nested type column
-    /// followed by an `id` column, then read it with a predicate on `id`.
-    /// This exercises the fallback field ID mapping path that Comet uses.
-    async fn read_migrated_file_with_nested_type_and_predicate(
-        iceberg_schema: SchemaRef,
-        arrow_schema: Arc<ArrowSchema>,
-        batch: RecordBatch,
-    ) {
+    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
+    /// predicate on a column after nested types in a migrated file (no field IDs).
+    /// Schema has struct, list, and map columns before the predicate target (`id`),
+    /// exercising the fallback field ID mapping across all nested type variants.
+    #[tokio::test]
+    async fn test_predicate_on_migrated_file_with_nested_types() {
+        use serde::{Deserialize, Serialize};
+        use serde_arrow::schema::{SchemaLike, TracingOptions};
+
+        #[derive(Serialize, Deserialize)]
+        struct Person {
+            name: String,
+            age: i32,
+        }
+
+        #[derive(Serialize, Deserialize)]
+        struct Row {
+            person: Person,
+            people: Vec<Person>,
+            props: std::collections::BTreeMap<String, String>,
+            id: i32,
+        }
+
+        let rows = vec![
+            Row {
+                person: Person {
+                    name: "Alice".into(),
+                    age: 30,
+                },
+                people: vec![Person {
+                    name: "Alice".into(),
+                    age: 30,
+                }],
+                props: [("k1".into(), "v1".into())].into(),
+                id: 1,
+            },
+            Row {
+                person: Person {
+                    name: "Bob".into(),
+                    age: 25,
+                },
+                people: vec![Person {
+                    name: "Bob".into(),
+                    age: 25,
+                }],
+                props: [("k2".into(), "v2".into())].into(),
+                id: 2,
+            },
+            Row {
+                person: Person {
+                    name: "Carol".into(),
+                    age: 40,
+                },
+                people: vec![Person {
+                    name: "Carol".into(),
+                    age: 40,
+                }],
+                props: [("k3".into(), "v3".into())].into(),
+                id: 3,
+            },
+        ];
+
+        let tracing_options = TracingOptions::default()
+            .map_as_struct(false)
+            .strings_as_large_utf8(false)
+            .sequence_as_large_list(false);
+        let fields = Vec::<arrow_schema::FieldRef>::from_type::<Row>(tracing_options).unwrap();
+        let arrow_schema = Arc::new(ArrowSchema::new(fields.clone()));
+        let batch = serde_arrow::to_record_batch(&fields, &rows).unwrap();
+
+        // Fallback field IDs: person=1, people=2, props=3, id=4
+        let iceberg_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(
+                        1,
+                        "person",
+                        Type::Struct(crate::spec::StructType::new(vec![
+                            NestedField::required(
+                                5,
+                                "name",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                            NestedField::required(6, "age", Type::Primitive(PrimitiveType::Int))
+                                .into(),
+                        ])),
+                    )
+                    .into(),
+                    NestedField::required(
+                        2,
+                        "people",
+                        Type::List(crate::spec::ListType {
+                            element_field: NestedField::required(
+                                7,
+                                "element",
+                                Type::Struct(crate::spec::StructType::new(vec![
+                                    NestedField::required(
+                                        8,
+                                        "name",
+                                        Type::Primitive(PrimitiveType::String),
+                                    )
+                                    .into(),
+                                    NestedField::required(
+                                        9,
+                                        "age",
+                                        Type::Primitive(PrimitiveType::Int),
+                                    )
+                                    .into(),
+                                ])),
+                            )
+                            .into(),
+                        }),
+                    )
+                    .into(),
+                    NestedField::required(
+                        3,
+                        "props",
+                        Type::Map(crate::spec::MapType {
+                            key_field: NestedField::required(
+                                10,
+                                "key",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                            value_field: NestedField::required(
+                                11,
+                                "value",
+                                Type::Primitive(PrimitiveType::String),
+                            )
+                            .into(),
+                        }),
+                    )
+                    .into(),
+                    NestedField::required(4, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
         let tmp_dir = TempDir::new().unwrap();
         let table_location = tmp_dir.path().to_str().unwrap().to_string();
         let file_path = format!("{table_location}/1.parquet");
@@ -4712,7 +4840,6 @@ message schema {
         writer.write(&batch).expect("Writing batch");
         writer.close().unwrap();
 
-        // Fallback field IDs: nested_col=1, id=2
         let predicate = Reference::new("id").greater_than(Datum::int(1));
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs())
@@ -4729,7 +4856,7 @@ message schema {
                 data_file_path: file_path,
                 data_file_format: DataFileFormat::Parquet,
                 schema: iceberg_schema.clone(),
-                project_field_ids: vec![2],
+                project_field_ids: vec![4],
                 predicate: Some(predicate.bind(iceberg_schema, true).unwrap()),
                 deletes: vec![],
                 partition: None,
@@ -4758,201 +4885,5 @@ message schema {
             })
             .collect();
         assert_eq!(ids, vec![2, 3]);
-    }
-
-    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
-    /// predicate on a column after a struct in a migrated file (no field IDs).
-    #[tokio::test]
-    async fn test_predicate_on_migrated_file_with_struct() {
-        let schema = Arc::new(
-            Schema::builder()
-                .with_schema_id(1)
-                .with_fields(vec![
-                    NestedField::required(
-                        1,
-                        "person",
-                        Type::Struct(crate::spec::StructType::new(vec![
-                            NestedField::required(
-                                3,
-                                "name",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
-                            NestedField::required(4, "age", Type::Primitive(PrimitiveType::Int))
-                                .into(),
-                        ])),
-                    )
-                    .into(),
-                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                ])
-                .build()
-                .unwrap(),
-        );
-
-        let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new(
-                "person",
-                DataType::Struct(Fields::from(vec![
-                    Field::new("name", DataType::Utf8, false),
-                    Field::new("age", DataType::Int32, false),
-                ])),
-                false,
-            ),
-            Field::new("id", DataType::Int32, false),
-        ]));
-
-        let person_data = Arc::new(StructArray::from(vec![
-            (
-                Arc::new(Field::new("name", DataType::Utf8, false)),
-                Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])) as ArrayRef,
-            ),
-            (
-                Arc::new(Field::new("age", DataType::Int32, false)),
-                Arc::new(Int32Array::from(vec![30, 25, 40])) as ArrayRef,
-            ),
-        ])) as ArrayRef;
-        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
-
-        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![person_data, id_data]).unwrap();
-
-        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
-    }
-
-    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
-    /// predicate on a column after a list in a migrated file (no field IDs).
-    /// Uses list-of-struct (2+ leaves) because a list of primitives has only 1 leaf,
-    /// which coincidentally produces the same mapping as a top-level primitive.
-    #[tokio::test]
-    async fn test_predicate_on_migrated_file_with_list() {
-        let schema = Arc::new(
-            Schema::builder()
-                .with_schema_id(1)
-                .with_fields(vec![
-                    NestedField::required(
-                        1,
-                        "people",
-                        Type::List(crate::spec::ListType {
-                            element_field: NestedField::required(
-                                3,
-                                "element",
-                                Type::Struct(crate::spec::StructType::new(vec![
-                                    NestedField::required(
-                                        4,
-                                        "name",
-                                        Type::Primitive(PrimitiveType::String),
-                                    )
-                                    .into(),
-                                    NestedField::required(
-                                        5,
-                                        "age",
-                                        Type::Primitive(PrimitiveType::Int),
-                                    )
-                                    .into(),
-                                ])),
-                            )
-                            .into(),
-                        }),
-                    )
-                    .into(),
-                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                ])
-                .build()
-                .unwrap(),
-        );
-
-        let name_field = Arc::new(Field::new("name", DataType::Utf8, false));
-        let age_field = Arc::new(Field::new("age", DataType::Int32, false));
-        let struct_fields = Fields::from(vec![name_field.clone(), age_field.clone()]);
-        let element_field = Field::new("element", DataType::Struct(struct_fields), false);
-        let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new_list("people", element_field, false),
-            Field::new("id", DataType::Int32, false),
-        ]));
-
-        // 3 rows, each with a single-element list of struct
-        let names = Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])) as ArrayRef;
-        let ages = Arc::new(Int32Array::from(vec![30, 25, 40])) as ArrayRef;
-        let structs = StructArray::from(vec![(name_field, names), (age_field, ages)]);
-        // One list element per row
-        let offsets = OffsetBuffer::from_lengths([1, 1, 1]);
-        let people_data = Arc::new(ListArray::new(
-            Arc::new(Field::new("element", structs.data_type().clone(), false)),
-            offsets,
-            Arc::new(structs),
-            None,
-        )) as ArrayRef;
-        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
-
-        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![people_data, id_data]).unwrap();
-
-        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
-    }
-
-    /// Regression for <https://github.com/apache/iceberg-rust/issues/2306>:
-    /// predicate on a column after a map in a migrated file (no field IDs).
-    #[tokio::test]
-    async fn test_predicate_on_migrated_file_with_map() {
-        let schema = Arc::new(
-            Schema::builder()
-                .with_schema_id(1)
-                .with_fields(vec![
-                    NestedField::required(
-                        1,
-                        "props",
-                        Type::Map(crate::spec::MapType {
-                            key_field: NestedField::required(
-                                3,
-                                "key",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
-                            value_field: NestedField::required(
-                                4,
-                                "value",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
-                        }),
-                    )
-                    .into(),
-                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                ])
-                .build()
-                .unwrap(),
-        );
-
-        let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new_map(
-                "props",
-                "entries",
-                Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Utf8, false),
-                false,
-                false,
-            ),
-            Field::new("id", DataType::Int32, false),
-        ]));
-
-        let key_field = Arc::new(Field::new("key", DataType::Utf8, false));
-        let value_field = Arc::new(Field::new("value", DataType::Utf8, false));
-        let mut map_builder =
-            arrow_array::builder::MapBuilder::new(None, StringBuilder::new(), StringBuilder::new())
-                .with_keys_field(key_field)
-                .with_values_field(value_field);
-        map_builder.keys().append_value("k1");
-        map_builder.values().append_value("v1");
-        map_builder.append(true).unwrap();
-        map_builder.keys().append_value("k2");
-        map_builder.values().append_value("v2");
-        map_builder.append(true).unwrap();
-        map_builder.keys().append_value("k3");
-        map_builder.values().append_value("v3");
-        map_builder.append(true).unwrap();
-        let props_data = Arc::new(map_builder.finish()) as ArrayRef;
-        let id_data = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
-
-        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![props_data, id_data]).unwrap();
-
-        read_migrated_file_with_nested_type_and_predicate(schema, arrow_schema, batch).await;
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1117,17 +1117,26 @@ fn build_field_id_map(parquet_schema: &SchemaDescriptor) -> Result<Option<HashMa
 /// top-level Arrow fields. Using leaf positions instead would produce wrong indices
 /// when nested types (struct/list/map) expand into multiple leaf columns.
 ///
-/// Matches iceberg-java's ParquetSchemaUtil.addFallbackIds().
+/// Mirrors iceberg-java's ParquetSchemaUtil.addFallbackIds() which iterates
+/// fileSchema.getFields() assigning ordinal IDs to top-level fields.
 fn build_fallback_field_id_map(parquet_schema: &SchemaDescriptor) -> HashMap<i32, usize> {
     let mut column_map = HashMap::new();
+    let mut leaf_idx = 0;
 
-    for leaf_idx in 0..parquet_schema.num_columns() {
-        let root_idx = parquet_schema.get_column_root_idx(leaf_idx);
-        // Only map primitive root columns; leaves inside groups (struct/list/map)
-        // don't get fallback IDs since predicates only target root-level primitives.
-        if !parquet_schema.get_column_root(leaf_idx).is_group() {
-            let field_id = (root_idx + 1) as i32;
+    for (top_pos, field) in parquet_schema.root_schema().get_fields().iter().enumerate() {
+        let field_id = (top_pos + 1) as i32;
+
+        if field.is_primitive() {
             column_map.insert(field_id, leaf_idx);
+            leaf_idx += 1;
+        } else {
+            // Advance past all leaves in this group. Count them by checking
+            // how many subsequent leaves share this root index.
+            while leaf_idx < parquet_schema.num_columns()
+                && parquet_schema.get_column_root_idx(leaf_idx) == top_pos
+            {
+                leaf_idx += 1;
+            }
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2306.
- Downstream issue: https://github.com/apache/datafusion-comet/issues/3860

## What changes are included in this PR?                  

`build_fallback_field_id_map` iterated over Parquet leaf columns instead of top-level fields when building the field ID to column index mapping for migrated files (no embedded field IDs). When nested types (struct, list, map) precede a primitive column, they expand into multiple leaves, causing the mapping to diverge from `add_fallback_field_ids_to_arrow_schema` which correctly assigns ordinal IDs to top-level Arrow fields. This made predicates on columns after nested types resolve to a leaf inside the group, crashing with "Leaf column `id` in predicates isn't a root column in Parquet schema".

The fix iterates `root_schema().get_fields()` directly, assigning ordinal IDs only to top-level fields. For non-primitive fields (struct/list/map), it uses `get_column_root_idx` to advance past their leaf columns. This mirrors iceberg-java's `ParquetSchemaUtil.addFallbackIds()`, which iterates `fileSchema.getFields()` assigning ordinal IDs to top-level fields.

Also renames "Leave column" to "Leaf column" in error messages.

## Are these changes tested?

- An integration test (`test_predicate_on_migrated_file_with_nested_types`) writes a Parquet file without field IDs containing struct, list, and map columns before an `id` column, then reads with a predicate on `id`. This reproduces the exact crash before the fix. Test data is constructed with `serde_arrow` for readability.

- [Apache DataFusion Comet](https://github.com/apache/datafusion-comet) used the repro test in
[apache/datafusion-comet#3860](https://github.com/apache/datafusion-comet/issues/3860) and it passes with this change:
https://github.com/apache/datafusion-comet/pull/3872