### PR TITLE
fix(ci): update codeql-action SHA to match v4 tag

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: actions
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         category: "/language:actions"


### PR DESCRIPTION
## Summary
- Updates `github/codeql-action` pinned SHA from `c10b8064` to `95e58e9a` to match the current `v4` tag
- Fixes zizmor `ref-version-mismatch` check that is failing on all PRs

## Test plan
- [ ] zizmor CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)