### PR TITLE
fix(iceberg): Implement JSON serde for Fixed/Binary literals

### DIFF
--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -422,6 +422,17 @@ impl Literal {
         }
     }
 
+    fn parse_hex_bytes(s: &str) -> Result<Vec<u8>> {
+        let invalid = || Error::new(ErrorKind::DataInvalid, format!("invalid hex string: {s}"));
+        if !s.is_ascii() || !s.len().is_multiple_of(2) {
+            return Err(invalid());
+        }
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|_| invalid()))
+            .collect()
+    }
+
     /// Create iceberg value from a json value
     ///
     /// See [this spec](https://iceberg.apache.org/spec/#json-single-value-serialization) for reference.
@@ -499,8 +510,22 @@ impl Literal {
                 (PrimitiveType::Uuid, JsonValue::String(s)) => Ok(Some(Literal::Primitive(
                     PrimitiveLiteral::UInt128(Uuid::parse_str(&s)?.as_u128()),
                 ))),
-                (PrimitiveType::Fixed(_), JsonValue::String(_)) => todo!(),
-                (PrimitiveType::Binary, JsonValue::String(_)) => todo!(),
+                (PrimitiveType::Fixed(n), JsonValue::String(s)) => {
+                    let bytes = Self::parse_hex_bytes(&s)?;
+                    if bytes.len() as u64 != *n {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!(
+                                "fixed literal length mismatch: expected {n}, got {}",
+                                bytes.len()
+                            ),
+                        ));
+                    }
+                    Ok(Some(Literal::Primitive(PrimitiveLiteral::Binary(bytes))))
+                }
+                (PrimitiveType::Binary, JsonValue::String(s)) => Ok(Some(Literal::Primitive(
+                    PrimitiveLiteral::Binary(Self::parse_hex_bytes(&s)?),
+                ))),
                 (
                     PrimitiveType::Decimal {
                         precision: _,
@@ -662,7 +687,7 @@ impl Literal {
                 (_, PrimitiveLiteral::Binary(val)) => Ok(JsonValue::String(val.iter().fold(
                     String::new(),
                     |mut acc, x| {
-                        acc.push_str(&format!("{x:x}"));
+                        acc.push_str(&format!("{x:02x}"));
                         acc
                     },
                 ))),

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -1352,3 +1352,34 @@ fn test_date_from_json_as_number() {
 
     // Both formats should produce the same Literal value
 }
+
+#[test]
+fn test_json_serde_binary() {
+    // "00ff05" covers both round-trip and zero-padding for bytes < 0x10.
+    check_json_serde(
+        "\"00ff05\"",
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![0x00, 0xff, 0x05])),
+        &Type::Primitive(PrimitiveType::Binary),
+    );
+}
+
+#[test]
+fn test_json_serde_fixed() {
+    check_json_serde(
+        "\"deadbeef\"",
+        Literal::Primitive(PrimitiveLiteral::Binary(vec![0xde, 0xad, 0xbe, 0xef])),
+        &Type::Primitive(PrimitiveType::Fixed(4)),
+    );
+}
+
+#[test]
+fn test_try_from_json_fixed_length_mismatch() {
+    let raw = JsonValue::String("deadbeef".into());
+    assert!(Literal::try_from_json(raw, &Type::Primitive(PrimitiveType::Fixed(5))).is_err());
+}
+
+#[test]
+fn test_try_from_json_binary_invalid_hex() {
+    let raw = JsonValue::String("zz".into());
+    assert!(Literal::try_from_json(raw, &Type::Primitive(PrimitiveType::Binary)).is_err());
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2430

## What changes are included in this PR?

Fixes two bugs in `Literal` JSON serialization for `Fixed`/`Binary`:

- `try_from_json`: replace `todo!()` with hex parsing; `Fixed(n)` validates length, invalid input returns `DataInvalid` instead of panicking.
- `try_into_json`: change `"{x:x}"` to `"{x:02x}"` so bytes `< 0x10` keep their leading zero (e.g. `[0x00, 0xff, 0x05]` now encodes to `"00ff05"`, not `"0ff5"`).

The two bugs masked each other — no existing test covered the `Fixed`/`Binary` JSON path. No new dependencies (uses `u8::from_str_radix`).

## Are these changes tested?

Yes, four new unit tests in `crates/iceberg/src/spec/values/tests.rs`:

- `test_json_serde_binary` — `Binary` round-trip with `"00ff05"` (regression for the zero-padding bug).
- `test_json_serde_fixed` — `Fixed(4)` round-trip.
- `test_try_from_json_fixed_length_mismatch` — `Fixed(5)` rejects 4-byte hex input.
- `test_try_from_json_binary_invalid_hex` — non-hex input returns `Err`.