### PR TITLE
feat(encryption) [4/N] Support encryption: StandardKeyMetadata

### DIFF
--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -43,7 +43,7 @@ use crate::{Error, ErrorKind, Result};
 /// containing `SensitiveBytes` can safely derive or implement `Debug`
 /// without risk of leaking key material.
 #[derive(Clone, PartialEq, Eq)]
-struct SensitiveBytes(Zeroizing<Box<[u8]>>);
+pub struct SensitiveBytes(Zeroizing<Box<[u8]>>);
 
 impl SensitiveBytes {
     /// Wraps the given bytes as sensitive material.
@@ -57,13 +57,11 @@ impl SensitiveBytes {
     }
 
     /// Returns the number of bytes.
-    #[allow(dead_code)] // Encryption work is ongoing so currently unused
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns `true` if the byte slice is empty.
-    #[allow(dead_code)] // Encryption work is ongoing so currently unused
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -79,8 +79,8 @@ impl StandardKeyMetadata {
     }
 
     /// Returns the plaintext Data Encryption Key.
-    pub fn encryption_key(&self) -> &[u8] {
-        self.encryption_key.as_bytes()
+    pub fn encryption_key(&self) -> &SensitiveBytes {
+        &self.encryption_key
     }
 
     /// Returns the AAD prefix.
@@ -232,7 +232,7 @@ mod tests {
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
-        assert_eq!(parsed.encryption_key(), key);
+        assert_eq!(parsed.encryption_key().as_bytes(), key);
         assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
         assert_eq!(parsed.file_length(), None);
     }
@@ -249,7 +249,7 @@ mod tests {
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
-        assert_eq!(parsed.encryption_key(), key);
+        assert_eq!(parsed.encryption_key().as_bytes(), key);
         assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
         assert_eq!(parsed.file_length(), Some(file_length));
     }
@@ -275,7 +275,7 @@ mod tests {
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
-        assert_eq!(parsed.encryption_key(), &[1, 2, 3, 4]);
+        assert_eq!(parsed.encryption_key().as_bytes(), &[1, 2, 3, 4]);
         assert_eq!(parsed.aad_prefix(), None);
     }
 }

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -71,7 +71,7 @@ static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
 #[derive(Clone, PartialEq, Eq)]
 pub struct StandardKeyMetadata {
     encryption_key: SensitiveBytes,
-    aad_prefix: Box<[u8]>,
+    aad_prefix: Option<Box<[u8]>>,
     file_length: Option<u64>,
 }
 
@@ -79,7 +79,13 @@ impl fmt::Debug for StandardKeyMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StandardKeyMetadata")
             .field("encryption_key", &self.encryption_key)
-            .field("aad_prefix", &format!("[{} bytes]", self.aad_prefix.len()))
+            .field(
+                "aad_prefix",
+                &self
+                    .aad_prefix
+                    .as_ref()
+                    .map(|b| format!("[{} bytes]", b.len())),
+            )
             .field("file_length", &self.file_length)
             .finish()
     }
@@ -87,15 +93,21 @@ impl fmt::Debug for StandardKeyMetadata {
 
 impl StandardKeyMetadata {
     /// Creates a new `StandardKeyMetadata`.
-    pub fn new(encryption_key: &[u8], aad_prefix: &[u8]) -> Self {
+    pub fn new(encryption_key: &[u8]) -> Self {
         Self {
             encryption_key: SensitiveBytes::new(encryption_key),
-            aad_prefix: aad_prefix.into(),
+            aad_prefix: None,
             file_length: None,
         }
     }
 
-    /// Adds a file length
+    /// Adds an AAD prefix.
+    pub fn with_aad_prefix(mut self, aad_prefix: &[u8]) -> Self {
+        self.aad_prefix = Some(aad_prefix.into());
+        self
+    }
+
+    /// Adds a file length.
     pub fn with_file_length(mut self, length: u64) -> Self {
         self.file_length = Some(length);
         self
@@ -107,8 +119,8 @@ impl StandardKeyMetadata {
     }
 
     /// Returns the AAD prefix.
-    pub fn aad_prefix(&self) -> &[u8] {
-        &self.aad_prefix
+    pub fn aad_prefix(&self) -> Option<&[u8]> {
+        self.aad_prefix.as_deref()
     }
 
     /// Returns the optional file length.
@@ -120,7 +132,10 @@ impl StandardKeyMetadata {
     pub fn serialize(&self) -> Result<Box<[u8]>> {
         let serde_repr = StandardKeyMetadataV1 {
             encryption_key: serde_bytes::ByteBuf::from(self.encryption_key.as_bytes()),
-            aad_prefix: Some(serde_bytes::ByteBuf::from(self.aad_prefix.as_ref())),
+            aad_prefix: self
+                .aad_prefix
+                .as_ref()
+                .map(|b| serde_bytes::ByteBuf::from(b.as_ref())),
             file_length: self.file_length,
         };
 
@@ -172,10 +187,7 @@ impl StandardKeyMetadata {
 
         Ok(Self {
             encryption_key: SensitiveBytes::new(v1.encryption_key.into_vec()),
-            aad_prefix: v1
-                .aad_prefix
-                .map(|b| b.into_vec().into_boxed_slice())
-                .unwrap_or_default(),
+            aad_prefix: v1.aad_prefix.map(|b| b.into_vec().into_boxed_slice()),
             file_length: v1.file_length,
         })
     }
@@ -199,12 +211,12 @@ mod tests {
         let key = b"0123456789012345";
         let aad = b"1234567890123456";
 
-        let metadata = StandardKeyMetadata::new(key, aad);
+        let metadata = StandardKeyMetadata::new(key).with_aad_prefix(aad);
         let serialized = metadata.serialize().unwrap();
         let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), key);
-        assert_eq!(parsed.aad_prefix(), aad);
+        assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
         assert_eq!(parsed.file_length(), None);
     }
 
@@ -214,12 +226,14 @@ mod tests {
         let aad = b"1234567890123456";
 
         let file_length = 100_000;
-        let metadata = StandardKeyMetadata::new(key, aad).with_file_length(file_length);
+        let metadata = StandardKeyMetadata::new(key)
+            .with_aad_prefix(aad)
+            .with_file_length(file_length);
         let serialized = metadata.serialize().unwrap();
         let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), key);
-        assert_eq!(parsed.aad_prefix(), aad);
+        assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
         assert_eq!(parsed.file_length(), Some(file_length));
     }
 
@@ -239,12 +253,12 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_with_empty_aad() {
-        let metadata = StandardKeyMetadata::new(&[1, 2, 3, 4], &[]);
+    fn test_roundtrip_without_aad() {
+        let metadata = StandardKeyMetadata::new(&[1, 2, 3, 4]);
         let serialized = metadata.serialize().unwrap();
         let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), &[1, 2, 3, 4]);
-        assert_eq!(parsed.aad_prefix(), &[] as &[u8]);
+        assert_eq!(parsed.aad_prefix(), None);
     }
 }

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -19,9 +19,6 @@
 //! `org.apache.iceberg.encryption.StandardKeyMetadata`.
 
 use std::fmt;
-use std::io::Cursor;
-
-use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value};
 
 use super::SensitiveBytes;
 use crate::{Error, ErrorKind, Result};
@@ -95,62 +92,20 @@ impl StandardKeyMetadata {
 
     /// Encodes to Java-compatible format: `[0x01] [Avro binary datum]`
     pub fn encode(&self) -> Result<Box<[u8]>> {
-        let serde_repr = _serde::StandardKeyMetadataV1::from(self);
-
-        let value = to_value(serde_repr)
-            .and_then(|v| v.resolve(&_serde::AVRO_SCHEMA_V1))
-            .map_err(|e| {
-                Error::new(ErrorKind::Unexpected, "Failed to encode key metadata").with_source(e)
-            })?;
-
-        let datum = to_avro_datum(&_serde::AVRO_SCHEMA_V1, value).map_err(|e| {
-            Error::new(ErrorKind::Unexpected, "Failed to encode key metadata").with_source(e)
-        })?;
-
-        let mut result = Vec::with_capacity(1 + datum.len());
-        result.push(_serde::V1);
-        result.extend_from_slice(&datum);
-        Ok(result.into_boxed_slice())
+        _serde::StandardKeyMetadataV1::from(self).encode()
     }
 
     /// Decodes from Java-compatible format.
     pub fn decode(bytes: &[u8]) -> Result<Self> {
-        if bytes.is_empty() {
-            return Err(Error::new(
-                ErrorKind::DataInvalid,
-                "Empty key metadata buffer",
-            ));
-        }
-
-        let version = bytes[0];
-        if version != _serde::V1 {
-            return Err(Error::new(
-                ErrorKind::FeatureUnsupported,
-                format!("Cannot resolve schema for version: {version}"),
-            ));
-        }
-
-        let mut reader = Cursor::new(&bytes[1..]);
-        let value = from_avro_datum(&_serde::AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
-            Error::new(ErrorKind::DataInvalid, "Failed to decode key metadata").with_source(e)
-        })?;
-
-        let v1: _serde::StandardKeyMetadataV1 = from_value(&value).map_err(|e| {
-            Error::new(
-                ErrorKind::DataInvalid,
-                "Failed to decode key metadata fields",
-            )
-            .with_source(e)
-        })?;
-
-        Ok(Self::from(v1))
+        _serde::StandardKeyMetadataV1::decode(bytes).map(Self::from)
     }
 }
 
 mod _serde {
+    use std::io::Cursor;
     use std::sync::{Arc, LazyLock};
 
-    use apache_avro::Schema as AvroSchema;
+    use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, Schema as AvroSchema};
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -193,6 +148,58 @@ mod _serde {
         pub encryption_key: serde_bytes::ByteBuf,
         pub aad_prefix: Option<serde_bytes::ByteBuf>,
         pub file_length: Option<u64>,
+    }
+
+    impl StandardKeyMetadataV1 {
+        pub(super) fn encode(&self) -> Result<Box<[u8]>> {
+            let value = to_value(self)
+                .and_then(|v| v.resolve(&AVRO_SCHEMA_V1))
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "Failed to encode key metadata")
+                        .with_source(e)
+                })?;
+
+            let datum = to_avro_datum(&AVRO_SCHEMA_V1, value).map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "Failed to encode key metadata").with_source(e)
+            })?;
+
+            let mut result = Vec::with_capacity(1 + datum.len());
+            result.push(V1);
+            result.extend_from_slice(&datum);
+            Ok(result.into_boxed_slice())
+        }
+
+        pub(super) fn decode(bytes: &[u8]) -> Result<Self> {
+            if bytes.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Empty key metadata buffer",
+                ));
+            }
+
+            let version = bytes[0];
+            if version != V1 {
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
+                    format!("Cannot resolve schema for version: {version}"),
+                ));
+            }
+
+            let mut reader = Cursor::new(&bytes[1..]);
+            let value =
+                from_avro_datum(&AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
+                    Error::new(ErrorKind::DataInvalid, "Failed to decode key metadata")
+                        .with_source(e)
+                })?;
+
+            from_value(&value).map_err(|e| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "Failed to decode key metadata fields",
+                )
+                .with_source(e)
+            })
+        }
     }
 
     impl From<&StandardKeyMetadata> for StandardKeyMetadataV1 {

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Avro-serialized key metadata format compatible with Java's
+//! `org.apache.iceberg.encryption.StandardKeyMetadata`.
+
+use std::fmt;
+use std::io::Cursor;
+use std::sync::LazyLock;
+
+use apache_avro::{Schema as AvroSchema, from_avro_datum, from_value, to_avro_datum, to_value};
+use serde::{Deserialize, Serialize};
+
+use super::SensitiveBytes;
+use crate::{Error, ErrorKind, Result};
+
+const V1: u8 = 1;
+
+/// Avro schema for StandardKeyMetadata V1, matching Java's layout.
+static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
+    AvroSchema::parse_str(
+        r#"{
+            "type": "record",
+            "name": "StandardKeyMetadata",
+            "namespace": "org.apache.iceberg.encryption",
+            "fields": [
+                {
+                    "name": "encryption_key",
+                    "type": "bytes",
+                    "field-id": 0
+                },
+                {
+                    "name": "aad_prefix",
+                    "type": ["null", "bytes"],
+                    "default": null,
+                    "field-id": 1
+                },
+                {
+                    "name": "file_length",
+                    "type": ["null", "long"],
+                    "default": null,
+                    "field-id": 2
+                }
+            ]
+        }"#,
+    )
+    .expect("Failed to parse StandardKeyMetadata Avro schema")
+});
+
+/// Standard key metadata for Iceberg table encryption.
+///
+/// Contains the Data Encryption Key (DEK), AAD prefix, and optional file
+/// length. Byte-compatible with Java's `StandardKeyMetadata` via Avro
+/// serialization.
+///
+/// Wire format: `[version byte (0x01)] [Avro binary datum]`
+#[derive(Clone, PartialEq, Eq)]
+pub struct StandardKeyMetadata {
+    encryption_key: SensitiveBytes,
+    aad_prefix: Box<[u8]>,
+    file_length: Option<i64>,
+}
+
+impl fmt::Debug for StandardKeyMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StandardKeyMetadata")
+            .field("encryption_key", &self.encryption_key)
+            .field("aad_prefix", &format!("[{} bytes]", self.aad_prefix.len()))
+            .field("file_length", &self.file_length)
+            .finish()
+    }
+}
+
+impl StandardKeyMetadata {
+    /// Creates a new `StandardKeyMetadata`.
+    pub fn new(encryption_key: &[u8], aad_prefix: &[u8]) -> Self {
+        Self {
+            encryption_key: SensitiveBytes::new(encryption_key),
+            aad_prefix: aad_prefix.into(),
+            file_length: None,
+        }
+    }
+
+    /// Returns the plaintext Data Encryption Key.
+    pub fn encryption_key(&self) -> &[u8] {
+        self.encryption_key.as_bytes()
+    }
+
+    /// Returns the AAD prefix.
+    pub fn aad_prefix(&self) -> &[u8] {
+        &self.aad_prefix
+    }
+
+    /// Returns the optional file length.
+    pub fn file_length(&self) -> Option<i64> {
+        self.file_length
+    }
+
+    /// Serializes to Java-compatible format: `[0x01] [Avro binary datum]`
+    pub fn serialize(&self) -> Result<Box<[u8]>> {
+        let serde_repr = StandardKeyMetadataV1 {
+            encryption_key: serde_bytes::ByteBuf::from(self.encryption_key.as_bytes()),
+            aad_prefix: Some(serde_bytes::ByteBuf::from(self.aad_prefix.as_ref())),
+            file_length: self.file_length,
+        };
+
+        let value = to_value(serde_repr)
+            .and_then(|v| v.resolve(&AVRO_SCHEMA_V1))
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "Failed to serialize key metadata").with_source(e)
+            })?;
+
+        let datum = to_avro_datum(&AVRO_SCHEMA_V1, value).map_err(|e| {
+            Error::new(ErrorKind::Unexpected, "Failed to serialize key metadata").with_source(e)
+        })?;
+
+        let mut result = Vec::with_capacity(1 + datum.len());
+        result.push(V1);
+        result.extend_from_slice(&datum);
+        Ok(result.into_boxed_slice())
+    }
+
+    /// Deserializes from Java-compatible format.
+    pub fn deserialize(bytes: &[u8]) -> Result<Self> {
+        if bytes.is_empty() {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Empty key metadata buffer",
+            ));
+        }
+
+        let version = bytes[0];
+        if version != V1 {
+            return Err(Error::new(
+                ErrorKind::FeatureUnsupported,
+                format!("Cannot resolve schema for version: {version}"),
+            ));
+        }
+
+        let mut reader = Cursor::new(&bytes[1..]);
+        let value = from_avro_datum(&AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
+            Error::new(ErrorKind::DataInvalid, "Failed to parse key metadata").with_source(e)
+        })?;
+
+        let v1: StandardKeyMetadataV1 = from_value(&value).map_err(|e| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "Failed to deserialize key metadata fields",
+            )
+            .with_source(e)
+        })?;
+
+        Ok(Self {
+            encryption_key: SensitiveBytes::new(v1.encryption_key.into_vec()),
+            aad_prefix: v1
+                .aad_prefix
+                .map(|b| b.into_vec().into_boxed_slice())
+                .unwrap_or_default(),
+            file_length: v1.file_length,
+        })
+    }
+}
+
+/// Serde struct for Avro serialization of [`StandardKeyMetadata`] V1.
+/// Field names must match [`AVRO_SCHEMA_V1`] exactly.
+#[derive(Serialize, Deserialize)]
+struct StandardKeyMetadataV1 {
+    encryption_key: serde_bytes::ByteBuf,
+    aad_prefix: Option<serde_bytes::ByteBuf>,
+    file_length: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        let key = b"0123456789012345";
+        let aad = b"1234567890123456";
+
+        let metadata = StandardKeyMetadata::new(key, aad);
+        let serialized = metadata.serialize().unwrap();
+        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+
+        assert_eq!(parsed.encryption_key(), key);
+        assert_eq!(parsed.aad_prefix(), aad);
+        assert_eq!(parsed.file_length(), None);
+    }
+
+    #[test]
+    fn test_unsupported_version() {
+        let result = StandardKeyMetadata::deserialize(&[0x02]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
+    }
+
+    #[test]
+    fn test_empty_buffer() {
+        let result = StandardKeyMetadata::deserialize(&[]);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::DataInvalid);
+    }
+
+    #[test]
+    fn test_roundtrip_with_empty_aad() {
+        let metadata = StandardKeyMetadata::new(&[1, 2, 3, 4], &[]);
+        let serialized = metadata.serialize().unwrap();
+        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+
+        assert_eq!(parsed.encryption_key(), &[1, 2, 3, 4]);
+        assert_eq!(parsed.aad_prefix(), &[] as &[u8]);
+    }
+}

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -148,44 +148,42 @@ impl StandardKeyMetadata {
 }
 
 mod _serde {
-    use std::sync::LazyLock;
+    use std::sync::{Arc, LazyLock};
 
     use apache_avro::Schema as AvroSchema;
     use serde::{Deserialize, Serialize};
 
     use super::*;
+    use crate::avro::schema_to_avro_schema;
+    use crate::spec::{NestedField, PrimitiveType, Schema, Type};
 
     pub(super) const V1: u8 = 1;
 
-    /// Avro schema for StandardKeyMetadata V1, matching Java's layout.
+    /// Avro schema for StandardKeyMetadata V1, derived from Iceberg schema.
     pub(super) static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
-        AvroSchema::parse_str(
-            r#"{
-                "type": "record",
-                "name": "StandardKeyMetadata",
-                "namespace": "org.apache.iceberg.encryption",
-                "fields": [
-                    {
-                        "name": "encryption_key",
-                        "type": "bytes",
-                        "field-id": 0
-                    },
-                    {
-                        "name": "aad_prefix",
-                        "type": ["null", "bytes"],
-                        "default": null,
-                        "field-id": 1
-                    },
-                    {
-                        "name": "file_length",
-                        "type": ["null", "long"],
-                        "default": null,
-                        "field-id": 2
-                    }
-                ]
-            }"#,
-        )
-        .expect("Failed to parse StandardKeyMetadata Avro schema")
+        let schema = Schema::builder()
+            .with_fields(vec![
+                Arc::new(NestedField::required(
+                    0,
+                    "encryption_key",
+                    Type::Primitive(PrimitiveType::Binary),
+                )),
+                Arc::new(NestedField::optional(
+                    1,
+                    "aad_prefix",
+                    Type::Primitive(PrimitiveType::Binary),
+                )),
+                Arc::new(NestedField::optional(
+                    2,
+                    "file_length",
+                    Type::Primitive(PrimitiveType::Long),
+                )),
+            ])
+            .build()
+            .expect("Failed to build StandardKeyMetadata Iceberg schema");
+
+        schema_to_avro_schema("StandardKeyMetadata", &schema)
+            .expect("Failed to convert StandardKeyMetadata to Avro schema")
     });
 
     /// Serde struct for Avro serialization of [`StandardKeyMetadata`] V1.

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -105,7 +105,7 @@ mod _serde {
     use std::io::Cursor;
     use std::sync::{Arc, LazyLock};
 
-    use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, Schema as AvroSchema};
+    use apache_avro::{Schema as AvroSchema, from_avro_datum, from_value, to_avro_datum, to_value};
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -186,11 +186,9 @@ mod _serde {
             }
 
             let mut reader = Cursor::new(&bytes[1..]);
-            let value =
-                from_avro_datum(&AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
-                    Error::new(ErrorKind::DataInvalid, "Failed to decode key metadata")
-                        .with_source(e)
-                })?;
+            let value = from_avro_datum(&AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
+                Error::new(ErrorKind::DataInvalid, "Failed to decode key metadata").with_source(e)
+            })?;
 
             from_value(&value).map_err(|e| {
                 Error::new(

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -20,46 +20,11 @@
 
 use std::fmt;
 use std::io::Cursor;
-use std::sync::LazyLock;
 
-use apache_avro::{Schema as AvroSchema, from_avro_datum, from_value, to_avro_datum, to_value};
-use serde::{Deserialize, Serialize};
+use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value};
 
 use super::SensitiveBytes;
 use crate::{Error, ErrorKind, Result};
-
-const V1: u8 = 1;
-
-/// Avro schema for StandardKeyMetadata V1, matching Java's layout.
-static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
-    AvroSchema::parse_str(
-        r#"{
-            "type": "record",
-            "name": "StandardKeyMetadata",
-            "namespace": "org.apache.iceberg.encryption",
-            "fields": [
-                {
-                    "name": "encryption_key",
-                    "type": "bytes",
-                    "field-id": 0
-                },
-                {
-                    "name": "aad_prefix",
-                    "type": ["null", "bytes"],
-                    "default": null,
-                    "field-id": 1
-                },
-                {
-                    "name": "file_length",
-                    "type": ["null", "long"],
-                    "default": null,
-                    "field-id": 2
-                }
-            ]
-        }"#,
-    )
-    .expect("Failed to parse StandardKeyMetadata Avro schema")
-});
 
 /// Standard key metadata for Iceberg table encryption.
 ///
@@ -128,35 +93,28 @@ impl StandardKeyMetadata {
         self.file_length
     }
 
-    /// Serializes to Java-compatible format: `[0x01] [Avro binary datum]`
-    pub fn serialize(&self) -> Result<Box<[u8]>> {
-        let serde_repr = StandardKeyMetadataV1 {
-            encryption_key: serde_bytes::ByteBuf::from(self.encryption_key.as_bytes()),
-            aad_prefix: self
-                .aad_prefix
-                .as_ref()
-                .map(|b| serde_bytes::ByteBuf::from(b.as_ref())),
-            file_length: self.file_length,
-        };
+    /// Encodes to Java-compatible format: `[0x01] [Avro binary datum]`
+    pub fn encode(&self) -> Result<Box<[u8]>> {
+        let serde_repr = _serde::StandardKeyMetadataV1::from(self);
 
         let value = to_value(serde_repr)
-            .and_then(|v| v.resolve(&AVRO_SCHEMA_V1))
+            .and_then(|v| v.resolve(&_serde::AVRO_SCHEMA_V1))
             .map_err(|e| {
-                Error::new(ErrorKind::Unexpected, "Failed to serialize key metadata").with_source(e)
+                Error::new(ErrorKind::Unexpected, "Failed to encode key metadata").with_source(e)
             })?;
 
-        let datum = to_avro_datum(&AVRO_SCHEMA_V1, value).map_err(|e| {
-            Error::new(ErrorKind::Unexpected, "Failed to serialize key metadata").with_source(e)
+        let datum = to_avro_datum(&_serde::AVRO_SCHEMA_V1, value).map_err(|e| {
+            Error::new(ErrorKind::Unexpected, "Failed to encode key metadata").with_source(e)
         })?;
 
         let mut result = Vec::with_capacity(1 + datum.len());
-        result.push(V1);
+        result.push(_serde::V1);
         result.extend_from_slice(&datum);
         Ok(result.into_boxed_slice())
     }
 
-    /// Deserializes from Java-compatible format.
-    pub fn deserialize(bytes: &[u8]) -> Result<Self> {
+    /// Decodes from Java-compatible format.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
         if bytes.is_empty() {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
@@ -165,7 +123,7 @@ impl StandardKeyMetadata {
         }
 
         let version = bytes[0];
-        if version != V1 {
+        if version != _serde::V1 {
             return Err(Error::new(
                 ErrorKind::FeatureUnsupported,
                 format!("Cannot resolve schema for version: {version}"),
@@ -173,33 +131,94 @@ impl StandardKeyMetadata {
         }
 
         let mut reader = Cursor::new(&bytes[1..]);
-        let value = from_avro_datum(&AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
-            Error::new(ErrorKind::DataInvalid, "Failed to parse key metadata").with_source(e)
+        let value = from_avro_datum(&_serde::AVRO_SCHEMA_V1, &mut reader, None).map_err(|e| {
+            Error::new(ErrorKind::DataInvalid, "Failed to decode key metadata").with_source(e)
         })?;
 
-        let v1: StandardKeyMetadataV1 = from_value(&value).map_err(|e| {
+        let v1: _serde::StandardKeyMetadataV1 = from_value(&value).map_err(|e| {
             Error::new(
                 ErrorKind::DataInvalid,
-                "Failed to deserialize key metadata fields",
+                "Failed to decode key metadata fields",
             )
             .with_source(e)
         })?;
 
-        Ok(Self {
-            encryption_key: SensitiveBytes::new(v1.encryption_key.into_vec()),
-            aad_prefix: v1.aad_prefix.map(|b| b.into_vec().into_boxed_slice()),
-            file_length: v1.file_length,
-        })
+        Ok(Self::from(v1))
     }
 }
 
-/// Serde struct for Avro serialization of [`StandardKeyMetadata`] V1.
-/// Field names must match [`AVRO_SCHEMA_V1`] exactly.
-#[derive(Serialize, Deserialize)]
-struct StandardKeyMetadataV1 {
-    encryption_key: serde_bytes::ByteBuf,
-    aad_prefix: Option<serde_bytes::ByteBuf>,
-    file_length: Option<u64>,
+mod _serde {
+    use std::sync::LazyLock;
+
+    use apache_avro::Schema as AvroSchema;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    pub(super) const V1: u8 = 1;
+
+    /// Avro schema for StandardKeyMetadata V1, matching Java's layout.
+    pub(super) static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
+        AvroSchema::parse_str(
+            r#"{
+                "type": "record",
+                "name": "StandardKeyMetadata",
+                "namespace": "org.apache.iceberg.encryption",
+                "fields": [
+                    {
+                        "name": "encryption_key",
+                        "type": "bytes",
+                        "field-id": 0
+                    },
+                    {
+                        "name": "aad_prefix",
+                        "type": ["null", "bytes"],
+                        "default": null,
+                        "field-id": 1
+                    },
+                    {
+                        "name": "file_length",
+                        "type": ["null", "long"],
+                        "default": null,
+                        "field-id": 2
+                    }
+                ]
+            }"#,
+        )
+        .expect("Failed to parse StandardKeyMetadata Avro schema")
+    });
+
+    /// Serde struct for Avro serialization of [`StandardKeyMetadata`] V1.
+    /// Field names must match [`AVRO_SCHEMA_V1`] exactly.
+    #[derive(Serialize, Deserialize)]
+    pub(super) struct StandardKeyMetadataV1 {
+        pub encryption_key: serde_bytes::ByteBuf,
+        pub aad_prefix: Option<serde_bytes::ByteBuf>,
+        pub file_length: Option<u64>,
+    }
+
+    impl From<&StandardKeyMetadata> for StandardKeyMetadataV1 {
+        fn from(metadata: &StandardKeyMetadata) -> Self {
+            Self {
+                encryption_key: serde_bytes::ByteBuf::from(metadata.encryption_key.as_bytes()),
+                aad_prefix: metadata
+                    .aad_prefix
+                    .as_ref()
+                    .map(|b| serde_bytes::ByteBuf::from(b.as_ref())),
+                file_length: metadata.file_length,
+            }
+        }
+    }
+
+    impl From<StandardKeyMetadataV1> for StandardKeyMetadata {
+        fn from(v1: StandardKeyMetadataV1) -> Self {
+            Self {
+                encryption_key: SensitiveBytes::new(v1.encryption_key.into_vec()),
+                aad_prefix: v1.aad_prefix.map(|b| b.into_vec().into_boxed_slice()),
+                file_length: v1.file_length,
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -212,8 +231,8 @@ mod tests {
         let aad = b"1234567890123456";
 
         let metadata = StandardKeyMetadata::new(key).with_aad_prefix(aad);
-        let serialized = metadata.serialize().unwrap();
-        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+        let serialized = metadata.encode().unwrap();
+        let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), key);
         assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
@@ -229,8 +248,8 @@ mod tests {
         let metadata = StandardKeyMetadata::new(key)
             .with_aad_prefix(aad)
             .with_file_length(file_length);
-        let serialized = metadata.serialize().unwrap();
-        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+        let serialized = metadata.encode().unwrap();
+        let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), key);
         assert_eq!(parsed.aad_prefix(), Some(aad.as_slice()));
@@ -239,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_version() {
-        let result = StandardKeyMetadata::deserialize(&[0x02]);
+        let result = StandardKeyMetadata::decode(&[0x02]);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
@@ -247,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_empty_buffer() {
-        let result = StandardKeyMetadata::deserialize(&[]);
+        let result = StandardKeyMetadata::decode(&[]);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), ErrorKind::DataInvalid);
     }
@@ -255,8 +274,8 @@ mod tests {
     #[test]
     fn test_roundtrip_without_aad() {
         let metadata = StandardKeyMetadata::new(&[1, 2, 3, 4]);
-        let serialized = metadata.serialize().unwrap();
-        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+        let serialized = metadata.encode().unwrap();
+        let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
         assert_eq!(parsed.encryption_key(), &[1, 2, 3, 4]);
         assert_eq!(parsed.aad_prefix(), None);

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -72,7 +72,7 @@ static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
 pub struct StandardKeyMetadata {
     encryption_key: SensitiveBytes,
     aad_prefix: Box<[u8]>,
-    file_length: Option<i64>,
+    file_length: Option<u64>,
 }
 
 impl fmt::Debug for StandardKeyMetadata {
@@ -95,6 +95,12 @@ impl StandardKeyMetadata {
         }
     }
 
+    /// Adds a file length
+    pub fn with_file_length(mut self, length: u64) -> Self {
+        self.file_length = Some(length);
+        self
+    }
+
     /// Returns the plaintext Data Encryption Key.
     pub fn encryption_key(&self) -> &[u8] {
         self.encryption_key.as_bytes()
@@ -106,7 +112,7 @@ impl StandardKeyMetadata {
     }
 
     /// Returns the optional file length.
-    pub fn file_length(&self) -> Option<i64> {
+    pub fn file_length(&self) -> Option<u64> {
         self.file_length
     }
 
@@ -181,7 +187,7 @@ impl StandardKeyMetadata {
 struct StandardKeyMetadataV1 {
     encryption_key: serde_bytes::ByteBuf,
     aad_prefix: Option<serde_bytes::ByteBuf>,
-    file_length: Option<i64>,
+    file_length: Option<u64>,
 }
 
 #[cfg(test)]
@@ -200,6 +206,21 @@ mod tests {
         assert_eq!(parsed.encryption_key(), key);
         assert_eq!(parsed.aad_prefix(), aad);
         assert_eq!(parsed.file_length(), None);
+    }
+
+    #[test]
+    fn test_roundtrip_with_length() {
+        let key = b"0123456789012345";
+        let aad = b"1234567890123456";
+
+        let file_length = 100_000;
+        let metadata = StandardKeyMetadata::new(key, aad).with_file_length(file_length);
+        let serialized = metadata.serialize().unwrap();
+        let parsed = StandardKeyMetadata::deserialize(&serialized).unwrap();
+
+        assert_eq!(parsed.encryption_key(), key);
+        assert_eq!(parsed.aad_prefix(), aad);
+        assert_eq!(parsed.file_length(), Some(file_length));
     }
 
     #[test]

--- a/crates/iceberg/src/encryption/mod.rs
+++ b/crates/iceberg/src/encryption/mod.rs
@@ -23,13 +23,13 @@
 mod crypto;
 mod file_decryptor;
 mod file_encryptor;
+pub(crate) mod key_metadata;
 pub mod kms;
 mod stream;
-pub(crate) mod key_metadata;
 
 pub use crypto::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
 pub use file_decryptor::AesGcmFileDecryptor;
 pub use file_encryptor::AesGcmFileEncryptor;
-pub use kms::{GeneratedKey, KeyManagementClient};
 pub use key_metadata::StandardKeyMetadata;
+pub use kms::{GeneratedKey, KeyManagementClient};
 pub use stream::{AesGcmFileRead, AesGcmFileWrite};

--- a/crates/iceberg/src/encryption/mod.rs
+++ b/crates/iceberg/src/encryption/mod.rs
@@ -25,9 +25,11 @@ mod file_decryptor;
 mod file_encryptor;
 pub mod kms;
 mod stream;
+pub(crate) mod key_metadata;
 
 pub use crypto::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
 pub use file_decryptor::AesGcmFileDecryptor;
 pub use file_encryptor::AesGcmFileEncryptor;
 pub use kms::{GeneratedKey, KeyManagementClient};
+pub use key_metadata::StandardKeyMetadata;
 pub use stream::{AesGcmFileRead, AesGcmFileWrite};

--- a/crates/iceberg/src/encryption/mod.rs
+++ b/crates/iceberg/src/encryption/mod.rs
@@ -23,9 +23,11 @@
 mod crypto;
 mod file_decryptor;
 mod file_encryptor;
+pub(crate) mod key_metadata;
 mod stream;
 
-pub use crypto::{AesGcmCipher, AesKeySize, SecureKey};
+pub use crypto::{AesGcmCipher, AesKeySize, SecureKey, SensitiveBytes};
 pub use file_decryptor::AesGcmFileDecryptor;
 pub use file_encryptor::AesGcmFileEncryptor;
+pub use key_metadata::StandardKeyMetadata;
 pub use stream::{AesGcmFileRead, AesGcmFileWrite};


### PR DESCRIPTION
## Which issue does this PR close?

Part of #2034

## What changes are included in this PR?

Adds `StandardKeyMetadata`, the Avro-serialized key metadata format that lives inside Iceberg's `key_metadata` binary fields (data file field 131, manifest list field 519). The Iceberg spec leaves the format of these bytes as ["implementation-specific"](https://iceberg.apache.org/spec/#data-file-fields). This implementation is byte-compatible with Java's `org.apache.iceberg.encryption.StandardKeyMetadata` for cross-language interop.


## Are these changes tested?
Yes
