### PR TITLE
feat(storage/opendal): route oss:// URLs through the S3 backend

### DIFF
--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -153,7 +153,15 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
             })),
-            #[cfg(feature = "opendal-oss")]
+            // OSS is S3-API-compatible; route through S3 so `s3.*` props
+            // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+            #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+            OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::S3 {
+                configured_scheme: "oss".to_string(),
+                config: s3_config_parse(config.props().clone())?.into(),
+                customized_credential_load: None,
+            })),
+            #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
             OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::Oss {
                 config: oss_config_parse(config.props().clone())?.into(),
             })),

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -155,7 +155,14 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
             })),
-            #[cfg(feature = "opendal-oss")]
+            // OSS is S3-API-compatible; route through S3 so `s3.*` props
+            // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+            #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+            OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::S3 {
+                config: s3_config_parse(config.props().clone())?.into(),
+                customized_credential_load: None,
+            })),
+            #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
             OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::Oss {
                 config: oss_config_parse(config.props().clone())?.into(),
             })),

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -100,6 +100,15 @@ cfg_if! {
 mod resolving;
 pub use resolving::{OpenDalResolvingStorage, OpenDalResolvingStorageFactory};
 
+/// Returns `true` when the property map contains S3-style configuration,
+/// indicating that `oss://` paths should be routed through the S3 backend
+/// (e.g. REST catalog vended credentials).
+#[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+fn has_s3_config(props: &HashMap<String, String>) -> bool {
+    props.contains_key(iceberg::io::S3_ENDPOINT)
+        || props.contains_key(iceberg::io::S3_ACCESS_KEY_ID)
+}
+
 /// OpenDAL-based storage factory.
 ///
 /// Maps scheme to the corresponding OpenDalStorage storage variant.
@@ -155,13 +164,22 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
             })),
-            // OSS is S3-API-compatible; route through S3 so `s3.*` props
-            // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+            // OSS: if `s3.*` props are present (REST catalog vended credentials),
+            // route through S3 backend (OSS is S3-API-compatible).
+            // Otherwise fall back to native OSS backend (RAM/OIDC auth).
             #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
-            OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::S3 {
-                config: s3_config_parse(config.props().clone())?.into(),
-                customized_credential_load: None,
-            })),
+            OpenDalStorageFactory::Oss => {
+                if has_s3_config(config.props()) {
+                    Ok(Arc::new(OpenDalStorage::S3 {
+                        config: s3_config_parse(config.props().clone())?.into(),
+                        customized_credential_load: None,
+                    }))
+                } else {
+                    Ok(Arc::new(OpenDalStorage::Oss {
+                        config: oss_config_parse(config.props().clone())?.into(),
+                    }))
+                }
+            }
             #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
             OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::Oss {
                 config: oss_config_parse(config.props().clone())?.into(),
@@ -224,7 +242,10 @@ pub enum OpenDalStorage {
         /// GCS configuration.
         config: Arc<GcsConfig>,
     },
-    /// OSS storage variant.
+    /// OSS storage variant (native OpenDAL OSS backend).
+    ///
+    /// Used when no `s3.*` configuration is present, allowing native
+    /// Aliyun authentication (RAM/OIDC/assume-role).
     #[cfg(feature = "opendal-oss")]
     Oss {
         /// OSS configuration.
@@ -689,7 +710,9 @@ mod tests {
         // All S3-family schemes are accepted by the same storage instance.
         // Custom schemes for S3-compatible stores (e.g., `minio://`) are also
         // accepted because the path's scheme is used as-is for prefix matching.
-        for scheme in ["s3", "s3a", "s3n", "minio"] {
+        // `oss://` is included because OSS is routed through this backend when
+        // `s3.*` config is present (see `has_s3_config`).
+        for scheme in ["s3", "s3a", "s3n", "minio", "oss"] {
             assert_eq!(
                 storage
                     .relativize_path(&format!("{scheme}://my-bucket/path/to/file.parquet"))

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -100,6 +100,15 @@ cfg_if! {
 mod resolving;
 pub use resolving::{OpenDalResolvingStorage, OpenDalResolvingStorageFactory};
 
+/// Returns `true` when the property map contains S3-style configuration,
+/// indicating that `oss://` paths should be routed through the S3 backend
+/// (e.g. REST catalog vended credentials).
+#[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+fn has_s3_config(props: &HashMap<String, String>) -> bool {
+    props.contains_key(iceberg::io::S3_ENDPOINT)
+        || props.contains_key(iceberg::io::S3_ACCESS_KEY_ID)
+}
+
 /// OpenDAL-based storage factory.
 ///
 /// Maps scheme to the corresponding OpenDalStorage storage variant.
@@ -181,13 +190,22 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
             })),
-            // OSS is S3-API-compatible; route through S3 so `s3.*` props
-            // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+            // OSS: if `s3.*` props are present (REST catalog vended credentials),
+            // route through S3 backend (OSS is S3-API-compatible).
+            // Otherwise fall back to native OSS backend (RAM/OIDC auth).
             #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
-            OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::S3 {
-                config: s3_config_parse(config.props().clone())?.into(),
-                customized_credential_load: None,
-            })),
+            OpenDalStorageFactory::Oss => {
+                if has_s3_config(config.props()) {
+                    Ok(Arc::new(OpenDalStorage::S3 {
+                        config: s3_config_parse(config.props().clone())?.into(),
+                        customized_credential_load: None,
+                    }))
+                } else {
+                    Ok(Arc::new(OpenDalStorage::Oss {
+                        config: oss_config_parse(config.props().clone())?.into(),
+                    }))
+                }
+            }
             #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
             OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::Oss {
                 config: oss_config_parse(config.props().clone())?.into(),
@@ -250,7 +268,10 @@ pub enum OpenDalStorage {
         /// GCS configuration.
         config: Arc<GcsConfig>,
     },
-    /// OSS storage variant.
+    /// OSS storage variant (native OpenDAL OSS backend).
+    ///
+    /// Used when no `s3.*` configuration is present, allowing native
+    /// Aliyun authentication (RAM/OIDC/assume-role).
     #[cfg(feature = "opendal-oss")]
     Oss {
         /// OSS configuration.
@@ -746,7 +767,9 @@ mod tests {
         // All S3-family schemes are accepted by the same storage instance.
         // Custom schemes for S3-compatible stores (e.g., `minio://`) are also
         // accepted because the path's scheme is used as-is for prefix matching.
-        for scheme in ["s3", "s3a", "s3n", "minio"] {
+        // `oss://` is included because OSS is routed through this backend when
+        // `s3.*` config is present (see `has_s3_config`).
+        for scheme in ["s3", "s3a", "s3n", "minio", "oss"] {
             assert_eq!(
                 storage
                     .relativize_path(&format!("{scheme}://my-bucket/path/to/file.parquet"))

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -100,13 +100,19 @@ cfg_if! {
 mod resolving;
 pub use resolving::{OpenDalResolvingStorage, OpenDalResolvingStorageFactory};
 
-/// Returns `true` when the property map contains S3-style configuration,
-/// indicating that `oss://` paths should be routed through the S3 backend
-/// (e.g. REST catalog vended credentials).
+/// Returns `true` when `oss://` paths should go through the S3 backend rather
+/// than the native OSS one (e.g. for REST catalog vended `s3.*` credentials).
+///
+/// `s3.endpoint` is required, not merely one of the `s3.*` keys: without it
+/// opendal falls back to `s3.amazonaws.com`, so an access key meant for Aliyun
+/// would be sent to AWS.
+///
+/// Note that one props map serves every scheme, so a map carrying both `s3.*`
+/// (for `s3://` paths) and `oss.*` (for `oss://` paths) sends `oss://` to the
+/// S3 endpoint. Configure the two in separate `FileIO`s.
 #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
-fn has_s3_config(props: &HashMap<String, String>) -> bool {
+fn routes_oss_via_s3(props: &HashMap<String, String>) -> bool {
     props.contains_key(iceberg::io::S3_ENDPOINT)
-        || props.contains_key(iceberg::io::S3_ACCESS_KEY_ID)
 }
 
 /// OpenDAL-based storage factory.
@@ -195,7 +201,7 @@ impl StorageFactory for OpenDalStorageFactory {
             // Otherwise fall back to native OSS backend (RAM/OIDC auth).
             #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
             OpenDalStorageFactory::Oss => {
-                if has_s3_config(config.props()) {
+                if routes_oss_via_s3(config.props()) {
                     Ok(Arc::new(OpenDalStorage::S3 {
                         config: s3_config_parse(config.props().clone())?.into(),
                         customized_credential_load: None,
@@ -714,6 +720,30 @@ mod tests {
             err.to_string()
                 .contains("custom AWS credential loaders cannot be serialized")
         );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn factory_routes_oss_like_the_resolver_does() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let via_s3 = StorageConfig::new()
+            .with_prop(S3_ENDPOINT, "https://oss-cn-shanghai.aliyuncs.com")
+            .with_prop(S3_ACCESS_KEY_ID, "AKIA_TEST");
+        // `Storage` is only debuggable through the trait object, and the
+        // variant name is what distinguishes the two backends.
+        let built = format!("{:?}", OpenDalStorageFactory::Oss.build(&via_s3).unwrap());
+        assert!(built.starts_with("S3"), "{built}");
+
+        // Credentials without an endpoint stay on the native backend — the
+        // same rule the resolver applies.
+        for props in [
+            StorageConfig::new().with_prop(S3_ACCESS_KEY_ID, "AKIA_TEST"),
+            StorageConfig::new(),
+        ] {
+            let built = format!("{:?}", OpenDalStorageFactory::Oss.build(&props).unwrap());
+            assert!(built.starts_with("Oss"), "{built}");
+        }
     }
 
     #[cfg(feature = "opendal-memory")]

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -181,7 +181,14 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Gcs => Ok(Arc::new(OpenDalStorage::Gcs {
                 config: gcs_config_parse(config.props().clone())?.into(),
             })),
-            #[cfg(feature = "opendal-oss")]
+            // OSS is S3-API-compatible; route through S3 so `s3.*` props
+            // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+            #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+            OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::S3 {
+                config: s3_config_parse(config.props().clone())?.into(),
+                customized_credential_load: None,
+            })),
+            #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
             OpenDalStorageFactory::Oss => Ok(Arc::new(OpenDalStorage::Oss {
                 config: oss_config_parse(config.props().clone())?.into(),
             })),

--- a/crates/storage/opendal/src/oss.rs
+++ b/crates/storage/opendal/src/oss.rs
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
-
-use iceberg::io::{OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_ENDPOINT};
 use iceberg::{Error, ErrorKind, Result};
 use opendal::services::OssConfig;
 use opendal::{Configurator, Operator};
@@ -26,7 +23,16 @@ use url::Url;
 use crate::utils::from_opendal_error;
 
 /// Parse iceberg props to oss config.
-pub(crate) fn oss_config_parse(mut m: HashMap<String, String>) -> Result<OssConfig> {
+///
+/// Only reachable when the native OSS service is used (i.e. `opendal-s3`
+/// is disabled); when `opendal-s3` is enabled, OSS is routed through the
+/// S3 code path and this function is dead code.
+#[cfg(not(feature = "opendal-s3"))]
+pub(crate) fn oss_config_parse(
+    mut m: std::collections::HashMap<String, String>,
+) -> Result<OssConfig> {
+    use iceberg::io::{OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_ENDPOINT};
+
     let mut cfg: OssConfig = OssConfig::default();
     if let Some(endpoint) = m.remove(OSS_ENDPOINT) {
         cfg.endpoint = Some(endpoint);

--- a/crates/storage/opendal/src/oss.rs
+++ b/crates/storage/opendal/src/oss.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
+
+use iceberg::io::{OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_ENDPOINT};
 use iceberg::{Error, ErrorKind, Result};
 use opendal::services::OssConfig;
 use opendal::{Configurator, Operator};
@@ -23,16 +26,7 @@ use url::Url;
 use crate::utils::from_opendal_error;
 
 /// Parse iceberg props to oss config.
-///
-/// Only reachable when the native OSS service is used (i.e. `opendal-s3`
-/// is disabled); when `opendal-s3` is enabled, OSS is routed through the
-/// S3 code path and this function is dead code.
-#[cfg(not(feature = "opendal-s3"))]
-pub(crate) fn oss_config_parse(
-    mut m: std::collections::HashMap<String, String>,
-) -> Result<OssConfig> {
-    use iceberg::io::{OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_ENDPOINT};
-
+pub(crate) fn oss_config_parse(mut m: HashMap<String, String>) -> Result<OssConfig> {
     let mut cfg: OssConfig = OssConfig::default();
     if let Some(endpoint) = m.remove(OSS_ENDPOINT) {
         cfg.endpoint = Some(endpoint);

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -104,7 +104,20 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
-        #[cfg(feature = "opendal-oss")]
+        // OSS is S3-API-compatible; route through S3 so `s3.*` props
+        // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+        #[cfg(feature = "opendal-s3")]
+        Scheme::Oss => {
+            let config = crate::s3::s3_config_parse(props.clone())?;
+            Ok(OpenDalStorage::S3 {
+                configured_scheme: scheme.to_string(),
+                config: Arc::new(config),
+                customized_credential_load: customized_credential_load.clone(),
+            })
+        }
+        // Fallback: builds without `opendal-s3` but with `opendal-oss`
+        // still use the native OSS service (which consumes `oss.*` keys).
+        #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
         Scheme::Oss => {
             let config = crate::oss::oss_config_parse(props.clone())?;
             Ok(OpenDalStorage::Oss {
@@ -315,5 +328,79 @@ impl Storage for OpenDalResolvingStorage {
             Arc::new(self.resolve(path)?.as_ref().clone()),
             path.to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "opendal-s3")]
+    #[test]
+    fn oss_scheme_routes_through_s3_backend_when_available() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let storage = build_storage_for_scheme(SCHEME_OSS, &props, &None).unwrap();
+
+        match storage {
+            OpenDalStorage::S3 {
+                configured_scheme, ..
+            } => {
+                assert_eq!(
+                    configured_scheme, SCHEME_OSS,
+                    "S3 backend should advertise the `oss` scheme so `oss://` \
+                     URLs are accepted by OpenDalStorage::S3::create_operator"
+                );
+            }
+            other => panic!(
+                "expected OpenDalStorage::S3 for oss://, got {other:?}; OSS is \
+                 S3-API-compatible and should share the S3 code path"
+            ),
+        }
+    }
+
+    #[cfg(feature = "opendal-s3")]
+    #[test]
+    fn oss_resolve_uses_s3_backend_and_caches() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let resolving = OpenDalResolvingStorage {
+            props,
+            storages: RwLock::new(HashMap::new()),
+            #[cfg(feature = "opendal-s3")]
+            customized_credential_load: None,
+        };
+
+        let storage = resolving.resolve("oss://my-bucket/path/to/file").unwrap();
+        assert!(matches!(storage.as_ref(), OpenDalStorage::S3 { .. }));
+
+        // Second call should hit the cache.
+        let cached = resolving.resolve("oss://my-bucket/other").unwrap();
+        assert!(Arc::ptr_eq(&storage, &cached));
+    }
+
+    #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
+    #[test]
+    fn oss_scheme_falls_back_to_native_oss_backend() {
+        let props = HashMap::new();
+        let storage = build_storage_for_scheme(SCHEME_OSS, &props).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::Oss { .. }),
+            "Without opendal-s3, OSS should use the native OSS backend"
+        );
     }
 }

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -102,18 +102,24 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
-        // OSS is S3-API-compatible; route through S3 so `s3.*` props
-        // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+        // OSS: if `s3.*` props are present (REST catalog vended credentials),
+        // route through S3 backend (OSS is S3-API-compatible).
+        // Otherwise fall back to native OSS backend (RAM/OIDC auth).
         #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
         "oss" => {
-            let config = crate::s3::s3_config_parse(props.clone())?;
-            Ok(OpenDalStorage::S3 {
-                config: Arc::new(config),
-                customized_credential_load: customized_credential_load.clone(),
-            })
+            if crate::has_s3_config(props) {
+                let config = crate::s3::s3_config_parse(props.clone())?;
+                Ok(OpenDalStorage::S3 {
+                    config: Arc::new(config),
+                    customized_credential_load: customized_credential_load.clone(),
+                })
+            } else {
+                let config = crate::oss::oss_config_parse(props.clone())?;
+                Ok(OpenDalStorage::Oss {
+                    config: Arc::new(config),
+                })
+            }
         }
-        // Fallback: builds without `opendal-s3` but with `opendal-oss`
-        // still use the native OSS service (which consumes `oss.*` keys).
         #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
         "oss" => {
             let config = crate::oss::oss_config_parse(props.clone())?;
@@ -386,7 +392,7 @@ mod tests {
 
     #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
     #[test]
-    fn oss_scheme_routes_through_s3_backend_when_available() {
+    fn oss_routes_through_s3_when_s3_config_present() {
         use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
 
         let mut props = HashMap::new();
@@ -399,7 +405,19 @@ mod tests {
         let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
         assert!(
             matches!(storage, OpenDalStorage::S3 { .. }),
-            "OSS should route through S3 backend when opendal-s3 is enabled"
+            "OSS with s3.* config should route through S3 backend"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_falls_back_to_native_without_s3_config() {
+        let props = HashMap::new();
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::Oss { .. }),
+            "OSS without s3.* config should use native OSS backend"
         );
     }
 
@@ -428,16 +446,5 @@ mod tests {
         // Second call should hit the cache.
         let cached = resolving.resolve("oss://my-bucket/other").unwrap();
         assert!(Arc::ptr_eq(&storage, &cached));
-    }
-
-    #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
-    #[test]
-    fn oss_scheme_falls_back_to_native_oss_backend() {
-        let props = HashMap::new();
-        let storage = build_storage_for_scheme("oss", &props).unwrap();
-        assert!(
-            matches!(storage, OpenDalStorage::Oss { .. }),
-            "Without opendal-s3, OSS should use the native OSS backend"
-        );
     }
 }

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -102,7 +102,19 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
-        #[cfg(feature = "opendal-oss")]
+        // OSS is S3-API-compatible; route through S3 so `s3.*` props
+        // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+        #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+        "oss" => {
+            let config = crate::s3::s3_config_parse(props.clone())?;
+            Ok(OpenDalStorage::S3 {
+                config: Arc::new(config),
+                customized_credential_load: customized_credential_load.clone(),
+            })
+        }
+        // Fallback: builds without `opendal-s3` but with `opendal-oss`
+        // still use the native OSS service (which consumes `oss.*` keys).
+        #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
         "oss" => {
             let config = crate::oss::oss_config_parse(props.clone())?;
             Ok(OpenDalStorage::Oss {
@@ -369,6 +381,63 @@ mod tests {
         assert!(
             Arc::ptr_eq(&abfss, &abfs),
             "abfss and abfs should share one instance"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_scheme_routes_through_s3_backend_when_available() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::S3 { .. }),
+            "OSS should route through S3 backend when opendal-s3 is enabled"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_resolve_uses_s3_backend_and_caches() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let resolving = OpenDalResolvingStorage {
+            props,
+            storages: RwLock::new(HashMap::new()),
+            #[cfg(feature = "opendal-s3")]
+            customized_credential_load: None,
+        };
+
+        let storage = resolving.resolve("oss://my-bucket/path/to/file").unwrap();
+        assert!(matches!(storage.as_ref(), OpenDalStorage::S3 { .. }));
+
+        // Second call should hit the cache.
+        let cached = resolving.resolve("oss://my-bucket/other").unwrap();
+        assert!(Arc::ptr_eq(&storage, &cached));
+    }
+
+    #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
+    #[test]
+    fn oss_scheme_falls_back_to_native_oss_backend() {
+        let props = HashMap::new();
+        let storage = build_storage_for_scheme("oss", &props).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::Oss { .. }),
+            "Without opendal-s3, OSS should use the native OSS backend"
         );
     }
 }

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -107,7 +107,7 @@ fn build_storage_for_scheme(
         // Otherwise fall back to native OSS backend (RAM/OIDC auth).
         #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
         "oss" => {
-            if crate::has_s3_config(props) {
+            if crate::routes_oss_via_s3(props) {
                 let config = crate::s3::s3_config_parse(props.clone())?;
                 Ok(OpenDalStorage::S3 {
                     config: Arc::new(config),
@@ -447,6 +447,40 @@ mod tests {
             matches!(storage, OpenDalStorage::S3 { .. }),
             "OSS with s3.* config should route through S3 backend"
         );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn vended_credentials_shape_routes_through_s3() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_SECRET_ACCESS_KEY, S3_SESSION_TOKEN};
+
+        // What a REST catalog vends for an OSS warehouse: S3-compatible
+        // credentials plus the OSS endpoint, and no `oss.*` keys.
+        let props = HashMap::from([
+            (
+                S3_ENDPOINT.to_string(),
+                "https://oss-cn-hangzhou-internal.aliyuncs.com".to_string(),
+            ),
+            (S3_ACCESS_KEY_ID.to_string(), "STS.key".to_string()),
+            (S3_SECRET_ACCESS_KEY.to_string(), "secret".to_string()),
+            (S3_SESSION_TOKEN.to_string(), "token".to_string()),
+        ]);
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(matches!(storage, OpenDalStorage::S3 { .. }));
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_needs_an_s3_endpoint_to_route_through_s3() {
+        use iceberg::io::S3_ACCESS_KEY_ID;
+
+        // Credentials alone are not enough: opendal would default to
+        // `s3.amazonaws.com` and send Aliyun keys to AWS.
+        let props = HashMap::from([(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string())]);
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(matches!(storage, OpenDalStorage::Oss { .. }));
     }
 
     #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -102,18 +102,24 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
-        // OSS is S3-API-compatible; route through S3 so `s3.*` props
-        // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+        // OSS: if `s3.*` props are present (REST catalog vended credentials),
+        // route through S3 backend (OSS is S3-API-compatible).
+        // Otherwise fall back to native OSS backend (RAM/OIDC auth).
         #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
         "oss" => {
-            let config = crate::s3::s3_config_parse(props.clone())?;
-            Ok(OpenDalStorage::S3 {
-                config: Arc::new(config),
-                customized_credential_load: customized_credential_load.clone(),
-            })
+            if crate::has_s3_config(props) {
+                let config = crate::s3::s3_config_parse(props.clone())?;
+                Ok(OpenDalStorage::S3 {
+                    config: Arc::new(config),
+                    customized_credential_load: customized_credential_load.clone(),
+                })
+            } else {
+                let config = crate::oss::oss_config_parse(props.clone())?;
+                Ok(OpenDalStorage::Oss {
+                    config: Arc::new(config),
+                })
+            }
         }
-        // Fallback: builds without `opendal-s3` but with `opendal-oss`
-        // still use the native OSS service (which consumes `oss.*` keys).
         #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
         "oss" => {
             let config = crate::oss::oss_config_parse(props.clone())?;
@@ -426,7 +432,7 @@ mod tests {
 
     #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
     #[test]
-    fn oss_scheme_routes_through_s3_backend_when_available() {
+    fn oss_routes_through_s3_when_s3_config_present() {
         use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
 
         let mut props = HashMap::new();
@@ -439,7 +445,19 @@ mod tests {
         let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
         assert!(
             matches!(storage, OpenDalStorage::S3 { .. }),
-            "OSS should route through S3 backend when opendal-s3 is enabled"
+            "OSS with s3.* config should route through S3 backend"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_falls_back_to_native_without_s3_config() {
+        let props = HashMap::new();
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::Oss { .. }),
+            "OSS without s3.* config should use native OSS backend"
         );
     }
 
@@ -468,16 +486,5 @@ mod tests {
         // Second call should hit the cache.
         let cached = resolving.resolve("oss://my-bucket/other").unwrap();
         assert!(Arc::ptr_eq(&storage, &cached));
-    }
-
-    #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
-    #[test]
-    fn oss_scheme_falls_back_to_native_oss_backend() {
-        let props = HashMap::new();
-        let storage = build_storage_for_scheme("oss", &props).unwrap();
-        assert!(
-            matches!(storage, OpenDalStorage::Oss { .. }),
-            "Without opendal-s3, OSS should use the native OSS backend"
-        );
     }
 }

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -102,7 +102,19 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
-        #[cfg(feature = "opendal-oss")]
+        // OSS is S3-API-compatible; route through S3 so `s3.*` props
+        // work for OSS-backed tables (mirrors pyiceberg/Java S3FileIO).
+        #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+        "oss" => {
+            let config = crate::s3::s3_config_parse(props.clone())?;
+            Ok(OpenDalStorage::S3 {
+                config: Arc::new(config),
+                customized_credential_load: customized_credential_load.clone(),
+            })
+        }
+        // Fallback: builds without `opendal-s3` but with `opendal-oss`
+        // still use the native OSS service (which consumes `oss.*` keys).
+        #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
         "oss" => {
             let config = crate::oss::oss_config_parse(props.clone())?;
             Ok(OpenDalStorage::Oss {
@@ -409,6 +421,63 @@ mod tests {
         assert!(
             Arc::ptr_eq(&abfss, &abfs),
             "abfss and abfs should share one instance"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_scheme_routes_through_s3_backend_when_available() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let storage = build_storage_for_scheme("oss", &props, &None).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::S3 { .. }),
+            "OSS should route through S3 backend when opendal-s3 is enabled"
+        );
+    }
+
+    #[cfg(all(feature = "opendal-oss", feature = "opendal-s3"))]
+    #[test]
+    fn oss_resolve_uses_s3_backend_and_caches() {
+        use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT};
+
+        let mut props = HashMap::new();
+        props.insert(S3_ACCESS_KEY_ID.to_string(), "AKIA_TEST".to_string());
+        props.insert(
+            S3_ENDPOINT.to_string(),
+            "https://oss-cn-shanghai.aliyuncs.com".to_string(),
+        );
+
+        let resolving = OpenDalResolvingStorage {
+            props,
+            storages: RwLock::new(HashMap::new()),
+            #[cfg(feature = "opendal-s3")]
+            customized_credential_load: None,
+        };
+
+        let storage = resolving.resolve("oss://my-bucket/path/to/file").unwrap();
+        assert!(matches!(storage.as_ref(), OpenDalStorage::S3 { .. }));
+
+        // Second call should hit the cache.
+        let cached = resolving.resolve("oss://my-bucket/other").unwrap();
+        assert!(Arc::ptr_eq(&storage, &cached));
+    }
+
+    #[cfg(all(feature = "opendal-oss", not(feature = "opendal-s3")))]
+    #[test]
+    fn oss_scheme_falls_back_to_native_oss_backend() {
+        let props = HashMap::new();
+        let storage = build_storage_for_scheme("oss", &props).unwrap();
+        assert!(
+            matches!(storage, OpenDalStorage::Oss { .. }),
+            "Without opendal-s3, OSS should use the native OSS backend"
         );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?
 N/A

## What changes are included in this PR?
  Aliyun OSS exposes an S3-compatible API, and the other two Iceberg implementations already read oss:// tables through their S3 code path with canonical s3.* properties:
  - pyiceberg: [constructs a pyarrow.fs.S3FileSystem for oss:// locations](https://github.com/apache/iceberg-python/blob/3a993e82b158919b3c1c110df6d21eb044a6616c/pyiceberg/io/pyarrow.py#L432-L462).
  - Java S3FileIO:  [accepts any URI scheme by design — the scheme is a label, transport is always the AWS S3 SDK.](https://github.com/apache/iceberg/blob/ec2de913bfea2e1799aa2b72a9a9796418a8d839/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java#L49-L77)

  iceberg-rust routes oss:// to opendal's native Oss service instead, which reads a separate oss.* namespace and can't be driven by the same credentials. Align with the rest of the ecosystem.
