### PR TITLE
fix(s3tables): use 's3' as the default scheme

### DIFF
--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -202,7 +202,7 @@ impl S3TablesCatalog {
         // Use provided factory or default to OpenDalStorageFactory::S3
         let factory = storage_factory.unwrap_or_else(|| {
             Arc::new(OpenDalStorageFactory::S3 {
-                configured_scheme: "s3a".to_string(),
+                configured_scheme: "s3".to_string(),
                 customized_credential_load: None,
             })
         });


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2312 

## What changes are included in this PR?

Changes the s3tables default scheme to "s3://"

## Are these changes tested?

With this change, I can read files resolved through an s3table catalog now.