### PR TITLE
fix: include missing crates in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,14 @@ jobs:
         package:
           - "crates/iceberg"
           - "crates/storage/opendal"
-          - "crates/catalog/glue"
-          - "crates/catalog/hms"
           - "crates/catalog/rest"
-          - "crates/catalog/s3tables"
           - "crates/catalog/sql"
+          - "crates/integrations/cache-moka"
           - "crates/integrations/datafusion"
+          - "crates/catalog/hms"
+          - "crates/catalog/glue"
+          - "crates/catalog/s3tables"
+          - "crates/catalog/loader"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ The Apache Iceberg Rust project is composed of the following components:
 | Name                          | Release                                                                  | Docs                                                                                                            |
 |-------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | [iceberg]                     | [![iceberg image]][iceberg link]                                         | [![docs release]][iceberg release docs] [![docs dev]][iceberg dev docs]                                         |
-| [iceberg-catalog-loader]      | [![iceberg-catalog-loader image]][iceberg-catalog-loader link]           | [![docs release]][iceberg-catalog-loader release docs] [![docs dev]][iceberg-catalog-loader dev docs]           |
-| [iceberg-catalog-glue]        | [![iceberg-catalog-glue image]][iceberg-catalog-glue link]               | [![docs release]][iceberg-catalog-glue release docs] [![docs dev]][iceberg-catalog-glue dev docs]               |
-| [iceberg-catalog-hms]         | [![iceberg-catalog-hms image]][iceberg-catalog-hms link]                 | [![docs release]][iceberg-catalog-hms release docs] [![docs dev]][iceberg-catalog-hms dev docs]                 |
+| [iceberg-storage-opendal]     | [![iceberg-storage-opendal image]][iceberg-storage-opendal link]         | [![docs release]][iceberg-storage-opendal release docs] [![docs dev]][iceberg-storage-opendal dev docs]         |
 | [iceberg-catalog-rest]        | [![iceberg-catalog-rest image]][iceberg-catalog-rest link]               | [![docs release]][iceberg-catalog-rest release docs] [![docs dev]][iceberg-catalog-rest dev docs]               |
-| [iceberg-catalog-s3tables]    | [![iceberg-catalog-s3tables image]][iceberg-catalog-s3tables link]       | [![docs release]][iceberg-catalog-s3tables release docs] [![docs dev]][iceberg-catalog-s3tables dev docs]       |
 | [iceberg-catalog-sql]         | [![iceberg-catalog-sql image]][iceberg-catalog-sql link]                 | [![docs release]][iceberg-catalog-sql release docs] [![docs dev]][iceberg-catalog-sql dev docs]                 |
 | [iceberg-cache-moka]          | [![iceberg-cache-moka image]][iceberg-cache-moka link]                   | [![docs release]][iceberg-cache-moka release docs] [![docs dev]][iceberg-cache-moka dev docs]                   |
 | [iceberg-datafusion]          | [![iceberg-datafusion image]][iceberg-datafusion link]                   | [![docs release]][iceberg-datafusion release docs] [![docs dev]][iceberg-datafusion dev docs]                   |
-| [iceberg-storage-opendal]     | [![iceberg-storage-opendal image]][iceberg-storage-opendal link]         | [![docs release]][iceberg-storage-opendal release docs] [![docs dev]][iceberg-storage-opendal dev docs]         |
+| [iceberg-catalog-hms]         | [![iceberg-catalog-hms image]][iceberg-catalog-hms link]                 | [![docs release]][iceberg-catalog-hms release docs] [![docs dev]][iceberg-catalog-hms dev docs]                 |
+| [iceberg-catalog-glue]        | [![iceberg-catalog-glue image]][iceberg-catalog-glue link]               | [![docs release]][iceberg-catalog-glue release docs] [![docs dev]][iceberg-catalog-glue dev docs]               |
+| [iceberg-catalog-s3tables]    | [![iceberg-catalog-s3tables image]][iceberg-catalog-s3tables link]       | [![docs release]][iceberg-catalog-s3tables release docs] [![docs dev]][iceberg-catalog-s3tables dev docs]       |
+| [iceberg-catalog-loader]      | [![iceberg-catalog-loader image]][iceberg-catalog-loader link]           | [![docs release]][iceberg-catalog-loader release docs] [![docs dev]][iceberg-catalog-loader dev docs]           |
 
 [docs release]: https://img.shields.io/badge/docs-release-blue
 [docs dev]: https://img.shields.io/badge/docs-dev-blue
@@ -48,23 +48,11 @@ The Apache Iceberg Rust project is composed of the following components:
 [iceberg release docs]: https://docs.rs/iceberg
 [iceberg dev docs]: https://rust.iceberg.apache.org/api/iceberg/
 
-[iceberg-datafusion]: crates/integrations/datafusion/README.md
-[iceberg-datafusion image]: https://img.shields.io/crates/v/iceberg-datafusion.svg
-[iceberg-datafusion link]: https://crates.io/crates/iceberg-datafusion
-[iceberg-datafusion dev docs]: https://rust.iceberg.apache.org/api/iceberg_datafusion/
-[iceberg-datafusion release docs]: https://docs.rs/iceberg-datafusion
-
-[iceberg-catalog-glue]: crates/catalog/glue/README.md
-[iceberg-catalog-glue image]: https://img.shields.io/crates/v/iceberg-catalog-glue.svg
-[iceberg-catalog-glue link]: https://crates.io/crates/iceberg-catalog-glue
-[iceberg-catalog-glue release docs]: https://docs.rs/iceberg-catalog-glue
-[iceberg-catalog-glue dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_glue/
-
-[iceberg-catalog-hms]: crates/catalog/hms/README.md
-[iceberg-catalog-hms image]: https://img.shields.io/crates/v/iceberg-catalog-hms.svg
-[iceberg-catalog-hms link]: https://crates.io/crates/iceberg-catalog-hms
-[iceberg-catalog-hms release docs]: https://docs.rs/iceberg-catalog-hms
-[iceberg-catalog-hms dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_hms/
+[iceberg-storage-opendal]: crates/storage/opendal/README.md
+[iceberg-storage-opendal image]: https://img.shields.io/crates/v/iceberg-storage-opendal.svg
+[iceberg-storage-opendal link]: https://crates.io/crates/iceberg-storage-opendal
+[iceberg-storage-opendal release docs]: https://docs.rs/iceberg-storage-opendal
+[iceberg-storage-opendal dev docs]: https://rust.iceberg.apache.org/api/iceberg_storage_opendal/
 
 [iceberg-catalog-rest]: crates/catalog/rest/README.md
 [iceberg-catalog-rest image]: https://img.shields.io/crates/v/iceberg-catalog-rest.svg
@@ -78,29 +66,41 @@ The Apache Iceberg Rust project is composed of the following components:
 [iceberg-catalog-sql release docs]: https://docs.rs/iceberg-catalog-sql
 [iceberg-catalog-sql dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_sql/
 
+[iceberg-cache-moka]: crates/integrations/cache-moka
+[iceberg-cache-moka image]: https://img.shields.io/crates/v/iceberg-cache-moka.svg
+[iceberg-cache-moka link]: https://crates.io/crates/iceberg-cache-moka
+[iceberg-cache-moka release docs]: https://docs.rs/iceberg-cache-moka
+[iceberg-cache-moka dev docs]: https://rust.iceberg.apache.org/api/iceberg_cache_moka/
+
+[iceberg-datafusion]: crates/integrations/datafusion/README.md
+[iceberg-datafusion image]: https://img.shields.io/crates/v/iceberg-datafusion.svg
+[iceberg-datafusion link]: https://crates.io/crates/iceberg-datafusion
+[iceberg-datafusion dev docs]: https://rust.iceberg.apache.org/api/iceberg_datafusion/
+[iceberg-datafusion release docs]: https://docs.rs/iceberg-datafusion
+
+[iceberg-catalog-hms]: crates/catalog/hms/README.md
+[iceberg-catalog-hms image]: https://img.shields.io/crates/v/iceberg-catalog-hms.svg
+[iceberg-catalog-hms link]: https://crates.io/crates/iceberg-catalog-hms
+[iceberg-catalog-hms release docs]: https://docs.rs/iceberg-catalog-hms
+[iceberg-catalog-hms dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_hms/
+
+[iceberg-catalog-glue]: crates/catalog/glue/README.md
+[iceberg-catalog-glue image]: https://img.shields.io/crates/v/iceberg-catalog-glue.svg
+[iceberg-catalog-glue link]: https://crates.io/crates/iceberg-catalog-glue
+[iceberg-catalog-glue release docs]: https://docs.rs/iceberg-catalog-glue
+[iceberg-catalog-glue dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_glue/
+
 [iceberg-catalog-s3tables]: crates/catalog/s3tables/README.md
 [iceberg-catalog-s3tables image]: https://img.shields.io/crates/v/iceberg-catalog-s3tables.svg
 [iceberg-catalog-s3tables link]: https://crates.io/crates/iceberg-catalog-s3tables
 [iceberg-catalog-s3tables release docs]: https://docs.rs/iceberg-catalog-s3tables
 [iceberg-catalog-s3tables dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_s3tables/
 
-[iceberg-storage-opendal]: crates/storage/opendal/README.md
-[iceberg-storage-opendal image]: https://img.shields.io/crates/v/iceberg-storage-opendal.svg
-[iceberg-storage-opendal link]: https://crates.io/crates/iceberg-storage-opendal
-[iceberg-storage-opendal release docs]: https://docs.rs/iceberg-storage-opendal
-[iceberg-storage-opendal dev docs]: https://rust.iceberg.apache.org/api/iceberg_storage_opendal/
-
 [iceberg-catalog-loader]: crates/catalog/loader
 [iceberg-catalog-loader image]: https://img.shields.io/crates/v/iceberg-catalog-loader.svg
 [iceberg-catalog-loader link]: https://crates.io/crates/iceberg-catalog-loader
 [iceberg-catalog-loader release docs]: https://docs.rs/iceberg-catalog-loader
 [iceberg-catalog-loader dev docs]: https://rust.iceberg.apache.org/api/iceberg_catalog_loader/
-
-[iceberg-cache-moka]: crates/integrations/cache-moka
-[iceberg-cache-moka image]: https://img.shields.io/crates/v/iceberg-cache-moka.svg
-[iceberg-cache-moka link]: https://crates.io/crates/iceberg-cache-moka
-[iceberg-cache-moka release docs]: https://docs.rs/iceberg-cache-moka
-[iceberg-cache-moka dev docs]: https://rust.iceberg.apache.org/api/iceberg_cache_moka/
 
 ## Iceberg Rust Implementation Status
 

--- a/crates/integrations/cache-moka/Cargo.toml
+++ b/crates/integrations/cache-moka/Cargo.toml
@@ -18,6 +18,10 @@
 [package]
 name = "iceberg-cache-moka"
 
+categories = ["caching"]
+description = "Apache Iceberg Moka cache implementation"
+keywords = ["iceberg", "cache", "moka"]
+
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

- None.

## What changes are included in this PR?

- Add `iceberg-cache-moka` and `iceberg-catalog-loader` to the publish workflow so all README-listed crates are released.
- Use dependency-aware publish ordering: core `iceberg` first, then storage, then crates that only depend on `iceberg`, then storage-backed catalog crates, and `iceberg-catalog-loader` last because it depends on catalog crates.
- Add missing crates.io metadata for `iceberg-cache-moka`.
- Align README component order with the publish order. This change is not necessary, but the publish matrix order is explicitly meaningful, and the README is the component table users see when comparing crate release status.

## Are these changes tested?

The actual publish workflow is only exercised on release tags, so the relevant local validation is a Cargo publish dry run.
