### PR TITLE
fix(spec): don't panic on overwrite-truncate when previous totals exceed i32::MAX or are non-numeric

### DIFF
--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -347,12 +347,10 @@ pub(crate) fn update_snapshot_summaries(
 
     let mut summary = match previous_summary {
         Some(prev_summary) if truncate_full_table && summary.operation == Operation::Overwrite => {
-            truncate_table_summary(summary, prev_summary)
-                .map_err(|err| {
-                    Error::new(ErrorKind::Unexpected, "Failed to truncate table summary.")
-                        .with_source(err)
-                })
-                .unwrap()
+            truncate_table_summary(summary, prev_summary).map_err(|err| {
+                Error::new(ErrorKind::Unexpected, "Failed to truncate table summary.")
+                    .with_source(err)
+            })?
         }
         _ => summary,
     };
@@ -407,16 +405,16 @@ pub(crate) fn update_snapshot_summaries(
     Ok(summary)
 }
 
-fn get_prop(previous_summary: &Summary, prop: &str) -> Result<i32> {
+fn get_prop(previous_summary: &Summary, prop: &str) -> Result<u64> {
     let value_str = previous_summary
         .additional_properties
         .get(prop)
         .map(String::as_str)
         .unwrap_or("0");
-    value_str.parse::<i32>().map_err(|err| {
+    value_str.parse::<u64>().map_err(|err| {
         Error::new(
             ErrorKind::Unexpected,
-            "Failed to parse value from previous summary property.",
+            format!("Failed to parse summary property '{prop}' value '{value_str}' as u64."),
         )
         .with_source(err)
     })
@@ -708,6 +706,83 @@ mod tests {
                 .get(REMOVED_EQUALITY_DELETES)
                 .unwrap(),
             "2"
+        );
+    }
+
+    #[test]
+    fn test_update_snapshot_summaries_overwrite_truncate_handles_totals_above_i32_max() {
+        // A table can legitimately accumulate more than i32::MAX rows or files
+        // over its lifetime. Truncating such a table on overwrite must succeed
+        // and surface the previous totals into the deleted-* counters.
+        let big = (i32::MAX as u64 + 1).to_string(); // 2_147_483_648
+        let prev_props: HashMap<String, String> = [
+            (TOTAL_DATA_FILES.to_string(), big.clone()),
+            (TOTAL_DELETE_FILES.to_string(), "0".to_string()),
+            (TOTAL_RECORDS.to_string(), big.clone()),
+            (TOTAL_FILE_SIZE.to_string(), "0".to_string()),
+            (TOTAL_POSITION_DELETES.to_string(), "0".to_string()),
+            (TOTAL_EQUALITY_DELETES.to_string(), "0".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let previous_summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: prev_props,
+        };
+
+        let summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: HashMap::new(),
+        };
+
+        let updated = update_snapshot_summaries(summary, Some(&previous_summary), true)
+            .expect("overwrite truncation should accept totals above i32::MAX");
+        assert_eq!(
+            updated
+                .additional_properties
+                .get(DELETED_DATA_FILES)
+                .unwrap(),
+            &big
+        );
+        assert_eq!(
+            updated.additional_properties.get(DELETED_RECORDS).unwrap(),
+            &big
+        );
+    }
+
+    #[test]
+    fn test_update_snapshot_summaries_overwrite_truncate_returns_err_on_malformed_total() {
+        // Non-numeric values in the previous summary (corruption, manual edits,
+        // a foreign implementation) must surface as a recoverable Err - not
+        // crash the process.
+        let prev_props: HashMap<String, String> = [
+            (TOTAL_DATA_FILES.to_string(), "not_a_number".to_string()),
+            (TOTAL_DELETE_FILES.to_string(), "0".to_string()),
+            (TOTAL_RECORDS.to_string(), "0".to_string()),
+            (TOTAL_FILE_SIZE.to_string(), "0".to_string()),
+            (TOTAL_POSITION_DELETES.to_string(), "0".to_string()),
+            (TOTAL_EQUALITY_DELETES.to_string(), "0".to_string()),
+        ]
+        .into_iter()
+        .collect();
+
+        let previous_summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: prev_props,
+        };
+
+        let summary = Summary {
+            operation: Operation::Overwrite,
+            additional_properties: HashMap::new(),
+        };
+
+        let err = update_snapshot_summaries(summary, Some(&previous_summary), true)
+            .expect_err("malformed previous summary must produce an Err, not a panic");
+        assert!(
+            err.message().contains("truncate table summary"),
+            "expected wrapped 'Failed to truncate table summary' context, got: {}",
+            err.message()
         );
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2510.

## What changes are included in this PR?

`update_snapshot_summaries` on the overwrite-with-truncate path was doing `truncate_table_summary(...).map_err(...).unwrap()`. The `unwrap()` turned a recoverable parse error into a process panic, and there are two ways to trip it from normal API usage.

The first is a sneaky one: `get_prop` parsed the previous snapshot's totals as `i32`, even though every other counter path in the same file already uses `u64`. So once a table accumulated more than ~2.15B data files / records / bytes (i.e. crossed `i32::MAX`), the next overwrite-with-truncate would parse-fail, hit the unwrap, and crash the writer. Quietly tableable too — nothing in the public API hints that `i32` is the secret ceiling.

The second is corruption / cross-implementation interop: any non-numeric value in a previous `total-*` property (a foreign implementation, a manual edit, a half-corrupt metadata file) produces a parse error and the same panic.

The fix is small. Widen `get_prop` to `u64` so it matches the rest of the file and lifts the artificial ceiling. Replace the `.unwrap()` with `?`, keeping the existing `\"Failed to truncate table summary.\"` wrapper as caller context so the error chain still tells you what was being attempted when the inner parse blew up. `get_prop`'s error message now includes the offending property name and value, which is what you actually need when triaging a malformed metadata file.

Scope-wise this only touches the overwrite-truncate path. `update_totals` has a structurally similar `unwrap()` antipattern that is a separate (lower-severity) issue and not included here.

## Are these changes tested?

Yes — two unit tests in `snapshot_summary.rs`, both red-state proven against the unfixed code:

The first asserts that a previous summary with `total-data-files = i32::MAX + 1` (and `total-records` similarly) survives the truncation and lands in `deleted-data-files` / `deleted-records` intact. Against the unfixed code this panics at `snapshot_summary.rs:356:18` with `\"number too large to fit in target type\"` — that's the i32-ceiling bug demonstrated directly.

The second feeds `\"not_a_number\"` as a previous total and asserts the function returns an `Err` whose message carries the `\"truncate table summary\"` wrapper. Against the unfixed code this panics at the same site with `\"invalid digit found in string\"` — the malformed-input bug.

I ran each test against the unfixed code, observed the panic, applied the fix, and watched them go green. Existing `test_truncate_table_summary` and `test_update_snapshot_summaries_append` continue to pass, and `cargo fmt --check` / `cargo clippy --all-features --tests -- -D warnings` are clean.