### PR TITLE
chore(refactor): add manifest list reader

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -677,7 +677,7 @@ impl Catalog for GlueCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(table_info).await
+        iceberg::drop_table_data(&table_info).await
     }
 
     /// Asynchronously checks the existence of a specified table

--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -677,12 +677,7 @@ impl Catalog for GlueCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(
-            table_info.file_io(),
-            table_info.metadata(),
-            table_info.metadata_location(),
-        )
-        .await
+        iceberg::drop_table_data(table_info).await
     }
 
     /// Asynchronously checks the existence of a specified table

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -624,12 +624,7 @@ impl Catalog for HmsCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(
-            table_info.file_io(),
-            table_info.metadata(),
-            table_info.metadata_location(),
-        )
-        .await
+        iceberg::drop_table_data(table_info).await
     }
 
     /// Asynchronously checks the existence of a specified table

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -624,7 +624,7 @@ impl Catalog for HmsCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(table_info).await
+        iceberg::drop_table_data(&table_info).await
     }
 
     /// Asynchronously checks the existence of a specified table

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -774,12 +774,7 @@ impl Catalog for SqlCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(
-            table_info.file_io(),
-            table_info.metadata(),
-            table_info.metadata_location(),
-        )
-        .await
+        iceberg::drop_table_data(table_info).await
     }
 
     async fn load_table(&self, identifier: &TableIdent) -> Result<Table> {

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -774,7 +774,7 @@ impl Catalog for SqlCatalog {
     async fn purge_table(&self, table: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table).await?;
         self.drop_table(table).await?;
-        iceberg::drop_table_data(table_info).await
+        iceberg::drop_table_data(&table_info).await
     }
 
     async fn load_table(&self, identifier: &TableIdent) -> Result<Table> {

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2025,9 +2025,6 @@ pub fn iceberg::spec::ManifestList::eq(&self, other: &iceberg::spec::ManifestLis
 impl core::fmt::Debug for iceberg::spec::ManifestList
 pub fn iceberg::spec::ManifestList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::spec::ManifestList
-pub struct iceberg::spec::ManifestListReader
-impl iceberg::spec::ManifestListReader
-pub async fn iceberg::spec::ManifestListReader::load(&self) -> iceberg::Result<iceberg::spec::ManifestList>
 pub struct iceberg::spec::ManifestListWriter
 impl iceberg::spec::ManifestListWriter
 pub fn iceberg::spec::ManifestListWriter::add_manifests(&mut self, manifests: impl core::iter::traits::iterator::Iterator<Item = iceberg::spec::ManifestFile>) -> iceberg::Result<()>
@@ -3016,7 +3013,6 @@ pub fn iceberg::table::Table::current_schema_ref(&self) -> iceberg::spec::Schema
 pub fn iceberg::table::Table::file_io(&self) -> &iceberg::io::FileIO
 pub fn iceberg::table::Table::identifier(&self) -> &iceberg::TableIdent
 pub fn iceberg::table::Table::inspect(&self) -> iceberg::inspect::MetadataTable<'_>
-pub fn iceberg::table::Table::manifest_list_reader(&self, snapshot: &iceberg::spec::SnapshotRef) -> iceberg::spec::ManifestListReader
 pub fn iceberg::table::Table::metadata(&self) -> &iceberg::spec::TableMetadata
 pub fn iceberg::table::Table::metadata_location(&self) -> core::option::Option<&str>
 pub fn iceberg::table::Table::metadata_location_result(&self) -> iceberg::Result<&str>
@@ -3668,5 +3664,5 @@ pub type iceberg::memory::MemoryCatalogBuilder::C = iceberg::memory::MemoryCatal
 pub fn iceberg::memory::MemoryCatalogBuilder::load(self, name: impl core::convert::Into<alloc::string::String>, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> impl core::future::future::Future<Output = iceberg::Result<Self::C>> + core::marker::Send
 pub fn iceberg::memory::MemoryCatalogBuilder::with_runtime(self, runtime: iceberg::Runtime) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_storage_factory(self, storage_factory: alloc::sync::Arc<dyn iceberg::io::StorageFactory>) -> Self
-pub async fn iceberg::drop_table_data(io: &iceberg::io::FileIO, metadata: &iceberg::spec::TableMetadata, metadata_location: core::option::Option<&str>) -> iceberg::Result<()>
+pub async fn iceberg::drop_table_data(table_info: iceberg::table::Table) -> iceberg::Result<()>
 pub type iceberg::Result<T> = core::result::Result<T, iceberg::Error>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3668,5 +3668,5 @@ pub type iceberg::memory::MemoryCatalogBuilder::C = iceberg::memory::MemoryCatal
 pub fn iceberg::memory::MemoryCatalogBuilder::load(self, name: impl core::convert::Into<alloc::string::String>, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> impl core::future::future::Future<Output = iceberg::Result<Self::C>> + core::marker::Send
 pub fn iceberg::memory::MemoryCatalogBuilder::with_runtime(self, runtime: iceberg::Runtime) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_storage_factory(self, storage_factory: alloc::sync::Arc<dyn iceberg::io::StorageFactory>) -> Self
-pub async fn iceberg::drop_table_data(table_info: iceberg::table::Table) -> iceberg::Result<()>
+pub async fn iceberg::drop_table_data(table_info: &iceberg::table::Table) -> iceberg::Result<()>
 pub type iceberg::Result<T> = core::result::Result<T, iceberg::Error>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2025,6 +2025,9 @@ pub fn iceberg::spec::ManifestList::eq(&self, other: &iceberg::spec::ManifestLis
 impl core::fmt::Debug for iceberg::spec::ManifestList
 pub fn iceberg::spec::ManifestList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::spec::ManifestList
+pub struct iceberg::spec::ManifestListReader
+impl iceberg::spec::ManifestListReader
+pub async fn iceberg::spec::ManifestListReader::load(&self) -> iceberg::Result<iceberg::spec::ManifestList>
 pub struct iceberg::spec::ManifestListWriter
 impl iceberg::spec::ManifestListWriter
 pub fn iceberg::spec::ManifestListWriter::add_manifests(&mut self, manifests: impl core::iter::traits::iterator::Iterator<Item = iceberg::spec::ManifestFile>) -> iceberg::Result<()>
@@ -3013,6 +3016,7 @@ pub fn iceberg::table::Table::current_schema_ref(&self) -> iceberg::spec::Schema
 pub fn iceberg::table::Table::file_io(&self) -> &iceberg::io::FileIO
 pub fn iceberg::table::Table::identifier(&self) -> &iceberg::TableIdent
 pub fn iceberg::table::Table::inspect(&self) -> iceberg::inspect::MetadataTable<'_>
+pub fn iceberg::table::Table::manifest_list_reader(&self, snapshot: &iceberg::spec::SnapshotRef) -> iceberg::spec::ManifestListReader
 pub fn iceberg::table::Table::metadata(&self) -> &iceberg::spec::TableMetadata
 pub fn iceberg::table::Table::metadata_location(&self) -> core::option::Option<&str>
 pub fn iceberg::table::Table::metadata_location_result(&self) -> iceberg::Result<&str>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2025,6 +2025,9 @@ pub fn iceberg::spec::ManifestList::eq(&self, other: &iceberg::spec::ManifestLis
 impl core::fmt::Debug for iceberg::spec::ManifestList
 pub fn iceberg::spec::ManifestList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::spec::ManifestList
+pub struct iceberg::spec::ManifestListReader<'a>
+impl<'a> iceberg::spec::ManifestListReader<'a>
+pub async fn iceberg::spec::ManifestListReader<'a>::load(&self) -> iceberg::Result<iceberg::spec::ManifestList>
 pub struct iceberg::spec::ManifestListWriter
 impl iceberg::spec::ManifestListWriter
 pub fn iceberg::spec::ManifestListWriter::add_manifests(&mut self, manifests: impl core::iter::traits::iterator::Iterator<Item = iceberg::spec::ManifestFile>) -> iceberg::Result<()>
@@ -3014,6 +3017,7 @@ pub fn iceberg::table::Table::current_schema_ref(&self) -> iceberg::spec::Schema
 pub fn iceberg::table::Table::file_io(&self) -> &iceberg::io::FileIO
 pub fn iceberg::table::Table::identifier(&self) -> &iceberg::TableIdent
 pub fn iceberg::table::Table::inspect(&self) -> iceberg::inspect::MetadataTable<'_>
+pub fn iceberg::table::Table::manifest_list_reader<'a>(&'a self, snapshot: &'a iceberg::spec::Snapshot) -> iceberg::spec::ManifestListReader<'a>
 pub fn iceberg::table::Table::metadata(&self) -> &iceberg::spec::TableMetadata
 pub fn iceberg::table::Table::metadata_location(&self) -> core::option::Option<&str>
 pub fn iceberg::table::Table::metadata_location_result(&self) -> iceberg::Result<&str>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2025,9 +2025,9 @@ pub fn iceberg::spec::ManifestList::eq(&self, other: &iceberg::spec::ManifestLis
 impl core::fmt::Debug for iceberg::spec::ManifestList
 pub fn iceberg::spec::ManifestList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::spec::ManifestList
-pub struct iceberg::spec::ManifestListReader<'a>
-impl<'a> iceberg::spec::ManifestListReader<'a>
-pub async fn iceberg::spec::ManifestListReader<'a>::load(&self) -> iceberg::Result<iceberg::spec::ManifestList>
+pub struct iceberg::spec::ManifestListReader
+impl iceberg::spec::ManifestListReader
+pub async fn iceberg::spec::ManifestListReader::load(&self) -> iceberg::Result<iceberg::spec::ManifestList>
 pub struct iceberg::spec::ManifestListWriter
 impl iceberg::spec::ManifestListWriter
 pub fn iceberg::spec::ManifestListWriter::add_manifests(&mut self, manifests: impl core::iter::traits::iterator::Iterator<Item = iceberg::spec::ManifestFile>) -> iceberg::Result<()>
@@ -2343,7 +2343,6 @@ impl iceberg::spec::Snapshot
 pub fn iceberg::spec::Snapshot::added_rows_count(&self) -> core::option::Option<u64>
 pub fn iceberg::spec::Snapshot::encryption_key_id(&self) -> core::option::Option<&str>
 pub fn iceberg::spec::Snapshot::first_row_id(&self) -> core::option::Option<u64>
-pub async fn iceberg::spec::Snapshot::load_manifest_list(&self, file_io: &iceberg::io::FileIO, table_metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<iceberg::spec::ManifestList>
 pub fn iceberg::spec::Snapshot::manifest_list(&self) -> &str
 pub fn iceberg::spec::Snapshot::parent_snapshot_id(&self) -> core::option::Option<i64>
 pub fn iceberg::spec::Snapshot::row_range(&self) -> core::option::Option<(u64, u64)>
@@ -3017,7 +3016,7 @@ pub fn iceberg::table::Table::current_schema_ref(&self) -> iceberg::spec::Schema
 pub fn iceberg::table::Table::file_io(&self) -> &iceberg::io::FileIO
 pub fn iceberg::table::Table::identifier(&self) -> &iceberg::TableIdent
 pub fn iceberg::table::Table::inspect(&self) -> iceberg::inspect::MetadataTable<'_>
-pub fn iceberg::table::Table::manifest_list_reader<'a>(&'a self, snapshot: &'a iceberg::spec::Snapshot) -> iceberg::spec::ManifestListReader<'a>
+pub fn iceberg::table::Table::manifest_list_reader(&self, snapshot: &iceberg::spec::SnapshotRef) -> iceberg::spec::ManifestListReader
 pub fn iceberg::table::Table::metadata(&self) -> &iceberg::spec::TableMetadata
 pub fn iceberg::table::Table::metadata_location(&self) -> core::option::Option<&str>
 pub fn iceberg::table::Table::metadata_location_result(&self) -> iceberg::Result<&str>

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -343,12 +343,7 @@ impl Catalog for MemoryCatalog {
     async fn purge_table(&self, table_ident: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table_ident).await?;
         self.drop_table(table_ident).await?;
-        crate::catalog::utils::drop_table_data(
-            table_info.file_io(),
-            table_info.metadata(),
-            table_info.metadata_location(),
-        )
-        .await
+        crate::catalog::utils::drop_table_data(table_info).await
     }
 
     /// Check if a table exists in the catalog.

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -343,7 +343,7 @@ impl Catalog for MemoryCatalog {
     async fn purge_table(&self, table_ident: &TableIdent) -> Result<()> {
         let table_info = self.load_table(table_ident).await?;
         self.drop_table(table_ident).await?;
-        crate::catalog::utils::drop_table_data(table_info).await
+        crate::catalog::utils::drop_table_data(&table_info).await
     }
 
     /// Check if a table exists in the catalog.

--- a/crates/iceberg/src/catalog/utils.rs
+++ b/crates/iceberg/src/catalog/utils.rs
@@ -23,7 +23,7 @@ use futures::{TryStreamExt, stream};
 
 use crate::Result;
 use crate::io::FileIO;
-use crate::spec::TableMetadata;
+use crate::spec::{ManifestListReader, TableMetadata};
 
 const DELETE_CONCURRENCY: usize = 10;
 
@@ -47,7 +47,9 @@ pub async fn drop_table_data(
     // Load all manifest lists concurrently
     let results: Vec<_> =
         futures::future::try_join_all(metadata.snapshots().map(|snapshot| async {
-            let manifest_list = snapshot.load_manifest_list(io, metadata).await?;
+            let manifest_list = ManifestListReader::new(snapshot, io, metadata)
+                .load()
+                .await?;
             Ok::<_, crate::Error>((snapshot.manifest_list().to_string(), manifest_list))
         }))
         .await?;

--- a/crates/iceberg/src/catalog/utils.rs
+++ b/crates/iceberg/src/catalog/utils.rs
@@ -23,7 +23,7 @@ use futures::{TryStreamExt, stream};
 
 use crate::Result;
 use crate::io::FileIO;
-use crate::spec::{ManifestListReader, TableMetadata, TableMetadataRef};
+use crate::table::Table;
 
 const DELETE_CONCURRENCY: usize = 10;
 
@@ -36,22 +36,16 @@ const DELETE_CONCURRENCY: usize = 10;
 /// Data files within manifests are only deleted if the `gc.enabled` table
 /// property is `true` (the default), to avoid corrupting other tables that
 /// may share the same data files.
-pub async fn drop_table_data(
-    io: &FileIO,
-    metadata: &TableMetadata,
-    metadata_location: Option<&str>,
-) -> Result<()> {
+pub async fn drop_table_data(table_info: Table) -> Result<()> {
     let mut manifest_lists_to_delete: HashSet<String> = HashSet::new();
     let mut manifests_to_delete: HashSet<String> = HashSet::new();
 
-    let metadata_ref = TableMetadataRef::new(metadata.clone());
+    let metadata = table_info.metadata_ref();
+    let io = table_info.file_io();
     // Load all manifest lists concurrently
     let results: Vec<_> =
         futures::future::try_join_all(metadata.snapshots().map(|snapshot| async {
-            let manifest_list =
-                ManifestListReader::new(snapshot.clone(), io.clone(), metadata_ref.clone())
-                    .load()
-                    .await?;
+            let manifest_list = table_info.manifest_list_reader(snapshot).load().await?;
             Ok::<_, crate::Error>((snapshot.manifest_list().to_string(), manifest_list))
         }))
         .await?;
@@ -101,7 +95,7 @@ pub async fn drop_table_data(
         .await?;
 
     // Delete the current metadata file
-    if let Some(location) = metadata_location {
+    if let Some(location) = table_info.metadata_location() {
         io.delete(location).await?;
     }
 

--- a/crates/iceberg/src/catalog/utils.rs
+++ b/crates/iceberg/src/catalog/utils.rs
@@ -23,7 +23,7 @@ use futures::{TryStreamExt, stream};
 
 use crate::Result;
 use crate::io::FileIO;
-use crate::spec::{ManifestListReader, TableMetadata};
+use crate::spec::{ManifestListReader, TableMetadata, TableMetadataRef};
 
 const DELETE_CONCURRENCY: usize = 10;
 
@@ -44,12 +44,14 @@ pub async fn drop_table_data(
     let mut manifest_lists_to_delete: HashSet<String> = HashSet::new();
     let mut manifests_to_delete: HashSet<String> = HashSet::new();
 
+    let metadata_ref = TableMetadataRef::new(metadata.clone());
     // Load all manifest lists concurrently
     let results: Vec<_> =
         futures::future::try_join_all(metadata.snapshots().map(|snapshot| async {
-            let manifest_list = ManifestListReader::new(snapshot, io, metadata)
-                .load()
-                .await?;
+            let manifest_list =
+                ManifestListReader::new(snapshot.clone(), io.clone(), metadata_ref.clone())
+                    .load()
+                    .await?;
             Ok::<_, crate::Error>((snapshot.manifest_list().to_string(), manifest_list))
         }))
         .await?;

--- a/crates/iceberg/src/catalog/utils.rs
+++ b/crates/iceberg/src/catalog/utils.rs
@@ -36,7 +36,7 @@ const DELETE_CONCURRENCY: usize = 10;
 /// Data files within manifests are only deleted if the `gc.enabled` table
 /// property is `true` (the default), to avoid corrupting other tables that
 /// may share the same data files.
-pub async fn drop_table_data(table_info: Table) -> Result<()> {
+pub async fn drop_table_data(table_info: &Table) -> Result<()> {
     let mut manifest_lists_to_delete: HashSet<String> = HashSet::new();
     let mut manifests_to_delete: HashSet<String> = HashSet::new();
 

--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -161,9 +161,7 @@ impl<'a> ManifestsTable<'a> {
         let mut partition_summaries = self.partition_summary_builder()?;
 
         if let Some(snapshot) = self.table.metadata().current_snapshot() {
-            let manifest_list = snapshot
-                .load_manifest_list(self.table.file_io(), &self.table.metadata_ref())
-                .await?;
+            let manifest_list = self.table.manifest_list_reader(snapshot).load().await?;
             for manifest in manifest_list.entries() {
                 content.append_value(manifest.content as i32);
                 path.append_value(manifest.manifest_path.clone());

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 
 use crate::io::FileIO;
 use crate::spec::{
-    FormatVersion, Manifest, ManifestFile, ManifestList, SchemaId, SnapshotRef, TableMetadataRef,
+    FormatVersion, Manifest, ManifestFile, ManifestList, ManifestListReader, SchemaId, SnapshotRef,
+    TableMetadataRef,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -126,8 +127,8 @@ impl ObjectCache {
         table_metadata: &TableMetadataRef,
     ) -> Result<Arc<ManifestList>> {
         if self.cache_disabled {
-            return snapshot
-                .load_manifest_list(&self.file_io, table_metadata)
+            return ManifestListReader::new(snapshot, &self.file_io, table_metadata)
+                .load()
                 .await
                 .map(Arc::new);
         }
@@ -173,8 +174,8 @@ impl ObjectCache {
         snapshot: &SnapshotRef,
         table_metadata: &TableMetadataRef,
     ) -> Result<CachedItem> {
-        let manifest_list = snapshot
-            .load_manifest_list(&self.file_io, table_metadata)
+        let manifest_list = ManifestListReader::new(snapshot, &self.file_io, table_metadata)
+            .load()
             .await?;
 
         Ok(CachedItem::ManifestList(Arc::new(manifest_list)))

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -127,10 +127,14 @@ impl ObjectCache {
         table_metadata: &TableMetadataRef,
     ) -> Result<Arc<ManifestList>> {
         if self.cache_disabled {
-            return ManifestListReader::new(snapshot, &self.file_io, table_metadata)
-                .load()
-                .await
-                .map(Arc::new);
+            return ManifestListReader::new(
+                snapshot.clone(),
+                self.file_io.clone(),
+                table_metadata.clone(),
+            )
+            .load()
+            .await
+            .map(Arc::new);
         }
 
         let key = CachedObjectKey::ManifestList((
@@ -174,9 +178,13 @@ impl ObjectCache {
         snapshot: &SnapshotRef,
         table_metadata: &TableMetadataRef,
     ) -> Result<CachedItem> {
-        let manifest_list = ManifestListReader::new(snapshot, &self.file_io, table_metadata)
-            .load()
-            .await?;
+        let manifest_list = ManifestListReader::new(
+            snapshot.clone(),
+            self.file_io.clone(),
+            table_metadata.clone(),
+        )
+        .load()
+        .await?;
 
         Ok(CachedItem::ManifestList(Arc::new(manifest_list)))
     }

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -28,7 +28,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use self::_const_schema::{MANIFEST_LIST_AVRO_SCHEMA_V1, MANIFEST_LIST_AVRO_SCHEMA_V2};
 use self::_serde::{ManifestFileV1, ManifestFileV2};
-use super::{FormatVersion, Manifest, Snapshot, TableMetadata};
+use super::{FormatVersion, Manifest, SnapshotRef, TableMetadataRef};
 use crate::error::Result;
 use crate::io::{FileIO, OutputFile};
 use crate::spec::manifest_list::_const_schema::MANIFEST_LIST_AVRO_SCHEMA_V3;
@@ -92,17 +92,17 @@ impl ManifestList {
 
 /// A manifest list reader that encapsulates the logic for loading and parsing a [`ManifestList`]
 /// from a snapshot.
-pub struct ManifestListReader<'a> {
-    snapshot: &'a Snapshot,
-    file_io: &'a FileIO,
-    table_metadata: &'a TableMetadata,
+pub struct ManifestListReader {
+    snapshot: SnapshotRef,
+    file_io: FileIO,
+    table_metadata: TableMetadataRef,
 }
 
-impl<'a> ManifestListReader<'a> {
+impl ManifestListReader {
     pub(crate) fn new(
-        snapshot: &'a Snapshot,
-        file_io: &'a FileIO,
-        table_metadata: &'a TableMetadata,
+        snapshot: SnapshotRef,
+        file_io: FileIO,
+        table_metadata: TableMetadataRef,
     ) -> Self {
         Self {
             snapshot,

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -92,7 +92,7 @@ impl ManifestList {
 
 /// A manifest list reader that encapsulates the logic for loading and parsing a [`ManifestList`]
 /// from a snapshot.
-pub(crate) struct ManifestListReader {
+pub struct ManifestListReader {
     snapshot: SnapshotRef,
     file_io: FileIO,
     table_metadata: TableMetadataRef,

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -92,7 +92,7 @@ impl ManifestList {
 
 /// A manifest list reader that encapsulates the logic for loading and parsing a [`ManifestList`]
 /// from a snapshot.
-pub struct ManifestListReader {
+pub(crate) struct ManifestListReader {
     snapshot: SnapshotRef,
     file_io: FileIO,
     table_metadata: TableMetadataRef,

--- a/crates/iceberg/src/spec/manifest_list.rs
+++ b/crates/iceberg/src/spec/manifest_list.rs
@@ -28,7 +28,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use self::_const_schema::{MANIFEST_LIST_AVRO_SCHEMA_V1, MANIFEST_LIST_AVRO_SCHEMA_V2};
 use self::_serde::{ManifestFileV1, ManifestFileV2};
-use super::{FormatVersion, Manifest};
+use super::{FormatVersion, Manifest, Snapshot, TableMetadata};
 use crate::error::Result;
 use crate::io::{FileIO, OutputFile};
 use crate::spec::manifest_list::_const_schema::MANIFEST_LIST_AVRO_SCHEMA_V3;
@@ -87,6 +87,41 @@ impl ManifestList {
     /// Take ownership of the entries in the manifest list, consuming it
     pub fn consume_entries(self) -> impl IntoIterator<Item = ManifestFile> {
         Box::new(self.entries.into_iter())
+    }
+}
+
+/// A manifest list reader that encapsulates the logic for loading and parsing a [`ManifestList`]
+/// from a snapshot.
+pub struct ManifestListReader<'a> {
+    snapshot: &'a Snapshot,
+    file_io: &'a FileIO,
+    table_metadata: &'a TableMetadata,
+}
+
+impl<'a> ManifestListReader<'a> {
+    pub(crate) fn new(
+        snapshot: &'a Snapshot,
+        file_io: &'a FileIO,
+        table_metadata: &'a TableMetadata,
+    ) -> Self {
+        Self {
+            snapshot,
+            file_io,
+            table_metadata,
+        }
+    }
+
+    /// Loads and returns the [`ManifestList`] for this snapshot.
+    pub async fn load(&self) -> Result<ManifestList> {
+        let manifest_list_content = self
+            .file_io
+            .new_input(self.snapshot.manifest_list())?
+            .read()
+            .await?;
+        ManifestList::parse_with_version(
+            &manifest_list_content,
+            self.table_metadata.format_version(),
+        )
     }
 }
 

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -195,6 +195,7 @@ impl Snapshot {
     }
 
     /// Load manifest list.
+    #[deprecated(since = "0.9.0", note = "Use `Table::manifest_list_reader()` instead")]
     pub async fn load_manifest_list(
         &self,
         file_io: &FileIO,

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -27,8 +27,7 @@ use typed_builder::TypedBuilder;
 
 use super::table_metadata::SnapshotLog;
 use crate::error::{Result, timestamp_ms_to_utc};
-use crate::io::FileIO;
-use crate::spec::{ManifestList, SchemaId, SchemaRef, TableMetadata};
+use crate::spec::{SchemaId, SchemaRef, TableMetadata};
 use crate::{Error, ErrorKind};
 
 /// The ref name of the main branch of the table.
@@ -192,22 +191,6 @@ impl Snapshot {
             Some(id) => table_metadata.snapshot_by_id(id).cloned(),
             None => None,
         }
-    }
-
-    /// Load manifest list.
-    #[deprecated(since = "0.9.0", note = "Use `Table::manifest_list_reader()` instead")]
-    pub async fn load_manifest_list(
-        &self,
-        file_io: &FileIO,
-        table_metadata: &TableMetadata,
-    ) -> Result<ManifestList> {
-        let manifest_list_content = file_io.new_input(&self.manifest_list)?.read().await?;
-        ManifestList::parse_with_version(
-            &manifest_list_content,
-            // TODO: You don't really need the version since you could just project any Avro in
-            // the version that you'd like to get (probably always the latest)
-            table_metadata.format_version(),
-        )
     }
 
     #[allow(dead_code)]

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -25,7 +25,7 @@ use crate::io::FileIO;
 use crate::io::object_cache::ObjectCache;
 use crate::runtime::Runtime;
 use crate::scan::TableScanBuilder;
-use crate::spec::{SchemaRef, TableMetadata, TableMetadataRef};
+use crate::spec::{ManifestListReader, SchemaRef, Snapshot, TableMetadata, TableMetadataRef};
 use crate::{Error, ErrorKind, Result, TableIdent};
 
 /// Builder to create table scan.
@@ -262,6 +262,11 @@ impl Table {
     /// Returns the current schema as a shared reference.
     pub fn current_schema_ref(&self) -> SchemaRef {
         self.metadata.current_schema().clone()
+    }
+
+    /// Creates a [`ManifestListReader`] for the given snapshot.
+    pub fn manifest_list_reader<'a>(&'a self, snapshot: &'a Snapshot) -> ManifestListReader<'a> {
+        ManifestListReader::new(snapshot, &self.file_io, &self.metadata)
     }
 
     /// Create a reader for the table.

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -265,7 +265,7 @@ impl Table {
     }
 
     /// Creates a [`ManifestListReader`] for the given snapshot.
-    pub fn manifest_list_reader(&self, snapshot: &SnapshotRef) -> ManifestListReader {
+    pub(crate) fn manifest_list_reader(&self, snapshot: &SnapshotRef) -> ManifestListReader {
         ManifestListReader::new(
             snapshot.clone(),
             self.file_io.clone(),

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -265,7 +265,7 @@ impl Table {
     }
 
     /// Creates a [`ManifestListReader`] for the given snapshot.
-    pub(crate) fn manifest_list_reader(&self, snapshot: &SnapshotRef) -> ManifestListReader {
+    pub fn manifest_list_reader(&self, snapshot: &SnapshotRef) -> ManifestListReader {
         ManifestListReader::new(
             snapshot.clone(),
             self.file_io.clone(),

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -25,7 +25,9 @@ use crate::io::FileIO;
 use crate::io::object_cache::ObjectCache;
 use crate::runtime::Runtime;
 use crate::scan::TableScanBuilder;
-use crate::spec::{ManifestListReader, SchemaRef, Snapshot, TableMetadata, TableMetadataRef};
+use crate::spec::{
+    ManifestListReader, SchemaRef, SnapshotRef, TableMetadata, TableMetadataRef,
+};
 use crate::{Error, ErrorKind, Result, TableIdent};
 
 /// Builder to create table scan.
@@ -265,8 +267,12 @@ impl Table {
     }
 
     /// Creates a [`ManifestListReader`] for the given snapshot.
-    pub fn manifest_list_reader<'a>(&'a self, snapshot: &'a Snapshot) -> ManifestListReader<'a> {
-        ManifestListReader::new(snapshot, &self.file_io, &self.metadata)
+    pub fn manifest_list_reader(&self, snapshot: &SnapshotRef) -> ManifestListReader {
+        ManifestListReader::new(
+            snapshot.clone(),
+            self.file_io.clone(),
+            self.metadata.clone(),
+        )
     }
 
     /// Create a reader for the table.

--- a/crates/iceberg/src/table.rs
+++ b/crates/iceberg/src/table.rs
@@ -25,9 +25,7 @@ use crate::io::FileIO;
 use crate::io::object_cache::ObjectCache;
 use crate::runtime::Runtime;
 use crate::scan::TableScanBuilder;
-use crate::spec::{
-    ManifestListReader, SchemaRef, SnapshotRef, TableMetadata, TableMetadataRef,
-};
+use crate::spec::{ManifestListReader, SchemaRef, SnapshotRef, TableMetadata, TableMetadataRef};
 use crate::{Error, ErrorKind, Result, TableIdent};
 
 /// Builder to create table scan.

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -128,11 +128,10 @@ impl SnapshotProduceOperation for FastAppendOperation {
             return Ok(vec![]);
         };
 
-        let manifest_list = snapshot
-            .load_manifest_list(
-                snapshot_produce.table.file_io(),
-                &snapshot_produce.table.metadata_ref(),
-            )
+        let manifest_list = snapshot_produce
+            .table
+            .manifest_list_reader(snapshot)
+            .load()
             .await?;
 
         Ok(manifest_list
@@ -507,8 +506,9 @@ mod tests {
         } else {
             unreachable!()
         };
-        let manifest_list = new_snapshot
-            .load_manifest_list(table.file_io(), table.metadata())
+        let manifest_list = table
+            .manifest_list_reader(new_snapshot)
+            .load()
             .await
             .unwrap();
         assert_eq!(1, manifest_list.entries().len());

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -507,7 +507,7 @@ mod tests {
             unreachable!()
         };
         let manifest_list = table
-            .manifest_list_reader(new_snapshot)
+            .manifest_list_reader(&SnapshotRef::new(new_snapshot.clone()))
             .load()
             .await
             .unwrap();

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -501,13 +501,13 @@ mod tests {
         );
 
         // check manifest list
-        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
-            snapshot
+        let new_snapshot: SnapshotRef = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            SnapshotRef::new(snapshot.clone())
         } else {
             unreachable!()
         };
         let manifest_list = table
-            .manifest_list_reader(&SnapshotRef::new(new_snapshot.clone()))
+            .manifest_list_reader(&new_snapshot)
             .load()
             .await
             .unwrap();

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -161,8 +161,8 @@ mod tests {
     use crate::io::FileIO;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestEntry,
-        ManifestListReader, ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef,
-        Struct, TableMetadata,
+        ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef, Struct,
+        TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -161,7 +161,8 @@ mod tests {
     use crate::io::FileIO;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestEntry,
-        ManifestListWriter, ManifestStatus, ManifestWriterBuilder, Struct, TableMetadata,
+        ManifestListReader, ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef,
+        Struct, TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;
@@ -337,14 +338,15 @@ mod tests {
         let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
         let updates = action_commit.take_updates();
 
-        let new_snapshot = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
-            snapshot
+        let new_snapshot: SnapshotRef = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            SnapshotRef::new(snapshot.clone())
         } else {
             unreachable!("first update of a fast append should be AddSnapshot")
         };
 
-        let manifest_list = new_snapshot
-            .load_manifest_list(table.file_io(), table.metadata())
+        let manifest_list = table
+            .manifest_list_reader(&new_snapshot)
+            .load()
             .await
             .unwrap();
 

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -606,11 +606,7 @@ mod test_row_lineage {
 
         // Check written manifest for first_row_id
         let snapshot = table.metadata().current_snapshot().unwrap();
-        let manifest_list = table
-            .manifest_list_reader(snapshot)
-            .load()
-            .await
-            .unwrap();
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
 
         assert_eq!(manifest_list.entries().len(), 1);
         let manifest_file = &manifest_list.entries()[0];
@@ -632,11 +628,7 @@ mod test_row_lineage {
         assert_eq!(table.metadata().next_row_id(), 30 + 17 + 11);
 
         // Check written manifest for first_row_id
-        let manifest_list = table
-            .manifest_list_reader(snapshot)
-            .load()
-            .await
-            .unwrap();
+        let manifest_list = table.manifest_list_reader(snapshot).load().await.unwrap();
         assert_eq!(manifest_list.entries().len(), 2);
         let manifest_file = &manifest_list.entries()[1];
         assert_eq!(manifest_file.first_row_id, Some(30));

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -605,11 +605,10 @@ mod test_row_lineage {
         assert_eq!(table.metadata().next_row_id(), 30);
 
         // Check written manifest for first_row_id
+        let snapshot = table.metadata().current_snapshot().unwrap();
         let manifest_list = table
-            .metadata()
-            .current_snapshot()
-            .unwrap()
-            .load_manifest_list(table.file_io(), table.metadata())
+            .manifest_list_reader(snapshot)
+            .load()
             .await
             .unwrap();
 
@@ -634,10 +633,8 @@ mod test_row_lineage {
 
         // Check written manifest for first_row_id
         let manifest_list = table
-            .metadata()
-            .current_snapshot()
-            .unwrap()
-            .load_manifest_list(table.file_io(), table.metadata())
+            .manifest_list_reader(snapshot)
+            .load()
             .await
             .unwrap();
         assert_eq!(manifest_list.entries().len(), 2);

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -178,8 +178,10 @@ impl<'a> SnapshotProducer<'a> {
 
         let runtime = self.table.runtime();
         let file_io = self.table.file_io();
-        let manifest_list = current_snapshot
-            .load_manifest_list(file_io, &self.table.metadata_ref())
+        let manifest_list = self
+            .table
+            .manifest_list_reader(current_snapshot)
+            .load()
             .await?;
 
         let new_files_ref = &new_files;

--- a/crates/integrations/datafusion/src/physical_plan/commit.rs
+++ b/crates/integrations/datafusion/src/physical_plan/commit.rs
@@ -504,8 +504,9 @@ mod tests {
         let current_snapshot = updated_table.metadata().current_snapshot().unwrap();
 
         // Load the manifest list to verify the data files were added
-        let manifest_list = current_snapshot
-            .load_manifest_list(updated_table.file_io(), updated_table.metadata())
+        let manifest_list = updated_table
+            .manifest_list_reader(current_snapshot)
+            .load()
             .await?;
 
         // There should be at least one manifest


### PR DESCRIPTION
## Which issue does this PR close?
Refactor required for [PR](https://github.com/apache/iceberg-rust/pull/2453/changes) which adds a `ManifestListReader` which mirrors the current `ManifestListWriter`. This will allow us to carry the encryption manager here also in the linked PR
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## What changes are included in this PR?
Adds a new public struct `ManifestListReader` which carries the things required to read a manifest list. Refactors call-sites to use this new struct and adds a deprecation for the old method.
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->