### PR TITLE
feat(runtime): add `RuntimeTracer` trait for task instrumentation

### DIFF
--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -90,7 +90,7 @@ pub mod transaction;
 pub mod transform;
 
 mod runtime;
-pub use runtime::{Runtime, RuntimeHandle};
+pub use runtime::{Runtime, RuntimeHandle, RuntimeTracer};
 
 pub mod arrow;
 pub(crate) mod delete_file_index;

--- a/crates/iceberg/src/runtime/mod.rs
+++ b/crates/iceberg/src/runtime/mod.rs
@@ -17,12 +17,16 @@
 
 // This module contains the async runtime abstraction for iceberg.
 
+mod tracer;
+
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use tokio::task;
+pub use tracer::RuntimeTracer;
 
 use crate::{Error, ErrorKind, Result};
 
@@ -57,35 +61,59 @@ impl<T: Send + 'static> Future for JoinHandle<T> {
 #[derive(Clone)]
 pub struct RuntimeHandle {
     handle: tokio::runtime::Handle,
+    tracer: Option<Arc<dyn RuntimeTracer>>,
 }
 
 impl fmt::Debug for RuntimeHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RuntimeHandle").finish()
+        f.debug_struct("RuntimeHandle")
+            .field("has_tracer", &self.tracer.is_some())
+            .finish()
     }
 }
 
 impl RuntimeHandle {
     fn from_tokio_handle(handle: tokio::runtime::Handle) -> Self {
-        Self { handle }
+        Self {
+            handle,
+            tracer: None,
+        }
     }
 
     /// Spawn an async task.
+    ///
+    /// If a [`RuntimeTracer`] is attached, the future is wrapped with
+    /// instrumentation before spawning.
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        JoinHandle(self.handle.spawn(future))
+        match &self.tracer {
+            Some(tracer) => {
+                let traced = tracer::trace_future(tracer.as_ref(), future);
+                JoinHandle(self.handle.spawn(traced))
+            }
+            None => JoinHandle(self.handle.spawn(future)),
+        }
     }
 
     /// Spawn a blocking task.
+    ///
+    /// If a [`RuntimeTracer`] is attached, the closure is wrapped with
+    /// instrumentation before spawning.
     pub fn spawn_blocking<F, T>(&self, f: F) -> JoinHandle<T>
     where
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
     {
-        JoinHandle(self.handle.spawn_blocking(f))
+        match &self.tracer {
+            Some(tracer) => {
+                let traced = tracer::trace_block(tracer.as_ref(), f);
+                JoinHandle(self.handle.spawn_blocking(traced))
+            }
+            None => JoinHandle(self.handle.spawn_blocking(f)),
+        }
     }
 }
 
@@ -135,6 +163,17 @@ impl Runtime {
             io: RuntimeHandle::from_tokio_handle(io_runtime.handle().clone()),
             cpu: RuntimeHandle::from_tokio_handle(cpu_runtime.handle().clone()),
         }
+    }
+
+    /// Attach a [`RuntimeTracer`] to both IO and CPU handles.
+    ///
+    /// Every future or blocking closure spawned through this runtime will be
+    /// passed through the tracer, allowing callers to inject instrumentation
+    /// (e.g. tracing spans, metrics) without modifying spawn sites.
+    pub fn with_tracer(mut self, tracer: Arc<dyn RuntimeTracer>) -> Self {
+        self.io.tracer = Some(tracer.clone());
+        self.cpu.tracer = Some(tracer);
+        self
     }
 
     /// Borrows the tokio runtime the caller is currently running in.
@@ -308,5 +347,123 @@ mod tests {
         let handle = rt.io().spawn(async { 1 });
         let result = driver.block_on(handle);
         assert!(result.is_err(), "expected error after runtime shutdown");
+    }
+
+    mod tracer_tests {
+        use std::any::Any;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures::future::BoxFuture;
+
+        use super::*;
+
+        struct CountingTracer {
+            futures_count: AtomicUsize,
+            blocks_count: AtomicUsize,
+        }
+
+        impl CountingTracer {
+            fn new() -> Self {
+                Self {
+                    futures_count: AtomicUsize::new(0),
+                    blocks_count: AtomicUsize::new(0),
+                }
+            }
+        }
+
+        impl RuntimeTracer for CountingTracer {
+            fn trace_future(
+                &self,
+                fut: BoxFuture<'static, Box<dyn Any + Send>>,
+            ) -> BoxFuture<'static, Box<dyn Any + Send>> {
+                self.futures_count.fetch_add(1, Ordering::Relaxed);
+                fut
+            }
+
+            fn trace_block(
+                &self,
+                f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
+            ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
+                self.blocks_count.fetch_add(1, Ordering::Relaxed);
+                f
+            }
+        }
+
+        #[test]
+        fn test_tracer_called_on_spawn() {
+            let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let tracer = Arc::new(CountingTracer::new());
+            let rt = Runtime::new(&tokio_rt).with_tracer(tracer.clone());
+
+            let handle = rt.io().spawn(async { 42 });
+            let result = tokio_rt.block_on(handle).unwrap();
+            assert_eq!(result, 42);
+            assert_eq!(tracer.futures_count.load(Ordering::Relaxed), 1);
+        }
+
+        #[test]
+        fn test_tracer_called_on_spawn_blocking() {
+            let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let tracer = Arc::new(CountingTracer::new());
+            let rt = Runtime::new(&tokio_rt).with_tracer(tracer.clone());
+
+            let handle = rt.cpu().spawn_blocking(|| 99);
+            let result = tokio_rt.block_on(handle).unwrap();
+            assert_eq!(result, 99);
+            assert_eq!(tracer.blocks_count.load(Ordering::Relaxed), 1);
+        }
+
+        #[test]
+        fn test_tracer_counts_multiple_spawns() {
+            let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let tracer = Arc::new(CountingTracer::new());
+            let rt = Runtime::new(&tokio_rt).with_tracer(tracer.clone());
+
+            tokio_rt.block_on(async {
+                rt.io().spawn(async { 1 }).await.unwrap();
+                rt.io().spawn(async { 2 }).await.unwrap();
+                rt.cpu().spawn(async { 3 }).await.unwrap();
+                rt.cpu().spawn_blocking(|| 4).await.unwrap();
+                rt.cpu().spawn_blocking(|| 5).await.unwrap();
+            });
+
+            assert_eq!(tracer.futures_count.load(Ordering::Relaxed), 3);
+            assert_eq!(tracer.blocks_count.load(Ordering::Relaxed), 2);
+        }
+
+        #[test]
+        fn test_no_tracer_passthrough() {
+            let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let rt = Runtime::new(&tokio_rt);
+
+            let handle = rt.io().spawn(async { "no tracer" });
+            let result = tokio_rt.block_on(handle).unwrap();
+            assert_eq!(result, "no tracer");
+        }
+
+        #[test]
+        fn test_with_tracer_debug_output() {
+            let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let tracer = Arc::new(CountingTracer::new());
+            let rt = Runtime::new(&tokio_rt).with_tracer(tracer);
+
+            let debug_str = format!("{:?}", rt.io());
+            assert!(debug_str.contains("has_tracer: true"));
+        }
     }
 }

--- a/crates/iceberg/src/runtime/mod.rs
+++ b/crates/iceberg/src/runtime/mod.rs
@@ -81,9 +81,6 @@ impl RuntimeHandle {
     }
 
     /// Spawn an async task.
-    ///
-    /// If a [`RuntimeTracer`] is attached, the future is wrapped with
-    /// instrumentation before spawning.
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
@@ -99,9 +96,6 @@ impl RuntimeHandle {
     }
 
     /// Spawn a blocking task.
-    ///
-    /// If a [`RuntimeTracer`] is attached, the closure is wrapped with
-    /// instrumentation before spawning.
     pub fn spawn_blocking<F, T>(&self, f: F) -> JoinHandle<T>
     where
         F: FnOnce() -> T + Send + 'static,

--- a/crates/iceberg/src/runtime/tracer.rs
+++ b/crates/iceberg/src/runtime/tracer.rs
@@ -46,26 +46,29 @@ pub trait RuntimeTracer: Send + Sync + 'static {
 
 /// Wraps a concrete future with the tracer, handling type erasure and
 /// restoration internally.
-pub(crate) fn trace_future<T, F>(tracer: &dyn RuntimeTracer, future: F) -> BoxFuture<'static, T>
+pub(crate) fn trace_future<T, F>(
+    tracer: &dyn RuntimeTracer,
+    future: F,
+) -> impl Future<Output = T> + Send + 'static
 where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
     let erased = async move { Box::new(future.await) as Box<dyn Any + Send> }.boxed();
 
-    tracer
-        .trace_future(erased)
-        .map(|any_box| {
-            *any_box
-                .downcast::<T>()
-                .expect("RuntimeTracer must preserve the future's output type")
-        })
-        .boxed()
+    tracer.trace_future(erased).map(|any_box| {
+        *any_box
+            .downcast::<T>()
+            .expect("RuntimeTracer must preserve the future's output type")
+    })
 }
 
 /// Wraps a concrete blocking closure with the tracer, handling type erasure and
 /// restoration internally.
-pub(crate) fn trace_block<T, F>(tracer: &dyn RuntimeTracer, f: F) -> Box<dyn FnOnce() -> T + Send>
+pub(crate) fn trace_block<T, F>(
+    tracer: &dyn RuntimeTracer,
+    f: F,
+) -> impl FnOnce() -> T + Send + 'static
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -75,9 +78,9 @@ where
 
     let traced = tracer.trace_block(erased);
 
-    Box::new(move || {
+    move || {
         *traced()
             .downcast::<T>()
             .expect("RuntimeTracer must preserve the closure's return type")
-    })
+    }
 }

--- a/crates/iceberg/src/runtime/tracer.rs
+++ b/crates/iceberg/src/runtime/tracer.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::future::Future;
+
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+/// A trait for injecting instrumentation into spawned tasks.
+///
+/// Implementations can wrap futures or blocking closures with tracing spans,
+/// metrics, or other observability hooks. The tracer receives type-erased
+/// values and must preserve the output without modification.
+pub trait RuntimeTracer: Send + Sync + 'static {
+    /// Wraps a type-erased future with instrumentation.
+    ///
+    /// The implementation must not alter the future's output value.
+    fn trace_future(
+        &self,
+        fut: BoxFuture<'static, Box<dyn Any + Send>>,
+    ) -> BoxFuture<'static, Box<dyn Any + Send>>;
+
+    /// Wraps a type-erased blocking closure with instrumentation.
+    ///
+    /// The implementation must not alter the closure's return value.
+    fn trace_block(
+        &self,
+        f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
+    ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>;
+}
+
+/// Wraps a concrete future with the tracer, handling type erasure and
+/// restoration internally.
+pub(crate) fn trace_future<T, F>(tracer: &dyn RuntimeTracer, future: F) -> BoxFuture<'static, T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let erased = async move { Box::new(future.await) as Box<dyn Any + Send> }.boxed();
+
+    tracer
+        .trace_future(erased)
+        .map(|any_box| {
+            *any_box
+                .downcast::<T>()
+                .expect("RuntimeTracer must preserve the future's output type")
+        })
+        .boxed()
+}
+
+/// Wraps a concrete blocking closure with the tracer, handling type erasure and
+/// restoration internally.
+pub(crate) fn trace_block<T, F>(tracer: &dyn RuntimeTracer, f: F) -> Box<dyn FnOnce() -> T + Send>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let erased: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> =
+        Box::new(|| Box::new(f()) as Box<dyn Any + Send>);
+
+    let traced = tracer.trace_block(erased);
+
+    Box::new(move || {
+        *traced()
+            .downcast::<T>()
+            .expect("RuntimeTracer must preserve the closure's return type")
+    })
+}


### PR DESCRIPTION
Allows callers to inject observability (tracing spans, metrics, etc.) into spawned tasks without modifying spawn sites. Inspired by DataFusion's [JoinSetTracer](https://docs.rs/datafusion-common-runtime/latest/datafusion_common_runtime/trait.JoinSetTracer.html) but scoped per-Runtime rather than global, enabling different tracers for IO vs CPU handles.


### Why `RuntimeTracer` instead of tokio's native tracing?

iceberg-rust is a library, it shouldn't dictate the observability stack. `RuntimeTracer` provides a spawn-site hook that lets consumers inject their own instrumentation without coupling the library to any specific tracing crate.

| Concern | tokio tracing | `RuntimeTracer` |
|---------|---------------|-----------------|
| Dependency | Requires `tracing` crate in the library | Zero added dependencies |
| Stack choice | Tied to `tracing` ecosystem (subscribers, layers) | Stack-neutral — implement with `tracing`, OTel, Prometheus, `log`, or anything else |
| Split runtimes | No concept of IO vs CPU categorization | Hooks are attached per-`RuntimeHandle`, so IO and CPU work are distinguishable |
| Control | Library authors decide what to instrument | Library consumers decide what to instrument |

The two approaches are complementary: a consumer could implement `RuntimeTracer` to attach a `tracing::Span`, getting tokio-console visibility *and* library-level spawn-site context without iceberg taking an opinion.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2468 

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->