### PR TITLE
feat(iceberg): log warning when available_parallelism falls back to default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,6 +3562,7 @@ dependencies = [
  "strum",
  "tempfile",
  "tokio",
+ "tracing",
  "typed-builder",
  "typetag",
  "url",

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -75,6 +75,7 @@ serde_repr = { workspace = true }
 serde_with = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, optional = false }
+tracing = { workspace = true }
 typed-builder = { workspace = true }
 typetag = { workspace = true }
 url = { workspace = true }

--- a/crates/iceberg/src/util/mod.rs
+++ b/crates/iceberg/src/util/mod.rs
@@ -35,11 +35,11 @@ const DEFAULT_PARALLELISM: usize = 1;
 /// parallelism can change during the lifetime of an executing
 /// process, but this should not be called in a hot loop.
 pub(crate) fn available_parallelism() -> NonZeroUsize {
-    std::thread::available_parallelism().unwrap_or_else(|_err| {
-        // Failed to get the level of parallelism.
-        // TODO: log/trace when this fallback occurs.
-
-        // Using a default value.
+    std::thread::available_parallelism().unwrap_or_else(|err| {
+        tracing::warn!(
+            error = %err,
+            "Failed to determine available parallelism; falling back to {DEFAULT_PARALLELISM}",
+        );
         NonZeroUsize::new(DEFAULT_PARALLELISM).unwrap()
     })
 }


### PR DESCRIPTION
## Which issue does this PR close?

Resolves the in-code `TODO` at `crates/iceberg/src/util/mod.rs:40` (no tracking issue).

## What changes are included in this PR?

When `std::thread::available_parallelism()` fails, `available_parallelism()` falls back to `DEFAULT_PARALLELISM` (= 1). Both call sites — `TableScanBuilder::new` and `ArrowReaderBuilder::new` — use this value to size their internal concurrency, so a silent fallback turns parallel execution into serial with no signal to the operator.

This PR emits a `tracing::warn!` carrying the underlying error so the degraded state is observable, e.g.:

```text
WARN error=...: Failed to determine available parallelism; falling back to 1
```

The `iceberg` crate gains a direct `tracing` dependency. `tracing` is already declared at the workspace level and is the agreed logging facade (per the conclusion of #482).

## Are these changes tested?

No new unit test. `std::thread::available_parallelism()` succeeds on every standard CI environment and cannot be forced to fail without mocking the standard library, so a fallback-path test would require either:

- a `cfg(test)` indirection layer to inject a mock `available_parallelism()`, or
- a custom runner inside a cgroup that artificially constrains parallelism.

Both seemed disproportionate for a one-line observability change. Existing callers (`TableScanBuilder`, `ArrowReaderBuilder`) continue to receive a valid `NonZeroUsize` on success, exercised by the existing test suite. Happy to add either approach if reviewers prefer.

Verified locally:

- `cargo check -p iceberg`
- `cargo test -p iceberg --lib util::`
- `cargo clippy -p iceberg --all-targets -- -D warnings`
- `cargo fmt -p iceberg --check`