### PR TITLE
feat(datafusion): show pushed-down limit in IcebergTableScan EXPLAIN output

### DIFF
--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -196,7 +196,11 @@ impl DisplayAs for IcebergTableScan {
             self.predicates
                 .clone()
                 .map_or(String::from(""), |p| format!("{p}"))
-        )
+        )?;
+        if let Some(limit) = self.limit {
+            write!(f, " limit:[{limit}]")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/sqllogictest/testdata/slts/df_test/basic_queries.slt
+++ b/crates/sqllogictest/testdata/slts/df_test/basic_queries.slt
@@ -43,6 +43,18 @@ INSERT INTO default.default.query_test_table VALUES
 ----
 10
 
+# Verify EXPLAIN shows limit is pushed down to IcebergTableScan
+query TT
+EXPLAIN SELECT * FROM default.default.query_test_table LIMIT 3
+----
+logical_plan
+01)Limit: skip=0, fetch=3
+02)--TableScan: default.default.query_test_table projection=[id, name, score, category], fetch=3
+physical_plan
+01)GlobalLimitExec: skip=0, fetch=3
+02)--CooperativeExec
+03)----IcebergTableScan projection:[id,name,score,category] predicate:[] limit:[3]
+
 # Test SELECT * with ORDER BY and LIMIT
 query ITRT
 SELECT * FROM default.default.query_test_table ORDER BY id LIMIT 3


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2359.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Emit ` limit:[N]` in `IcebergTableScan`'s `DisplayAs` output when a `LIMIT` is pushed down to the scan. When no limit is pushed down, the output is unchanged.

- Before (unchanged):
`IcebergTableScan projection:[id,name] predicate:[...]`

- After (new, only when a limit reaches the scan):
`IcebergTableScan projection:[...] predicate:[] limit:[3]`

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes: new `EXPLAIN ... LIMIT 3` assertion in `crates/sqllogictest/testdata/slts/df_test/basic_queries.slt`. Existing snapshots are unchanged, which confirms the additive-only behavior.