### PR TITLE
fix: add space in decimal type serialization for cross-engine compat

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -340,7 +340,7 @@ fn serialize_decimal<S>(
 where
     S: Serializer,
 {
-    serializer.serialize_str(&format!("decimal({precision},{scale})"))
+    serializer.serialize_str(&format!("decimal({precision}, {scale})"))
 }
 
 fn deserialize_fixed<'de, D>(deserializer: D) -> std::result::Result<PrimitiveType, D::Error>
@@ -370,7 +370,7 @@ impl fmt::Display for PrimitiveType {
             PrimitiveType::Float => write!(f, "float"),
             PrimitiveType::Double => write!(f, "double"),
             PrimitiveType::Decimal { precision, scale } => {
-                write!(f, "decimal({precision},{scale})")
+                write!(f, "decimal({precision}, {scale})")
             }
             PrimitiveType::Date => write!(f, "date"),
             PrimitiveType::Time => write!(f, "time"),
@@ -874,7 +874,7 @@ mod tests {
             {"id": 3, "name": "long_field", "required": true, "type": "long"},
             {"id": 4, "name": "float_field", "required": true, "type": "float"},
             {"id": 5, "name": "double_field", "required": true, "type": "double"},
-            {"id": 6, "name": "decimal_field", "required": true, "type": "decimal(9,2)"},
+            {"id": 6, "name": "decimal_field", "required": true, "type": "decimal(9, 2)"},
             {"id": 7, "name": "date_field", "required": true, "type": "date"},
             {"id": 8, "name": "time_field", "required": true, "type": "time"},
             {"id": 9, "name": "timestamp_field", "required": true, "type": "timestamp"},


### PR DESCRIPTION
## Summary

iceberg-rust serializes the decimal type as `decimal(P,S)` (no space), while the Iceberg spec, Java, and Python all use `decimal(P, S)` (space after comma). This mismatch can cause issues when metadata written by iceberg-rust is read by strict parsers in other implementations.

### What changed

- `serialize_decimal`: `decimal({precision},{scale})` → `decimal({precision}, {scale})`
- `Display for PrimitiveType`: same fix for the decimal arm
- Updated the one test fixture that asserted the old format

### Why this is safe

The deserializer already uses `.trim()` on both precision and scale components, so it accepts both `decimal(9,2)` and `decimal(9, 2)`. Existing metadata files with the old format continue to be readable.

Closes #2534

## Test plan

- [x] All 1300+ iceberg crate tests pass
- [x] Workspace compiles cleanly
- [x] Backwards compat: deserializer handles both formats via trim()