### PR TITLE
ci(python): verify wheel abi3 compatibility with --no-build

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -113,7 +113,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --reinstall dist/pyiceberg_core-*.whl
+          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core
       - name: Run tests
         working-directory: "bindings/python"
         shell: bash

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -149,8 +149,9 @@ jobs:
               os: ubuntu-latest,
               target: "aarch64",
               manylinux: "manylinux_2_28",
+              uv-platform: "manylinux_2_28_aarch64",
             }
-          - { os: ubuntu-latest, target: "armv7l" }
+          - { os: ubuntu-latest, target: "armv7l", uv-platform: "manylinux_2_17_armv7l" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -191,6 +192,15 @@ jobs:
           working-directory: "bindings/python"
           command: build
           args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.9.3"
+          enable-cache: true
+      - name: Verify wheel installs with no build fallback
+        working-directory: "bindings/python"
+        shell: bash
+        run: |
+          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core --python python3.12 ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -200,7 +200,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core --python python3.12 ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
+          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -149,9 +149,8 @@ jobs:
               os: ubuntu-latest,
               target: "aarch64",
               manylinux: "manylinux_2_28",
-              uv-platform: "manylinux_2_28_aarch64",
             }
-          - { os: ubuntu-latest, target: "armv7l", uv-platform: "manylinux_2_17_armv7l" }
+          - { os: ubuntu-latest, target: "armv7l" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -196,11 +195,15 @@ jobs:
         with:
           version: "0.9.3"
           enable-cache: true
+      # Verify the wheel is abi3-compatible and installable without building from source.
+      # Skipped for cross-compiled targets since they share the same maturin config;
+      # if abi3 is broken, the native target build will catch it.
       - name: Verify wheel installs with no build fallback
+        if: matrix.target != 'aarch64' && matrix.target != 'armv7l'
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
+          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -74,8 +74,9 @@ jobs:
               os: ubuntu-latest,
               target: "aarch64",
               manylinux: "manylinux_2_28",
+              uv-platform: "manylinux_2_28_aarch64",
             }
-          - { os: ubuntu-latest, target: "armv7l" }
+          - { os: ubuntu-latest, target: "armv7l", uv-platform: "manylinux_2_17_armv7l" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -105,6 +106,16 @@ jobs:
           working-directory: "bindings/python"
           command: build
           args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.9.3"
+          enable-cache: true
+      - name: Verify wheel installs with no build fallback
+        working-directory: "bindings/python"
+        shell: bash
+        run: |
+          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core --python python3.12 ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -74,9 +74,8 @@ jobs:
               os: ubuntu-latest,
               target: "aarch64",
               manylinux: "manylinux_2_28",
-              uv-platform: "manylinux_2_28_aarch64",
             }
-          - { os: ubuntu-latest, target: "armv7l", uv-platform: "manylinux_2_17_armv7l" }
+          - { os: ubuntu-latest, target: "armv7l" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -111,11 +110,15 @@ jobs:
         with:
           version: "0.9.3"
           enable-cache: true
+      # Verify the wheel is abi3-compatible and installable without building from source.
+      # Skipped for cross-compiled targets since they share the same maturin config;
+      # if abi3 is broken, the native target build will catch it.
       - name: Verify wheel installs with no build fallback
+        if: matrix.target != 'aarch64' && matrix.target != 'armv7l'
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
+          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core --python python3.12 ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
+          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core ${{ matrix.uv-platform && format('--python-platform {0}', matrix.uv-platform) || '' }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Verify that `pyiceberg-core` does not need to be built when installing 

Adds a `uv pip install --no-build` check after maturin builds to verify the produced wheel is abi3-compatible with Python 3.12.

This prevents a repeat of https://github.com/apache/iceberg-python/issues/3190 where maturin picked Python 3.8 inside a manylinux container, producing a `cp38-cp38` wheel instead of `cp310-abi3`. 
**With `--no-build`, the install fails if the wheel isn't compatible — no fallback to source builds.**

**Changes:**
- `bindings_python_ci.yml`: use `--no-build` when installing the built wheel in CI
- `release_python.yml` / `release_python_nightly.yml`: add verification step after each maturin build

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes
* .github/workflows/bindings_python_ci.yml in CI
* [release_python.yml](https://github.com/kevinjqliu/iceberg-rust/actions/runs/25125359496) / [release_python_nightly.yml](https://github.com/kevinjqliu/iceberg-rust/actions/runs/25125566003) in fork