### PR TITLE
docs(arrow): clarify ScanMetrics::bytes_read includes delete files

### DIFF
--- a/crates/iceberg/src/arrow/scan_metrics.rs
+++ b/crates/iceberg/src/arrow/scan_metrics.rs
@@ -66,7 +66,7 @@ impl ScanMetrics {
         &self.bytes_read
     }
 
-    /// Total bytes read from storage for data files during this scan.
+    /// Total bytes read from storage during this scan, including data files and delete files.
     pub fn bytes_read(&self) -> u64 {
         self.bytes_read.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## What changes are included in this PR?

Fix the `ScanMetrics::bytes_read` docstring. The counter is shared with `CachingDeleteFileLoader`, so it already includes delete-file reads, not just data files. Docstring now reflects that.

## Are these changes tested?

Docstring-only change, no behavior change, so no new tests.