### PR TITLE
feat(encryption) [3/N] Support encryption: KMS

### DIFF
--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -83,9 +83,10 @@ impl fmt::Display for SensitiveBytes {
 ///
 /// The Iceberg spec supports 128, 192, and 256-bit keys for AES-GCM.
 /// See: <https://iceberg.apache.org/gcm-stream-spec/#goals>
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AesKeySize {
-    /// 128-bit AES key (16 bytes)
+    /// 128-bit AES key (16 bytes). Default per the Iceberg spec.
+    #[default]
     Bits128 = 128,
     /// 192-bit AES key (24 bytes)
     Bits192 = 192,

--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -43,7 +43,7 @@ use crate::{Error, ErrorKind, Result};
 /// containing `SensitiveBytes` can safely derive or implement `Debug`
 /// without risk of leaking key material.
 #[derive(Clone, PartialEq, Eq)]
-struct SensitiveBytes(Zeroizing<Box<[u8]>>);
+pub struct SensitiveBytes(Zeroizing<Box<[u8]>>);
 
 impl SensitiveBytes {
     /// Wraps the given bytes as sensitive material.
@@ -57,13 +57,11 @@ impl SensitiveBytes {
     }
 
     /// Returns the number of bytes.
-    #[allow(dead_code)] // Encryption work is ongoing so currently unused
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns `true` if the byte slice is empty.
-    #[allow(dead_code)] // Encryption work is ongoing so currently unused
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -31,10 +31,25 @@ use crate::Result;
 /// Returned by [`KeyManagementClient::generate_key`] when the KMS supports
 /// atomic key generation and wrapping.
 pub struct GeneratedKey {
-    /// The plaintext key bytes. Zeroized on drop, redacted in Debug.
-    pub key: SensitiveBytes,
-    /// The wrapped (encrypted) key bytes.
-    pub wrapped_key: Vec<u8>,
+    key: SensitiveBytes,
+    wrapped_key: Vec<u8>,
+}
+
+impl GeneratedKey {
+    /// Creates a new `GeneratedKey` from plaintext key bytes and wrapped key bytes.
+    pub fn new(key: SensitiveBytes, wrapped_key: Vec<u8>) -> Self {
+        Self { key, wrapped_key }
+    }
+
+    /// Returns the plaintext key bytes. Zeroized on drop, redacted in Debug.
+    pub fn key(&self) -> &SensitiveBytes {
+        &self.key
+    }
+
+    /// Returns the wrapped (encrypted) key bytes.
+    pub fn wrapped_key(&self) -> &[u8] {
+        &self.wrapped_key
+    }
 }
 
 /// Pluggable interface for key management systems (AWS KMS, Azure Key Vault, etc.).

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::encryption::SensitiveBytes;
-use crate::{Error, ErrorKind, Result};
+use crate::Result;
 
 /// Result of a server-side key generation operation.
 ///
@@ -52,20 +52,13 @@ pub trait KeyManagementClient: Send + Sync + std::fmt::Debug {
     /// If `true`, callers can use [`generate_key`](Self::generate_key) for atomic
     /// key generation and wrapping, which is more secure than generating a key
     /// locally and then wrapping it.
-    fn supports_key_generation(&self) -> bool {
-        false
-    }
+    fn supports_key_generation(&self) -> bool;
 
     /// Generate a new key and wrap it atomically on the server side.
     ///
     /// This is only supported when [`supports_key_generation`](Self::supports_key_generation)
-    /// returns `true`. The default implementation returns `FeatureUnsupported`.
-    async fn generate_key(&self, _wrapping_key_id: &str) -> Result<GeneratedKey> {
-        Err(Error::new(
-            ErrorKind::FeatureUnsupported,
-            "This KMS client does not support server-side key generation",
-        ))
-    }
+    /// returns `true`.
+    async fn generate_key(&self, wrapping_key_id: &str) -> Result<GeneratedKey>;
 }
 
 #[async_trait]

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -19,8 +19,6 @@
 //!
 //! Mirrors the Java `KeyManagementClient` interface from the Apache Iceberg spec.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 
 use crate::Result;
@@ -77,7 +75,7 @@ pub trait KeyManagementClient: Send + Sync + std::fmt::Debug {
 }
 
 #[async_trait]
-impl KeyManagementClient for Arc<dyn KeyManagementClient> {
+impl<T: AsRef<dyn KeyManagementClient> + Send + Sync + std::fmt::Debug> KeyManagementClient for T {
     async fn wrap_key(&self, key: &[u8], wrapping_key_id: &str) -> Result<Vec<u8>> {
         self.as_ref().wrap_key(key, wrapping_key_id).await
     }

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::encryption::SensitiveBytes;
 use crate::Result;
+use crate::encryption::SensitiveBytes;
 
 /// Result of a server-side key generation operation.
 ///

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Key management client trait for encryption key operations.
+//!
+//! Mirrors the Java `KeyManagementClient` interface from the Apache Iceberg spec.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::encryption::SensitiveBytes;
+use crate::{Error, ErrorKind, Result};
+
+/// Result of a server-side key generation operation.
+///
+/// Returned by [`KeyManagementClient::generate_key`] when the KMS supports
+/// atomic key generation and wrapping.
+pub struct KeyGenerationResult {
+    /// The plaintext key bytes. Zeroized on drop, redacted in Debug.
+    pub key: SensitiveBytes,
+    /// The wrapped (encrypted) key bytes.
+    pub wrapped_key: Vec<u8>,
+}
+
+/// Pluggable interface for key management systems (AWS KMS, Azure Key Vault, etc.).
+#[async_trait]
+pub trait KeyManagementClient: Send + Sync + std::fmt::Debug {
+    /// Wrap (encrypt) a key using a wrapping key managed by the KMS.
+    async fn wrap_key(&self, key: &[u8], wrapping_key_id: &str) -> Result<Vec<u8>>;
+
+    /// Unwrap (decrypt) a previously wrapped key.
+    async fn unwrap_key(&self, wrapped_key: &[u8], wrapping_key_id: &str)
+    -> Result<SensitiveBytes>;
+
+    /// Whether this KMS supports server-side key generation.
+    ///
+    /// If `true`, callers can use [`generate_key`](Self::generate_key) for atomic
+    /// key generation and wrapping, which is more secure than generating a key
+    /// locally and then wrapping it.
+    fn supports_key_generation(&self) -> bool {
+        false
+    }
+
+    /// Generate a new key and wrap it atomically on the server side.
+    ///
+    /// This is only supported when [`supports_key_generation`](Self::supports_key_generation)
+    /// returns `true`. The default implementation returns `FeatureUnsupported`.
+    async fn generate_key(&self, _wrapping_key_id: &str) -> Result<KeyGenerationResult> {
+        Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "This KMS client does not support server-side key generation",
+        ))
+    }
+}
+
+#[async_trait]
+impl KeyManagementClient for Arc<dyn KeyManagementClient> {
+    async fn wrap_key(&self, key: &[u8], wrapping_key_id: &str) -> Result<Vec<u8>> {
+        self.as_ref().wrap_key(key, wrapping_key_id).await
+    }
+
+    async fn unwrap_key(
+        &self,
+        wrapped_key: &[u8],
+        wrapping_key_id: &str,
+    ) -> Result<SensitiveBytes> {
+        self.as_ref().unwrap_key(wrapped_key, wrapping_key_id).await
+    }
+
+    fn supports_key_generation(&self) -> bool {
+        self.as_ref().supports_key_generation()
+    }
+
+    async fn generate_key(&self, wrapping_key_id: &str) -> Result<KeyGenerationResult> {
+        self.as_ref().generate_key(wrapping_key_id).await
+    }
+}

--- a/crates/iceberg/src/encryption/kms/client.rs
+++ b/crates/iceberg/src/encryption/kms/client.rs
@@ -30,7 +30,7 @@ use crate::{Error, ErrorKind, Result};
 ///
 /// Returned by [`KeyManagementClient::generate_key`] when the KMS supports
 /// atomic key generation and wrapping.
-pub struct KeyGenerationResult {
+pub struct GeneratedKey {
     /// The plaintext key bytes. Zeroized on drop, redacted in Debug.
     pub key: SensitiveBytes,
     /// The wrapped (encrypted) key bytes.
@@ -60,7 +60,7 @@ pub trait KeyManagementClient: Send + Sync + std::fmt::Debug {
     ///
     /// This is only supported when [`supports_key_generation`](Self::supports_key_generation)
     /// returns `true`. The default implementation returns `FeatureUnsupported`.
-    async fn generate_key(&self, _wrapping_key_id: &str) -> Result<KeyGenerationResult> {
+    async fn generate_key(&self, _wrapping_key_id: &str) -> Result<GeneratedKey> {
         Err(Error::new(
             ErrorKind::FeatureUnsupported,
             "This KMS client does not support server-side key generation",
@@ -86,7 +86,7 @@ impl KeyManagementClient for Arc<dyn KeyManagementClient> {
         self.as_ref().supports_key_generation()
     }
 
-    async fn generate_key(&self, wrapping_key_id: &str) -> Result<KeyGenerationResult> {
+    async fn generate_key(&self, wrapping_key_id: &str) -> Result<GeneratedKey> {
         self.as_ref().generate_key(wrapping_key_id).await
     }
 }

--- a/crates/iceberg/src/encryption/kms/in_memory.rs
+++ b/crates/iceberg/src/encryption/kms/in_memory.rs
@@ -165,6 +165,17 @@ impl KeyManagementClient for InMemoryKeyManagementClient {
 
         Ok(SensitiveBytes::new(cipher.decrypt(wrapped_key, None)?))
     }
+
+    fn supports_key_generation(&self) -> bool {
+        false
+    }
+
+    async fn generate_key(&self, _wrapping_key_id: &str) -> Result<super::GeneratedKey> {
+        Err(Error::new(
+            ErrorKind::FeatureUnsupported,
+            "InMemoryKeyManagementClient does not support server-side key generation",
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/encryption/kms/in_memory.rs
+++ b/crates/iceberg/src/encryption/kms/in_memory.rs
@@ -54,13 +54,13 @@ fn lock_error<T>(e: PoisonError<T>) -> Error {
 #[derive(Clone)]
 pub struct InMemoryKeyManagementClient {
     master_keys: Arc<RwLock<HashMap<String, SensitiveBytes>>>,
-    key_size: AesKeySize,
+    master_key_size: AesKeySize,
 }
 
 impl fmt::Debug for InMemoryKeyManagementClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InMemoryKeyManagementClient")
-            .field("key_size", &self.key_size)
+            .field("master_key_size", &self.master_key_size)
             .field("key_count", &self.key_count())
             .finish()
     }
@@ -77,21 +77,21 @@ impl InMemoryKeyManagementClient {
     pub fn new() -> Self {
         Self {
             master_keys: Arc::new(RwLock::new(HashMap::new())),
-            key_size: AesKeySize::Bits128,
+            master_key_size: AesKeySize::Bits128,
         }
     }
 
-    /// Creates a new in-memory KMS with the specified key size.
-    pub fn with_key_size(key_size: AesKeySize) -> Self {
+    /// Creates a new in-memory KMS with the specified master key size.
+    pub fn with_master_key_size(master_key_size: AesKeySize) -> Self {
         Self {
             master_keys: Arc::new(RwLock::new(HashMap::new())),
-            key_size,
+            master_key_size,
         }
     }
 
     /// Adds a randomly generated master key with the given ID.
     pub fn add_master_key(&self, key_id: impl Into<String>) -> Result<()> {
-        let key = SecureKey::generate(self.key_size);
+        let key = SecureKey::generate(self.master_key_size);
         self.insert_key(key_id.into(), SensitiveBytes::new(key.as_bytes()))
     }
 
@@ -266,8 +266,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_key_size() {
-        let kms = InMemoryKeyManagementClient::with_key_size(AesKeySize::Bits256);
+    async fn test_with_master_key_size() {
+        let kms = InMemoryKeyManagementClient::with_master_key_size(AesKeySize::Bits256);
         kms.add_master_key("master-256").unwrap();
 
         let dek = vec![0u8; 16];

--- a/crates/iceberg/src/encryption/kms/in_memory.rs
+++ b/crates/iceberg/src/encryption/kms/in_memory.rs
@@ -1,0 +1,287 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! In-memory KMS implementation for testing and development.
+//!
+//! **WARNING**: This implementation is NOT suitable for production use.
+//! Keys are stored in memory only and will be lost when the process exits.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, PoisonError, RwLock};
+
+use async_trait::async_trait;
+
+use super::KeyManagementClient;
+use crate::encryption::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
+use crate::{Error, ErrorKind, Result};
+
+fn lock_error<T>(e: PoisonError<T>) -> Error {
+    Error::new(ErrorKind::Unexpected, format!("Lock poisoned: {e}"))
+}
+
+/// In-memory KMS for testing. Not suitable for production use.
+///
+/// ```
+/// use iceberg::encryption::KeyManagementClient;
+/// use iceberg::encryption::kms::InMemoryKeyManagementClient;
+///
+/// # async fn example() -> iceberg::Result<()> {
+/// let kms = InMemoryKeyManagementClient::new();
+/// kms.add_master_key("my-master-key")?;
+///
+/// let dek = vec![0u8; 16];
+/// let wrapped = kms.wrap_key(&dek, "my-master-key").await?;
+/// let unwrapped = kms.unwrap_key(&wrapped, "my-master-key").await?;
+/// assert_eq!(dek.as_slice(), unwrapped.as_bytes());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct InMemoryKeyManagementClient {
+    master_keys: Arc<RwLock<HashMap<String, SensitiveBytes>>>,
+    key_size: AesKeySize,
+}
+
+impl fmt::Debug for InMemoryKeyManagementClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InMemoryKeyManagementClient")
+            .field("key_size", &self.key_size)
+            .field("key_count", &self.key_count())
+            .finish()
+    }
+}
+
+impl Default for InMemoryKeyManagementClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryKeyManagementClient {
+    /// Creates a new in-memory KMS with 128-bit AES keys.
+    pub fn new() -> Self {
+        Self {
+            master_keys: Arc::new(RwLock::new(HashMap::new())),
+            key_size: AesKeySize::Bits128,
+        }
+    }
+
+    /// Creates a new in-memory KMS with the specified key size.
+    pub fn with_key_size(key_size: AesKeySize) -> Self {
+        Self {
+            master_keys: Arc::new(RwLock::new(HashMap::new())),
+            key_size,
+        }
+    }
+
+    /// Adds a randomly generated master key with the given ID.
+    pub fn add_master_key(&self, key_id: impl Into<String>) -> Result<()> {
+        let key = SecureKey::generate(self.key_size);
+        self.insert_key(key_id.into(), SensitiveBytes::new(key.as_bytes()))
+    }
+
+    /// Adds a master key with explicit key bytes.
+    ///
+    /// Use this to seed the KMS with known key material, e.g. for
+    /// cross-language integration tests where both Java and Rust must
+    /// share the same master key bytes.
+    pub fn add_master_key_bytes(&self, key_id: impl Into<String>, key_bytes: &[u8]) -> Result<()> {
+        let _ = SecureKey::new(key_bytes)?;
+        self.insert_key(key_id.into(), SensitiveBytes::new(key_bytes))
+    }
+
+    fn insert_key(&self, key_id: String, key: SensitiveBytes) -> Result<()> {
+        let mut keys = self.master_keys.write().map_err(lock_error)?;
+
+        if keys.contains_key(&key_id) {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!("Master key already exists: {key_id}"),
+            ));
+        }
+
+        keys.insert(key_id, key);
+        Ok(())
+    }
+
+    fn get_master_key(&self, key_id: &str) -> Result<SensitiveBytes> {
+        let keys = self.master_keys.read().map_err(lock_error)?;
+
+        keys.get(key_id).cloned().ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                format!("Master key not found: {key_id}"),
+            )
+        })
+    }
+
+    /// Number of master keys stored.
+    pub fn key_count(&self) -> usize {
+        self.master_keys.read().map(|keys| keys.len()).unwrap_or(0)
+    }
+
+    /// Whether a master key with the given ID exists.
+    pub fn has_key(&self, key_id: &str) -> bool {
+        self.master_keys
+            .read()
+            .map(|keys| keys.contains_key(key_id))
+            .unwrap_or(false)
+    }
+}
+
+#[async_trait]
+impl KeyManagementClient for InMemoryKeyManagementClient {
+    async fn wrap_key(&self, key: &[u8], wrapping_key_id: &str) -> Result<Vec<u8>> {
+        let master_key_bytes = self.get_master_key(wrapping_key_id)?;
+        let master_key = SecureKey::new(master_key_bytes.as_bytes())?;
+        let cipher = AesGcmCipher::new(master_key);
+
+        cipher.encrypt(key, None)
+    }
+
+    async fn unwrap_key(
+        &self,
+        wrapped_key: &[u8],
+        wrapping_key_id: &str,
+    ) -> Result<SensitiveBytes> {
+        let master_key_bytes = self.get_master_key(wrapping_key_id)?;
+        let master_key = SecureKey::new(master_key_bytes.as_bytes())?;
+        let cipher = AesGcmCipher::new(master_key);
+
+        Ok(SensitiveBytes::new(cipher.decrypt(wrapped_key, None)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_wrap_unwrap_roundtrip() {
+        let kms = InMemoryKeyManagementClient::new();
+        kms.add_master_key("master-1").unwrap();
+        let dek = vec![0u8; 16];
+
+        let wrapped = kms.wrap_key(&dek, "master-1").await.unwrap();
+        let unwrapped = kms.unwrap_key(&wrapped, "master-1").await.unwrap();
+        assert_eq!(unwrapped.as_bytes(), dek.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_wrap_unknown_key_fails() {
+        let kms = InMemoryKeyManagementClient::new();
+        let dek = vec![0u8; 16];
+
+        let result = kms.wrap_key(&dek, "nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_wrong_master_key_fails_unwrap() {
+        let kms = InMemoryKeyManagementClient::new();
+        kms.add_master_key("master-1").unwrap();
+        kms.add_master_key("master-2").unwrap();
+        let dek = vec![0u8; 16];
+
+        let wrapped = kms.wrap_key(&dek, "master-1").await.unwrap();
+
+        let result = kms.unwrap_key(&wrapped, "master-2").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_does_not_support_key_generation() {
+        let kms = InMemoryKeyManagementClient::new();
+        assert!(!kms.supports_key_generation());
+
+        let result = kms.generate_key("master-1").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_master_keys() {
+        let kms = InMemoryKeyManagementClient::new();
+        kms.add_master_key("master-1").unwrap();
+        kms.add_master_key("master-2").unwrap();
+        let dek1 = vec![1u8; 16];
+        let dek2 = vec![2u8; 16];
+
+        let wrapped1 = kms.wrap_key(&dek1, "master-1").await.unwrap();
+        let wrapped2 = kms.wrap_key(&dek2, "master-2").await.unwrap();
+
+        let unwrapped1 = kms.unwrap_key(&wrapped1, "master-1").await.unwrap();
+        let unwrapped2 = kms.unwrap_key(&wrapped2, "master-2").await.unwrap();
+
+        assert_eq!(unwrapped1.as_bytes(), dek1.as_slice());
+        assert_eq!(unwrapped2.as_bytes(), dek2.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_add_master_key() {
+        let kms = InMemoryKeyManagementClient::new();
+
+        kms.add_master_key("my-key").unwrap();
+        assert!(kms.has_key("my-key"));
+        assert_eq!(kms.key_count(), 1);
+
+        let result = kms.add_master_key("my-key");
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_add_master_key_bytes() {
+        let kms = InMemoryKeyManagementClient::new();
+        let key_bytes = [42u8; 16];
+
+        kms.add_master_key_bytes("my-key", &key_bytes).unwrap();
+        assert!(kms.has_key("my-key"));
+
+        let dek = vec![7u8; 16];
+        let wrapped = kms.wrap_key(&dek, "my-key").await.unwrap();
+        let unwrapped = kms.unwrap_key(&wrapped, "my-key").await.unwrap();
+        assert_eq!(unwrapped.as_bytes(), dek.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_add_master_key_bytes_invalid_length() {
+        let kms = InMemoryKeyManagementClient::new();
+
+        let result = kms.add_master_key_bytes("my-key", &[0u8; 7]);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_with_key_size() {
+        let kms = InMemoryKeyManagementClient::with_key_size(AesKeySize::Bits256);
+        kms.add_master_key("master-256").unwrap();
+
+        let dek = vec![0u8; 16];
+        let wrapped = kms.wrap_key(&dek, "master-256").await.unwrap();
+        let unwrapped = kms.unwrap_key(&wrapped, "master-256").await.unwrap();
+        assert_eq!(unwrapped.as_bytes(), dek.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_state() {
+        let kms1 = InMemoryKeyManagementClient::new();
+        let kms2 = kms1.clone();
+
+        kms1.add_master_key("shared-key").unwrap();
+        assert!(kms2.has_key("shared-key"));
+    }
+}

--- a/crates/iceberg/src/encryption/kms/memory.rs
+++ b/crates/iceberg/src/encryption/kms/memory.rs
@@ -38,10 +38,10 @@ fn lock_error<T>(e: PoisonError<T>) -> Error {
 ///
 /// ```
 /// use iceberg::encryption::KeyManagementClient;
-/// use iceberg::encryption::kms::InMemoryKeyManagementClient;
+/// use iceberg::encryption::kms::MemoryKeyManagementClient;
 ///
 /// # async fn example() -> iceberg::Result<()> {
-/// let kms = InMemoryKeyManagementClient::new();
+/// let kms = MemoryKeyManagementClient::new();
 /// kms.add_master_key("my-master-key")?;
 ///
 /// let dek = vec![0u8; 16];
@@ -52,27 +52,27 @@ fn lock_error<T>(e: PoisonError<T>) -> Error {
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct InMemoryKeyManagementClient {
+pub struct MemoryKeyManagementClient {
     master_keys: Arc<RwLock<HashMap<String, SensitiveBytes>>>,
     master_key_size: AesKeySize,
 }
 
-impl fmt::Debug for InMemoryKeyManagementClient {
+impl fmt::Debug for MemoryKeyManagementClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InMemoryKeyManagementClient")
+        f.debug_struct("MemoryKeyManagementClient")
             .field("master_key_size", &self.master_key_size)
             .field("key_count", &self.key_count())
             .finish()
     }
 }
 
-impl Default for InMemoryKeyManagementClient {
+impl Default for MemoryKeyManagementClient {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl InMemoryKeyManagementClient {
+impl MemoryKeyManagementClient {
     /// Creates a new in-memory KMS with 128-bit AES keys.
     pub fn new() -> Self {
         Self {
@@ -145,7 +145,7 @@ impl InMemoryKeyManagementClient {
 }
 
 #[async_trait]
-impl KeyManagementClient for InMemoryKeyManagementClient {
+impl KeyManagementClient for MemoryKeyManagementClient {
     async fn wrap_key(&self, key: &[u8], wrapping_key_id: &str) -> Result<Vec<u8>> {
         let master_key_bytes = self.get_master_key(wrapping_key_id)?;
         let master_key = SecureKey::new(master_key_bytes.as_bytes())?;
@@ -173,7 +173,7 @@ impl KeyManagementClient for InMemoryKeyManagementClient {
     async fn generate_key(&self, _wrapping_key_id: &str) -> Result<super::GeneratedKey> {
         Err(Error::new(
             ErrorKind::FeatureUnsupported,
-            "InMemoryKeyManagementClient does not support server-side key generation",
+            "MemoryKeyManagementClient does not support server-side key generation",
         ))
     }
 }
@@ -184,7 +184,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrap_unwrap_roundtrip() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         kms.add_master_key("master-1").unwrap();
         let dek = vec![0u8; 16];
 
@@ -195,7 +195,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrap_unknown_key_fails() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         let dek = vec![0u8; 16];
 
         let result = kms.wrap_key(&dek, "nonexistent").await;
@@ -204,7 +204,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_wrong_master_key_fails_unwrap() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         kms.add_master_key("master-1").unwrap();
         kms.add_master_key("master-2").unwrap();
         let dek = vec![0u8; 16];
@@ -217,7 +217,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_does_not_support_key_generation() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         assert!(!kms.supports_key_generation());
 
         let result = kms.generate_key("master-1").await;
@@ -226,7 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_master_keys() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         kms.add_master_key("master-1").unwrap();
         kms.add_master_key("master-2").unwrap();
         let dek1 = vec![1u8; 16];
@@ -244,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_master_key() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
 
         kms.add_master_key("my-key").unwrap();
         assert!(kms.has_key("my-key"));
@@ -256,7 +256,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_master_key_bytes() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
         let key_bytes = [42u8; 16];
 
         kms.add_master_key_bytes("my-key", &key_bytes).unwrap();
@@ -270,7 +270,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_master_key_bytes_invalid_length() {
-        let kms = InMemoryKeyManagementClient::new();
+        let kms = MemoryKeyManagementClient::new();
 
         let result = kms.add_master_key_bytes("my-key", &[0u8; 7]);
         assert!(result.is_err());
@@ -278,7 +278,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_master_key_size() {
-        let kms = InMemoryKeyManagementClient::with_master_key_size(AesKeySize::Bits256);
+        let kms = MemoryKeyManagementClient::with_master_key_size(AesKeySize::Bits256);
         kms.add_master_key("master-256").unwrap();
 
         let dek = vec![0u8; 16];
@@ -289,7 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clone_shares_state() {
-        let kms1 = InMemoryKeyManagementClient::new();
+        let kms1 = MemoryKeyManagementClient::new();
         let kms2 = kms1.clone();
 
         kms1.add_master_key("shared-key").unwrap();

--- a/crates/iceberg/src/encryption/kms/memory.rs
+++ b/crates/iceberg/src/encryption/kms/memory.rs
@@ -93,8 +93,14 @@ impl MemoryKeyManagementClient {
         key_id: impl Into<String>,
         key_bytes: SensitiveBytes,
     ) -> Result<()> {
-        let _ = SecureKey::new(key_bytes.as_bytes())?;
+        Self::check_key_length(&key_bytes)?;
         self.insert_key(key_id.into(), key_bytes)
+    }
+
+    /// Check the key length is valid by constructing a SecureKey.
+    fn check_key_length(key_bytes: &SensitiveBytes) -> Result<()> {
+        SecureKey::new(key_bytes.as_bytes())?;
+        Ok(())
     }
 
     fn insert_key(&self, key_id: String, key: SensitiveBytes) -> Result<()> {

--- a/crates/iceberg/src/encryption/kms/memory.rs
+++ b/crates/iceberg/src/encryption/kms/memory.rs
@@ -22,17 +22,14 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::{Arc, PoisonError, RwLock};
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 
 use super::KeyManagementClient;
 use crate::encryption::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
+use crate::error::lock_error;
 use crate::{Error, ErrorKind, Result};
-
-fn lock_error<T>(e: PoisonError<T>) -> Error {
-    Error::new(ErrorKind::Unexpected, format!("Lock poisoned: {e}"))
-}
 
 /// In-memory KMS for testing. Not suitable for production use.
 ///
@@ -69,10 +66,7 @@ impl fmt::Debug for MemoryKeyManagementClient {
 impl MemoryKeyManagementClient {
     /// Creates a new in-memory KMS with 128-bit AES keys.
     pub fn new() -> Self {
-        Self {
-            master_keys: Arc::new(RwLock::new(HashMap::new())),
-            master_key_size: AesKeySize::Bits128,
-        }
+        Self::default()
     }
 
     /// Creates a new in-memory KMS with the specified master key size.
@@ -94,9 +88,13 @@ impl MemoryKeyManagementClient {
     /// Use this to seed the KMS with known key material, e.g. for
     /// cross-language integration tests where both Java and Rust must
     /// share the same master key bytes.
-    pub fn add_master_key_bytes(&self, key_id: impl Into<String>, key_bytes: &[u8]) -> Result<()> {
-        let _ = SecureKey::new(key_bytes)?;
-        self.insert_key(key_id.into(), SensitiveBytes::new(key_bytes))
+    pub fn add_master_key_bytes(
+        &self,
+        key_id: impl Into<String>,
+        key_bytes: SensitiveBytes,
+    ) -> Result<()> {
+        let _ = SecureKey::new(key_bytes.as_bytes())?;
+        self.insert_key(key_id.into(), key_bytes)
     }
 
     fn insert_key(&self, key_id: String, key: SensitiveBytes) -> Result<()> {
@@ -251,9 +249,9 @@ mod tests {
     #[tokio::test]
     async fn test_add_master_key_bytes() {
         let kms = MemoryKeyManagementClient::new();
-        let key_bytes = [42u8; 16];
+        let key_bytes = SensitiveBytes::new([42u8; 16]);
 
-        kms.add_master_key_bytes("my-key", &key_bytes).unwrap();
+        kms.add_master_key_bytes("my-key", key_bytes).unwrap();
         assert!(kms.has_key("my-key"));
 
         let dek = vec![7u8; 16];
@@ -266,7 +264,7 @@ mod tests {
     async fn test_add_master_key_bytes_invalid_length() {
         let kms = MemoryKeyManagementClient::new();
 
-        let result = kms.add_master_key_bytes("my-key", &[0u8; 7]);
+        let result = kms.add_master_key_bytes("my-key", SensitiveBytes::new([0u8; 7]));
         assert!(result.is_err());
     }
 

--- a/crates/iceberg/src/encryption/kms/memory.rs
+++ b/crates/iceberg/src/encryption/kms/memory.rs
@@ -51,7 +51,7 @@ fn lock_error<T>(e: PoisonError<T>) -> Error {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct MemoryKeyManagementClient {
     master_keys: Arc<RwLock<HashMap<String, SensitiveBytes>>>,
     master_key_size: AesKeySize,
@@ -63,12 +63,6 @@ impl fmt::Debug for MemoryKeyManagementClient {
             .field("master_key_size", &self.master_key_size)
             .field("key_count", &self.key_count())
             .finish()
-    }
-}
-
-impl Default for MemoryKeyManagementClient {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/iceberg/src/encryption/kms/mod.rs
+++ b/crates/iceberg/src/encryption/kms/mod.rs
@@ -21,7 +21,7 @@
 //! integration and implementations for different key management systems.
 
 mod client;
-mod in_memory;
+mod memory;
 
 pub use client::{GeneratedKey, KeyManagementClient};
-pub use in_memory::InMemoryKeyManagementClient;
+pub use memory::MemoryKeyManagementClient;

--- a/crates/iceberg/src/encryption/kms/mod.rs
+++ b/crates/iceberg/src/encryption/kms/mod.rs
@@ -23,5 +23,5 @@
 mod client;
 mod in_memory;
 
-pub use client::{KeyGenerationResult, KeyManagementClient};
+pub use client::{GeneratedKey, KeyManagementClient};
 pub use in_memory::InMemoryKeyManagementClient;

--- a/crates/iceberg/src/encryption/kms/mod.rs
+++ b/crates/iceberg/src/encryption/kms/mod.rs
@@ -15,19 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Encryption module for Apache Iceberg.
+//! Key Management System trait and implementations.
 //!
-//! This module provides core cryptographic primitives and key management
-//! for encrypting and decrypting data in Iceberg tables.
+//! This module provides the [`KeyManagementClient`] trait for pluggable KMS
+//! integration and implementations for different key management systems.
 
-mod crypto;
-mod file_decryptor;
-mod file_encryptor;
-pub mod kms;
-mod stream;
+mod client;
+mod in_memory;
 
-pub use crypto::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
-pub use file_decryptor::AesGcmFileDecryptor;
-pub use file_encryptor::AesGcmFileEncryptor;
-pub use kms::{KeyGenerationResult, KeyManagementClient};
-pub use stream::{AesGcmFileRead, AesGcmFileWrite};
+pub use client::{KeyGenerationResult, KeyManagementClient};
+pub use in_memory::InMemoryKeyManagementClient;

--- a/crates/iceberg/src/encryption/mod.rs
+++ b/crates/iceberg/src/encryption/mod.rs
@@ -29,5 +29,5 @@ mod stream;
 pub use crypto::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
 pub use file_decryptor::AesGcmFileDecryptor;
 pub use file_encryptor::AesGcmFileEncryptor;
-pub use kms::{KeyGenerationResult, KeyManagementClient};
+pub use kms::{GeneratedKey, KeyManagementClient};
 pub use stream::{AesGcmFileRead, AesGcmFileWrite};

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -18,6 +18,7 @@
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
+use std::sync::PoisonError;
 
 use chrono::{DateTime, TimeZone as _, Utc};
 
@@ -421,6 +422,11 @@ define_from_err!(
 );
 
 define_from_err!(std::io::Error, ErrorKind::Unexpected, "IO Operation failed");
+
+/// Converts a [`PoisonError`] from a poisoned lock into an [`Error`].
+pub(crate) fn lock_error<T>(e: PoisonError<T>) -> Error {
+    Error::new(ErrorKind::Unexpected, format!("Lock poisoned: {e}"))
+}
 
 /// Converts a timestamp in milliseconds to `DateTime<Utc>`, handling errors.
 ///


### PR DESCRIPTION
## Which issue does this PR close?

Part of #2034 

## What changes are included in this PR?

Adds the `KeyManagementClient` trait and an in-memory implementation for testing.

- `KeyManagementClient` trait mirrors Java's `KeyManagementClient` [interface](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/encryption/KeyManagementClient.java). 
- `InMemoryKeyManagementClient`  for testing-only KMS that stores master keys in memory to wrap/unwrap. Supports configurable key sizes and explicit key bytes for cross-language interop tests.


## Are these changes tested?

Tests covered for `InMemoryKeyManagementClient`
