### PR TITLE
fix(tests): remove unnecessary `.to_string()` calls for metadata_location

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -2390,7 +2390,7 @@ mod tests {
 
             Table::builder()
                 .metadata(resp)
-                .metadata_location("s3://bucket/test/location/metadata/00000-8a62c37d-4573-4021-952a-c0baef7d21d0.metadata.json".to_string())
+                .metadata_location("s3://bucket/test/location/metadata/00000-8a62c37d-4573-4021-952a-c0baef7d21d0.metadata.json")
                 .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
                 .file_io(FileIO::new_with_memory())
                 .build()

--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -2709,7 +2709,7 @@ mod tests {
 
         let table = Table::builder()
             .metadata(resp)
-            .metadata_location("s3://bucket/test/location/metadata/v1.json".to_string())
+            .metadata_location("s3://bucket/test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .build()
@@ -2740,7 +2740,7 @@ mod tests {
 
         let table = Table::builder()
             .metadata(resp)
-            .metadata_location("s3://bucket/test/location/metadata/v1.json".to_string())
+            .metadata_location("s3://bucket/test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .build()

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -254,7 +254,7 @@ mod tests {
 
         Table::builder()
             .metadata(resp)
-            .metadata_location("s3://bucket/test/location/metadata/v1.json".to_string())
+            .metadata_location("s3://bucket/test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .build()
@@ -273,7 +273,7 @@ mod tests {
 
         Table::builder()
             .metadata(resp)
-            .metadata_location("s3://bucket/test/location/metadata/v1.json".to_string())
+            .metadata_location("s3://bucket/test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .build()
@@ -292,7 +292,7 @@ mod tests {
 
         Table::builder()
             .metadata(resp)
-            .metadata_location("s3://bucket/test/location/metadata/v1.json".to_string())
+            .metadata_location("s3://bucket/test/location/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .build()

--- a/crates/integrations/datafusion/src/physical_plan/project.rs
+++ b/crates/integrations/datafusion/src/physical_plan/project.rs
@@ -447,7 +447,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/metadata.json".to_string())
+            .metadata_location("/test/metadata.json")
             .build()
             .unwrap();
 
@@ -505,7 +505,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/metadata.json".to_string())
+            .metadata_location("/test/metadata.json")
             .build()
             .unwrap();
 
@@ -577,7 +577,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/metadata.json".to_string())
+            .metadata_location("/test/metadata.json")
             .build()
             .unwrap();
 

--- a/crates/integrations/datafusion/src/physical_plan/repartition.rs
+++ b/crates/integrations/datafusion/src/physical_plan/repartition.rs
@@ -222,7 +222,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/metadata.json".to_string())
+            .metadata_location("/test/metadata.json")
             .build()
             .unwrap()
     }
@@ -379,7 +379,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "bucketed_table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/bucketed_metadata.json".to_string())
+            .metadata_location("/test/bucketed_metadata.json")
             .build()
             .unwrap();
 
@@ -464,7 +464,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "partitioned_bucketed_table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/partitioned_bucketed_metadata.json".to_string())
+            .metadata_location("/test/partitioned_bucketed_metadata.json")
             .build()
             .unwrap();
 
@@ -548,7 +548,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "none_table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/none_metadata.json".to_string())
+            .metadata_location("/test/none_metadata.json")
             .build()
             .unwrap();
 
@@ -620,7 +620,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "range_only_table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/range_only_metadata.json".to_string())
+            .metadata_location("/test/range_only_metadata.json")
             .build()
             .unwrap();
 
@@ -695,7 +695,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "mixed_transforms_table"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/mixed_transforms_metadata.json".to_string())
+            .metadata_location("/test/mixed_transforms_metadata.json")
             .build()
             .unwrap();
 
@@ -778,7 +778,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "temporal_partition"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/temporal_metadata.json".to_string())
+            .metadata_location("/test/temporal_metadata.json")
             .build()
             .unwrap();
 
@@ -851,7 +851,7 @@ mod tests {
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "identity_partition"]).unwrap())
             .file_io(FileIO::new_with_fs())
-            .metadata_location("/test/identity_metadata.json".to_string())
+            .metadata_location("/test/identity_metadata.json")
             .build()
             .unwrap();
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No related issue. Just some simple fixes for unnecessary `.to_string()` calls.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Remove some redundant `to_string()` calls in `mod tests` for method `metadata_location`.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Sure.