### PR TITLE
chore(spec): remove stale #[allow(dead_code)] from snapshot_summary

### DIFF
--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -329,7 +329,6 @@ where T: PartialOrd + Default + ToString {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn update_snapshot_summaries(
     summary: Summary,
     previous_summary: Option<&Summary>,
@@ -408,7 +407,6 @@ pub(crate) fn update_snapshot_summaries(
     Ok(summary)
 }
 
-#[allow(dead_code)]
 fn get_prop(previous_summary: &Summary, prop: &str) -> Result<i32> {
     let value_str = previous_summary
         .additional_properties
@@ -424,7 +422,6 @@ fn get_prop(previous_summary: &Summary, prop: &str) -> Result<i32> {
     })
 }
 
-#[allow(dead_code)]
 fn truncate_table_summary(mut summary: Summary, previous_summary: &Summary) -> Result<Summary> {
     for prop in [
         TOTAL_DATA_FILES,
@@ -481,7 +478,6 @@ fn truncate_table_summary(mut summary: Summary, previous_summary: &Summary) -> R
     Ok(summary)
 }
 
-#[allow(dead_code)]
 fn update_totals(
     summary: &mut Summary,
     previous_summary: Option<&Summary>,


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to review feedback on #2511 ([thread](https://github.com/apache/iceberg-rust/pull/2511#discussion_r3303563092)).

## What changes are included in this PR?

Removes all four `#[allow(dead_code)]` attributes in `crates/iceberg/src/spec/snapshot_summary.rs`. They were added in #1085 when the module was first introduced, before any caller existed. The chain is now production-live:

- `update_snapshot_summaries` is called from `transaction/snapshot.rs`
- `truncate_table_summary` is called from `update_snapshot_summaries`
- `get_prop` is called 6 times from `truncate_table_summary`
- `update_totals` is called 6 times from `update_snapshot_summaries`

None of these need the suppression any more — the dead_code lint is silent without them.

Kept out of #2511 to keep that PR's scope focused on the overwrite-truncate panic fix.

## Are these changes tested?

`cargo check -p iceberg` and `cargo clippy -p iceberg --all-features --tests -- -D warnings` both stay clean after the removals — i.e. no dead_code warning re-emerges.