### PR TITLE
fix(puffin): add missing magic number validation for puffins

### DIFF
--- a/crates/iceberg/src/puffin/metadata.rs
+++ b/crates/iceberg/src/puffin/metadata.rs
@@ -392,6 +392,7 @@ mod tests {
     use bytes::Bytes;
     use tempfile::TempDir;
 
+    use crate::ErrorKind;
     use crate::io::{FileIO, InputFile};
     use crate::puffin::metadata::{BlobMetadata, CompressionCodec, FileMetadata};
     use crate::puffin::test_utils::{
@@ -981,11 +982,16 @@ mod tests {
 
         let input_file = input_file_with_bytes(&temp_dir, &bytes).await;
 
-        assert!(FileMetadata::read(&input_file).await.is_err(),);
-        assert!(
+        assert_eq!(
+            FileMetadata::read(&input_file).await.unwrap_err().kind(),
+            ErrorKind::DataInvalid,
+        );
+        assert_eq!(
             FileMetadata::read_with_prefetch(&input_file, prefetch_hint)
                 .await
-                .is_err(),
+                .unwrap_err()
+                .kind(),
+            ErrorKind::DataInvalid,
         );
     }
 

--- a/crates/iceberg/src/puffin/metadata.rs
+++ b/crates/iceberg/src/puffin/metadata.rs
@@ -324,7 +324,11 @@ impl FileMetadata {
                 return FileMetadata::read(input_file).await;
             }
 
-            // Read footer based on prefetchi hint
+            // Validate file header magic
+            let first_four_bytes = file_read.read(0..FileMetadata::MAGIC_LENGTH.into()).await?;
+            FileMetadata::check_magic(&first_four_bytes)?;
+
+            // Read footer based on prefetch hint
             let start = input_file_length - prefetch_hint as u64;
             let end = input_file_length;
             let footer_bytes = file_read.read(start..end).await?;
@@ -956,6 +960,33 @@ mod tests {
             .unwrap();
 
         assert_eq!(file_metadata, zstd_compressed_metric_file_metadata());
+    }
+
+    #[tokio::test]
+    async fn test_read_with_incorrect_header_magic() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let prefetch_hint: u8 = 64;
+        let mut bytes = vec![];
+        // Invalid header magic
+        bytes.extend([0x00, 0x00, 0x00, 0x00]);
+        // Intentionally keep file size larger than prefetch_hint.
+        bytes.extend(vec![0u8; prefetch_hint as usize]);
+        // Valid footer: magic + payload + footer struct
+        bytes.extend(FileMetadata::MAGIC);
+        bytes.extend(empty_footer_payload_bytes());
+        bytes.extend(empty_footer_payload_bytes_length_bytes());
+        bytes.extend(vec![0, 0, 0, 0]); // flags
+        bytes.extend(FileMetadata::MAGIC);
+
+        let input_file = input_file_with_bytes(&temp_dir, &bytes).await;
+
+        assert!(FileMetadata::read(&input_file).await.is_err(),);
+        assert!(
+            FileMetadata::read_with_prefetch(&input_file, prefetch_hint)
+                .await
+                .is_err(),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changes are included in this PR?

We have two functions to read puffin metadata: `read` and `read_with_prefetch`. In theory these two functions should be similarly the same apart from IO-related logic, but `read_with_prefetch` seems to miss magic number validation: https://github.com/apache/iceberg-rust/blob/4f21e503afc5363c10fafac917f0febe136c464e/crates/iceberg/src/puffin/metadata.rs#L284

In terms of implementation, I thought about extracting validation+footer parse into a separate function, but the code is very simple here, don't think it necessary. 

## Are these changes tested?

Yes, the newly added regression test fails for the current codebase