### PR TITLE
fix(sqllogictest): add missing tokio `rt-multi-thread` feature

### DIFF
--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -39,7 +39,7 @@ sqllogictest = { workspace = true }
 toml = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 libtest-mimic = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2385 .

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

`crates/sqllogictest/Cargo.toml` was missing the `rt-multi-thread` feature for tokio, while `tests/sqllogictests.rs` calls `tokio::runtime::Builder::new_multi_thread()` which requires it.

This meant `cargo test -p iceberg-sqllogictest` failed to compile when run in isolation. The issue was invisible when using `make build`                                       (`--all-features --workspace`) because `crates/examples` already enables                                        `tokio = { features = ["full"] }`, and Cargo features are additive across                                       the workspace graph.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

```sh
cargo test -p iceberg-sqllogictest
```