### PR TITLE
docs: Correct docs for Int128 and UInt128 being big-endian not little-endian

### DIFF
--- a/crates/iceberg/src/spec/values/primitive.rs
+++ b/crates/iceberg/src/spec/values/primitive.rs
@@ -36,9 +36,9 @@ pub enum PrimitiveLiteral {
     String(String),
     /// Binary value (without length)
     Binary(Vec<u8>),
-    /// Stored as 16-byte little-endian
+    /// Stored as 16-byte big-endian
     Int128(i128),
-    /// Stored as 16-byte little-endian
+    /// Stored as 16-byte big-endian
     UInt128(u128),
     /// When a number is larger than it can hold
     AboveMax,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.
Found this whilst working on https://github.com/apache/iceberg-rust/pull/2398
## What changes are included in this PR?
[Spec](https://iceberg.apache.org/spec/#binary-single-value-serialization) says `Int128` and `UInt128` are big-endian not little-endian and indeed we are using big-endian [here](https://github.com/apache/iceberg-rust/blob/c1538de36dd53e491299b62ad89286f2db496bc7/crates/iceberg/src/arrow/schema.rs#L761) for example. I think it's just the doc string which needs correcting.
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->