### PR TITLE
feat: refactor `UpdateSchemaAction` for schema evolution in Iceberg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5950,12 +5950,12 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "munge",
  "ptr_meta",
@@ -5968,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7072,7 +7072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -281,7 +281,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
 dependencies = [
  "bytes",
  "half",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3152,6 +3152,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"

--- a/crates/catalog/loader/tests/schema_update_suite.rs
+++ b/crates/catalog/loader/tests/schema_update_suite.rs
@@ -1,0 +1,312 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Common schema-update behavior across catalogs.
+//!
+//! These tests assume Docker containers are started externally via `make docker-up`.
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{CatalogKind, cleanup_namespace_dyn, load_catalog};
+use iceberg::spec::{
+    AddColumn, DeleteColumn, NestedField, PrimitiveType, Schema, SchemaOperation, StructType, Type,
+};
+use iceberg::transaction::Transaction;
+use iceberg::{ErrorKind, NamespaceIdent, Result, TableCreation, TableIdent};
+use iceberg_test_utils::normalize_test_name_with_parts;
+use rstest::rstest;
+
+fn base_schema() -> Schema {
+    Schema::builder()
+        .with_fields(vec![
+            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+        ])
+        .with_identifier_field_ids(vec![2])
+        .build()
+        .unwrap()
+}
+
+// Common behavior: adding a top-level column appends it to the schema.
+// HMS is excluded because update_table is not yet supported.
+#[rstest]
+#[case::rest_catalog(CatalogKind::Rest)]
+#[case::glue_catalog(CatalogKind::Glue)]
+#[case::sql_catalog(CatalogKind::Sql)]
+#[case::s3tables_catalog(CatalogKind::S3Tables)]
+#[case::memory_catalog(CatalogKind::Memory)]
+#[tokio::test]
+async fn test_catalog_schema_add_column(#[case] kind: CatalogKind) -> Result<()> {
+    use iceberg::transaction::ApplyTransactionAction;
+
+    let Some(harness) = load_catalog(kind).await else {
+        return Ok(());
+    };
+    let catalog = harness.catalog;
+    let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
+        "catalog_schema_add_column",
+        harness.label
+    ));
+
+    cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
+    catalog.create_namespace(&namespace, HashMap::new()).await?;
+
+    let table_name =
+        normalize_test_name_with_parts!("catalog_schema_add_column", harness.label, "table");
+    let table = catalog
+        .create_table(
+            &namespace,
+            TableCreation::builder()
+                .name(table_name)
+                .schema(base_schema())
+                .build(),
+        )
+        .await?;
+
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(SchemaOperation::Add(
+            AddColumn::builder()
+                .name("a")
+                .r#type(PrimitiveType::Int.into())
+                .build(),
+        ))
+        .apply(tx)?;
+    let updated = tx.commit(catalog.as_ref()).await?;
+
+    let schema = updated.metadata().current_schema();
+    let field_a = schema.field_by_name("a").expect("field 'a' should exist");
+    assert_eq!(field_a.id, 4);
+    assert_eq!(*field_a.field_type, Type::Primitive(PrimitiveType::Int));
+
+    Ok(())
+}
+
+// Common behavior: adding a nested struct column then a sub-field within it,
+// and deleting another top-level column, all persist correctly.
+// HMS is excluded because update_table is not yet supported.
+#[rstest]
+#[case::rest_catalog(CatalogKind::Rest)]
+#[case::glue_catalog(CatalogKind::Glue)]
+#[case::sql_catalog(CatalogKind::Sql)]
+#[case::s3tables_catalog(CatalogKind::S3Tables)]
+#[case::memory_catalog(CatalogKind::Memory)]
+#[tokio::test]
+async fn test_catalog_schema_add_nested_and_delete_column(#[case] kind: CatalogKind) -> Result<()> {
+    use iceberg::transaction::ApplyTransactionAction;
+
+    let Some(harness) = load_catalog(kind).await else {
+        return Ok(());
+    };
+    let catalog = harness.catalog;
+    let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
+        "catalog_schema_add_nested_and_delete_column",
+        harness.label
+    ));
+
+    cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
+    catalog.create_namespace(&namespace, HashMap::new()).await?;
+
+    let table_name = normalize_test_name_with_parts!(
+        "catalog_schema_add_nested_and_delete_column",
+        harness.label,
+        "table"
+    );
+    let table = catalog
+        .create_table(
+            &namespace,
+            TableCreation::builder()
+                .name(table_name)
+                .schema(base_schema())
+                .build(),
+        )
+        .await?;
+
+    // First transaction: add a nested struct column.
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(
+            AddColumn::builder()
+                .name("info")
+                .r#type(
+                    StructType::new(vec![
+                        NestedField::optional(0, "city", PrimitiveType::String.into()).into(),
+                    ])
+                    .into(),
+                )
+                .build()
+                .into(),
+        )
+        .apply(tx)?;
+    let table = tx.commit(catalog.as_ref()).await?;
+
+    // Second transaction: add a sub-field to the nested struct and delete a top-level column.
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(
+            AddColumn::builder()
+                .name("zip")
+                .r#type(PrimitiveType::String.into())
+                .parent("info".into())
+                .build()
+                .into(),
+        )
+        .push_operation(DeleteColumn::new("baz").into())
+        .apply(tx)?;
+    let table = tx.commit(catalog.as_ref()).await?;
+
+    let schema = table.metadata().current_schema();
+    assert!(schema.field_by_name("info").is_some());
+    assert!(schema.field_by_name("info.city").is_some());
+    assert!(schema.field_by_name("info.zip").is_some());
+    assert!(schema.field_by_name("baz").is_none());
+
+    Ok(())
+}
+
+// Common behavior: deleting an identifier field or a nonexistent field must fail.
+// HMS is excluded because update_table is not yet supported.
+#[rstest]
+#[case::rest_catalog(CatalogKind::Rest)]
+#[case::glue_catalog(CatalogKind::Glue)]
+#[case::sql_catalog(CatalogKind::Sql)]
+#[case::s3tables_catalog(CatalogKind::S3Tables)]
+#[case::memory_catalog(CatalogKind::Memory)]
+#[tokio::test]
+async fn test_catalog_schema_delete_invalid_column_errors(#[case] kind: CatalogKind) -> Result<()> {
+    use iceberg::transaction::ApplyTransactionAction;
+
+    let Some(harness) = load_catalog(kind).await else {
+        return Ok(());
+    };
+    let catalog = harness.catalog;
+    let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
+        "catalog_schema_delete_invalid_column_errors",
+        harness.label
+    ));
+
+    cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
+    catalog.create_namespace(&namespace, HashMap::new()).await?;
+
+    let table_name = normalize_test_name_with_parts!(
+        "catalog_schema_delete_invalid_column_errors",
+        harness.label,
+        "table"
+    );
+    let table = catalog
+        .create_table(
+            &namespace,
+            TableCreation::builder()
+                .name(table_name)
+                .schema(base_schema())
+                .build(),
+        )
+        .await?;
+
+    // Deleting an identifier field must fail.
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(DeleteColumn::new("bar").into())
+        .apply(tx)?;
+    let err = tx.commit(catalog.as_ref()).await.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::PreconditionFailed);
+
+    // Deleting a nonexistent field must fail.
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(DeleteColumn::new("nonexistent").into())
+        .apply(tx)?;
+    let err = tx.commit(catalog.as_ref()).await.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::PreconditionFailed);
+
+    Ok(())
+}
+
+// Common behavior: loading a table after a schema update reflects the new schema.
+// HMS is excluded because update_table is not yet supported.
+#[rstest]
+#[case::rest_catalog(CatalogKind::Rest)]
+#[case::glue_catalog(CatalogKind::Glue)]
+#[case::sql_catalog(CatalogKind::Sql)]
+#[case::s3tables_catalog(CatalogKind::S3Tables)]
+#[case::memory_catalog(CatalogKind::Memory)]
+#[tokio::test]
+async fn test_catalog_schema_update_persisted_after_reload(
+    #[case] kind: CatalogKind,
+) -> Result<()> {
+    use iceberg::transaction::ApplyTransactionAction;
+
+    let Some(harness) = load_catalog(kind).await else {
+        return Ok(());
+    };
+    let catalog = harness.catalog;
+    let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
+        "catalog_schema_update_persisted_after_reload",
+        harness.label
+    ));
+
+    cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
+    catalog.create_namespace(&namespace, HashMap::new()).await?;
+
+    let table_name = normalize_test_name_with_parts!(
+        "catalog_schema_update_persisted_after_reload",
+        harness.label,
+        "table"
+    );
+    let table_ident = TableIdent::new(namespace.clone(), table_name.clone());
+    let table = catalog
+        .create_table(
+            &namespace,
+            TableCreation::builder()
+                .name(table_name)
+                .schema(base_schema())
+                .build(),
+        )
+        .await?;
+
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .update_schema()
+        .push_operation(
+            AddColumn::builder()
+                .name("new_field")
+                .r#type(PrimitiveType::Long.into())
+                .build()
+                .into(),
+        )
+        .apply(tx)?;
+    tx.commit(catalog.as_ref()).await?;
+
+    let reloaded = catalog.load_table(&table_ident).await?;
+    assert!(
+        reloaded
+            .metadata()
+            .current_schema()
+            .field_by_name("new_field")
+            .is_some()
+    );
+
+    Ok(())
+}

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -469,6 +469,16 @@ macro_rules! ensure_data_valid {
     };
 }
 
+/// Helper macro to check preconditions.
+#[macro_export]
+macro_rules! ensure_precondition {
+    ($cond: expr, $fmt: literal, $($arg:tt)*) => {
+        if !$cond {
+            return Err($crate::error::Error::new($crate::error::ErrorKind::PreconditionFailed, format!($fmt, $($arg)*)))
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;

--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -116,6 +116,18 @@ impl Type {
         matches!(self, Type::Struct(_))
     }
 
+    /// Whether the type is list type.
+    #[inline(always)]
+    pub fn is_list(&self) -> bool {
+        matches!(self, Type::List(_))
+    }
+
+    /// Whether the type is map type.
+    #[inline(always)]
+    pub fn is_map(&self) -> bool {
+        matches!(self, Type::Map(_))
+    }
+
     /// Whether the type is nested type.
     #[inline(always)]
     pub fn is_nested(&self) -> bool {
@@ -160,7 +172,7 @@ impl Type {
         Ok(REQUIRED_LENGTH[precision as usize - 1])
     }
 
-    /// Creates  decimal type.
+    /// Creates decimal type.
     #[inline(always)]
     pub fn decimal(precision: u32, scale: u32) -> Result<Self> {
         ensure_data_valid!(
@@ -634,6 +646,16 @@ impl NestedField {
         Self::new(id, LIST_FIELD_NAME, field_type, required)
     }
 
+    /// Construct required list type's element field.
+    pub fn list_required_element(id: i32, field_type: Type) -> Self {
+        Self::list_element(id, field_type, true)
+    }
+
+    /// Construct optional list type's element field.
+    pub fn list_optional_element(id: i32, field_type: Type) -> Self {
+        Self::list_element(id, field_type, false)
+    }
+
     /// Construct map type's key field.
     pub fn map_key_element(id: i32, field_type: Type) -> Self {
         Self::required(id, MAP_KEY_FIELD_NAME, field_type)
@@ -667,6 +689,18 @@ impl NestedField {
         self.id = id;
         self
     }
+
+    /// Set the type of the field
+    pub(crate) fn of_type(mut self, field_type: Box<Type>) -> Self {
+        self.field_type = field_type;
+        self
+    }
+
+    /// Set the name of the field.
+    pub(crate) fn with_name(mut self, name: impl ToString) -> Self {
+        self.name = name.to_string();
+        self
+    }
 }
 
 impl fmt::Display for NestedField {
@@ -698,6 +732,20 @@ impl ListType {
     /// Construct a list type with the given element field.
     pub fn new(element_field: NestedFieldRef) -> Self {
         Self { element_field }
+    }
+
+    /// Construct an optional list type with the given element field.
+    pub fn optional(element_id: i32, element_type: Type) -> Self {
+        Self {
+            element_field: NestedField::list_element(element_id, element_type, false).into(),
+        }
+    }
+
+    /// Construct a required list type with the given element field.
+    pub fn required(element_id: i32, element_type: Type) -> Self {
+        Self {
+            element_field: NestedField::list_element(element_id, element_type, true).into(),
+        }
     }
 }
 

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -53,6 +53,8 @@ pub type SchemaId = i32;
 pub type SchemaRef = Arc<Schema>;
 /// Default schema id.
 pub const DEFAULT_SCHEMA_ID: SchemaId = 0;
+/// Delimiter for schema name, which denotes a nested struct.
+pub const SCHEMA_NAME_DELIMITER: &str = ".";
 
 /// Defines schema in iceberg.
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -21,8 +21,10 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+mod update;
 mod utils;
 mod visitor;
+pub use self::update::*;
 pub use self::visitor::*;
 pub(super) mod _serde;
 mod id_reassigner;

--- a/crates/iceberg/src/spec/schema/update.rs
+++ b/crates/iceberg/src/spec/schema/update.rs
@@ -1,0 +1,1521 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use typed_builder::TypedBuilder;
+
+use crate::spec::schema::index::index_parents;
+use crate::spec::{
+    ListType, Literal, MapType, NestedField, NestedFieldRef, PrimitiveType, Schema, SchemaRef,
+    SchemaVisitor, StructType, Type, visit_schema,
+};
+use crate::{Error, ErrorKind, Result, ensure_data_valid};
+
+const TABLE_ROOT_ID: i32 = -1;
+
+/// Operations that can be applied to a schema to produce a new schema. These are used in `UpdateSchemaAction` and are not intended to be used directly by end users. Instead, end users should use `UpdateSchema` which will be converted into a list of `SchemaOperation`s.
+pub enum SchemaOperation {
+    /// Add a column to the schema
+    Add(AddColumn),
+    /// Update a column's type, doc, or default value
+    Update(UpdateColumn),
+    /// Rename a column
+    Rename(RenameColumn),
+    /// Delete a column
+    Delete(DeleteColumn),
+    /// Move a column
+    Move(MoveColumn),
+}
+
+/// A column to be added to the schema.
+#[derive(TypedBuilder)]
+pub struct AddColumn {
+    #[builder(default, setter(strip_option))]
+    parent: Option<String>,
+    #[builder(setter(into))]
+    name: String,
+    #[builder(default = true)]
+    is_optional: bool,
+    r#type: Type,
+    #[builder(default, setter(strip_option))]
+    doc: Option<Option<String>>,
+    #[builder(default, setter(strip_option))]
+    default_value: Option<Literal>,
+}
+
+/// A column to be deleted from the schema.
+pub struct DeleteColumn {
+    name: String,
+}
+
+impl DeleteColumn {
+    /// Create a new `DeleteColumn` with the given column name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+/// A column to be renamed in the schema.
+#[derive(TypedBuilder)]
+pub struct RenameColumn {
+    #[builder(setter(into))]
+    name: String,
+    #[builder(setter(into))]
+    new_name: String,
+}
+
+/// A column to be updated in the schema.
+#[derive(TypedBuilder)]
+pub struct UpdateColumn {
+    #[builder(setter(into))]
+    name: String,
+    #[builder(default, setter(strip_option))]
+    new_type: Option<Type>,
+    #[builder(default, setter(strip_option))]
+    new_doc: Option<Option<String>>,
+    #[builder(default, setter(strip_option))]
+    new_default_value: Option<Option<Literal>>,
+}
+
+/// A column to be moved in the schema.
+pub struct MoveColumn {
+    name: String,
+    reference_name: String,
+    move_type: MoveType,
+}
+
+impl MoveColumn {
+    /// Move the column to the first position.
+    pub fn first(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            reference_name: String::new(),
+            move_type: MoveType::First,
+        }
+    }
+
+    /// Move the column before the reference column.
+    pub fn before(name: impl Into<String>, reference: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            reference_name: reference.into(),
+            move_type: MoveType::Before,
+        }
+    }
+
+    /// Move the column after the reference column.
+    pub fn after(name: impl Into<String>, reference: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            reference_name: reference.into(),
+            move_type: MoveType::After,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MoveType {
+    First,
+    Before,
+    After,
+}
+
+#[derive(Clone, Debug)]
+struct Move {
+    field_id: i32,
+    reference_field_id: i32,
+    r#type: MoveType,
+}
+
+impl Move {
+    fn first(field_id: i32) -> Self {
+        Move::new(field_id, TABLE_ROOT_ID, MoveType::First)
+    }
+
+    fn before(field_id: i32, reference_field_id: i32) -> Self {
+        Move::new(field_id, reference_field_id, MoveType::Before)
+    }
+
+    fn after(field_id: i32, reference_field_id: i32) -> Self {
+        Move::new(field_id, reference_field_id, MoveType::After)
+    }
+
+    fn new(field_id: i32, reference_field_id: i32, r#type: MoveType) -> Self {
+        Move {
+            field_id,
+            reference_field_id,
+            r#type,
+        }
+    }
+
+    fn field_id(&self) -> i32 {
+        self.field_id
+    }
+
+    fn reference_field_id(&self) -> i32 {
+        self.reference_field_id
+    }
+
+    fn r#type(&self) -> MoveType {
+        self.r#type
+    }
+}
+
+/// Applies a list of `SchemaOperation`s to a `Schema` to produce a new `Schema`. This is used in `UpdateSchemaAction` to apply schema changes as part of a transaction commit. This function validates that the schema operations are valid (e.g. that added columns do not have duplicate names, that deleted columns exist, etc.) and returns an error if any invalid operations are found. If all operations are valid, it returns the updated schema.
+pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Result<SchemaRef> {
+    let mut updates: HashMap<i32, NestedFieldRef> = HashMap::new();
+    let mut deletes = Vec::new();
+    let mut moves: HashMap<_, Vec<_>> = HashMap::new();
+    let mut parent_to_added_ids: HashMap<_, Vec<_>> = HashMap::new();
+    let mut id_to_parent = index_parents(&schema.r#struct).unwrap();
+    let mut last_column_id = schema.highest_field_id;
+    let mut added_name_to_id = HashMap::new();
+    let mut identifier_field_ids = schema.identifier_field_ids.clone();
+
+    for operation in operations {
+        match operation {
+            SchemaOperation::Add(add) => {
+                let (parent, name, is_optional, field_type, doc, default_value) = (
+                    &add.parent,
+                    &add.name,
+                    add.is_optional,
+                    &add.r#type,
+                    &add.doc,
+                    &add.default_value,
+                );
+                let mut parent_id = TABLE_ROOT_ID;
+                let full_name = if let Some(parent) = parent {
+                    let parent_field = schema.field_by_name(parent).ok_or(Error::new(
+                        ErrorKind::PreconditionFailed,
+                        format!("Cannot find parent struct: {}", parent),
+                    ))?;
+                    let parent_field = if parent_field.field_type.is_nested() {
+                        let parent_type = parent_field.field_type.as_ref();
+                        match parent_type {
+                            Type::List(nested) => nested.element_field.as_ref(), // fields are added to the element type
+                            Type::Map(nested) => nested.value_field.as_ref(), // fields are added to the map value type
+                            _ => parent_field,
+                        }
+                    } else {
+                        parent_field
+                    };
+                    ensure_data_valid!(
+                        parent_field.field_type.is_struct(),
+                        "Cannot add to non-struct column: {}: {}",
+                        &parent,
+                        parent_field.field_type
+                    );
+                    parent_id = parent_field.id;
+                    let full_name = format!("{}.{}", parent, name);
+                    let current_field = schema.field_by_name(&full_name);
+                    ensure_data_valid!(
+                        !deletes.contains(&parent_id),
+                        "Can not add a column that will be deleted: {}",
+                        name
+                    );
+                    ensure_data_valid!(
+                        current_field.is_none() || deletes.contains(&current_field.unwrap().id),
+                        "Cannot add column, name already exists: {}",
+                        &name
+                    );
+                    full_name
+                } else {
+                    let current_field = schema.field_by_name(name);
+                    ensure_data_valid!(
+                        current_field.is_none() || deletes.contains(&current_field.unwrap().id),
+                        "Cannot add column, name already exists: {}",
+                        &name
+                    );
+                    name.clone()
+                };
+                ensure_data_valid!(
+                    default_value.is_some() || is_optional,
+                    "Incompatible change: cannot add required column without a default value: {}",
+                    full_name
+                );
+                last_column_id += 1;
+                let new_id = last_column_id;
+                added_name_to_id.insert(full_name, new_id);
+
+                if parent_id != TABLE_ROOT_ID {
+                    id_to_parent.insert(new_id, parent_id);
+                }
+                // TODO: Maybe we can use `ReassignFieldIds`?
+                let assigned_type = assign_fresh_ids(field_type.clone(), &mut last_column_id);
+                let mut new_field = NestedField::new(new_id, name, assigned_type, !is_optional);
+                if let Some(doc) = doc {
+                    new_field.doc = doc.clone();
+                }
+                new_field.write_default = default_value.clone();
+                new_field.initial_default = default_value.clone();
+                updates.insert(new_id, new_field.into());
+                parent_to_added_ids
+                    .entry(parent_id)
+                    .or_default()
+                    .push(new_id);
+            }
+            SchemaOperation::Delete(delete) => {
+                let field = schema.field_by_name(&delete.name).ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::PreconditionFailed,
+                        format!("Cannot delete missing column: {}", delete.name),
+                    )
+                })?;
+                ensure_data_valid!(
+                    !parent_to_added_ids.contains_key(&field.id),
+                    "Cannot delete a column that has updates: {}",
+                    delete.name
+                );
+                ensure_data_valid!(
+                    !updates.contains_key(&field.id),
+                    "Cannot delete a column that has updates: {}",
+                    delete.name
+                );
+                deletes.push(field.id);
+            }
+            SchemaOperation::Rename(rename) => {
+                let (name, new_name) = (&rename.name, &rename.new_name);
+                let field = schema.field_by_name(name).ok_or(Error::new(
+                    ErrorKind::PreconditionFailed,
+                    format!("Cannot rename missing column: {}", name),
+                ))?;
+                ensure_data_valid!(
+                    !deletes.contains(&field.id),
+                    "Cannot rename a column that will be deleted: {}",
+                    name
+                );
+                // merge with an update, if present
+                let field_id = field.id;
+                let update = updates.get(&field_id);
+                let new_field = if let Some(update) = update {
+                    Arc::unwrap_or_clone(update.clone()).with_name(new_name)
+                } else {
+                    Arc::unwrap_or_clone(field.clone()).with_name(new_name)
+                };
+                updates.insert(field_id, Arc::new(new_field));
+                if identifier_field_ids.contains(&field_id) {
+                    identifier_field_ids.remove(&field_id);
+                    identifier_field_ids.insert(field_id);
+                }
+            }
+            SchemaOperation::Update(update) => {
+                let (name, new_type, new_doc, new_default_value) = (
+                    &update.name,
+                    &update.new_type,
+                    &update.new_doc,
+                    &update.new_default_value,
+                );
+                let field = find_for_update(name, schema.clone(), &updates, &added_name_to_id)?
+                    .ok_or(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("Cannot update missing column: {}", name),
+                    ))?;
+                ensure_data_valid!(
+                    !deletes.contains(&field.id),
+                    "Cannot update column that will be deleted: {}",
+                    name,
+                );
+                let mut new_field = Arc::unwrap_or_clone(field.clone());
+                if let Some(new_type) = new_type {
+                    *new_field.field_type = new_type.clone();
+                }
+                if let Some(new_doc) = new_doc {
+                    new_field.doc = new_doc.clone();
+                }
+                if let Some(new_default_value) = new_default_value {
+                    new_field.write_default = new_default_value.clone();
+                }
+                updates.insert(field.id, Arc::new(new_field));
+            }
+            SchemaOperation::Move(r#move) => {
+                let (name, reference_name, move_type) =
+                    (&r#move.name, &r#move.reference_name, &r#move.move_type);
+                let field_id =
+                    find_for_move(name, schema.clone(), &added_name_to_id)?.ok_or(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("Cannot move missing column: {}", name),
+                    ))?;
+                let r#move = if move_type == &MoveType::First {
+                    Move::first(field_id)
+                } else {
+                    let reference_field_id = find_for_move(
+                        reference_name,
+                        schema.clone(),
+                        &added_name_to_id,
+                    )?
+                    .ok_or(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("Cannot move relative to missing column: {}", reference_name),
+                    ))?;
+                    match move_type {
+                        MoveType::Before => Move::before(field_id, reference_field_id),
+                        MoveType::After => Move::after(field_id, reference_field_id),
+                        _ => unreachable!(),
+                    }
+                };
+                let parent_id = id_to_parent.get(&field_id);
+                if let Some(&parent_id) = parent_id {
+                    let parent = schema.field_by_id(parent_id).unwrap();
+                    ensure_data_valid!(
+                        parent.field_type.is_struct(),
+                        "Cannot move field in non-struct type: {}",
+                        parent
+                    );
+                    if r#move.r#type == MoveType::After || r#move.r#type == MoveType::Before {
+                        ensure_data_valid!(
+                            parent_id == *id_to_parent.get(&r#move.reference_field_id).unwrap(),
+                            "Cannot move field {} to a different struct",
+                            name,
+                        );
+                    }
+                    moves.entry(parent_id).or_default().push(r#move);
+                } else {
+                    if move_type == &MoveType::After || move_type == &MoveType::Before {
+                        ensure_data_valid!(
+                            !id_to_parent.contains_key(&r#move.reference_field_id),
+                            "Cannot move field {} to a different struct",
+                            name,
+                        );
+                    }
+                    moves.entry(TABLE_ROOT_ID).or_default().push(r#move);
+                }
+            }
+        }
+    }
+    // apply schema changes
+    let mut visitor = ApplyChangesVisitor {
+        deletes,
+        updates,
+        parent_to_added_ids,
+        moves,
+    };
+    let struct_type = visit_schema(schema.as_ref(), &mut visitor)?
+        .unwrap()
+        .to_struct_type()
+        .unwrap();
+    // validate identifier requirements based on the latest schema
+    Ok(Schema::builder()
+        .with_fields(struct_type.fields().to_vec())
+        .with_identifier_field_ids(identifier_field_ids)
+        .build()?
+        .into())
+}
+
+fn find_for_update(
+    name: &str,
+    schema: SchemaRef,
+    updates: &HashMap<i32, NestedFieldRef>,
+    added_name_to_id: &HashMap<String, i32>,
+) -> Result<Option<NestedFieldRef>> {
+    let field = schema.field_by_name(name);
+    if let Some(field) = field {
+        let pending_update = updates.get(&field.id);
+        if let Some(pending_update) = pending_update {
+            Ok(Some(pending_update.clone()))
+        } else {
+            Ok(Some(field.clone()))
+        }
+    } else {
+        let added_id = added_name_to_id.get(name);
+        if let Some(added_id) = added_id {
+            Ok(updates.get(added_id).cloned())
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn find_for_move(
+    name: &str,
+    schema: SchemaRef,
+    added_name_to_id: &HashMap<String, i32>,
+) -> Result<Option<i32>> {
+    let added_id = added_name_to_id.get(name);
+    if let Some(added_id) = added_id {
+        return Ok(Some(*added_id));
+    }
+    let field = schema.field_by_name(name);
+    if let Some(field) = field {
+        return Ok(Some(field.id));
+    }
+    Ok(None)
+}
+
+fn assign_fresh_ids(field_type: Type, next_id: &mut i32) -> Type {
+    match field_type {
+        Type::Primitive(_) => field_type,
+        Type::Struct(s) => {
+            let new_fields = s
+                .fields()
+                .iter()
+                .map(|field| {
+                    *next_id += 1;
+                    let new_field_id = *next_id;
+                    let new_type = assign_fresh_ids((*field.field_type).clone(), next_id);
+                    Arc::new(NestedField::new(
+                        new_field_id,
+                        &field.name,
+                        new_type,
+                        field.required,
+                    ))
+                })
+                .collect();
+            Type::Struct(StructType::new(new_fields))
+        }
+        Type::List(list) => {
+            *next_id += 1;
+            let element_id = *next_id;
+            let element_type = assign_fresh_ids((*list.element_field.field_type).clone(), next_id);
+            Type::List(ListType::new(Arc::new(NestedField::new(
+                element_id,
+                &list.element_field.name,
+                element_type,
+                list.element_field.required,
+            ))))
+        }
+        Type::Map(map) => {
+            *next_id += 1;
+            let key_id = *next_id;
+            *next_id += 1;
+            let value_id = *next_id;
+            let key_type = assign_fresh_ids((*map.key_field.field_type).clone(), next_id);
+            let value_type = assign_fresh_ids((*map.value_field.field_type).clone(), next_id);
+            Type::Map(MapType::new(
+                Arc::new(NestedField::new(
+                    key_id,
+                    &map.key_field.name,
+                    key_type,
+                    true,
+                )),
+                Arc::new(NestedField::new(
+                    value_id,
+                    &map.value_field.name,
+                    value_type,
+                    map.value_field.required,
+                )),
+            ))
+        }
+    }
+}
+
+struct ApplyChangesVisitor {
+    deletes: Vec<i32>,
+    updates: HashMap<i32, NestedFieldRef>,
+    parent_to_added_ids: HashMap<i32, Vec<i32>>,
+    moves: HashMap<i32, Vec<Move>>,
+}
+
+impl SchemaVisitor for ApplyChangesVisitor {
+    type T = Option<Type>;
+
+    fn schema(&mut self, _schema: &Schema, value: Self::T) -> Result<Self::T> {
+        let added_fields: Vec<NestedFieldRef> = self
+            .parent_to_added_ids
+            .get(&TABLE_ROOT_ID)
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|id| self.updates.get(id).unwrap().clone())
+            .collect();
+        let fields = add_and_move_fields(
+            value.clone().unwrap().to_struct_type().unwrap().fields(),
+            &added_fields,
+            self.moves.get(&TABLE_ROOT_ID).unwrap_or(&vec![]),
+        );
+        if !fields.is_empty() {
+            return Ok(Some(Type::Struct(StructType::new(fields))));
+        }
+        Ok(value)
+    }
+
+    fn r#struct(&mut self, r#struct: &StructType, results: Vec<Self::T>) -> Result<Self::T> {
+        let mut has_change = false;
+        let mut new_fields: Vec<NestedFieldRef> = Vec::with_capacity(results.len());
+        for (result_type, field) in results.iter().zip(r#struct.fields()) {
+            if result_type.is_none() {
+                has_change = true;
+                continue;
+            }
+            let result_type = result_type.clone().unwrap();
+            let update = self.updates.get(&field.id);
+            let updated = if let Some(update) = update {
+                Arc::unwrap_or_clone(update.clone()).of_type(Box::new(result_type))
+            } else {
+                Arc::unwrap_or_clone(field.clone()).of_type(Box::new(result_type))
+            };
+            if field.as_ref() == &updated {
+                new_fields.push(field.clone());
+            } else {
+                has_change = true;
+                new_fields.push(updated.into());
+            }
+        }
+        if has_change {
+            return Ok(Some(Type::Struct(StructType::new(new_fields))));
+        }
+        Ok(Some(Type::Struct(r#struct.clone())))
+    }
+
+    fn field(&mut self, field: &NestedFieldRef, value: Self::T) -> Result<Self::T> {
+        let field_id = field.id;
+        // handle deletes
+        if self.deletes.contains(&field_id) {
+            return Ok(None);
+        }
+        // handle updates
+        let update = self.updates.get(&field_id);
+        if let Some(update) = update
+            && update.field_type.as_ref() != field.field_type.as_ref()
+        {
+            return Ok(Some(*update.field_type.clone()));
+        }
+        // handle adds
+        let new_fields: Vec<_> = self
+            .parent_to_added_ids
+            .get(&field_id)
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|id| self.updates.get(id))
+            .cloned()
+            .collect();
+        let columns_to_move = self.moves.get(&field_id).cloned().unwrap_or(vec![]);
+        if !new_fields.is_empty() || !columns_to_move.is_empty() {
+            let fields = add_and_move_fields(
+                value.clone().unwrap().to_struct_type().unwrap().fields(),
+                &new_fields,
+                &columns_to_move,
+            );
+            if !fields.is_empty() {
+                return Ok(Some(Type::Struct(StructType::new(fields))));
+            }
+        }
+        Ok(value)
+    }
+
+    fn list(&mut self, list: &ListType, element_result: Self::T) -> Result<Self::T> {
+        let element_field = list.element_field.clone();
+        let element_type = self
+            .field(&element_field, element_result)?
+            .ok_or(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Cannot delete list element type from list: {:?}", list),
+            ))?;
+        let element_update = self.updates.get(&element_field.id);
+        let is_element_optional = if let Some(element_update) = element_update {
+            !element_update.required
+        } else {
+            !element_field.required
+        };
+        let is_element_required = !is_element_optional;
+        if is_element_required == element_field.required
+            && &element_type == list.element_field.field_type.as_ref()
+        {
+            return Ok(Some(Type::List(list.clone())));
+        }
+        if is_element_optional {
+            Ok(Some(Type::List(ListType::optional(
+                list.element_field.id,
+                element_type,
+            ))))
+        } else {
+            Ok(Some(Type::List(ListType::required(
+                list.element_field.id,
+                element_type,
+            ))))
+        }
+    }
+
+    fn map(
+        &mut self,
+        map: &MapType,
+        key_result: Self::T,
+        value_result: Self::T,
+    ) -> Result<Self::T> {
+        let key_id = map.key_field.id;
+        if self.deletes.contains(&key_id) {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Cannot delete map keys: {:?}", map),
+            ));
+        } else if self.updates.contains_key(&key_id) {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Cannot update map keys: {:?}", map),
+            ));
+        } else if self.parent_to_added_ids.contains_key(&key_id) {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Cannot add fields to map keys: {:?}", map),
+            ));
+        } else if map.key_field.field_type.as_ref() != &key_result.unwrap() {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                format!("Cannot alter map keys: {:?}", map),
+            ));
+        }
+        let value_field = map.value_field.clone();
+        let value_type = self.field(&value_field, value_result)?.ok_or(Error::new(
+            ErrorKind::PreconditionFailed,
+            format!("Cannot delete value type from map: {:?}", map),
+        ))?;
+        let value_update = self.updates.get(&value_field.id);
+        let is_value_required = if let Some(update) = value_update {
+            update.required
+        } else {
+            map.value_field.required
+        };
+        if is_value_required == map.value_field.required
+            && map.value_field.field_type.as_ref() == &value_type
+        {
+            return Ok(Some(Type::Map(map.clone())));
+        }
+        if is_value_required {
+            Ok(Some(Type::Map(MapType::required(
+                map.key_field.id,
+                *map.key_field.field_type.clone(),
+                map.value_field.id,
+                value_type,
+            ))))
+        } else {
+            Ok(Some(Type::Map(MapType::optional(
+                map.key_field.id,
+                *map.key_field.field_type.clone(),
+                map.value_field.id,
+                value_type,
+            ))))
+        }
+    }
+
+    fn primitive(&mut self, p: &PrimitiveType) -> Result<Self::T> {
+        Ok(Some(Type::Primitive(p.clone())))
+    }
+}
+
+fn add_and_move_fields(
+    fields: &[NestedFieldRef],
+    adds: &[NestedFieldRef],
+    moves: &[Move],
+) -> Vec<NestedFieldRef> {
+    if !adds.is_empty() {
+        if !moves.is_empty() {
+            return move_fields(&add_fields(fields, adds), moves);
+        }
+        return add_fields(fields, adds);
+    } else if !moves.is_empty() {
+        return move_fields(fields, moves);
+    }
+    vec![]
+}
+
+fn add_fields(fields: &[NestedFieldRef], adds: &[NestedFieldRef]) -> Vec<NestedFieldRef> {
+    let mut new_fields = fields.to_owned();
+    new_fields.extend(adds.iter().cloned());
+    new_fields
+}
+
+fn move_fields(fields: &[NestedFieldRef], moves: &[Move]) -> Vec<NestedFieldRef> {
+    let mut reordered = fields.to_vec();
+    for r#move in moves {
+        let idx = reordered
+            .iter()
+            .position(|f| f.id == r#move.field_id())
+            .unwrap();
+        let to_move = reordered.remove(idx);
+        match r#move.r#type() {
+            MoveType::First => {
+                reordered.insert(0, to_move);
+            }
+            MoveType::Before => {
+                let before_idx = reordered
+                    .iter()
+                    .position(|f| f.id == r#move.reference_field_id())
+                    .unwrap();
+                reordered.insert(before_idx, to_move);
+            }
+            MoveType::After => {
+                let after_idx = reordered
+                    .iter()
+                    .position(|f| f.id == r#move.reference_field_id())
+                    .unwrap();
+                reordered.insert(after_idx + 1, to_move);
+            }
+        }
+    }
+    reordered
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, LazyLock};
+
+    use crate::spec::{
+        AddColumn, ListType, Literal, MapType, NestedField, PrimitiveType, RenameColumn, Schema,
+        SchemaOperation, StructType, Type, UpdateColumn, schema_update,
+    };
+
+    static SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
+        Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "data", PrimitiveType::String.into()).into(),
+                NestedField::optional(
+                    3,
+                    "preferences",
+                    StructType::new(vec![
+                        NestedField::required(8, "feature1", PrimitiveType::Boolean.into()).into(),
+                        NestedField::optional(9, "feature2", PrimitiveType::Boolean.into()).into(),
+                    ])
+                    .into(),
+                )
+                .with_doc("struct of named boolean options")
+                .into(),
+                NestedField::required(
+                    4,
+                    "locations",
+                    MapType::required(
+                        10,
+                        StructType::new(vec![
+                            NestedField::required(20, "address", PrimitiveType::String.into())
+                                .into(),
+                            NestedField::required(21, "city", PrimitiveType::String.into()).into(),
+                            NestedField::required(22, "state", PrimitiveType::String.into()).into(),
+                            NestedField::required(23, "zip", PrimitiveType::Int.into()).into(),
+                        ])
+                        .into(),
+                        11,
+                        StructType::new(vec![
+                            NestedField::required(12, "lat", PrimitiveType::Float.into()).into(),
+                            NestedField::required(13, "long", PrimitiveType::Float.into()).into(),
+                        ])
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("map of address to coordinate")
+                .into(),
+                NestedField::optional(
+                    5,
+                    "points",
+                    ListType::new(
+                        NestedField::list_optional_element(
+                            14,
+                            StructType::new(vec![
+                                NestedField::required(15, "x", PrimitiveType::Long.into()).into(),
+                                NestedField::required(16, "y", PrimitiveType::Long.into()).into(),
+                            ])
+                            .into(),
+                        )
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("2-D cartesian points")
+                .into(),
+                NestedField::required(
+                    6,
+                    "doubles",
+                    ListType::new(
+                        NestedField::list_required_element(17, PrimitiveType::Double.into()).into(),
+                    )
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    7,
+                    "properties",
+                    MapType::optional(
+                        18,
+                        PrimitiveType::String.into(),
+                        19,
+                        PrimitiveType::String.into(),
+                    )
+                    .into(),
+                )
+                .with_doc("string map of properties")
+                .into(),
+            ])
+            .build()
+            .unwrap()
+    });
+
+    #[test]
+    fn no_changes() {
+        let base = SCHEMA.clone();
+        let expected = SCHEMA.clone();
+        let updated = schema_update(Arc::new(base), &[]).unwrap();
+        assert_eq!(updated.as_ref(), &expected);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn delete_fields() {}
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn delete_fields_case_sensitive_disabled() {
+        todo!()
+    }
+
+    #[test]
+    fn update_types() {
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Long.into()).into(),
+                NestedField::optional(2, "data", PrimitiveType::String.into()).into(),
+                NestedField::optional(
+                    3,
+                    "preferences",
+                    StructType::new(vec![
+                        NestedField::required(8, "feature1", PrimitiveType::Boolean.into()).into(),
+                        NestedField::optional(9, "feature2", PrimitiveType::Boolean.into()).into(),
+                    ])
+                    .into(),
+                )
+                .with_doc("struct of named boolean options")
+                .into(),
+                NestedField::required(
+                    4,
+                    "locations",
+                    MapType::required(
+                        10,
+                        StructType::new(vec![
+                            NestedField::required(20, "address", PrimitiveType::String.into())
+                                .into(),
+                            NestedField::required(21, "city", PrimitiveType::String.into()).into(),
+                            NestedField::required(22, "state", PrimitiveType::String.into()).into(),
+                            NestedField::required(23, "zip", PrimitiveType::Int.into()).into(),
+                        ])
+                        .into(),
+                        11,
+                        StructType::new(vec![
+                            NestedField::required(12, "lat", PrimitiveType::Double.into()).into(),
+                            NestedField::required(13, "long", PrimitiveType::Double.into()).into(),
+                        ])
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("map of address to coordinate")
+                .into(),
+                NestedField::optional(
+                    5,
+                    "points",
+                    ListType::new(
+                        NestedField::list_optional_element(
+                            14,
+                            StructType::new(vec![
+                                NestedField::required(15, "x", PrimitiveType::Long.into()).into(),
+                                NestedField::required(16, "y", PrimitiveType::Long.into()).into(),
+                            ])
+                            .into(),
+                        )
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("2-D cartesian points")
+                .into(),
+                NestedField::required(
+                    6,
+                    "doubles",
+                    ListType::new(
+                        NestedField::list_required_element(17, PrimitiveType::Double.into()).into(),
+                    )
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    7,
+                    "properties",
+                    MapType::optional(
+                        18,
+                        PrimitiveType::String.into(),
+                        19,
+                        PrimitiveType::String.into(),
+                    )
+                    .into(),
+                )
+                .with_doc("string map of properties")
+                .into(),
+            ])
+            .build()
+            .unwrap();
+        let updated = schema_update(Arc::new(SCHEMA.clone()), &[
+            SchemaOperation::Update(
+                UpdateColumn::builder()
+                    .name("id")
+                    .new_type(PrimitiveType::Long.into())
+                    .build(),
+            ),
+            SchemaOperation::Update(
+                UpdateColumn::builder()
+                    .name("locations.lat")
+                    .new_type(PrimitiveType::Double.into())
+                    .build(),
+            ),
+            SchemaOperation::Update(
+                UpdateColumn::builder()
+                    .name("locations.long")
+                    .new_type(PrimitiveType::Double.into())
+                    .build(),
+            ),
+        ])
+        .unwrap();
+        assert_eq!(&expected, updated.as_ref());
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn update_type_preserves_other_metadata() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn update_doc_preserves_other_metadata() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn update_default_preserves_other_metadata() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn update_types_case_insensitive() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn update_failure() {
+        todo!()
+    }
+
+    #[test]
+    fn rename() {
+        let renamed = schema_update(Arc::new(SCHEMA.clone()), &[
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("data")
+                    .new_name("json")
+                    .build(),
+            ),
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("preferences")
+                    .new_name("options")
+                    .build(),
+            ),
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("preferences.feature2")
+                    .new_name("newfeature")
+                    .build(),
+            ),
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("locations.lat")
+                    .new_name("latitude")
+                    .build(),
+            ),
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("points.x")
+                    .new_name("X")
+                    .build(),
+            ),
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("points.y")
+                    .new_name("Y")
+                    .build(),
+            ),
+        ]);
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "json", PrimitiveType::String.into()).into(),
+                NestedField::optional(
+                    3,
+                    "options",
+                    StructType::new(vec![
+                        NestedField::required(8, "feature1", PrimitiveType::Boolean.into()).into(),
+                        NestedField::optional(9, "newfeature", PrimitiveType::Boolean.into())
+                            .into(),
+                    ])
+                    .into(),
+                )
+                .with_doc("struct of named boolean options")
+                .into(),
+                NestedField::required(
+                    4,
+                    "locations",
+                    MapType::new(
+                        NestedField::map_key_element(
+                            10,
+                            StructType::new(vec![
+                                NestedField::required(20, "address", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(21, "city", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(22, "state", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(23, "zip", PrimitiveType::Int.into()).into(),
+                            ])
+                            .into(),
+                        )
+                        .into(),
+                        NestedField::map_value_element(
+                            11,
+                            StructType::new(vec![
+                                NestedField::required(12, "latitude", PrimitiveType::Float.into())
+                                    .into(),
+                                NestedField::required(13, "long", PrimitiveType::Float.into())
+                                    .into(),
+                            ])
+                            .into(),
+                            true,
+                        )
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("map of address to coordinate")
+                .into(),
+                NestedField::optional(
+                    5,
+                    "points",
+                    ListType::new(
+                        NestedField::list_element(
+                            14,
+                            StructType::new(vec![
+                                NestedField::required(15, "X", PrimitiveType::Long.into()).into(),
+                                NestedField::required(16, "Y", PrimitiveType::Long.into()).into(),
+                            ])
+                            .into(),
+                            false,
+                        )
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("2-D cartesian points")
+                .into(),
+                NestedField::required(
+                    6,
+                    "doubles",
+                    ListType::new(
+                        NestedField::required(17, "element", PrimitiveType::Double.into()).into(),
+                    )
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    7,
+                    "properties",
+                    MapType::optional(
+                        18,
+                        PrimitiveType::String.into(),
+                        19,
+                        PrimitiveType::String.into(),
+                    )
+                    .into(),
+                )
+                .with_doc("string map of properties")
+                .into(),
+            ])
+            .build()
+            .unwrap();
+        assert_eq!(renamed.unwrap().as_ref(), &expected);
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn rename_case_insensitive() {}
+
+    #[test]
+    fn add_fields() {
+        let added = schema_update(Arc::new(SCHEMA.clone()), &[
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .name("topLevel")
+                    .r#type(Type::Primitive(PrimitiveType::Decimal {
+                        precision: 9,
+                        scale: 2,
+                    }))
+                    .build(),
+            ),
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .parent("locations".to_string())
+                    .name("alt")
+                    .r#type(Type::Primitive(PrimitiveType::Float))
+                    .build(),
+            ),
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .parent("points".to_string())
+                    .name("z")
+                    .r#type(Type::Primitive(PrimitiveType::Long))
+                    .build(),
+            ),
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .parent("points".to_string())
+                    .name("t.t")
+                    .r#type(Type::Primitive(PrimitiveType::Long))
+                    .build(),
+            ),
+        ])
+        .unwrap();
+
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "data", PrimitiveType::String.into()).into(),
+                NestedField::optional(
+                    3,
+                    "preferences",
+                    StructType::new(vec![
+                        NestedField::required(8, "feature1", PrimitiveType::Boolean.into()).into(),
+                        NestedField::optional(9, "feature2", PrimitiveType::Boolean.into()).into(),
+                    ])
+                    .into(),
+                )
+                .with_doc("struct of named boolean options")
+                .into(),
+                NestedField::required(
+                    4,
+                    "locations",
+                    MapType::new(
+                        NestedField::map_key_element(
+                            10,
+                            StructType::new(vec![
+                                NestedField::required(20, "address", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(21, "city", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(22, "state", PrimitiveType::String.into())
+                                    .into(),
+                                NestedField::required(23, "zip", PrimitiveType::Int.into()).into(),
+                            ])
+                            .into(),
+                        )
+                        .into(),
+                        NestedField::map_value_element(
+                            11,
+                            StructType::new(vec![
+                                NestedField::required(12, "lat", PrimitiveType::Float.into())
+                                    .into(),
+                                NestedField::required(13, "long", PrimitiveType::Float.into())
+                                    .into(),
+                                NestedField::optional(25, "alt", PrimitiveType::Float.into())
+                                    .into(),
+                            ])
+                            .into(),
+                            true,
+                        )
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("map of address to coordinate")
+                .into(),
+                NestedField::optional(
+                    5,
+                    "points",
+                    ListType::optional(
+                        14,
+                        StructType::new(vec![
+                            NestedField::required(15, "x", PrimitiveType::Long.into()).into(),
+                            NestedField::required(16, "y", PrimitiveType::Long.into()).into(),
+                            NestedField::optional(26, "z", PrimitiveType::Long.into()).into(),
+                            NestedField::optional(27, "t.t", PrimitiveType::Long.into()).into(),
+                        ])
+                        .into(),
+                    )
+                    .into(),
+                )
+                .with_doc("2-D cartesian points")
+                .into(),
+                NestedField::required(
+                    6,
+                    "doubles",
+                    ListType::new(
+                        NestedField::required(17, "element", PrimitiveType::Double.into()).into(),
+                    )
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    7,
+                    "properties",
+                    MapType::optional(
+                        18,
+                        PrimitiveType::String.into(),
+                        19,
+                        PrimitiveType::String.into(),
+                    )
+                    .into(),
+                )
+                .with_doc("string map of properties")
+                .into(),
+                NestedField::optional(
+                    24,
+                    "topLevel",
+                    PrimitiveType::Decimal {
+                        precision: 9,
+                        scale: 2,
+                    }
+                    .into(),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap();
+
+        assert_eq!(added.as_struct(), expected.as_struct());
+    }
+
+    #[test]
+    fn add_column_with_default() {
+        let schema: Arc<Schema> = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::optional(1, "id", PrimitiveType::Int.into()).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "data", PrimitiveType::String.into())
+                    .with_doc("description")
+                    .with_initial_default(Literal::string("unknown"))
+                    .with_write_default(Literal::string("unknown"))
+                    .into(),
+            ])
+            .build()
+            .unwrap();
+        let result = schema_update(schema.clone(), &[SchemaOperation::Add(
+            AddColumn::builder()
+                .name("data")
+                .r#type(Type::Primitive(PrimitiveType::String))
+                .doc(Some("description".into()))
+                .default_value(Literal::string("unknown"))
+                .build(),
+        )])
+        .unwrap();
+        assert_eq!(&expected, result.as_ref());
+    }
+
+    #[test]
+    fn add_column_with_update_column_default() {
+        let schema: Arc<Schema> = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::optional(1, "id", PrimitiveType::Int.into()).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "data", PrimitiveType::String.into())
+                    .with_write_default(Literal::string("unknown"))
+                    .into(),
+            ])
+            .build()
+            .unwrap();
+        let result = schema_update(schema.clone(), &[
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .name("data")
+                    .r#type(PrimitiveType::String.into())
+                    .build(),
+            ),
+            SchemaOperation::Update(
+                UpdateColumn::builder()
+                    .name("data")
+                    .new_default_value(Some(Literal::string("unknown")))
+                    .build(),
+            ),
+        ])
+        .unwrap();
+        assert_eq!(&expected, result.as_ref());
+    }
+
+    #[test]
+    fn add_nested_struct() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let struct_type = StructType::new(vec![
+            NestedField::required(1, "lat", PrimitiveType::Int.into()).into(),
+            NestedField::optional(2, "long", PrimitiveType::Int.into()).into(),
+        ]);
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(
+                    2,
+                    "location",
+                    StructType::new(vec![
+                        NestedField::required(3, "lat", PrimitiveType::Int.into()).into(),
+                        NestedField::optional(4, "long", PrimitiveType::Int.into()).into(),
+                    ])
+                    .into(),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap();
+
+        let result = schema_update(schema.clone(), &[SchemaOperation::Add(
+            AddColumn::builder()
+                .name("location")
+                .r#type(Type::Struct(struct_type))
+                .build(),
+        )])
+        .unwrap();
+        assert_eq!(&expected, result.as_ref());
+    }
+
+    #[test]
+    fn add_nested_map_of_structs() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(
+                    2,
+                    "locations",
+                    MapType::optional(
+                        3,
+                        StructType::new(vec![
+                            NestedField::required(5, "address", PrimitiveType::String.into())
+                                .into(),
+                            NestedField::required(6, "city", PrimitiveType::String.into()).into(),
+                            NestedField::required(7, "state", PrimitiveType::String.into()).into(),
+                            NestedField::required(8, "zip", PrimitiveType::Int.into()).into(),
+                        ])
+                        .into(),
+                        4,
+                        StructType::new(vec![
+                            NestedField::required(9, "lat", PrimitiveType::Int.into()).into(),
+                            NestedField::optional(10, "long", PrimitiveType::Int.into()).into(),
+                        ])
+                        .into(),
+                    )
+                    .into(),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap();
+        let map = MapType::optional(
+            1,
+            StructType::new(vec![
+                NestedField::required(20, "address", PrimitiveType::String.into()).into(),
+                NestedField::required(21, "city", PrimitiveType::String.into()).into(),
+                NestedField::required(22, "state", PrimitiveType::String.into()).into(),
+                NestedField::required(23, "zip", PrimitiveType::Int.into()).into(),
+            ])
+            .into(),
+            2,
+            StructType::new(vec![
+                NestedField::required(9, "lat", PrimitiveType::Int.into()).into(),
+                NestedField::optional(8, "long", PrimitiveType::Int.into()).into(),
+            ])
+            .into(),
+        );
+        let result = schema_update(schema, &[SchemaOperation::Add(
+            AddColumn::builder()
+                .name("locations")
+                .r#type(map.into())
+                .build(),
+        )])
+        .unwrap();
+        assert_eq!(&expected, result.as_ref())
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_nested_list_of_structs() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_required_column_without_default() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_required_column_with_default() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_required_column_with_update_column_default() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_required_column_case_insensitive() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn add_multiple_required_column_case_insensitive() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn make_column_optional() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn require_column() {
+        todo!()
+    }
+}

--- a/crates/iceberg/src/spec/schema/update.rs
+++ b/crates/iceberg/src/spec/schema/update.rs
@@ -25,7 +25,7 @@ use crate::spec::{
     ListType, Literal, MapType, NestedField, NestedFieldRef, PrimitiveType, Schema, SchemaRef,
     SchemaVisitor, StructType, Type, visit_schema,
 };
-use crate::{Error, ErrorKind, Result, ensure_data_valid};
+use crate::{Error, ErrorKind, Result, ensure_precondition};
 
 const TABLE_ROOT_ID: i32 = -1;
 
@@ -59,6 +59,12 @@ pub struct AddColumn {
     default_value: Option<Literal>,
 }
 
+impl From<AddColumn> for SchemaOperation {
+    fn from(add: AddColumn) -> Self {
+        SchemaOperation::Add(add)
+    }
+}
+
 /// A column to be deleted from the schema.
 pub struct DeleteColumn {
     name: String,
@@ -71,6 +77,12 @@ impl DeleteColumn {
     }
 }
 
+impl From<DeleteColumn> for SchemaOperation {
+    fn from(delete: DeleteColumn) -> Self {
+        SchemaOperation::Delete(delete)
+    }
+}
+
 /// A column to be renamed in the schema.
 #[derive(TypedBuilder)]
 pub struct RenameColumn {
@@ -78,6 +90,12 @@ pub struct RenameColumn {
     name: String,
     #[builder(setter(into))]
     new_name: String,
+}
+
+impl From<RenameColumn> for SchemaOperation {
+    fn from(rename: RenameColumn) -> Self {
+        SchemaOperation::Rename(rename)
+    }
 }
 
 /// A column to be updated in the schema.
@@ -93,11 +111,23 @@ pub struct UpdateColumn {
     new_default_value: Option<Option<Literal>>,
 }
 
+impl From<UpdateColumn> for SchemaOperation {
+    fn from(update: UpdateColumn) -> Self {
+        SchemaOperation::Update(update)
+    }
+}
+
 /// A column to be moved in the schema.
 pub struct MoveColumn {
     name: String,
     reference_name: String,
     move_type: MoveType,
+}
+
+impl From<MoveColumn> for SchemaOperation {
+    fn from(move_col: MoveColumn) -> Self {
+        SchemaOperation::Move(move_col)
+    }
 }
 
 impl MoveColumn {
@@ -215,7 +245,7 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     } else {
                         parent_field
                     };
-                    ensure_data_valid!(
+                    ensure_precondition!(
                         parent_field.field_type.is_struct(),
                         "Cannot add to non-struct column: {}: {}",
                         &parent,
@@ -224,12 +254,12 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     parent_id = parent_field.id;
                     let full_name = format!("{}.{}", parent, name);
                     let current_field = schema.field_by_name(&full_name);
-                    ensure_data_valid!(
+                    ensure_precondition!(
                         !deletes.contains(&parent_id),
                         "Can not add a column that will be deleted: {}",
                         name
                     );
-                    ensure_data_valid!(
+                    ensure_precondition!(
                         current_field.is_none() || deletes.contains(&current_field.unwrap().id),
                         "Cannot add column, name already exists: {}",
                         &name
@@ -237,14 +267,14 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     full_name
                 } else {
                     let current_field = schema.field_by_name(name);
-                    ensure_data_valid!(
+                    ensure_precondition!(
                         current_field.is_none() || deletes.contains(&current_field.unwrap().id),
                         "Cannot add column, name already exists: {}",
                         &name
                     );
                     name.clone()
                 };
-                ensure_data_valid!(
+                ensure_precondition!(
                     default_value.is_some() || is_optional,
                     "Incompatible change: cannot add required column without a default value: {}",
                     full_name
@@ -277,12 +307,12 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                         format!("Cannot delete missing column: {}", delete.name),
                     )
                 })?;
-                ensure_data_valid!(
+                ensure_precondition!(
                     !parent_to_added_ids.contains_key(&field.id),
                     "Cannot delete a column that has updates: {}",
                     delete.name
                 );
-                ensure_data_valid!(
+                ensure_precondition!(
                     !updates.contains_key(&field.id),
                     "Cannot delete a column that has updates: {}",
                     delete.name
@@ -295,7 +325,7 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     ErrorKind::PreconditionFailed,
                     format!("Cannot rename missing column: {}", name),
                 ))?;
-                ensure_data_valid!(
+                ensure_precondition!(
                     !deletes.contains(&field.id),
                     "Cannot rename a column that will be deleted: {}",
                     name
@@ -323,10 +353,10 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                 );
                 let field = find_for_update(name, schema.clone(), &updates, &added_name_to_id)?
                     .ok_or(Error::new(
-                        ErrorKind::DataInvalid,
+                        ErrorKind::PreconditionFailed,
                         format!("Cannot update missing column: {}", name),
                     ))?;
-                ensure_data_valid!(
+                ensure_precondition!(
                     !deletes.contains(&field.id),
                     "Cannot update column that will be deleted: {}",
                     name,
@@ -348,7 +378,7 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     (&r#move.name, &r#move.reference_name, &r#move.move_type);
                 let field_id =
                     find_for_move(name, schema.clone(), &added_name_to_id)?.ok_or(Error::new(
-                        ErrorKind::DataInvalid,
+                        ErrorKind::PreconditionFailed,
                         format!("Cannot move missing column: {}", name),
                     ))?;
                 let r#move = if move_type == &MoveType::First {
@@ -360,7 +390,7 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                         &added_name_to_id,
                     )?
                     .ok_or(Error::new(
-                        ErrorKind::DataInvalid,
+                        ErrorKind::PreconditionFailed,
                         format!("Cannot move relative to missing column: {}", reference_name),
                     ))?;
                     match move_type {
@@ -372,13 +402,13 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                 let parent_id = id_to_parent.get(&field_id);
                 if let Some(&parent_id) = parent_id {
                     let parent = schema.field_by_id(parent_id).unwrap();
-                    ensure_data_valid!(
+                    ensure_precondition!(
                         parent.field_type.is_struct(),
                         "Cannot move field in non-struct type: {}",
                         parent
                     );
                     if r#move.r#type == MoveType::After || r#move.r#type == MoveType::Before {
-                        ensure_data_valid!(
+                        ensure_precondition!(
                             parent_id == *id_to_parent.get(&r#move.reference_field_id).unwrap(),
                             "Cannot move field {} to a different struct",
                             name,
@@ -387,7 +417,7 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     moves.entry(parent_id).or_default().push(r#move);
                 } else {
                     if move_type == &MoveType::After || move_type == &MoveType::Before {
-                        ensure_data_valid!(
+                        ensure_precondition!(
                             !id_to_parent.contains_key(&r#move.reference_field_id),
                             "Cannot move field {} to a different struct",
                             name,
@@ -395,6 +425,27 @@ pub fn schema_update(schema: SchemaRef, operations: &[SchemaOperation]) -> Resul
                     }
                     moves.entry(TABLE_ROOT_ID).or_default().push(r#move);
                 }
+            }
+        }
+    }
+    for &id in &identifier_field_ids {
+        let field = schema.field_by_id(id);
+        if let Some(field) = field {
+            // TODO: add support for `setIdentifierFields` to update identifier fields
+            ensure_precondition!(
+                !deletes.contains(&id),
+                "Cannot delete identifier field: {}.",
+                field.name
+            );
+            let mut parent_id = id_to_parent.get(&id);
+            while let Some(p_id) = parent_id {
+                ensure_precondition!(
+                    !deletes.contains(p_id),
+                    "Cannot delete field {} as it will delete nested identifier field {}.",
+                    p_id,
+                    field.name
+                );
+                parent_id = id_to_parent.get(p_id);
             }
         }
     }

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -58,6 +58,7 @@ mod snapshot;
 mod sort_order;
 mod update_location;
 mod update_properties;
+mod update_schema;
 mod update_statistics;
 mod upgrade_format_version;
 
@@ -74,6 +75,7 @@ use crate::transaction::append::FastAppendAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
 use crate::transaction::update_properties::UpdatePropertiesAction;
+use crate::transaction::update_schema::UpdateSchemaAction;
 use crate::transaction::update_statistics::UpdateStatisticsAction;
 use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
 use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
@@ -154,6 +156,11 @@ impl Transaction {
     /// Update the statistics of table
     pub fn update_statistics(&self) -> UpdateStatisticsAction {
         UpdateStatisticsAction::new()
+    }
+
+    /// Update the schema of table
+    pub fn update_schema(&self) -> UpdateSchemaAction {
+        UpdateSchemaAction::new()
     }
 
     /// Commit transaction.

--- a/crates/iceberg/src/transaction/update_schema.rs
+++ b/crates/iceberg/src/transaction/update_schema.rs
@@ -1,0 +1,241 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::spec::{SchemaOperation, schema_update};
+use crate::table::Table;
+use crate::transaction::{ActionCommit, TransactionAction};
+use crate::{Result, TableRequirement, TableUpdate};
+
+pub struct UpdateSchemaAction {
+    operations: Vec<SchemaOperation>,
+}
+
+impl UpdateSchemaAction {
+    pub fn new() -> Self {
+        Self {
+            operations: Vec::new(),
+        }
+    }
+
+    pub fn push_operation(mut self, op: SchemaOperation) -> Self {
+        self.operations.push(op);
+        self
+    }
+}
+
+impl Default for UpdateSchemaAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionAction for UpdateSchemaAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        let schema = schema_update(table.current_schema_ref(), &self.operations)?;
+        let current_schema_id = table.metadata().current_schema_id();
+        let last_column_id = table.metadata().last_column_id();
+        Ok(ActionCommit::new(
+            vec![
+                TableUpdate::AddSchema {
+                    schema: Arc::unwrap_or_clone(schema),
+                },
+                TableUpdate::SetCurrentSchema { schema_id: -1 },
+            ],
+            vec![
+                TableRequirement::CurrentSchemaIdMatch { current_schema_id },
+                TableRequirement::LastAssignedFieldIdMatch {
+                    last_assigned_field_id: last_column_id,
+                },
+            ],
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, LazyLock};
+
+    use crate::spec::{
+        AddColumn, DeleteColumn, ListType, MapType, MoveColumn, NestedField, PrimitiveType,
+        RenameColumn, Schema, SchemaOperation, StructType, UpdateColumn, schema_update,
+    };
+
+    /// Build a schema with top-level and nested fields to exercise all operations.
+    ///
+    /// Schema:
+    ///   1  id        required int
+    ///   2  name      optional string
+    ///   3  address   optional struct
+    ///     4  street   required string
+    ///     5  city     optional string
+    ///     6  zip      optional int
+    ///   7  tags      optional list<string>  (element id 8)
+    ///   9  metrics   optional map<string, double>  (key 10, value 11)
+    static SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
+        Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(2, "name", PrimitiveType::String.into()).into(),
+                NestedField::optional(
+                    3,
+                    "address",
+                    StructType::new(vec![
+                        NestedField::required(4, "street", PrimitiveType::String.into()).into(),
+                        NestedField::optional(5, "city", PrimitiveType::String.into()).into(),
+                        NestedField::optional(6, "zip", PrimitiveType::Int.into()).into(),
+                    ])
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    7,
+                    "tags",
+                    ListType::optional(8, PrimitiveType::String.into()).into(),
+                )
+                .into(),
+                NestedField::optional(
+                    9,
+                    "metrics",
+                    MapType::optional(
+                        10,
+                        PrimitiveType::String.into(),
+                        11,
+                        PrimitiveType::Double.into(),
+                    )
+                    .into(),
+                )
+                .into(),
+            ])
+            .build()
+            .unwrap()
+    });
+
+    /// A complex schema evolution test exercising add, rename, update, move, and delete
+    /// on both top-level and nested fields in a single schema_update call.
+    ///
+    /// Operations applied (in order):
+    ///   1. Add    top-level "score" (optional float)
+    ///   2. Add    nested "address.country" (optional string)
+    ///   3. Rename "name" → "full_name"
+    ///   4. Rename nested "address.city" → "town"
+    ///   5. Update "address.zip" doc to "postal code"
+    ///   6. Delete "tags"
+    ///   7. Move   "id" after "name"  (so order becomes: full_name, id, ...)
+    ///   8. Move   nested "address.street" after "address.city"
+    ///
+    /// Expected result:
+    ///   2  full_name   optional string
+    ///   1  id          required int
+    ///   3  address     optional struct
+    ///     5  town       optional string
+    ///     4  street     required string
+    ///     6  zip        optional int    doc="postal code"
+    ///    13  country    optional string
+    ///   9  metrics     optional map<string, double>
+    ///  12  score       optional float
+    #[test]
+    fn complex_schema_evolution() {
+        let schema = Arc::new(SCHEMA.clone());
+        let result = schema_update(schema, &[
+            // 1. Add top-level "score"
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .name("score")
+                    .r#type(PrimitiveType::Float.into())
+                    .build(),
+            ),
+            // 2. Add nested "address.country"
+            SchemaOperation::Add(
+                AddColumn::builder()
+                    .parent("address".to_string())
+                    .name("country")
+                    .r#type(PrimitiveType::String.into())
+                    .build(),
+            ),
+            // 3. Rename "name" → "full_name"
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("name")
+                    .new_name("full_name")
+                    .build(),
+            ),
+            // 4. Rename nested "address.city" → "town"
+            SchemaOperation::Rename(
+                RenameColumn::builder()
+                    .name("address.city")
+                    .new_name("town")
+                    .build(),
+            ),
+            // 5. Update "address.zip" doc
+            SchemaOperation::Update(
+                UpdateColumn::builder()
+                    .name("address.zip")
+                    .new_doc(Some("postal code".into()))
+                    .build(),
+            ),
+            // 6. Delete "tags"
+            SchemaOperation::Delete(DeleteColumn::new("tags")),
+            // 7. Move "id" after "name"
+            SchemaOperation::Move(MoveColumn::after("id", "name")),
+            // 8. Move nested "address.street" after "address.city"
+            SchemaOperation::Move(MoveColumn::after("address.street", "address.city")),
+        ])
+        .unwrap();
+
+        let expected = Schema::builder()
+            .with_fields(vec![
+                NestedField::optional(2, "full_name", PrimitiveType::String.into()).into(),
+                NestedField::required(1, "id", PrimitiveType::Int.into()).into(),
+                NestedField::optional(
+                    3,
+                    "address",
+                    StructType::new(vec![
+                        NestedField::optional(5, "town", PrimitiveType::String.into()).into(),
+                        NestedField::required(4, "street", PrimitiveType::String.into()).into(),
+                        NestedField::optional(6, "zip", PrimitiveType::Int.into())
+                            .with_doc("postal code")
+                            .into(),
+                        NestedField::optional(13, "country", PrimitiveType::String.into()).into(),
+                    ])
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(
+                    9,
+                    "metrics",
+                    MapType::optional(
+                        10,
+                        PrimitiveType::String.into(),
+                        11,
+                        PrimitiveType::Double.into(),
+                    )
+                    .into(),
+                )
+                .into(),
+                NestedField::optional(12, "score", PrimitiveType::Float.into()).into(),
+            ])
+            .build()
+            .unwrap();
+
+        assert_eq!(result.as_struct(), expected.as_struct());
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2119 #697

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Add `schema_update` function and refactor `UpdateSchemaAction` to support schema evolution operations on Iceberg tables.

- Define `SchemaOperation` enum supporting Add, Update, Delete, Rename, and Move column operations
- Define operation structs: `AddColumn`, `UpdateColumn`, `DeleteColumn`, `RenameColumn`, `MoveColumn`
- Implement `schema_update()` function that validates and applies a list of schema operations to produce a new schema
- Implement `assign_fresh_ids()` to reassign field IDs for newly added nested types(May be replaced with `ReassignFieldIds`, but simpler)
- Implement `ApplyChangesVisitor` (using `SchemaVisitor` trait) to apply deletes, updates, adds, and moves to the schema tree

A similar PR #2120(only add column and delete column), but refactor it to add more features. 

Some helper additions

- Add `Type::is_list()`, `Type::is_map()` convenience methods
- Add `NestedField::list_required_element()`, `list_optional_element()`, `of_type()`, `with_name()`
- Add `ListType::optional()`, `ListType::required()` convenience constructors
- Fix doc typo: `Creates  decimal` -> `Creates decimal`

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Besides, I add some complex test cases which are ported from iceberg-java, a few of them to be implemented.