### PR TITLE
feat(storage): Add HDFS backend via opendal services-hdfs-native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,20 @@ jobs:
             cargo test --no-fail-fast ${{ matrix.test-suite.args }}
           fi
 
+      # HDFS integration tests are `#[ignore]`d so a plain `cargo test`
+      # skips them locally on macOS/Windows where the docker fixture's
+      # host networking is unreliable; CI opts them in by filtering on
+      # the `file_io_hdfs` substring in the test name.
+      - name: Run HDFS integration tests
+        if: matrix.test-suite.name == 'default'
+        shell: bash
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
+        run: |
+          cargo nextest run ${{ matrix.test-suite.args }} \
+            --run-ignored=only \
+            -E 'test(file_io_hdfs)'
+
       - name: Stop Docker containers
         if: always() && matrix.test-suite.name == 'default'
         run: make docker-down

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures 0.2.17",
 ]
@@ -49,7 +49,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -204,6 +204,15 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1038,7 +1047,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "cpufeatures 0.2.17",
 ]
@@ -1115,6 +1124,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1200,6 +1220,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1216,7 +1242,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
@@ -1417,10 +1443,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1437,6 +1488,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+dependencies = [
+ "futures-io",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1486,7 +1546,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1660,7 +1720,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -2510,6 +2570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2641,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "socket2 0.6.3",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2734,7 +2815,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "home",
  "windows-sys 0.48.0",
 ]
@@ -2806,7 +2887,7 @@ version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rustix",
  "windows-sys 0.59.0",
 ]
@@ -3009,6 +3090,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "g2gen"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7e0eb46f83a20260b850117d204366674e85d3a908d90865c78df9a6b1dfc"
+dependencies = [
+ "g2poly",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "g2p"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539e2644c030d3bf4cd208cb842d2ce2f80e82e6e8472390bcef83ceba0d80ad"
+dependencies = [
+ "g2gen",
+ "g2poly",
+]
+
+[[package]]
+name = "g2poly"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
+name = "gearhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cf82cf76cd16485e56295a1377c775ce708c9f1a0be6b029076d60a245d213"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,10 +3142,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3037,7 +3155,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -3051,12 +3169,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3067,6 +3187,26 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3113,7 +3253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -3169,6 +3309,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdfs-native"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51610510377a0847d53b78b53f9c6c9b7df3ffb300d1181b2e04f68bba363734"
+dependencies = [
+ "aes",
+ "base64",
+ "bitflags",
+ "bumpalo",
+ "bytes",
+ "cbc",
+ "chrono",
+ "cipher",
+ "crc",
+ "ctr",
+ "des",
+ "dns-lookup",
+ "futures",
+ "g2p",
+ "hex",
+ "hmac",
+ "libc",
+ "libloading",
+ "log",
+ "md-5",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "rand 0.9.4",
+ "regex",
+ "roxmltree",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "uuid",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3366,28 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "more-asserts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
+]
 
 [[package]]
 name = "hive_metastore"
@@ -3350,9 +3559,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3656,7 +3867,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures",
  "iceberg",
  "iceberg_test_utils",
@@ -3958,7 +4169,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys",
@@ -4037,6 +4248,23 @@ dependencies = [
  "signature",
  "simple_asn1",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lazy_static"
@@ -4121,6 +4349,16 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
 
 [[package]]
 name = "liblzma"
@@ -4268,12 +4506,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest",
 ]
 
@@ -4356,7 +4603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4366,7 +4613,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "downcast",
  "fragile",
  "mockall_derive",
@@ -4380,7 +4627,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -4430,6 +4677,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "motore"
@@ -4508,7 +4761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset",
@@ -4521,9 +4774,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4630,6 +4892,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,6 +5006,8 @@ dependencies = [
  "opendal-service-azdls",
  "opendal-service-fs",
  "opendal-service-gcs",
+ "opendal-service-hdfs-native",
+ "opendal-service-hf",
  "opendal-service-oss",
  "opendal-service-s3",
 ]
@@ -4850,6 +5148,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal-service-hdfs-native"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2aba838c127b1131f9ec81d46248ada30b08f25a762b8e062dcd19be9e7a85f"
+dependencies = [
+ "bytes",
+ "futures",
+ "hdfs-native",
+ "log",
+ "opendal-core",
+ "serde",
+]
+
+[[package]]
+name = "opendal-service-hf"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2ab7a2a8a11dfe257ef4db5c0de798acbcd0d6429c37382dad2154bc06a388"
+dependencies = [
+ "bytes",
+ "hf-xet",
+ "http 1.4.0",
+ "log",
+ "opendal-core",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "opendal-service-oss"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,6 +5259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,7 +5301,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -5225,7 +5563,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
@@ -5636,6 +5974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5920,6 +6267,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5935,13 +6284,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
@@ -5988,6 +6351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6025,7 +6397,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "glob",
  "proc-macro-crate",
  "proc-macro2",
@@ -6043,7 +6415,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ordered-multimap",
 ]
 
@@ -6121,7 +6493,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -6167,7 +6539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.4",
  "clipboard-win",
  "fd-lock",
  "home",
@@ -6187,6 +6559,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe-transmute"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "salsa20"
@@ -6287,7 +6665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6501,7 +6879,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest",
 ]
@@ -6512,9 +6890,19 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6524,6 +6912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -6645,7 +7044,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5661364b38abad49cf1ade6631fcc35d2ccf882a7d68616b4228b7717feb5fba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -6656,7 +7055,7 @@ checksum = "0275f9f2f07d47556fe60c2759da8bc4be6083b047b491b2d476aa0bfa558eb1"
 dependencies = [
  "bumpalo",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.4",
  "faststr",
  "itoa",
  "ref-cast",
@@ -6674,7 +7073,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f944718c33623919878cf74b4c9361eb3024f635733922b26722b14cd3f8cc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -6866,7 +7265,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -6903,7 +7302,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -6943,10 +7342,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
 ]
 
 [[package]]
@@ -7029,6 +7444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7057,6 +7478,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7130,7 +7586,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -7235,6 +7691,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
 ]
 
 [[package]]
@@ -7401,6 +7868,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7433,17 +7913,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -7513,6 +8010,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "typify"
@@ -7794,6 +8297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7818,12 +8330,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -7836,7 +8357,7 @@ version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "js-sys",
  "once_cell",
@@ -7990,8 +8511,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+ "web-sys",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -8000,6 +8551,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
 ]
 
 [[package]]
@@ -8013,6 +8591,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8042,6 +8631,27 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -8152,6 +8762,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -8412,6 +9031,153 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xet-client"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bytes",
+ "clap",
+ "crc32fast",
+ "futures",
+ "http 1.4.0",
+ "hyper",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "redb",
+ "reqwest 0.13.3",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "clap",
+ "countio",
+ "csv",
+ "futures",
+ "futures-util",
+ "getrandom 0.4.2",
+ "heapify",
+ "itertools 0.14.0",
+ "lazy_static",
+ "lz4_flex",
+ "more-asserts",
+ "rand 0.10.1",
+ "regex",
+ "safe-transmute",
+ "serde",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "clap",
+ "gearhash",
+ "http 1.4.0",
+ "itertools 0.14.0",
+ "lazy_static",
+ "more-asserts",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor",
+ "dirs",
+ "futures",
+ "git-version",
+ "humantime",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "whoami 2.1.1",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/storage/opendal/Cargo.toml
+++ b/crates/storage/opendal/Cargo.toml
@@ -28,11 +28,23 @@ keywords = ["iceberg", "opendal", "storage"]
 
 [features]
 default = ["opendal-memory", "opendal-fs", "opendal-s3"]
-opendal-all = ["opendal-memory", "opendal-fs", "opendal-s3", "opendal-gcs", "opendal-oss", "opendal-azdls", "opendal-hf"]
+opendal-all = [
+    "opendal-memory",
+    "opendal-fs",
+    "opendal-s3",
+    "opendal-gcs",
+    "opendal-oss",
+    "opendal-azdls",
+    "opendal-hf",
+    "opendal-hdfs-native",
+]
 
 opendal-azdls = ["opendal/services-azdls"]
 opendal-fs = ["opendal/services-fs"]
 opendal-gcs = ["opendal/services-gcs"]
+# Requires `libgssapi_krb5` at the OS level (e.g. `brew install krb5` on macOS,
+# `apt install libgssapi-krb5-2` on Debian).
+opendal-hdfs-native = ["opendal/services-hdfs-native"]
 opendal-hf = ["opendal/services-hf"]
 opendal-memory = ["opendal/services-memory"]
 opendal-oss = ["opendal/services-oss"]

--- a/crates/storage/opendal/src/hdfs.rs
+++ b/crates/storage/opendal/src/hdfs.rs
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! HDFS storage support via OpenDAL's `services-hdfs-native` backend.
+//!
+//! Cluster topology (HA name services, namenode RPC addresses) and Kerberos
+//! authentication are entirely delegated to `hdfs-native` and its
+//! environment. `hdfs-native` reads `core-site.xml` / `hdfs-site.xml` from
+//! `$HADOOP_CONF_DIR` (or `$HADOOP_HOME/etc/hadoop`); Kerberos goes through
+//! `libgssapi_krb5` via the standard `KRB5CCNAME` / `KRB5_CONFIG` env. The
+//! caller's `libgssapi_krb5` must be installed on the host (e.g.
+//! `brew install krb5` on macOS, `apt install libgssapi-krb5-2` on Debian)
+//! for HDFS calls to link at runtime.
+//!
+//! No iceberg-level HDFS configuration is exposed - mirroring the Java
+//! HadoopFileIO, which has no iceberg-side HDFS knobs and defers everything
+//! to Hadoop's `Configuration`. Paths with an authority (`hdfs://ns/foo`)
+//! route to that name node; authority-less paths (`hdfs:///foo`) are passed
+//! to `hdfs-native` without an explicit name node, so it picks up
+//! `fs.defaultFS` from the loaded Hadoop config.
+
+use iceberg::{Error, ErrorKind, Result};
+use opendal::Operator;
+use opendal::services::HdfsNative;
+use url::Url;
+
+use crate::utils::from_opendal_error;
+
+/// Parse an HDFS path into its name node (when an authority is present) and
+/// the relative path beginning with `/`.
+///
+/// The returned `Option<String>` is `Some("hdfs://<authority>")` when the
+/// input has an authority and `None` when it does not. `None` causes the
+/// operator to be built without an explicit name node, so that `hdfs-native`
+/// resolves `fs.defaultFS` from the loaded Hadoop config.
+pub(crate) fn parse_hdfs_path(path: &str) -> Result<(Option<String>, &str)> {
+    let url = Url::parse(path).map_err(|e| {
+        Error::new(
+            ErrorKind::DataInvalid,
+            format!("Invalid hdfs path: {path}: {e}"),
+        )
+    })?;
+    if url.scheme() != "hdfs" {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!("Invalid hdfs path: {path}, expected scheme `hdfs://`"),
+        ));
+    }
+
+    let name_node = url.host_str().filter(|h| !h.is_empty()).map(|host| {
+        url.port()
+            .map(|port| format!("hdfs://{host}:{port}"))
+            .unwrap_or_else(|| format!("hdfs://{host}"))
+    });
+
+    // `url.path()` borrows from `url` and can't be returned with the input's
+    // lifetime. Slice the path component out of the original input instead;
+    // it always starts at the first `/` after the `hdfs://` prefix, or is
+    // implicitly `/` when only an authority is given.
+    let after_scheme = &path["hdfs://".len()..];
+    let rel = match after_scheme.find('/') {
+        Some(i) => &after_scheme[i..],
+        None => "/",
+    };
+
+    Ok((name_node, rel))
+}
+
+/// Build a new OpenDAL [`Operator`] for the given name node, or - when
+/// `name_node` is `None` - one that defers to `fs.defaultFS` from the
+/// `hdfs-native`-loaded Hadoop config.
+pub(crate) fn hdfs_operator_build(name_node: Option<&str>) -> Result<Operator> {
+    let mut builder = HdfsNative::default().root("/");
+    if let Some(nn) = name_node {
+        builder = builder.name_node(nn);
+    }
+    Ok(Operator::new(builder).map_err(from_opendal_error)?.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_hdfs_path_with_authority_and_rel() {
+        let (nn, rel) = parse_hdfs_path("hdfs://nameservice1/a/b").unwrap();
+
+        assert_eq!(nn.as_deref(), Some("hdfs://nameservice1"));
+        assert_eq!(rel, "/a/b");
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_with_authority_and_port() {
+        let (nn, rel) = parse_hdfs_path("hdfs://nn:8020/foo").unwrap();
+
+        assert_eq!(nn.as_deref(), Some("hdfs://nn:8020"));
+        assert_eq!(rel, "/foo");
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_with_authority_no_path() {
+        let (nn, rel) = parse_hdfs_path("hdfs://nameservice1").unwrap();
+
+        assert_eq!(nn.as_deref(), Some("hdfs://nameservice1"));
+        assert_eq!(rel, "/");
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_with_authority_trailing_slash() {
+        let (nn, rel) = parse_hdfs_path("hdfs://nameservice1/").unwrap();
+
+        assert_eq!(nn.as_deref(), Some("hdfs://nameservice1"));
+        assert_eq!(rel, "/");
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_authority_less_returns_none() {
+        let (nn, rel) = parse_hdfs_path("hdfs:///a/b").unwrap();
+
+        assert_eq!(nn, None);
+        assert_eq!(rel, "/a/b");
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_wrong_scheme_errors() {
+        let err = parse_hdfs_path("file:///tmp/x").unwrap_err();
+
+        assert!(err.to_string().contains("expected scheme `hdfs://`"));
+    }
+
+    #[test]
+    fn test_parse_hdfs_path_invalid_url_errors() {
+        let err = parse_hdfs_path("not-a-url").unwrap_err();
+
+        assert!(err.to_string().contains("Invalid hdfs path"));
+    }
+}

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -75,6 +75,14 @@ cfg_if! {
 }
 
 cfg_if! {
+    if #[cfg(feature = "opendal-hdfs-native")] {
+        mod hdfs;
+        use hdfs::*;
+        use std::sync::RwLock;
+    }
+}
+
+cfg_if! {
     if #[cfg(feature = "opendal-memory")] {
         mod memory;
         use memory::*;
@@ -131,6 +139,9 @@ pub enum OpenDalStorageFactory {
     /// HuggingFace Hub storage factory.
     #[cfg(feature = "opendal-hf")]
     Hf,
+    /// HDFS storage factory (via OpenDAL `services-hdfs-native`).
+    #[cfg(feature = "opendal-hdfs-native")]
+    Hdfs,
 }
 
 #[typetag::serde(name = "OpenDalStorageFactory")]
@@ -167,6 +178,10 @@ impl StorageFactory for OpenDalStorageFactory {
             OpenDalStorageFactory::Hf => Ok(Arc::new(OpenDalStorage::Hf {
                 config: hf_config_parse(config.props().clone())?.into(),
             })),
+            #[cfg(feature = "opendal-hdfs-native")]
+            OpenDalStorageFactory::Hdfs => Ok(Arc::new(OpenDalStorage::Hdfs {
+                operators: Arc::new(RwLock::new(HashMap::new())),
+            })),
             #[cfg(all(
                 not(feature = "opendal-memory"),
                 not(feature = "opendal-fs"),
@@ -175,6 +190,7 @@ impl StorageFactory for OpenDalStorageFactory {
                 not(feature = "opendal-oss"),
                 not(feature = "opendal-azdls"),
                 not(feature = "opendal-hf"),
+                not(feature = "opendal-hdfs-native"),
             ))]
             _ => Err(Error::new(
                 ErrorKind::FeatureUnsupported,
@@ -243,6 +259,20 @@ pub enum OpenDalStorage {
     Hf {
         /// HuggingFace Hub configuration (token + endpoint).
         config: Arc<HfConfig>,
+    },
+    /// HDFS storage variant (via OpenDAL `services-hdfs-native`).
+    ///
+    /// Accepts paths of the form `hdfs://<authority>/<rel>` (or
+    /// `hdfs:///<rel>` for authority-less paths, which defer to
+    /// `fs.defaultFS` from the `hdfs-native`-loaded Hadoop config). The
+    /// authority - or `None` when absent - keys a per-name-node `Operator`
+    /// cache, so distinct name nodes coexist in a single storage instance.
+    #[cfg(feature = "opendal-hdfs-native")]
+    Hdfs {
+        /// Operator cache. `Some("hdfs://<authority>")` for paths with an
+        /// authority; `None` for authority-less paths (`fs.defaultFS`).
+        #[serde(skip, default)]
+        operators: Arc<RwLock<HashMap<Option<String>, Operator>>>,
     },
 }
 
@@ -339,6 +369,33 @@ impl OpenDalStorage {
             OpenDalStorage::Azdls { config } => azdls_create_operator(path, config)?,
             #[cfg(feature = "opendal-hf")]
             OpenDalStorage::Hf { config } => hf_config_build(config, path)?,
+            #[cfg(feature = "opendal-hdfs-native")]
+            OpenDalStorage::Hdfs { operators } => {
+                let (name_node, rel) = parse_hdfs_path(path)?;
+
+                if let Some(op) = operators
+                    .read()
+                    .map_err(|_| {
+                        Error::new(ErrorKind::Unexpected, "HDFS operator cache lock poisoned")
+                    })?
+                    .get(&name_node)
+                {
+                    (op.clone(), rel)
+                } else {
+                    let mut cache = operators.write().map_err(|_| {
+                        Error::new(ErrorKind::Unexpected, "HDFS operator cache lock poisoned")
+                    })?;
+                    let op = match cache.get(&name_node) {
+                        Some(op) => op.clone(),
+                        None => {
+                            let op = hdfs_operator_build(name_node.as_deref())?;
+                            cache.insert(name_node, op.clone());
+                            op
+                        }
+                    };
+                    (op, rel)
+                }
+            }
             #[cfg(all(
                 not(feature = "opendal-s3"),
                 not(feature = "opendal-fs"),
@@ -346,6 +403,7 @@ impl OpenDalStorage {
                 not(feature = "opendal-oss"),
                 not(feature = "opendal-azdls"),
                 not(feature = "opendal-hf"),
+                not(feature = "opendal-hdfs-native"),
             ))]
             _ => {
                 return Err(Error::new(
@@ -459,6 +517,11 @@ impl OpenDalStorage {
                 })?;
                 Ok(&path[path.len() - parsed.path.len()..])
             }
+            #[cfg(feature = "opendal-hdfs-native")]
+            OpenDalStorage::Hdfs { .. } => {
+                let (_, rel) = parse_hdfs_path(path)?;
+                Ok(rel)
+            }
             #[cfg(all(
                 not(feature = "opendal-s3"),
                 not(feature = "opendal-fs"),
@@ -466,6 +529,7 @@ impl OpenDalStorage {
                 not(feature = "opendal-oss"),
                 not(feature = "opendal-azdls"),
                 not(feature = "opendal-hf"),
+                not(feature = "opendal-hdfs-native"),
             ))]
             _ => Err(Error::new(
                 ErrorKind::FeatureUnsupported,
@@ -740,6 +804,47 @@ mod tests {
                 .relativize_path("s3://my-bucket/path/to/file.parquet")
                 .is_err()
         );
+    }
+
+    #[cfg(feature = "opendal-hdfs-native")]
+    #[test]
+    fn test_relativize_path_hdfs() {
+        let storage = OpenDalStorage::Hdfs {
+            operators: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        assert_eq!(
+            storage
+                .relativize_path("hdfs://nameservice1/a/b.parquet")
+                .unwrap(),
+            "/a/b.parquet"
+        );
+        assert_eq!(
+            storage
+                .relativize_path("hdfs://nn:8020/warehouse/db/t")
+                .unwrap(),
+            "/warehouse/db/t"
+        );
+    }
+
+    #[cfg(feature = "opendal-hdfs-native")]
+    #[test]
+    fn test_relativize_path_hdfs_authority_less() {
+        let storage = OpenDalStorage::Hdfs {
+            operators: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        assert_eq!(storage.relativize_path("hdfs:///a/b").unwrap(), "/a/b");
+    }
+
+    #[cfg(feature = "opendal-hdfs-native")]
+    #[test]
+    fn test_relativize_path_hdfs_wrong_scheme_errors() {
+        let storage = OpenDalStorage::Hdfs {
+            operators: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        assert!(storage.relativize_path("s3://bucket/x").is_err());
     }
 
     #[cfg(feature = "opendal-azdls")]

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -51,6 +51,7 @@ pub const SCHEME_ABFS: &str = "abfs";
 pub const SCHEME_WASBS: &str = "wasbs";
 pub const SCHEME_WASB: &str = "wasb";
 pub const SCHEME_HF: &str = "hf";
+pub const SCHEME_HDFS: &str = "hdfs";
 
 /// Parse a URL scheme string.
 fn parse_scheme(scheme: &str) -> Result<&'static str> {
@@ -62,6 +63,7 @@ fn parse_scheme(scheme: &str) -> Result<&'static str> {
         SCHEME_OSS => Ok("oss"),
         SCHEME_ABFSS | SCHEME_ABFS | SCHEME_WASBS | SCHEME_WASB => Ok("azdls"),
         SCHEME_HF => Ok("hf"),
+        SCHEME_HDFS => Ok("hdfs"),
         s => Err(Error::new(
             ErrorKind::FeatureUnsupported,
             format!("Unsupported storage scheme: {s}"),
@@ -116,6 +118,10 @@ fn build_storage_for_scheme(
                 config: Arc::new(config),
             })
         }
+        #[cfg(feature = "opendal-hdfs-native")]
+        "hdfs" => Ok(OpenDalStorage::Hdfs {
+            operators: Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
+        }),
         #[cfg(feature = "opendal-fs")]
         "file" => Ok(OpenDalStorage::LocalFs),
         #[cfg(feature = "opendal-memory")]
@@ -351,6 +357,33 @@ mod tests {
 
         assert!(Arc::ptr_eq(&a, &b), "s3 and s3a should share one instance");
         assert!(Arc::ptr_eq(&a, &c), "s3 and s3n should share one instance");
+    }
+
+    #[cfg(feature = "opendal-hdfs-native")]
+    #[test]
+    fn test_resolve_hdfs_returns_hdfs_variant() {
+        let storage = empty_resolving_storage();
+
+        let resolved = storage.resolve("hdfs://nameservice1/a/b").unwrap();
+
+        assert!(
+            matches!(&*resolved, crate::OpenDalStorage::Hdfs { .. }),
+            "expected Hdfs variant, got {resolved:?}"
+        );
+    }
+
+    #[cfg(feature = "opendal-hdfs-native")]
+    #[test]
+    fn test_resolve_hdfs_distinct_authorities_share_instance() {
+        let storage = empty_resolving_storage();
+
+        let a = storage.resolve("hdfs://ns1/a").unwrap();
+        let b = storage.resolve("hdfs://ns2/b").unwrap();
+
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "different authorities should share the OpenDalStorage::Hdfs instance (operator cache is internal)"
+        );
     }
 
     #[cfg(feature = "opendal-azdls")]

--- a/crates/storage/opendal/tests/file_io_hdfs_test.rs
+++ b/crates/storage/opendal/tests/file_io_hdfs_test.rs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integration tests for HDFS FileIO via OpenDAL `services-hdfs-native`.
+//!
+//! These tests need a single-node HDFS cluster (the `hdfs-namenode` +
+//! `hdfs-datanode` services from `dev/docker-compose.yaml`, mirroring
+//! apache/opendal's own `fixtures/hdfs/docker-compose-hdfs-cluster.yml`).
+//! The docker fixture uses `network_mode: host`, which works on Linux CI
+//! but has known issues on macOS / Windows Docker Desktop. Tests are
+//! therefore marked `#[ignore]` so a plain `cargo test` skips them; CI
+//! opts in with `cargo nextest run --run-ignored=only ...`.
+#[cfg(feature = "opendal-hdfs-native")]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use iceberg::io::{FileIO, FileIOBuilder};
+    use iceberg_storage_opendal::OpenDalStorageFactory;
+    use iceberg_test_utils::{get_hdfs_endpoint, normalize_test_name_with_parts, set_up};
+
+    fn get_file_io() -> FileIO {
+        set_up();
+        FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Hdfs)).build()
+    }
+
+    fn test_path(suffix: &str) -> String {
+        format!(
+            "{}/{}",
+            get_hdfs_endpoint(),
+            normalize_test_name_with_parts!(suffix)
+        )
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_exists() {
+        let file_io = get_file_io();
+
+        let absent = test_path("test_file_io_hdfs_exists_absent");
+        assert!(!file_io.exists(&absent).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_write_and_read() {
+        let file_io = get_file_io();
+        let path = test_path("test_file_io_hdfs_write_and_read");
+        let _ = file_io.delete(&path).await;
+
+        let output = file_io.new_output(&path).unwrap();
+        output
+            .write(Bytes::from_static(b"hello hdfs"))
+            .await
+            .unwrap();
+
+        assert!(file_io.exists(&path).await.unwrap());
+        let input = file_io.new_input(&path).unwrap();
+        assert_eq!(
+            input.read().await.unwrap(),
+            Bytes::from_static(b"hello hdfs")
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_metadata() {
+        let file_io = get_file_io();
+        let path = test_path("test_file_io_hdfs_metadata");
+        let _ = file_io.delete(&path).await;
+        let content = Bytes::from_static(b"0123456789");
+
+        file_io
+            .new_output(&path)
+            .unwrap()
+            .write(content.clone())
+            .await
+            .unwrap();
+
+        let metadata = file_io.new_input(&path).unwrap().metadata().await.unwrap();
+        assert_eq!(metadata.size, content.len() as u64);
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_delete() {
+        let file_io = get_file_io();
+        let path = test_path("test_file_io_hdfs_delete");
+
+        file_io
+            .new_output(&path)
+            .unwrap()
+            .write(Bytes::from_static(b"x"))
+            .await
+            .unwrap();
+        assert!(file_io.exists(&path).await.unwrap());
+
+        file_io.delete(&path).await.unwrap();
+        assert!(!file_io.exists(&path).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_delete_prefix() {
+        let file_io = get_file_io();
+        let dir = test_path("test_file_io_hdfs_delete_prefix");
+        let _ = file_io.delete_prefix(&dir).await;
+
+        for i in 0..3 {
+            let path = format!("{dir}/file_{i}");
+            file_io
+                .new_output(&path)
+                .unwrap()
+                .write(Bytes::from(format!("payload {i}")))
+                .await
+                .unwrap();
+        }
+        assert!(file_io.exists(&format!("{dir}/file_0")).await.unwrap());
+
+        file_io.delete_prefix(&dir).await.unwrap();
+
+        for i in 0..3 {
+            assert!(!file_io.exists(&format!("{dir}/file_{i}")).await.unwrap());
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_reader_range() {
+        let file_io = get_file_io();
+        let path = test_path("test_file_io_hdfs_reader_range");
+        let _ = file_io.delete(&path).await;
+        let content = Bytes::from_static(b"abcdefghij");
+
+        file_io
+            .new_output(&path)
+            .unwrap()
+            .write(content.clone())
+            .await
+            .unwrap();
+
+        let reader = file_io.new_input(&path).unwrap().reader().await.unwrap();
+        assert_eq!(
+            reader.read(0..5).await.unwrap(),
+            Bytes::from_static(b"abcde")
+        );
+        assert_eq!(
+            reader.read(5..10).await.unwrap(),
+            Bytes::from_static(b"fghij")
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "Linux-only: HDFS docker fixture uses host networking"]
+    async fn test_file_io_hdfs_streaming_writer() {
+        let file_io = get_file_io();
+        let path = test_path("test_file_io_hdfs_streaming_writer");
+        let _ = file_io.delete(&path).await;
+
+        let output = file_io.new_output(&path).unwrap();
+        let mut writer = output.writer().await.unwrap();
+        writer.write(Bytes::from_static(b"part1 ")).await.unwrap();
+        writer.write(Bytes::from_static(b"part2")).await.unwrap();
+        writer.close().await.unwrap();
+
+        let read = file_io.new_input(&path).unwrap().read().await.unwrap();
+        assert_eq!(read, Bytes::from_static(b"part1 part2"));
+    }
+}

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -42,6 +42,7 @@ mod common {
     pub const ENV_HMS_ENDPOINT: &str = "ICEBERG_TEST_HMS_ENDPOINT";
     pub const ENV_GLUE_ENDPOINT: &str = "ICEBERG_TEST_GLUE_ENDPOINT";
     pub const ENV_GCS_ENDPOINT: &str = "ICEBERG_TEST_GCS_ENDPOINT";
+    pub const ENV_HDFS_ENDPOINT: &str = "ICEBERG_TEST_HDFS_ENDPOINT";
 
     // Default ports matching dev/docker-compose.yaml
     pub const DEFAULT_MINIO_PORT: u16 = 9000;
@@ -49,6 +50,7 @@ mod common {
     pub const DEFAULT_HMS_PORT: u16 = 9083;
     pub const DEFAULT_GLUE_PORT: u16 = 5001;
     pub const DEFAULT_GCS_PORT: u16 = 4443;
+    pub const DEFAULT_HDFS_NN_PORT: u16 = 8020;
 
     /// Returns the MinIO S3-compatible endpoint.
     /// Checks ICEBERG_TEST_MINIO_ENDPOINT env var, otherwise returns localhost default.
@@ -82,6 +84,13 @@ mod common {
     pub fn get_gcs_endpoint() -> String {
         std::env::var(ENV_GCS_ENDPOINT)
             .unwrap_or_else(|_| format!("http://localhost:{DEFAULT_GCS_PORT}"))
+    }
+
+    /// Returns the HDFS NameNode endpoint (e.g. `hdfs://localhost:8020`).
+    /// Checks ICEBERG_TEST_HDFS_ENDPOINT env var, otherwise returns localhost default.
+    pub fn get_hdfs_endpoint() -> String {
+        std::env::var(ENV_HDFS_ENDPOINT)
+            .unwrap_or_else(|_| format!("hdfs://localhost:{DEFAULT_HDFS_NN_PORT}"))
     }
 
     /// Helper to clean up a namespace and its tables before a test runs.

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -148,6 +148,64 @@ services:
       retries: 5
 
   # =============================================================================
+  # HDFS - single-node NameNode + DataNode for HDFS tests
+  # =============================================================================
+  # Uses the official apache/hadoop image. Configuration is vendored as
+  # static core-site.xml / hdfs-site.xml under dev/hdfs/ (the apache image
+  # has no env-var-to-xml translator like the bde2020 images do, so the
+  # files are mounted directly into the image's $HADOOP_CONF_DIR).
+  #
+  # Host networking is required because hdfs-native 0.13.5 connects to the
+  # DataNode by IP from `DatanodeIdProto.ip_addr` (not by hostname). On a
+  # docker bridge the DN would register with an unroutable bridge IP; host
+  # networking lets it bind directly on the host network namespace so the
+  # registered address is host-reachable.
+  #
+  # This works on Linux CI runners. On macOS / Windows Docker Desktop
+  # host networking has known issues (e.g. unresolvable VM hostname), so
+  # the HDFS integration tests are `#[ignore]`d; CI explicitly opts them
+  # in via `cargo nextest --run-ignored=only` (see .github/workflows/ci.yml).
+  hdfs-namenode:
+    image: apache/hadoop:3.5.0
+    network_mode: "host"
+    command: ["hdfs", "namenode"]
+    environment:
+      # First-boot formats /tmp/hadoop-root/dfs/name when it doesn't exist
+      # (starter.sh in the image checks this var); matches dfs.namenode.name.dir
+      # in dev/hdfs/hdfs-site.xml.
+      ENSURE_NAMENODE_DIR: "/tmp/hadoop-root/dfs/name"
+    # Make `InetAddress.getLocalHost()` succeed inside the container even
+    # when the host's hostname isn't already in /etc/hosts (e.g. macOS
+    # Docker Desktop, where the VM hostname is `docker-desktop`). On Linux
+    # CI runners the real hostname resolves via the system /etc/hosts and
+    # these entries are harmless extras.
+    extra_hosts:
+      - "docker-desktop:127.0.0.1"
+    volumes:
+      - ./hdfs/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml:ro
+      - ./hdfs/hdfs-site.xml:/opt/hadoop/etc/hadoop/hdfs-site.xml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "hdfs dfsadmin -safemode get | grep -q OFF"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  hdfs-datanode:
+    image: apache/hadoop:3.5.0
+    network_mode: "host"
+    command: ["hdfs", "datanode"]
+    depends_on:
+      hdfs-namenode:
+        condition: service_healthy
+    # See hdfs-namenode above for why docker-desktop is mapped here.
+    extra_hosts:
+      - "docker-desktop:127.0.0.1"
+    volumes:
+      - ./hdfs/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml:ro
+      - ./hdfs/hdfs-site.xml:/opt/hadoop/etc/hadoop/hdfs-site.xml:ro
+
+  # =============================================================================
   # Fake GCS Server - GCS emulator for GCS tests
   # =============================================================================
   gcs-server:

--- a/dev/hdfs/core-site.xml
+++ b/dev/hdfs/core-site.xml
@@ -1,0 +1,27 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://localhost:8020</value>
+    </property>
+    <property>
+        <name>hadoop.http.staticuser.user</name>
+        <value>root</value>
+    </property>
+</configuration>

--- a/dev/hdfs/hdfs-site.xml
+++ b/dev/hdfs/hdfs-site.xml
@@ -1,0 +1,35 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.permissions.enabled</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>dfs.namenode.name.dir</name>
+        <value>file:///tmp/hadoop-root/dfs/name</value>
+    </property>
+    <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>file:///tmp/hadoop-root/dfs/data</value>
+    </property>
+</configuration>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2440.

## What changes are included in this PR?

```
Add an opendal-hdfs-native cargo feature plus
OpenDalStorageFactory::Hdfs and OpenDalStorage::Hdfs variants in
iceberg-storage-opendal. The variant uses OpenDAL's
services-hdfs-native, which talks the HDFS RPC protocol directly in
pure Rust (no JNI / libhdfs).

The wire-up in crates/storage/opendal/src/lib.rs and resolving.rs
follows the same factory + variant + scheme-routing pattern used by
every other OpenDAL-backed storage in that crate (s3, gcs, oss,
azdls), to the letter.

Mirroring the Java HadoopFileIO, no iceberg-level HDFS configuration
is exposed: there is no HdfsConfig type and no `hdfs.*` property
constants. HDFS topology (HA name services, namenode RPC addresses)
and Kerberos authentication are entirely delegated to hdfs-native
and its environment. hdfs-native reads core-site.xml / hdfs-site.xml
from HADOOP_CONF_DIR (or HADOOP_HOME/etc/hadoop); Kerberos auth is
delegated to libgssapi_krb5 via the standard KRB5CCNAME /
KRB5_CONFIG env. These deployment requirements are documented in the
opendal backend module (crates/storage/opendal/src/hdfs.rs). The
opendal-hdfs-native feature is added to opendal-all but not to the
default set; it requires libgssapi_krb5 installed at the OS level
for the runtime dlopen (brew install krb5 on macOS,
apt install libgssapi-krb5-2 on Debian).

Path parsing uses url::Url. Paths with an authority
(`hdfs://nameservice1/foo`) build an operator targeted at that name
node; authority-less paths (`hdfs:///foo`) build an operator without
an explicit name node, so hdfs-native picks up `fs.defaultFS` from
the loaded Hadoop config - the same behavior Java HadoopFileIO gets
via Hadoop's Configuration. OpenDalStorage::Hdfs holds a
per-name-node operator cache
(Arc<RwLock<HashMap<Option<String>, Operator>>> keyed by
`Some("hdfs://<authority>")` for authority-bearing paths and `None`
for authority-less paths). The cache uses stdlib primitives
(Arc + RwLock + HashMap) rather than a third-party concurrent map
crate; for the typical workload (one to a few nameservices,
read-heavy after warmup) the RwLock-guarded map is more than
adequate and avoids an additional workspace dependency. OpenDAL's
RetryLayer is applied uniformly to every operator at the call site;
no bespoke retry logic.

The integration-test docker-compose fixture mirrors apache/opendal's
own HDFS fixture (fixtures/hdfs/docker-compose-hdfs-cluster.yml):
the same bde2020 hadoop-namenode and hadoop-datanode images, both
running in host network mode. Host networking is required because
hdfs-native 0.13.5 connects to the DataNode by IP from
DatanodeIdProto.ip_addr; on a docker bridge the DN would register
with an unroutable bridge IP. Host networking works on Linux CI
runners but has known issues on macOS / Windows Docker Desktop, so
the integration tests are marked `#[ignore]` and CI explicitly opts
them in via `cargo nextest --run-ignored=only -E 'test(file_io_hdfs)'`
in the existing Linux-only tests job in .github/workflows/ci.yml.
```

## Are these changes tested?

Yes, we have unit tests to ensure appropriate caching per name service as well as integration tests at parity with other storage backends.