### PR TITLE
fix: NaN pushdown correctly pushes down NaNs correctness issue 

### DIFF
--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1515,8 +1515,7 @@ fn project_column(
 fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
     // Compute NaN over the contiguous values slice, then fold the null bitmap
     // in with a single bitwise AND so that null slots become false.
-    // Per the Iceberg spec, is_nan is non-null-propagating: NULL → false.
-    let (values, nulls) = match array.data_type() {
+    let (is_nan, nulls) = match array.data_type() {
         DataType::Float32 => {
             let arr = array.as_primitive::<Float32Type>();
             (
@@ -1535,8 +1534,8 @@ fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowEr
     };
 
     let values = match nulls {
-        Some(nulls) => &values & nulls.inner(),
-        None => values,
+        Some(nulls) => &is_nan & nulls.inner(),
+        None => is_nan,
     };
 
     Ok(BooleanArray::new(values, None))

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -26,6 +26,7 @@ use arrow_arith::boolean::{and, and_kleene, is_not_null, is_null, not, or, or_kl
 use arrow_array::cast::AsArray;
 use arrow_array::types::{Float32Type, Float64Type};
 use arrow_array::{Array, ArrayRef, BooleanArray, Datum as ArrowDatum, RecordBatch, Scalar};
+use arrow_buffer::BooleanBuffer;
 use arrow_cast::cast::cast;
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{
@@ -1512,42 +1513,33 @@ fn project_column(
 }
 
 fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
+    // Compute NaN over the contiguous values slice, then fold the null bitmap
+    // in with a single bitwise AND so that null slots become false.
     // Per the Iceberg spec, is_nan is non-null-propagating: NULL → false.
-    // When there are no nulls, from_unary is a fast vectorized path.
-    // When there are nulls, we iterate to avoid propagating them.
-    if array.null_count() == 0 {
-        return match array.data_type() {
-            DataType::Float32 => Ok(BooleanArray::from_unary(
-                array.as_primitive::<Float32Type>(),
-                |v| v.is_nan(),
-            )),
-            DataType::Float64 => Ok(BooleanArray::from_unary(
-                array.as_primitive::<Float64Type>(),
-                |v| v.is_nan(),
-            )),
-            _ => unreachable!("is_nan is only valid for float types"),
-        };
-    }
-
-    match array.data_type() {
+    let (values, nulls) = match array.data_type() {
         DataType::Float32 => {
             let arr = array.as_primitive::<Float32Type>();
-            Ok(BooleanArray::from(
-                (0..arr.len())
-                    .map(|i| arr.is_valid(i) && arr.value(i).is_nan())
-                    .collect::<Vec<_>>(),
-            ))
+            (
+                BooleanBuffer::from_iter(arr.values().iter().map(|v| v.is_nan())),
+                arr.nulls(),
+            )
         }
         DataType::Float64 => {
             let arr = array.as_primitive::<Float64Type>();
-            Ok(BooleanArray::from(
-                (0..arr.len())
-                    .map(|i| arr.is_valid(i) && arr.value(i).is_nan())
-                    .collect::<Vec<_>>(),
-            ))
+            (
+                BooleanBuffer::from_iter(arr.values().iter().map(|v| v.is_nan())),
+                arr.nulls(),
+            )
         }
         _ => unreachable!("is_nan is only valid for float types"),
-    }
+    };
+
+    let values = match nulls {
+        Some(nulls) => &values & nulls.inner(),
+        None => values,
+    };
+
+    Ok(BooleanArray::new(values, None))
 }
 
 type PredicateResult =
@@ -5557,15 +5549,19 @@ message schema {
         let values = vec![Some(1.0f32), Some(f32::NAN), None, Some(0.0f32)];
 
         // is_nan: non-null-propagating per Iceberg spec — NULL → false
-        let batch = RecordBatch::try_new(
-            arrow_schema.clone(),
-            vec![Arc::new(Float32Array::from(values.clone()))],
-        )
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(
+            values.clone(),
+        ))])
         .unwrap();
         let result =
             apply_predicate_to_batch(Reference::new("qux").is_nan(), schema.clone(), batch);
         assert_eq!(
-            [result.value(0), result.value(1), result.value(2), result.value(3)],
+            [
+                result.value(0),
+                result.value(1),
+                result.value(2),
+                result.value(3)
+            ],
             [false, true, false, false]
         );
         assert!(!result.is_null(2));
@@ -5575,7 +5571,12 @@ message schema {
             RecordBatch::try_new(arrow_schema, vec![Arc::new(Float32Array::from(values))]).unwrap();
         let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);
         assert_eq!(
-            [result.value(0), result.value(1), result.value(2), result.value(3)],
+            [
+                result.value(0),
+                result.value(1),
+                result.value(2),
+                result.value(3)
+            ],
             [true, false, true, true]
         );
         assert!(!result.is_null(2));

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -5547,7 +5547,7 @@ message schema {
         )]));
         let values = vec![Some(1.0f32), Some(f32::NAN), None, Some(0.0f32)];
 
-        // is_nan: non-null-propagating per Iceberg spec — NULL → false
+        // is_nan: non-null-propagating per Java's implementation - NULL → false
         let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(
             values.clone(),
         ))])
@@ -5565,7 +5565,7 @@ message schema {
         );
         assert!(!result.is_null(2));
 
-        // not_nan: non-null-propagating per Iceberg spec — NULL → true
+        // not_nan: non-null-propagating per Java's implementation - NULL → true
         let batch =
             RecordBatch::try_new(arrow_schema, vec![Arc::new(Float32Array::from(values))]).unwrap();
         let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -1512,16 +1512,41 @@ fn project_column(
 }
 
 fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
+    // Per the Iceberg spec, is_nan is non-null-propagating: NULL → false.
+    // When there are no nulls, from_unary is a fast vectorized path.
+    // When there are nulls, we iterate to avoid propagating them.
+    if array.null_count() == 0 {
+        return match array.data_type() {
+            DataType::Float32 => Ok(BooleanArray::from_unary(
+                array.as_primitive::<Float32Type>(),
+                |v| v.is_nan(),
+            )),
+            DataType::Float64 => Ok(BooleanArray::from_unary(
+                array.as_primitive::<Float64Type>(),
+                |v| v.is_nan(),
+            )),
+            _ => unreachable!("is_nan is only valid for float types"),
+        };
+    }
+
     match array.data_type() {
-        DataType::Float32 => Ok(BooleanArray::from_unary(
-            array.as_primitive::<Float32Type>(),
-            |v| v.is_nan(),
-        )),
-        DataType::Float64 => Ok(BooleanArray::from_unary(
-            array.as_primitive::<Float64Type>(),
-            |v| v.is_nan(),
-        )),
-        _ => Ok(BooleanArray::from(vec![false; array.len()])),
+        DataType::Float32 => {
+            let arr = array.as_primitive::<Float32Type>();
+            Ok(BooleanArray::from(
+                (0..arr.len())
+                    .map(|i| arr.is_valid(i) && arr.value(i).is_nan())
+                    .collect::<Vec<_>>(),
+            ))
+        }
+        DataType::Float64 => {
+            let arr = array.as_primitive::<Float64Type>();
+            Ok(BooleanArray::from(
+                (0..arr.len())
+                    .map(|i| arr.is_valid(i) && arr.value(i).is_nan())
+                    .collect::<Vec<_>>(),
+            ))
+        }
+        _ => unreachable!("is_nan is only valid for float types"),
     }
 }
 
@@ -5531,21 +5556,28 @@ message schema {
         )]));
         let values = vec![Some(1.0f32), Some(f32::NAN), None, Some(0.0f32)];
 
-        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(
-            values.clone(),
-        ))])
+        // is_nan: non-null-propagating per Iceberg spec — NULL → false
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Float32Array::from(values.clone()))],
+        )
         .unwrap();
         let result =
             apply_predicate_to_batch(Reference::new("qux").is_nan(), schema.clone(), batch);
-        assert_eq!([result.value(0), result.value(1), result.value(3)], [
-            false, true, false
-        ]);
+        assert_eq!(
+            [result.value(0), result.value(1), result.value(2), result.value(3)],
+            [false, true, false, false]
+        );
+        assert!(!result.is_null(2));
 
+        // not_nan: non-null-propagating per Iceberg spec — NULL → true
         let batch =
             RecordBatch::try_new(arrow_schema, vec![Arc::new(Float32Array::from(values))]).unwrap();
         let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);
-        assert_eq!([result.value(0), result.value(1), result.value(3)], [
-            true, false, true
-        ]);
+        assert_eq!(
+            [result.value(0), result.value(1), result.value(2), result.value(3)],
+            [true, false, true, true]
+        );
+        assert!(!result.is_null(2));
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -5538,21 +5538,21 @@ message schema {
         )]));
         let values = vec![Some(1.0f32), Some(f32::NAN), None, Some(0.0f32)];
 
-        let batch =
-            RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(values.clone()))]).unwrap();
-        let result = apply_predicate_to_batch(Reference::new("qux").is_nan(), schema.clone(), batch);
-        assert_eq!(
-            [result.value(0), result.value(1), result.value(3)],
-            [false, true, false]
-        );
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(
+            values.clone(),
+        ))])
+        .unwrap();
+        let result =
+            apply_predicate_to_batch(Reference::new("qux").is_nan(), schema.clone(), batch);
+        assert_eq!([result.value(0), result.value(1), result.value(3)], [
+            false, true, false
+        ]);
 
         let batch =
             RecordBatch::try_new(arrow_schema, vec![Arc::new(Float32Array::from(values))]).unwrap();
         let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);
-        assert_eq!(
-            [result.value(0), result.value(1), result.value(3)],
-            [true, false, true]
-        );
+        assert_eq!([result.value(0), result.value(1), result.value(3)], [
+            true, false, true
+        ]);
     }
-
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -23,7 +23,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use arrow_arith::boolean::{and, and_kleene, is_not_null, is_null, not, or, or_kleene};
-use arrow_array::{Array, ArrayRef, BooleanArray, Datum as ArrowDatum, RecordBatch, Scalar};
+use arrow_array::{
+    Array, ArrayRef, BooleanArray, Datum as ArrowDatum, Float32Array, Float64Array, RecordBatch,
+    Scalar,
+};
 use arrow_cast::cast::cast;
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{
@@ -1509,6 +1512,26 @@ fn project_column(
     }
 }
 
+fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
+    match array.data_type() {
+        DataType::Float32 => {
+            let float_array = array
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| ArrowError::CastError("Expected Float32Array".to_string()))?;
+            Ok(BooleanArray::from_unary(float_array, |v| v.is_nan()))
+        }
+        DataType::Float64 => {
+            let float_array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| ArrowError::CastError("Expected Float64Array".to_string()))?;
+            Ok(BooleanArray::from_unary(float_array, |v| v.is_nan()))
+        }
+        _ => Ok(BooleanArray::from(vec![false; array.len()])),
+    }
+}
+
 type PredicateResult =
     dyn FnMut(RecordBatch) -> std::result::Result<BooleanArray, ArrowError> + Send + 'static;
 
@@ -1591,8 +1614,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
-        if self.bound_reference(reference)?.is_some() {
-            self.build_always_true()
+        if let Some(idx) = self.bound_reference(reference)? {
+            Ok(Box::new(move |batch| {
+                let column = project_column(&batch, idx)?;
+                compute_is_nan(&column)
+            }))
         } else {
             // A missing column, treating it as null.
             self.build_always_false()
@@ -1604,8 +1630,12 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
-        if self.bound_reference(reference)?.is_some() {
-            self.build_always_false()
+        if let Some(idx) = self.bound_reference(reference)? {
+            Ok(Box::new(move |batch| {
+                let column = project_column(&batch, idx)?;
+                let is_nan = compute_is_nan(&column)?;
+                not(&is_nan)
+            }))
         } else {
             // A missing column, treating it as null.
             self.build_always_true()
@@ -2002,7 +2032,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::cast::AsArray;
-    use arrow_array::{ArrayRef, LargeStringArray, RecordBatch, StringArray};
+    use arrow_array::{Array, ArrayRef, BooleanArray, LargeStringArray, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
     use futures::TryStreamExt;
     use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
@@ -5463,5 +5493,136 @@ message schema {
             "INT96 in map: got {}, expected {expected_micros}",
             ts_array.value(0)
         );
+    }
+
+    fn apply_predicate_to_batch(
+        predicate: Predicate,
+        schema: SchemaRef,
+        batch: RecordBatch,
+    ) -> BooleanArray {
+        use super::PredicateConverter;
+
+        let bound = predicate.bind(schema, true).unwrap();
+
+        // Build a trivial Parquet schema with one float column at field id 4
+        let message_type = "
+            message schema {
+              optional float qux = 4;
+            }
+        ";
+        let parquet_type = parse_message_type(message_type).expect("parse schema");
+        let parquet_schema = SchemaDescriptor::new(Arc::new(parquet_type));
+
+        let column_map = HashMap::from([(4i32, 0usize)]);
+        let column_indices = vec![0usize];
+
+        let mut converter = PredicateConverter {
+            parquet_schema: &parquet_schema,
+            column_map: &column_map,
+            column_indices: &column_indices,
+        };
+
+        let mut predicate_fn = visit(&mut converter, &bound).unwrap();
+        predicate_fn(batch).unwrap()
+    }
+
+    #[test]
+    fn test_predicate_converter_is_nan() {
+        use arrow_array::Float32Array;
+
+        let schema = table_schema_simple();
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "qux",
+                DataType::Float32,
+                true,
+            )])),
+            vec![Arc::new(Float32Array::from(vec![
+                Some(1.0f32),
+                Some(f32::NAN),
+                None,
+                Some(f32::NAN),
+            ]))],
+        )
+        .unwrap();
+
+        let result = apply_predicate_to_batch(Reference::new("qux").is_nan(), schema, batch);
+
+        assert!(!result.value(0)); // 1.0 -> false
+        assert!(result.value(1)); // NaN -> true
+        assert!(result.value(3)); // NaN -> true
+    }
+
+    #[test]
+    fn test_predicate_converter_not_nan() {
+        use arrow_array::Float32Array;
+
+        let schema = table_schema_simple();
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "qux",
+                DataType::Float32,
+                true,
+            )])),
+            vec![Arc::new(Float32Array::from(vec![
+                Some(1.0f32),
+                Some(f32::NAN),
+                None,
+                Some(0.0f32),
+            ]))],
+        )
+        .unwrap();
+
+        let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);
+
+        assert!(result.value(0)); // 1.0 -> true (not NaN)
+        assert!(!result.value(1)); // NaN -> false
+        assert!(result.value(3)); // 0.0 -> true (not NaN)
+    }
+
+    #[test]
+    fn test_compute_is_nan_float32() {
+        use arrow_array::Float32Array;
+
+        let array: ArrayRef = Arc::new(Float32Array::from(vec![
+            Some(1.0f32),
+            Some(f32::NAN),
+            None,
+            Some(0.0f32),
+            Some(f32::NAN),
+        ]));
+        let result = super::compute_is_nan(&array).unwrap();
+
+        // NaN check: null values should remain null (not true)
+        assert!(!result.value(0)); // 1.0 is not NaN
+        assert!(result.value(1)); // NaN
+        assert!(result.is_null(2)); // null stays null
+        assert!(!result.value(3)); // 0.0 is not NaN
+        assert!(result.value(4)); // NaN
+    }
+
+    #[test]
+    fn test_compute_is_nan_float64() {
+        use arrow_array::Float64Array;
+
+        let array: ArrayRef = Arc::new(Float64Array::from(vec![Some(f64::NAN), Some(42.0), None]));
+        let result = super::compute_is_nan(&array).unwrap();
+
+        assert!(result.value(0)); // NaN
+        assert!(!result.value(1)); // 42.0 is not NaN
+        assert!(result.is_null(2)); // null stays null
+    }
+
+    #[test]
+    fn test_compute_is_nan_non_float() {
+        use arrow_array::Int32Array;
+
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let result = super::compute_is_nan(&array).unwrap();
+
+        // Non-float types: all false
+        assert!(!result.value(0));
+        assert!(!result.value(1));
+        assert!(!result.value(2));
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -23,10 +23,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use arrow_arith::boolean::{and, and_kleene, is_not_null, is_null, not, or, or_kleene};
-use arrow_array::{
-    Array, ArrayRef, BooleanArray, Datum as ArrowDatum, Float32Array, Float64Array, RecordBatch,
-    Scalar,
-};
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Float32Type, Float64Type};
+use arrow_array::{Array, ArrayRef, BooleanArray, Datum as ArrowDatum, RecordBatch, Scalar};
 use arrow_cast::cast::cast;
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{
@@ -1514,20 +1513,14 @@ fn project_column(
 
 fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
     match array.data_type() {
-        DataType::Float32 => {
-            let float_array = array
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| ArrowError::CastError("Expected Float32Array".to_string()))?;
-            Ok(BooleanArray::from_unary(float_array, |v| v.is_nan()))
-        }
-        DataType::Float64 => {
-            let float_array = array
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .ok_or_else(|| ArrowError::CastError("Expected Float64Array".to_string()))?;
-            Ok(BooleanArray::from_unary(float_array, |v| v.is_nan()))
-        }
+        DataType::Float32 => Ok(BooleanArray::from_unary(
+            array.as_primitive::<Float32Type>(),
+            |v| v.is_nan(),
+        )),
+        DataType::Float64 => Ok(BooleanArray::from_unary(
+            array.as_primitive::<Float64Type>(),
+            |v| v.is_nan(),
+        )),
         _ => Ok(BooleanArray::from(vec![false; array.len()])),
     }
 }

--- a/crates/iceberg/src/arrow/reader.rs
+++ b/crates/iceberg/src/arrow/reader.rs
@@ -5527,102 +5527,32 @@ message schema {
     }
 
     #[test]
-    fn test_predicate_converter_is_nan() {
+    fn test_predicate_converter_nan() {
         use arrow_array::Float32Array;
 
         let schema = table_schema_simple();
-        let batch = RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![Field::new(
-                "qux",
-                DataType::Float32,
-                true,
-            )])),
-            vec![Arc::new(Float32Array::from(vec![
-                Some(1.0f32),
-                Some(f32::NAN),
-                None,
-                Some(f32::NAN),
-            ]))],
-        )
-        .unwrap();
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "qux",
+            DataType::Float32,
+            true,
+        )]));
+        let values = vec![Some(1.0f32), Some(f32::NAN), None, Some(0.0f32)];
 
-        let result = apply_predicate_to_batch(Reference::new("qux").is_nan(), schema, batch);
+        let batch =
+            RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(Float32Array::from(values.clone()))]).unwrap();
+        let result = apply_predicate_to_batch(Reference::new("qux").is_nan(), schema.clone(), batch);
+        assert_eq!(
+            [result.value(0), result.value(1), result.value(3)],
+            [false, true, false]
+        );
 
-        assert!(!result.value(0)); // 1.0 -> false
-        assert!(result.value(1)); // NaN -> true
-        assert!(result.value(3)); // NaN -> true
-    }
-
-    #[test]
-    fn test_predicate_converter_not_nan() {
-        use arrow_array::Float32Array;
-
-        let schema = table_schema_simple();
-        let batch = RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![Field::new(
-                "qux",
-                DataType::Float32,
-                true,
-            )])),
-            vec![Arc::new(Float32Array::from(vec![
-                Some(1.0f32),
-                Some(f32::NAN),
-                None,
-                Some(0.0f32),
-            ]))],
-        )
-        .unwrap();
-
+        let batch =
+            RecordBatch::try_new(arrow_schema, vec![Arc::new(Float32Array::from(values))]).unwrap();
         let result = apply_predicate_to_batch(Reference::new("qux").is_not_nan(), schema, batch);
-
-        assert!(result.value(0)); // 1.0 -> true (not NaN)
-        assert!(!result.value(1)); // NaN -> false
-        assert!(result.value(3)); // 0.0 -> true (not NaN)
+        assert_eq!(
+            [result.value(0), result.value(1), result.value(3)],
+            [true, false, true]
+        );
     }
 
-    #[test]
-    fn test_compute_is_nan_float32() {
-        use arrow_array::Float32Array;
-
-        let array: ArrayRef = Arc::new(Float32Array::from(vec![
-            Some(1.0f32),
-            Some(f32::NAN),
-            None,
-            Some(0.0f32),
-            Some(f32::NAN),
-        ]));
-        let result = super::compute_is_nan(&array).unwrap();
-
-        // NaN check: null values should remain null (not true)
-        assert!(!result.value(0)); // 1.0 is not NaN
-        assert!(result.value(1)); // NaN
-        assert!(result.is_null(2)); // null stays null
-        assert!(!result.value(3)); // 0.0 is not NaN
-        assert!(result.value(4)); // NaN
-    }
-
-    #[test]
-    fn test_compute_is_nan_float64() {
-        use arrow_array::Float64Array;
-
-        let array: ArrayRef = Arc::new(Float64Array::from(vec![Some(f64::NAN), Some(42.0), None]));
-        let result = super::compute_is_nan(&array).unwrap();
-
-        assert!(result.value(0)); // NaN
-        assert!(!result.value(1)); // 42.0 is not NaN
-        assert!(result.is_null(2)); // null stays null
-    }
-
-    #[test]
-    fn test_compute_is_nan_non_float() {
-        use arrow_array::Int32Array;
-
-        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let result = super::compute_is_nan(&array).unwrap();
-
-        // Non-float types: all false
-        assert!(!result.value(0));
-        assert!(!result.value(1));
-        assert!(!result.value(2));
-    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Not tied to a specific issue - found during an audit of pushdown filter gaps.

## What changes are included in this PR?

`PredicateConverter::is_nan` and `not_nan` were never actually implemented - `is_nan` returned `always_true` (matches every row) and `not_nan` returned `always_false` (matches no rows). 

Every other predicate in `PredicateConverter` projects the column from the batch and runs an arrow compute kernel, but these two just returned constants.

This adds a `compute_is_nan` helper that downcasts to `Float32Array`/`Float64Array` and checks each value with `f.is_nan()`, preserving nulls. Non-float types return all false. `is_nan` and `not_nan` now use it the same way `is_null`/`not_null` use `arrow::is_null`/`is_not_null`.

## Are these changes tested?
Yes, test added 
