### PR TITLE
fix(catalog/memory): relax strict ms inequality in test_update_table

### DIFF
--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -1888,7 +1888,7 @@ pub(crate) mod tests {
 
         assert_eq!(table.identifier(), updated_table.identifier());
         assert_eq!(table.metadata().uuid(), updated_table.metadata().uuid());
-        assert!(table.metadata().last_updated_ms() < updated_table.metadata().last_updated_ms());
+        assert!(table.metadata().last_updated_ms() <= updated_table.metadata().last_updated_ms());
         assert_ne!(table.metadata_location(), updated_table.metadata_location());
 
         assert!(

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -1888,7 +1888,6 @@ pub(crate) mod tests {
 
         assert_eq!(table.identifier(), updated_table.identifier());
         assert_eq!(table.metadata().uuid(), updated_table.metadata().uuid());
-        assert!(table.metadata().last_updated_ms() <= updated_table.metadata().last_updated_ms());
         assert_ne!(table.metadata_location(), updated_table.metadata_location());
 
         assert!(


### PR DESCRIPTION
While running make unit-test for verifying the RC the update_table test in /src/memory/catalog.rs was failing because it checks for the table and updated_table to have different updated timestamps down to the ms, but on a fast enough machine the test can update the updated_table in the same ms as the table causing the test to incorrectly fail.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2393 .

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

 - Updates the last updated ms check to be less than or equal to between `table` and `updated_table` as its possible for both to be updated in the same ms

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

 - Yes and they all pass.