### PR TITLE
feat(transaction): add RewriteManifestsAction for manifest compaction

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2752,6 +2752,8 @@ pub iceberg::spec::TableProperties::write_datafusion_fanout_enabled: bool
 pub iceberg::spec::TableProperties::write_format_default: alloc::string::String
 pub iceberg::spec::TableProperties::write_target_file_size_bytes: usize
 impl iceberg::spec::TableProperties
+pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES: &str
+pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES_DEFAULT: u64
 pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MAX_RETRY_WAIT_MS: &str
 pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MAX_RETRY_WAIT_MS_DEFAULT: u64
 pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MIN_RETRY_WAIT_MS: &str
@@ -3143,6 +3145,7 @@ pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::tr
 pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::rewrite_manifests(&self) -> iceberg::transaction::rewrite_manifests::RewriteManifestsAction
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
 pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -216,6 +216,12 @@ impl TableProperties {
     /// Default value for total maximum retry time (ms).
     pub const PROPERTY_COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT: u64 = 30 * 60 * 1000; // 30 minutes
 
+    /// Target manifest file size in bytes used by manifest-rewrite/compaction actions.
+    pub const PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES: &str =
+        "commit.manifest.target-size-bytes";
+    /// Default target manifest file size: 8 MiB (matches Java).
+    pub const PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES_DEFAULT: u64 = 8 * 1024 * 1024;
+
     /// Default file format for data files
     pub const PROPERTY_DEFAULT_FILE_FORMAT: &str = "write.format.default";
     /// Default file format for delete files

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -55,6 +55,7 @@ mod action;
 pub use action::*;
 mod append;
 mod expire_snapshots;
+mod rewrite_manifests;
 mod snapshot;
 mod sort_order;
 mod update_location;
@@ -75,6 +76,7 @@ use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
 use crate::transaction::append::FastAppendAction;
 use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
+use crate::transaction::rewrite_manifests::RewriteManifestsAction;
 use crate::transaction::sort_order::ReplaceSortOrderAction;
 use crate::transaction::update_location::UpdateLocationAction;
 use crate::transaction::update_properties::UpdatePropertiesAction;
@@ -149,6 +151,11 @@ impl Transaction {
     /// Creates a fast append action.
     pub fn fast_append(&self) -> FastAppendAction {
         FastAppendAction::new()
+    }
+
+    /// Creates a rewrite-manifests (manifest compaction) action.
+    pub fn rewrite_manifests(&self) -> RewriteManifestsAction {
+        RewriteManifestsAction::new()
     }
 
     /// Creates replace sort order action.

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -34,23 +34,13 @@ use crate::transaction::snapshot::generate_unique_snapshot_id;
 use crate::transaction::{ActionCommit, TransactionAction};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
-const META_ROOT_PATH: &str = "metadata";
-
-/// Approximate serialized cost of a single manifest entry, in bytes. Mirrors the
-/// rough order of magnitude of Avro-encoded `manifest_entry` records (header +
-/// data file struct + bounds, summarized), used as the rolling proxy because
-/// `ManifestWriter` does not currently expose its in-flight byte count.
+/// Rolling-size proxy for one manifest entry; `ManifestWriter` does not expose live byte count.
 const APPROX_BYTES_PER_ENTRY: u64 = 256;
 
-/// Bin-pack and rewrite the data manifests of the current snapshot into manifests of
-/// approximately `target_size_bytes`, mirroring Java's `RewriteManifests`. Live entries
-/// are preserved verbatim (status=Existing), so file paths, snapshot ids, sequence
-/// numbers, and v3 row lineage are unchanged. Produces a `Replace` snapshot.
-///
-/// Explicit-subset (Java parity ceiling): no `rewriteIf` predicate, no `clusterBy`,
-/// no caller-specified `specId`, no branch override (always commits to `main`). Only
-/// data manifests on the table's *default* partition spec are rewritten; manifests
-/// on older specs and delete manifests are kept untouched.
+/// Bin-pack live data manifests of the current snapshot into manifests of approximately
+/// `target_size_bytes` (Java parity: `RewriteManifests`); commits a `Replace` snapshot.
+/// Only the default partition spec is rewritten; older specs and delete manifests pass through.
+/// Holds all live entries in memory; not suitable for tables with more than ~1M data files.
 pub struct RewriteManifestsAction {
     target_size_bytes: Option<u64>,
     snapshot_properties: HashMap<String, String>,
@@ -64,8 +54,7 @@ impl RewriteManifestsAction {
         }
     }
 
-    /// Override the target manifest file size in bytes. Defaults to the table
-    /// property `commit.manifest.target-size-bytes`, or 8 MiB if unset.
+    /// Override the target manifest size; defaults to `commit.manifest.target-size-bytes` (8 MiB).
     pub fn set_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
         self.target_size_bytes = Some(target_size_bytes);
         self
@@ -120,8 +109,6 @@ impl TransactionAction for RewriteManifestsAction {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
 
-        // Mirrors Java RewriteManifestsSparkAction: skip when the input would already
-        // fit in a single target-sized manifest (target_num_manifests == 1 && len == 1).
         let total_size: u64 = to_rewrite
             .iter()
             .map(|m| u64::try_from(m.manifest_length).unwrap_or(0))
@@ -129,15 +116,13 @@ impl TransactionAction for RewriteManifestsAction {
         if to_rewrite.len() == 1 && total_size <= target_size_bytes {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
+        let manifests_replaced = to_rewrite.len();
 
         let commit_uuid = Uuid::now_v7();
         let snapshot_id = generate_unique_snapshot_id(table);
 
-        // Load manifests concurrently (bounded) — sequential I/O is a perf cliff on
-        // tables with many manifests; ordering doesn't matter because we re-group by
-        // partition tuple below.
         let file_io = table.file_io().clone();
-        let loaded: Vec<_> = stream::iter(to_rewrite.clone())
+        let loaded: Vec<_> = stream::iter(to_rewrite)
             .map(|m| {
                 let file_io = file_io.clone();
                 async move { m.load_manifest(&file_io).await }
@@ -146,8 +131,6 @@ impl TransactionAction for RewriteManifestsAction {
             .try_collect()
             .await?;
 
-        // Group live entries by partition tuple. We store only the four fields we need
-        // (data file + identity numbers) to avoid cloning the full ManifestEntry.
         type EntryRecord = (DataFile, i64, i64, Option<i64>);
         let mut grouped: Vec<Vec<EntryRecord>> = Vec::new();
         let mut group_index: HashMap<Struct, usize> = HashMap::new();
@@ -171,27 +154,26 @@ impl TransactionAction for RewriteManifestsAction {
                     )
                 })?;
                 let data_file = entry.data_file().clone();
-                let key = data_file.partition.clone();
-                let idx = *group_index.entry(key).or_insert_with(|| {
-                    let i = grouped.len();
-                    grouped.push(Vec::new());
-                    i
-                });
+                let idx = match group_index.get(&data_file.partition) {
+                    Some(&i) => i,
+                    None => {
+                        let i = grouped.len();
+                        group_index.insert(data_file.partition.clone(), i);
+                        grouped.push(Vec::new());
+                        i
+                    }
+                };
                 grouped[idx].push((data_file, snap_id, seq, entry.file_sequence_number));
                 entries_processed += 1;
             }
         }
 
         let mut counter: u64 = 0;
-        let mut new_manifests: Vec<ManifestFile> = Vec::new();
-        let mut next_writer = || -> Result<ManifestWriter> {
-            let n = counter;
-            counter += 1;
-            new_manifest_writer(table, &commit_uuid, n, snapshot_id)
-        };
+        let mut new_manifests: Vec<ManifestFile> = Vec::with_capacity(grouped.len());
 
         for group in grouped {
-            let mut writer = next_writer()?;
+            let mut writer = new_manifest_writer(table, &commit_uuid, counter, snapshot_id)?;
+            counter += 1;
             let mut accumulated: u64 = 0;
             let mut min_first_row_id: Option<u64> = None;
 
@@ -204,7 +186,8 @@ impl TransactionAction for RewriteManifestsAction {
                         written.first_row_id = min_first_row_id;
                     }
                     new_manifests.push(written);
-                    writer = next_writer()?;
+                    writer = new_manifest_writer(table, &commit_uuid, counter, snapshot_id)?;
+                    counter += 1;
                     accumulated = 0;
                     min_first_row_id = None;
                 }
@@ -225,29 +208,27 @@ impl TransactionAction for RewriteManifestsAction {
         }
 
         let manifest_list_path = format!(
-            "{}/{}/snap-{}-0-{}.{}",
+            "{}/metadata/snap-{}-0-{}.{}",
             metadata.location(),
-            META_ROOT_PATH,
             snapshot_id,
             commit_uuid,
             DataFileFormat::Avro,
         );
         let next_seq_num = metadata.next_sequence_number();
         let next_row_id = metadata.next_row_id();
+        let output = table.file_io().new_output(manifest_list_path.clone())?;
         let mut list_writer = match format_version {
-            FormatVersion::V1 => ManifestListWriter::v1(
-                table.file_io().new_output(manifest_list_path.clone())?,
-                snapshot_id,
-                metadata.current_snapshot_id(),
-            ),
+            FormatVersion::V1 => {
+                ManifestListWriter::v1(output, snapshot_id, metadata.current_snapshot_id())
+            }
             FormatVersion::V2 => ManifestListWriter::v2(
-                table.file_io().new_output(manifest_list_path.clone())?,
+                output,
                 snapshot_id,
                 metadata.current_snapshot_id(),
                 next_seq_num,
             ),
             FormatVersion::V3 => ManifestListWriter::v3(
-                table.file_io().new_output(manifest_list_path.clone())?,
+                output,
                 snapshot_id,
                 metadata.current_snapshot_id(),
                 next_seq_num,
@@ -255,7 +236,6 @@ impl TransactionAction for RewriteManifestsAction {
             ),
         };
         let manifests_created = new_manifests.len();
-        let manifests_replaced = to_rewrite.len();
         let manifests_kept = kept.len();
         list_writer.add_manifests(new_manifests.into_iter().chain(kept))?;
         list_writer.close().await?;
@@ -273,10 +253,7 @@ impl TransactionAction for RewriteManifestsAction {
                 additional_properties.insert(k.to_string(), v.clone());
             }
         }
-        // For pure rewrites (status=Existing only, zero adds/deletes) the totals are
-        // by definition unchanged, so we copy them through verbatim. If the action is
-        // ever extended to add or remove data files, port Java's
-        // SnapshotProducer.updateTotal (previous + added - deleted) instead.
+        // Pure rewrite preserves totals verbatim (no add/delete files).
         additional_properties.insert(
             "manifests-created".to_string(),
             manifests_created.to_string(),
@@ -342,9 +319,8 @@ fn new_manifest_writer(
 ) -> Result<ManifestWriter> {
     let metadata = table.metadata();
     let path = format!(
-        "{}/{}/{}-m{}.{}",
+        "{}/metadata/{}-m{}.{}",
         metadata.location(),
-        META_ROOT_PATH,
         commit_uuid,
         n,
         DataFileFormat::Avro,
@@ -568,25 +544,31 @@ mod tests {
         let table = append_one(&catalog, table, data_file("b", 1, 100, 17)).await;
         let table = append_one(&catalog, table, data_file("c", 1, 100, 11)).await;
 
-        let pre_first_row_ids: Vec<Option<i64>> = {
-            let list = table
+        async fn collect(t: &Table) -> Vec<(String, Option<i64>, Option<i64>, Option<i64>)> {
+            let list = t
                 .metadata()
                 .current_snapshot()
                 .unwrap()
-                .load_manifest_list(table.file_io(), table.metadata())
+                .load_manifest_list(t.file_io(), t.metadata())
                 .await
                 .unwrap();
             let mut v = Vec::new();
             for m in list.entries() {
-                let manifest = m.load_manifest(table.file_io()).await.unwrap();
+                let manifest = m.load_manifest(t.file_io()).await.unwrap();
                 for entry in manifest.entries() {
-                    v.push(entry.data_file().first_row_id);
+                    v.push((
+                        entry.data_file().file_path().to_string(),
+                        entry.data_file().first_row_id,
+                        entry.sequence_number(),
+                        entry.file_sequence_number,
+                    ));
                 }
             }
             v.sort();
             v
-        };
+        }
 
+        let pre = collect(&table).await;
         let next_row_id_before = table.metadata().next_row_id();
 
         let tx = Transaction::new(&table);
@@ -606,22 +588,11 @@ mod tests {
         let snap = table.metadata().current_snapshot().unwrap();
         assert_eq!(snap.row_range(), Some((next_row_id_before, 0)));
 
-        let post_first_row_ids: Vec<Option<i64>> = {
-            let list = snap
-                .load_manifest_list(table.file_io(), table.metadata())
-                .await
-                .unwrap();
-            let mut v = Vec::new();
-            for m in list.entries() {
-                let manifest = m.load_manifest(table.file_io()).await.unwrap();
-                for entry in manifest.entries() {
-                    v.push(entry.data_file().first_row_id);
-                }
-            }
-            v.sort();
-            v
-        };
-        assert_eq!(pre_first_row_ids, post_first_row_ids);
+        let post = collect(&table).await;
+        assert_eq!(
+            pre, post,
+            "first_row_id, sequence_number, and file_sequence_number must be preserved per-entry"
+        );
     }
 
     #[tokio::test]
@@ -643,9 +614,8 @@ mod tests {
         .await
         .unwrap();
         let updates = commit.take_updates();
-        let snap = match &updates[0] {
-            TableUpdate::AddSnapshot { snapshot } => snapshot,
-            _ => unreachable!(),
+        let TableUpdate::AddSnapshot { snapshot: snap } = &updates[0] else {
+            unreachable!()
         };
         let s = &snap.summary().additional_properties;
         assert_eq!(snap.summary().operation, Operation::Replace);
@@ -656,6 +626,44 @@ mod tests {
         // Two distinct partitions → grouped into two new manifests.
         assert_eq!(s.get("manifests-created").unwrap(), "2");
         assert_eq!(s.get("total-records").unwrap(), "30");
+    }
+
+    #[tokio::test]
+    async fn test_idempotent_after_consolidation() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let mut t = table;
+        for i in 0..3 {
+            t = append_one(&catalog, t, data_file(&format!("f{i}"), 1, 100, 1)).await;
+        }
+
+        let tx = Transaction::new(&t);
+        let t = tx
+            .rewrite_manifests()
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+        let post_count = t
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .load_manifest_list(t.file_io(), t.metadata())
+            .await
+            .unwrap()
+            .entries()
+            .len();
+        assert_eq!(post_count, 1, "single partition consolidates to 1 manifest");
+
+        let mut commit2 = Arc::new(Transaction::new(&t).rewrite_manifests())
+            .commit(&t)
+            .await
+            .unwrap();
+        assert!(
+            commit2.take_updates().is_empty(),
+            "second rewrite must no-op when input already fits in one manifest"
+        );
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -16,15 +16,16 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::ops::RangeFrom;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::TryStreamExt;
+use futures::stream::{self, StreamExt};
 use uuid::Uuid;
 
 use crate::error::Result;
 use crate::spec::{
-    DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestFile,
+    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestFile,
     ManifestListWriter, ManifestWriter, ManifestWriterBuilder, Operation, Snapshot,
     SnapshotReference, SnapshotRetention, Struct, Summary, TableProperties,
 };
@@ -35,13 +36,24 @@ use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
 
-/// Rewrite the data manifests of a table's current snapshot, mirroring Java's
-/// `RewriteManifests`. Produces a `Replace` snapshot that preserves every live
-/// entry's data file, snapshot id, sequence numbers, and (on v3) row lineage.
+/// Approximate serialized cost of a single manifest entry, in bytes. Mirrors the
+/// rough order of magnitude of Avro-encoded `manifest_entry` records (header +
+/// data file struct + bounds, summarized), used as the rolling proxy because
+/// `ManifestWriter` does not currently expose its in-flight byte count.
+const APPROX_BYTES_PER_ENTRY: u64 = 256;
+
+/// Bin-pack and rewrite the data manifests of the current snapshot into manifests of
+/// approximately `target_size_bytes`, mirroring Java's `RewriteManifests`. Live entries
+/// are preserved verbatim (status=Existing), so file paths, snapshot ids, sequence
+/// numbers, and v3 row lineage are unchanged. Produces a `Replace` snapshot.
+///
+/// Explicit-subset (Java parity ceiling): no `rewriteIf` predicate, no `clusterBy`,
+/// no caller-specified `specId`, no branch override (always commits to `main`). Only
+/// data manifests on the table's *default* partition spec are rewritten; manifests
+/// on older specs and delete manifests are kept untouched.
 pub struct RewriteManifestsAction {
     target_size_bytes: Option<u64>,
     snapshot_properties: HashMap<String, String>,
-    commit_uuid: Option<Uuid>,
 }
 
 impl RewriteManifestsAction {
@@ -49,26 +61,19 @@ impl RewriteManifestsAction {
         Self {
             target_size_bytes: None,
             snapshot_properties: HashMap::new(),
-            commit_uuid: None,
         }
     }
 
-    /// Override the target manifest file size in bytes (default
-    /// `commit.manifest.target-size-bytes`, then 8 MiB).
+    /// Override the target manifest file size in bytes. Defaults to the table
+    /// property `commit.manifest.target-size-bytes`, or 8 MiB if unset.
     pub fn set_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
         self.target_size_bytes = Some(target_size_bytes);
         self
     }
 
-    /// Set the snapshot summary properties.
+    /// Set custom properties to attach to the snapshot summary.
     pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
         self.snapshot_properties = snapshot_properties;
-        self
-    }
-
-    /// Set commit UUID for the snapshot.
-    pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
-        self.commit_uuid = Some(commit_uuid);
         self
     }
 }
@@ -98,8 +103,8 @@ impl TransactionAction for RewriteManifestsAction {
             .load_manifest_list(table.file_io(), &table.metadata_ref())
             .await?;
 
-        let mut kept: Vec<ManifestFile> = Vec::with_capacity(manifest_list.entries().len());
-        let mut to_rewrite: Vec<ManifestFile> = Vec::with_capacity(manifest_list.entries().len());
+        let mut kept: Vec<ManifestFile> = Vec::new();
+        let mut to_rewrite: Vec<ManifestFile> = Vec::new();
         for manifest in manifest_list.entries() {
             let is_data = manifest.content == ManifestContentType::Data;
             let on_default_spec = manifest.partition_spec_id == default_spec_id;
@@ -117,72 +122,41 @@ impl TransactionAction for RewriteManifestsAction {
 
         // Mirrors Java RewriteManifestsSparkAction: skip when the input would already
         // fit in a single target-sized manifest (target_num_manifests == 1 && len == 1).
-        let total_size: u64 = to_rewrite.iter().map(|m| m.manifest_length as u64).sum();
+        let total_size: u64 = to_rewrite
+            .iter()
+            .map(|m| u64::try_from(m.manifest_length).unwrap_or(0))
+            .sum();
         if to_rewrite.len() == 1 && total_size <= target_size_bytes {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
 
-        let commit_uuid = self.commit_uuid.unwrap_or_else(Uuid::now_v7);
+        let commit_uuid = Uuid::now_v7();
         let snapshot_id = generate_unique_snapshot_id(table);
 
-        let mut grouped: Vec<Vec<crate::spec::ManifestEntry>> = Vec::new();
+        // Load manifests concurrently (bounded) — sequential I/O is a perf cliff on
+        // tables with many manifests; ordering doesn't matter because we re-group by
+        // partition tuple below.
+        let file_io = table.file_io().clone();
+        let loaded: Vec<_> = stream::iter(to_rewrite.clone())
+            .map(|m| {
+                let file_io = file_io.clone();
+                async move { m.load_manifest(&file_io).await }
+            })
+            .buffer_unordered(16)
+            .try_collect()
+            .await?;
+
+        // Group live entries by partition tuple. We store only the four fields we need
+        // (data file + identity numbers) to avoid cloning the full ManifestEntry.
+        type EntryRecord = (DataFile, i64, i64, Option<i64>);
+        let mut grouped: Vec<Vec<EntryRecord>> = Vec::new();
         let mut group_index: HashMap<Struct, usize> = HashMap::new();
         let mut entries_processed: u64 = 0;
 
-        for manifest_file in &to_rewrite {
-            let manifest = manifest_file.load_manifest(table.file_io()).await?;
+        for manifest in loaded {
             for entry in manifest.entries() {
                 if !entry.is_alive() {
                     continue;
-                }
-                let key = entry.data_file().partition.clone();
-                let idx = match group_index.get(&key) {
-                    Some(&i) => i,
-                    None => {
-                        let i = grouped.len();
-                        group_index.insert(key, i);
-                        grouped.push(Vec::new());
-                        i
-                    }
-                };
-                grouped[idx].push((**entry).clone());
-                entries_processed += 1;
-            }
-        }
-
-        let mut counter: RangeFrom<u64> = 0..;
-        let mut new_manifests: Vec<ManifestFile> = Vec::with_capacity(grouped.len());
-
-        for group in grouped {
-            let mut writer =
-                new_manifest_writer(table, &commit_uuid, counter.next().unwrap(), snapshot_id)?;
-            let mut accumulated: u64 = 0;
-            let mut min_first_row_id: Option<u64> = None;
-
-            for entry in group {
-                let entry_proxy_size = entry.data_file().file_size_in_bytes;
-                if accumulated > 0
-                    && accumulated.saturating_add(entry_proxy_size) > target_size_bytes
-                {
-                    let mut written = writer.write_manifest_file().await?;
-                    if format_version == FormatVersion::V3 {
-                        written.first_row_id = min_first_row_id;
-                    }
-                    new_manifests.push(written);
-                    writer = new_manifest_writer(
-                        table,
-                        &commit_uuid,
-                        counter.next().unwrap(),
-                        snapshot_id,
-                    )?;
-                    accumulated = 0;
-                    min_first_row_id = None;
-                }
-                if let Some(frid) = entry.data_file().first_row_id
-                    && frid >= 0
-                {
-                    let frid_u = frid as u64;
-                    min_first_row_id = Some(min_first_row_id.map_or(frid_u, |m| m.min(frid_u)));
                 }
                 let snap_id = entry.snapshot_id().ok_or_else(|| {
                     Error::new(
@@ -196,10 +170,52 @@ impl TransactionAction for RewriteManifestsAction {
                         "Live manifest entry is missing sequence_number",
                     )
                 })?;
-                let file_seq = entry.file_sequence_number;
                 let data_file = entry.data_file().clone();
+                let key = data_file.partition.clone();
+                let idx = *group_index.entry(key).or_insert_with(|| {
+                    let i = grouped.len();
+                    grouped.push(Vec::new());
+                    i
+                });
+                grouped[idx].push((data_file, snap_id, seq, entry.file_sequence_number));
+                entries_processed += 1;
+            }
+        }
+
+        let mut counter: u64 = 0;
+        let mut new_manifests: Vec<ManifestFile> = Vec::new();
+        let mut next_writer = || -> Result<ManifestWriter> {
+            let n = counter;
+            counter += 1;
+            new_manifest_writer(table, &commit_uuid, n, snapshot_id)
+        };
+
+        for group in grouped {
+            let mut writer = next_writer()?;
+            let mut accumulated: u64 = 0;
+            let mut min_first_row_id: Option<u64> = None;
+
+            for (data_file, snap_id, seq, file_seq) in group {
+                if accumulated > 0
+                    && accumulated.saturating_add(APPROX_BYTES_PER_ENTRY) > target_size_bytes
+                {
+                    let mut written = writer.write_manifest_file().await?;
+                    if format_version == FormatVersion::V3 {
+                        written.first_row_id = min_first_row_id;
+                    }
+                    new_manifests.push(written);
+                    writer = next_writer()?;
+                    accumulated = 0;
+                    min_first_row_id = None;
+                }
+                if let Some(frid) = data_file.first_row_id
+                    && frid >= 0
+                {
+                    let frid_u = frid as u64;
+                    min_first_row_id = Some(min_first_row_id.map_or(frid_u, |m| m.min(frid_u)));
+                }
                 writer.add_existing_file(data_file, snap_id, seq, file_seq)?;
-                accumulated = accumulated.saturating_add(entry_proxy_size);
+                accumulated = accumulated.saturating_add(APPROX_BYTES_PER_ENTRY);
             }
             let mut written = writer.write_manifest_file().await?;
             if format_version == FormatVersion::V3 {
@@ -257,10 +273,23 @@ impl TransactionAction for RewriteManifestsAction {
                 additional_properties.insert(k.to_string(), v.clone());
             }
         }
-        additional_properties.insert("manifests-created".into(), manifests_created.to_string());
-        additional_properties.insert("manifests-replaced".into(), manifests_replaced.to_string());
-        additional_properties.insert("manifests-kept".into(), manifests_kept.to_string());
-        additional_properties.insert("entries-processed".into(), entries_processed.to_string());
+        // For pure rewrites (status=Existing only, zero adds/deletes) the totals are
+        // by definition unchanged, so we copy them through verbatim. If the action is
+        // ever extended to add or remove data files, port Java's
+        // SnapshotProducer.updateTotal (previous + added - deleted) instead.
+        additional_properties.insert(
+            "manifests-created".to_string(),
+            manifests_created.to_string(),
+        );
+        additional_properties.insert(
+            "manifests-replaced".to_string(),
+            manifests_replaced.to_string(),
+        );
+        additional_properties.insert("manifests-kept".to_string(), manifests_kept.to_string());
+        additional_properties.insert(
+            "entries-processed".to_string(),
+            entries_processed.to_string(),
+        );
         let summary = Summary {
             operation: Operation::Replace,
             additional_properties,
@@ -500,9 +529,11 @@ mod tests {
         }
 
         let tx = Transaction::new(&t);
+        // Target just above one entry's proxy cost (APPROX_BYTES_PER_ENTRY = 256)
+        // so each new manifest holds at most one entry.
         let t = tx
             .rewrite_manifests()
-            .set_target_size_bytes(15_000)
+            .set_target_size_bytes(400)
             .apply(tx)
             .unwrap()
             .commit(&catalog)
@@ -625,5 +656,59 @@ mod tests {
         // Two distinct partitions → grouped into two new manifests.
         assert_eq!(s.get("manifests-created").unwrap(), "2");
         assert_eq!(s.get("total-records").unwrap(), "30");
+    }
+
+    #[tokio::test]
+    async fn test_partition_grouping_and_catalog_commit() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let table = append_one(&catalog, table, data_file("a", 1, 100, 1)).await;
+        let table = append_one(&catalog, table, data_file("b", 1, 100, 1)).await;
+        let table = append_one(&catalog, table, data_file("c", 2, 100, 1)).await;
+        let table = append_one(&catalog, table, data_file("d", 2, 100, 1)).await;
+
+        let pre_id = table.metadata().current_snapshot_id().unwrap();
+        let pre_seq = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .sequence_number();
+
+        let tx = Transaction::new(&table);
+        let table = tx
+            .rewrite_manifests()
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let snap = table.metadata().current_snapshot().unwrap();
+        assert_eq!(snap.parent_snapshot_id(), Some(pre_id));
+        assert_eq!(snap.sequence_number(), pre_seq + 1);
+
+        // Each output manifest's entries must all share the same partition tuple.
+        let post_list = snap
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap();
+        assert_eq!(
+            post_list.entries().len(),
+            2,
+            "two distinct partitions → two output manifests"
+        );
+        for m in post_list.entries() {
+            let manifest = m.load_manifest(table.file_io()).await.unwrap();
+            let partitions: std::collections::HashSet<Struct> = manifest
+                .entries()
+                .iter()
+                .map(|e| e.data_file().partition.clone())
+                .collect();
+            assert_eq!(
+                partitions.len(),
+                1,
+                "all entries within a manifest share one partition tuple"
+            );
+        }
     }
 }

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -322,7 +322,6 @@ fn new_manifest_writer(
     let builder = ManifestWriterBuilder::new(
         output,
         Some(snapshot_id),
-        None,
         metadata.current_schema().clone(),
         metadata.default_partition_spec().as_ref().clone(),
     );

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -227,8 +227,8 @@ impl TransactionAction for RewriteManifestsAction {
                 Some(next_row_id),
             ),
         };
-        let manifests_created = new_manifests.len().to_string();
-        let manifests_kept = kept.len().to_string();
+        let manifests_created = new_manifests.len();
+        let manifests_kept = kept.len();
         list_writer.add_manifests(new_manifests.into_iter().chain(kept))?;
         list_writer.close().await?;
 
@@ -245,12 +245,15 @@ impl TransactionAction for RewriteManifestsAction {
                 additional_properties.insert(k.to_string(), v.clone());
             }
         }
-        additional_properties.insert("manifests-created".to_string(), manifests_created);
+        additional_properties.insert(
+            "manifests-created".to_string(),
+            manifests_created.to_string(),
+        );
         additional_properties.insert(
             "manifests-replaced".to_string(),
             manifests_replaced.to_string(),
         );
-        additional_properties.insert("manifests-kept".to_string(), manifests_kept);
+        additional_properties.insert("manifests-kept".to_string(), manifests_kept.to_string());
         additional_properties.insert(
             "entries-processed".to_string(),
             entries_processed.to_string(),
@@ -371,8 +374,10 @@ mod tests {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
         let action = tx.rewrite_manifests();
-        let res = Arc::new(action).commit(&table).await;
-        assert!(res.is_err(), "expected PreconditionFailed without snapshot");
+        match Arc::new(action).commit(&table).await {
+            Ok(_) => panic!("expected error"),
+            Err(e) => assert_eq!(e.kind(), crate::ErrorKind::PreconditionFailed),
+        }
     }
 
     #[tokio::test]
@@ -386,7 +391,7 @@ mod tests {
         let action = tx.rewrite_manifests();
         let mut commit = Arc::new(action).commit(&table).await.unwrap();
         let updates = commit.take_updates();
-        assert!(updates.is_empty(), "single small manifest should be no-op");
+        assert!(updates.is_empty());
 
         let table = tx
             .rewrite_manifests()
@@ -479,6 +484,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_target_size_from_table_property() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let mut t = table;
+        for i in 0..6 {
+            t = append_one(&catalog, t, data_file(&format!("f{i}"), 1, 10_000, 1)).await;
+        }
+
+        let tx = Transaction::new(&t);
+        let t = tx
+            .update_table_properties()
+            .set(
+                "commit.manifest.target-size-bytes".to_string(),
+                "400".to_string(),
+            )
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let tx = Transaction::new(&t);
+        let t = tx
+            .rewrite_manifests()
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let post_list = t
+            .manifest_list_reader(t.metadata().current_snapshot().unwrap())
+            .load()
+            .await
+            .unwrap();
+        assert!(post_list.entries().len() > 1);
+    }
+
+    #[tokio::test]
     async fn test_target_size_rolls_multiple_manifests() {
         let catalog = new_memory_catalog().await;
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
@@ -502,10 +546,7 @@ mod tests {
             .load()
             .await
             .unwrap();
-        assert!(
-            post_list.entries().len() > 1,
-            "rolling should produce multiple manifests when target is small"
-        );
+        assert!(post_list.entries().len() > 1);
 
         let mut total = 0;
         for m in post_list.entries() {
@@ -744,11 +785,7 @@ mod tests {
         assert_ne!(snap.snapshot_id(), pre_id);
 
         let post_list = table.manifest_list_reader(snap).load().await.unwrap();
-        assert_eq!(
-            post_list.entries().len(),
-            2,
-            "two distinct partitions → two output manifests"
-        );
+        assert_eq!(post_list.entries().len(), 2);
         for m in post_list.entries() {
             let manifest = m.load_manifest(table.file_io()).await.unwrap();
             let partitions: std::collections::HashSet<Struct> = manifest

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -36,7 +36,6 @@ use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const FALLBACK_BYTES_PER_ENTRY: u64 = 256;
 
-/// Bin-pack live data manifests into manifests of approximately `target_size_bytes`.
 pub struct RewriteManifestsAction {
     target_size_bytes: Option<u64>,
     snapshot_properties: HashMap<String, String>,
@@ -102,11 +101,24 @@ impl TransactionAction for RewriteManifestsAction {
         if to_rewrite.len() == 1 && total_size <= target_size_bytes {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
+        let total_input_entries: u64 = to_rewrite
+            .iter()
+            .map(|m| {
+                u64::from(m.added_files_count.unwrap_or(0))
+                    + u64::from(m.existing_files_count.unwrap_or(0))
+            })
+            .sum();
+        let bytes_per_entry = if total_input_entries > 0 {
+            (total_size / total_input_entries).max(1)
+        } else {
+            FALLBACK_BYTES_PER_ENTRY
+        };
+        let manifests_replaced = to_rewrite.len();
 
         let commit_uuid = Uuid::now_v7();
         let snapshot_id = generate_unique_snapshot_id(table);
 
-        let loaded: Vec<_> = stream::iter(to_rewrite.iter().cloned())
+        let loaded: Vec<_> = stream::iter(to_rewrite)
             .map(|m| {
                 let file_io = table.file_io().clone();
                 async move { m.load_manifest(&file_io).await }
@@ -150,12 +162,6 @@ impl TransactionAction for RewriteManifestsAction {
                 entries_processed += 1;
             }
         }
-
-        let bytes_per_entry = if entries_processed > 0 {
-            total_size / entries_processed
-        } else {
-            FALLBACK_BYTES_PER_ENTRY
-        };
 
         let mut counter: u64 = 0;
         let mut new_manifests: Vec<ManifestFile> = Vec::with_capacity(grouped.len());
@@ -222,7 +228,6 @@ impl TransactionAction for RewriteManifestsAction {
             ),
         };
         let manifests_created = new_manifests.len().to_string();
-        let manifests_replaced = to_rewrite.len().to_string();
         let manifests_kept = kept.len().to_string();
         list_writer.add_manifests(new_manifests.into_iter().chain(kept))?;
         list_writer.close().await?;
@@ -241,7 +246,10 @@ impl TransactionAction for RewriteManifestsAction {
             }
         }
         additional_properties.insert("manifests-created".to_string(), manifests_created);
-        additional_properties.insert("manifests-replaced".to_string(), manifests_replaced);
+        additional_properties.insert(
+            "manifests-replaced".to_string(),
+            manifests_replaced.to_string(),
+        );
         additional_properties.insert("manifests-kept".to_string(), manifests_kept);
         additional_properties.insert(
             "entries-processed".to_string(),
@@ -508,6 +516,64 @@ mod tests {
                 "each rolled manifest should hold at most ~2 entries when target is just above bytes_per_entry"
             );
             total += n;
+        }
+        assert_eq!(total, 6);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_single_manifest_is_split() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let files: Vec<_> = (0..6)
+            .map(|i| data_file(&format!("f{i}"), 1, 10_000, 1))
+            .collect();
+
+        let tx = Transaction::new(&table);
+        let table = tx
+            .fast_append()
+            .add_data_files(files)
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let pre_list = table
+            .manifest_list_reader(table.metadata().current_snapshot().unwrap())
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(pre_list.entries().len(), 1);
+
+        let tx = Transaction::new(&table);
+        let table = tx
+            .rewrite_manifests()
+            .set_target_size_bytes(400)
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let snap = table.metadata().current_snapshot().unwrap();
+        let post_list = table.manifest_list_reader(snap).load().await.unwrap();
+        assert!(post_list.entries().len() > 1);
+        assert_eq!(
+            snap.summary()
+                .additional_properties
+                .get("manifests-replaced")
+                .unwrap(),
+            "1"
+        );
+
+        let mut total = 0;
+        for m in post_list.entries() {
+            total += m
+                .load_manifest(table.file_io())
+                .await
+                .unwrap()
+                .entries()
+                .len();
         }
         assert_eq!(total, 6);
     }

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::ops::RangeFrom;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -25,29 +26,22 @@ use crate::error::Result;
 use crate::spec::{
     DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestFile,
     ManifestListWriter, ManifestWriter, ManifestWriterBuilder, Operation, Snapshot,
-    SnapshotReference, SnapshotRetention, Struct, Summary,
+    SnapshotReference, SnapshotRetention, Struct, Summary, TableProperties,
 };
 use crate::table::Table;
+use crate::transaction::snapshot::generate_unique_snapshot_id;
 use crate::transaction::{ActionCommit, TransactionAction};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
-const DEFAULT_TARGET_MANIFEST_SIZE_BYTES: u64 = 8 * 1024 * 1024;
 
-/// Rewrite the data manifests of a table's current snapshot.
-///
-/// Mirrors Java's `RewriteManifests`: groups live entries from existing data
-/// manifests bound to the current default partition spec by partition tuple
-/// and writes them into a smaller number of larger manifests, while
-/// preserving every entry's data file, snapshot id, and data/file sequence
-/// numbers (and, on v3, row lineage). Delete manifests and data manifests
-/// bound to non-default partition specs are kept unchanged. Produces a
-/// `Replace` snapshot.
+/// Rewrite the data manifests of a table's current snapshot, mirroring Java's
+/// `RewriteManifests`. Produces a `Replace` snapshot that preserves every live
+/// entry's data file, snapshot id, sequence numbers, and (on v3) row lineage.
 pub struct RewriteManifestsAction {
     target_size_bytes: Option<u64>,
     snapshot_properties: HashMap<String, String>,
     commit_uuid: Option<Uuid>,
-    key_metadata: Option<Vec<u8>>,
 }
 
 impl RewriteManifestsAction {
@@ -56,14 +50,12 @@ impl RewriteManifestsAction {
             target_size_bytes: None,
             snapshot_properties: HashMap::new(),
             commit_uuid: None,
-            key_metadata: None,
         }
     }
 
-    /// Override the target manifest file size in bytes used to roll a new
-    /// manifest. Defaults to 8 MiB to match the Java
-    /// `commit.manifest.target-size-bytes` default.
-    pub fn with_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
+    /// Override the target manifest file size in bytes (default
+    /// `commit.manifest.target-size-bytes`, then 8 MiB).
+    pub fn set_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
         self.target_size_bytes = Some(target_size_bytes);
         self
     }
@@ -79,12 +71,6 @@ impl RewriteManifestsAction {
         self.commit_uuid = Some(commit_uuid);
         self
     }
-
-    /// Set encryption key metadata for newly written manifest files.
-    pub fn set_key_metadata(mut self, key_metadata: Vec<u8>) -> Self {
-        self.key_metadata = Some(key_metadata);
-        self
-    }
 }
 
 #[async_trait]
@@ -98,9 +84,13 @@ impl TransactionAction for RewriteManifestsAction {
             ));
         };
 
-        let target_size_bytes = self
-            .target_size_bytes
-            .unwrap_or(DEFAULT_TARGET_MANIFEST_SIZE_BYTES);
+        let target_size_bytes = self.target_size_bytes.unwrap_or_else(|| {
+            metadata
+                .properties()
+                .get(TableProperties::PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES)
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(TableProperties::PROPERTY_COMMIT_MANIFEST_TARGET_SIZE_BYTES_DEFAULT)
+        });
         let default_spec_id = metadata.default_partition_spec_id();
         let format_version = metadata.format_version();
 
@@ -108,8 +98,8 @@ impl TransactionAction for RewriteManifestsAction {
             .load_manifest_list(table.file_io(), &table.metadata_ref())
             .await?;
 
-        let mut kept: Vec<ManifestFile> = Vec::new();
-        let mut to_rewrite: Vec<ManifestFile> = Vec::new();
+        let mut kept: Vec<ManifestFile> = Vec::with_capacity(manifest_list.entries().len());
+        let mut to_rewrite: Vec<ManifestFile> = Vec::with_capacity(manifest_list.entries().len());
         for manifest in manifest_list.entries() {
             let is_data = manifest.content == ManifestContentType::Data;
             let on_default_spec = manifest.partition_spec_id == default_spec_id;
@@ -121,16 +111,15 @@ impl TransactionAction for RewriteManifestsAction {
             }
         }
 
-        let single_below_target =
-            to_rewrite.len() == 1 && (to_rewrite[0].manifest_length as u64) <= target_size_bytes;
-        if to_rewrite.is_empty() || single_below_target {
+        if to_rewrite.is_empty() {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
 
-        let mut replaced_active_files: u64 = 0;
-        for m in &to_rewrite {
-            replaced_active_files += m.added_files_count.unwrap_or(0) as u64;
-            replaced_active_files += m.existing_files_count.unwrap_or(0) as u64;
+        // Mirrors Java RewriteManifestsSparkAction: skip when the input would already
+        // fit in a single target-sized manifest (target_num_manifests == 1 && len == 1).
+        let total_size: u64 = to_rewrite.iter().map(|m| m.manifest_length as u64).sum();
+        if to_rewrite.len() == 1 && total_size <= target_size_bytes {
+            return Ok(ActionCommit::new(vec![], vec![]));
         }
 
         let commit_uuid = self.commit_uuid.unwrap_or_else(Uuid::now_v7);
@@ -161,30 +150,12 @@ impl TransactionAction for RewriteManifestsAction {
             }
         }
 
-        if entries_processed != replaced_active_files {
-            return Err(Error::new(
-                ErrorKind::DataInvalid,
-                format!(
-                    "Manifest list active file count ({replaced_active_files}) disagrees with manifest entry count ({entries_processed})"
-                ),
-            ));
-        }
-
-        for group in &mut grouped {
-            group.sort_by(|a, b| a.data_file().file_path.cmp(&b.data_file().file_path));
-        }
-
-        let mut counter: u64 = 0;
-        let mut new_manifests: Vec<ManifestFile> = Vec::new();
+        let mut counter: RangeFrom<u64> = 0..;
+        let mut new_manifests: Vec<ManifestFile> = Vec::with_capacity(grouped.len());
 
         for group in grouped {
-            let mut writer = new_manifest_writer(
-                table,
-                &commit_uuid,
-                &mut counter,
-                self.key_metadata.clone(),
-                snapshot_id,
-            )?;
+            let mut writer =
+                new_manifest_writer(table, &commit_uuid, counter.next().unwrap(), snapshot_id)?;
             let mut accumulated: u64 = 0;
             let mut min_first_row_id: Option<u64> = None;
 
@@ -201,8 +172,7 @@ impl TransactionAction for RewriteManifestsAction {
                     writer = new_manifest_writer(
                         table,
                         &commit_uuid,
-                        &mut counter,
-                        self.key_metadata.clone(),
+                        counter.next().unwrap(),
                         snapshot_id,
                     )?;
                     accumulated = 0;
@@ -238,22 +208,14 @@ impl TransactionAction for RewriteManifestsAction {
             new_manifests.push(written);
         }
 
-        let new_active_files: u64 = new_manifests
-            .iter()
-            .map(|m| {
-                m.added_files_count.unwrap_or(0) as u64 + m.existing_files_count.unwrap_or(0) as u64
-            })
-            .sum();
-        if new_active_files != replaced_active_files {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                format!(
-                    "Rewrite produced {new_active_files} active files, expected {replaced_active_files}"
-                ),
-            ));
-        }
-
-        let manifest_list_path = generate_manifest_list_file_path(table, snapshot_id, commit_uuid);
+        let manifest_list_path = format!(
+            "{}/{}/snap-{}-0-{}.{}",
+            metadata.location(),
+            META_ROOT_PATH,
+            snapshot_id,
+            commit_uuid,
+            DataFileFormat::Avro,
+        );
         let next_seq_num = metadata.next_sequence_number();
         let next_row_id = metadata.next_row_id();
         let mut list_writer = match format_version {
@@ -279,10 +241,10 @@ impl TransactionAction for RewriteManifestsAction {
         let manifests_created = new_manifests.len();
         let manifests_replaced = to_rewrite.len();
         let manifests_kept = kept.len();
-        list_writer.add_manifests(new_manifests.into_iter().chain(kept.into_iter()))?;
+        list_writer.add_manifests(new_manifests.into_iter().chain(kept))?;
         list_writer.close().await?;
 
-        let mut additional_properties = HashMap::new();
+        let mut additional_properties: HashMap<String, String> = self.snapshot_properties.clone();
         for k in [
             "total-data-files",
             "total-delete-files",
@@ -295,22 +257,10 @@ impl TransactionAction for RewriteManifestsAction {
                 additional_properties.insert(k.to_string(), v.clone());
             }
         }
-        additional_properties.insert(
-            "manifests-created".to_string(),
-            manifests_created.to_string(),
-        );
-        additional_properties.insert(
-            "manifests-replaced".to_string(),
-            manifests_replaced.to_string(),
-        );
-        additional_properties.insert("manifests-kept".to_string(), manifests_kept.to_string());
-        additional_properties.insert(
-            "entries-processed".to_string(),
-            entries_processed.to_string(),
-        );
-        for (k, v) in &self.snapshot_properties {
-            additional_properties.insert(k.clone(), v.clone());
-        }
+        additional_properties.insert("manifests-created".into(), manifests_created.to_string());
+        additional_properties.insert("manifests-replaced".into(), manifests_replaced.to_string());
+        additional_properties.insert("manifests-kept".into(), manifests_kept.to_string());
+        additional_properties.insert("entries-processed".into(), entries_processed.to_string());
         let summary = Summary {
             operation: Operation::Replace,
             additional_properties,
@@ -358,58 +308,31 @@ impl TransactionAction for RewriteManifestsAction {
 fn new_manifest_writer(
     table: &Table,
     commit_uuid: &Uuid,
-    counter: &mut u64,
-    key_metadata: Option<Vec<u8>>,
+    n: u64,
     snapshot_id: i64,
 ) -> Result<ManifestWriter> {
-    let n = *counter;
-    *counter += 1;
+    let metadata = table.metadata();
     let path = format!(
         "{}/{}/{}-m{}.{}",
-        table.metadata().location(),
+        metadata.location(),
         META_ROOT_PATH,
         commit_uuid,
         n,
-        DataFileFormat::Avro
+        DataFileFormat::Avro,
     );
     let output = table.file_io().new_output(path)?;
     let builder = ManifestWriterBuilder::new(
         output,
         Some(snapshot_id),
-        key_metadata,
-        table.metadata().current_schema().clone(),
-        table.metadata().default_partition_spec().as_ref().clone(),
+        None,
+        metadata.current_schema().clone(),
+        metadata.default_partition_spec().as_ref().clone(),
     );
-    Ok(match table.metadata().format_version() {
+    Ok(match metadata.format_version() {
         FormatVersion::V1 => builder.build_v1(),
         FormatVersion::V2 => builder.build_v2_data(),
         FormatVersion::V3 => builder.build_v3_data(),
     })
-}
-
-fn generate_manifest_list_file_path(table: &Table, snapshot_id: i64, commit_uuid: Uuid) -> String {
-    format!(
-        "{}/{}/snap-{}-{}-{}.{}",
-        table.metadata().location(),
-        META_ROOT_PATH,
-        snapshot_id,
-        0,
-        commit_uuid,
-        DataFileFormat::Avro
-    )
-}
-
-fn generate_unique_snapshot_id(table: &Table) -> i64 {
-    let gen_id = || -> i64 {
-        let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
-        let id = (lhs ^ rhs) as i64;
-        if id < 0 { -id } else { id }
-    };
-    let mut id = gen_id();
-    while table.metadata().snapshots().any(|s| s.snapshot_id() == id) {
-        id = gen_id();
-    }
-    id
 }
 
 #[cfg(test)]
@@ -579,7 +502,7 @@ mod tests {
         let tx = Transaction::new(&t);
         let t = tx
             .rewrite_manifests()
-            .with_target_size_bytes(15_000)
+            .set_target_size_bytes(15_000)
             .apply(tx)
             .unwrap()
             .commit(&catalog)

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -88,9 +88,7 @@ impl TransactionAction for RewriteManifestsAction {
         let default_spec_id = metadata.default_partition_spec_id();
         let format_version = metadata.format_version();
 
-        let manifest_list = current_snapshot
-            .load_manifest_list(table.file_io(), &table.metadata_ref())
-            .await?;
+        let manifest_list = table.manifest_list_reader(current_snapshot).load().await?;
 
         let mut kept: Vec<ManifestFile> = Vec::new();
         let mut to_rewrite: Vec<ManifestFile> = Vec::new();
@@ -440,10 +438,8 @@ mod tests {
         assert!(seq_a < seq_b && seq_b < seq_c);
 
         let pre_manifest_count = table
-            .metadata()
-            .current_snapshot()
-            .unwrap()
-            .load_manifest_list(table.file_io(), table.metadata())
+            .manifest_list_reader(table.metadata().current_snapshot().unwrap())
+            .load()
             .await
             .unwrap()
             .entries()
@@ -462,10 +458,7 @@ mod tests {
         let snapshot = table.metadata().current_snapshot().unwrap();
         assert_eq!(snapshot.summary().operation, Operation::Replace);
 
-        let post_list = snapshot
-            .load_manifest_list(table.file_io(), table.metadata())
-            .await
-            .unwrap();
+        let post_list = table.manifest_list_reader(snapshot).load().await.unwrap();
         let total_entries: usize = {
             let mut n = 0;
             for m in post_list.entries() {
@@ -517,10 +510,8 @@ mod tests {
             .unwrap();
 
         let post_list = t
-            .metadata()
-            .current_snapshot()
-            .unwrap()
-            .load_manifest_list(t.file_io(), t.metadata())
+            .manifest_list_reader(t.metadata().current_snapshot().unwrap())
+            .load()
             .await
             .unwrap();
         assert!(
@@ -546,10 +537,8 @@ mod tests {
 
         async fn collect(t: &Table) -> Vec<(String, Option<i64>, Option<i64>, Option<i64>)> {
             let list = t
-                .metadata()
-                .current_snapshot()
-                .unwrap()
-                .load_manifest_list(t.file_io(), t.metadata())
+                .manifest_list_reader(t.metadata().current_snapshot().unwrap())
+                .load()
                 .await
                 .unwrap();
             let mut v = Vec::new();
@@ -646,10 +635,8 @@ mod tests {
             .await
             .unwrap();
         let post_count = t
-            .metadata()
-            .current_snapshot()
-            .unwrap()
-            .load_manifest_list(t.file_io(), t.metadata())
+            .manifest_list_reader(t.metadata().current_snapshot().unwrap())
+            .load()
             .await
             .unwrap()
             .entries()
@@ -696,10 +683,7 @@ mod tests {
         assert_eq!(snap.sequence_number(), pre_seq + 1);
 
         // Each output manifest's entries must all share the same partition tuple.
-        let post_list = snap
-            .load_manifest_list(table.file_io(), table.metadata())
-            .await
-            .unwrap();
+        let post_list = table.manifest_list_reader(snap).load().await.unwrap();
         assert_eq!(
             post_list.entries().len(),
             2,

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -108,11 +108,9 @@ impl TransactionAction for RewriteManifestsAction {
                     + u64::from(m.existing_files_count.unwrap_or(0))
             })
             .sum();
-        let bytes_per_entry = if total_input_entries > 0 {
-            (total_size / total_input_entries).max(1)
-        } else {
-            FALLBACK_BYTES_PER_ENTRY
-        };
+        let bytes_per_entry = total_size
+            .checked_div(total_input_entries)
+            .map_or(FALLBACK_BYTES_PER_ENTRY, |b| b.max(1));
         let manifests_replaced = to_rewrite.len();
 
         let commit_uuid = Uuid::now_v7();

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -34,13 +34,9 @@ use crate::transaction::snapshot::generate_unique_snapshot_id;
 use crate::transaction::{ActionCommit, TransactionAction};
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
-/// Rolling-size proxy for one manifest entry; `ManifestWriter` does not expose live byte count.
-const APPROX_BYTES_PER_ENTRY: u64 = 256;
+const FALLBACK_BYTES_PER_ENTRY: u64 = 256;
 
-/// Bin-pack live data manifests of the current snapshot into manifests of approximately
-/// `target_size_bytes` (Java parity: `RewriteManifests`); commits a `Replace` snapshot.
-/// Only the default partition spec is rewritten; older specs and delete manifests pass through.
-/// Holds all live entries in memory; not suitable for tables with more than ~1M data files.
+/// Bin-pack live data manifests into manifests of approximately `target_size_bytes`.
 pub struct RewriteManifestsAction {
     target_size_bytes: Option<u64>,
     snapshot_properties: HashMap<String, String>,
@@ -54,13 +50,11 @@ impl RewriteManifestsAction {
         }
     }
 
-    /// Override the target manifest size; defaults to `commit.manifest.target-size-bytes` (8 MiB).
     pub fn set_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
         self.target_size_bytes = Some(target_size_bytes);
         self
     }
 
-    /// Set custom properties to attach to the snapshot summary.
     pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
         self.snapshot_properties = snapshot_properties;
         self
@@ -90,18 +84,12 @@ impl TransactionAction for RewriteManifestsAction {
 
         let manifest_list = table.manifest_list_reader(current_snapshot).load().await?;
 
-        let mut kept: Vec<ManifestFile> = Vec::new();
-        let mut to_rewrite: Vec<ManifestFile> = Vec::new();
-        for manifest in manifest_list.entries() {
-            let is_data = manifest.content == ManifestContentType::Data;
-            let on_default_spec = manifest.partition_spec_id == default_spec_id;
-            let has_live = manifest.has_added_files() || manifest.has_existing_files();
-            if is_data && on_default_spec && has_live {
-                to_rewrite.push(manifest.clone());
-            } else {
-                kept.push(manifest.clone());
-            }
-        }
+        let (to_rewrite, kept): (Vec<ManifestFile>, Vec<ManifestFile>) =
+            manifest_list.entries().iter().cloned().partition(|m| {
+                m.content == ManifestContentType::Data
+                    && m.partition_spec_id == default_spec_id
+                    && (m.has_added_files() || m.has_existing_files())
+            });
 
         if to_rewrite.is_empty() {
             return Ok(ActionCommit::new(vec![], vec![]));
@@ -114,23 +102,20 @@ impl TransactionAction for RewriteManifestsAction {
         if to_rewrite.len() == 1 && total_size <= target_size_bytes {
             return Ok(ActionCommit::new(vec![], vec![]));
         }
-        let manifests_replaced = to_rewrite.len();
 
         let commit_uuid = Uuid::now_v7();
         let snapshot_id = generate_unique_snapshot_id(table);
 
-        let file_io = table.file_io().clone();
-        let loaded: Vec<_> = stream::iter(to_rewrite)
+        let loaded: Vec<_> = stream::iter(to_rewrite.iter().cloned())
             .map(|m| {
-                let file_io = file_io.clone();
+                let file_io = table.file_io().clone();
                 async move { m.load_manifest(&file_io).await }
             })
             .buffer_unordered(16)
             .try_collect()
             .await?;
 
-        type EntryRecord = (DataFile, i64, i64, Option<i64>);
-        let mut grouped: Vec<Vec<EntryRecord>> = Vec::new();
+        let mut grouped: Vec<Vec<(DataFile, i64, i64, Option<i64>)>> = Vec::new();
         let mut group_index: HashMap<Struct, usize> = HashMap::new();
         let mut entries_processed: u64 = 0;
 
@@ -166,6 +151,12 @@ impl TransactionAction for RewriteManifestsAction {
             }
         }
 
+        let bytes_per_entry = if entries_processed > 0 {
+            total_size / entries_processed
+        } else {
+            FALLBACK_BYTES_PER_ENTRY
+        };
+
         let mut counter: u64 = 0;
         let mut new_manifests: Vec<ManifestFile> = Vec::with_capacity(grouped.len());
 
@@ -177,7 +168,7 @@ impl TransactionAction for RewriteManifestsAction {
 
             for (data_file, snap_id, seq, file_seq) in group {
                 if accumulated > 0
-                    && accumulated.saturating_add(APPROX_BYTES_PER_ENTRY) > target_size_bytes
+                    && accumulated.saturating_add(bytes_per_entry) > target_size_bytes
                 {
                     let mut written = writer.write_manifest_file().await?;
                     if format_version == FormatVersion::V3 {
@@ -189,14 +180,11 @@ impl TransactionAction for RewriteManifestsAction {
                     accumulated = 0;
                     min_first_row_id = None;
                 }
-                if let Some(frid) = data_file.first_row_id
-                    && frid >= 0
-                {
-                    let frid_u = frid as u64;
+                if let Some(frid_u) = data_file.first_row_id.and_then(|f| u64::try_from(f).ok()) {
                     min_first_row_id = Some(min_first_row_id.map_or(frid_u, |m| m.min(frid_u)));
                 }
                 writer.add_existing_file(data_file, snap_id, seq, file_seq)?;
-                accumulated = accumulated.saturating_add(APPROX_BYTES_PER_ENTRY);
+                accumulated = accumulated.saturating_add(bytes_per_entry);
             }
             let mut written = writer.write_manifest_file().await?;
             if format_version == FormatVersion::V3 {
@@ -233,8 +221,9 @@ impl TransactionAction for RewriteManifestsAction {
                 Some(next_row_id),
             ),
         };
-        let manifests_created = new_manifests.len();
-        let manifests_kept = kept.len();
+        let manifests_created = new_manifests.len().to_string();
+        let manifests_replaced = to_rewrite.len().to_string();
+        let manifests_kept = kept.len().to_string();
         list_writer.add_manifests(new_manifests.into_iter().chain(kept))?;
         list_writer.close().await?;
 
@@ -251,16 +240,9 @@ impl TransactionAction for RewriteManifestsAction {
                 additional_properties.insert(k.to_string(), v.clone());
             }
         }
-        // Pure rewrite preserves totals verbatim (no add/delete files).
-        additional_properties.insert(
-            "manifests-created".to_string(),
-            manifests_created.to_string(),
-        );
-        additional_properties.insert(
-            "manifests-replaced".to_string(),
-            manifests_replaced.to_string(),
-        );
-        additional_properties.insert("manifests-kept".to_string(), manifests_kept.to_string());
+        additional_properties.insert("manifests-created".to_string(), manifests_created);
+        additional_properties.insert("manifests-replaced".to_string(), manifests_replaced);
+        additional_properties.insert("manifests-kept".to_string(), manifests_kept);
         additional_properties.insert(
             "entries-processed".to_string(),
             entries_processed.to_string(),
@@ -413,7 +395,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_multi_manifest_merge_v2_preserves_sequence_numbers() {
+    async fn test_multi_manifest_merge_preserves_sequence_numbers() {
         let catalog = new_memory_catalog().await;
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
 
@@ -498,8 +480,6 @@ mod tests {
         }
 
         let tx = Transaction::new(&t);
-        // Target just above one entry's proxy cost (APPROX_BYTES_PER_ENTRY = 256)
-        // so each new manifest holds at most one entry.
         let t = tx
             .rewrite_manifests()
             .set_target_size_bytes(400)
@@ -522,7 +502,12 @@ mod tests {
         let mut total = 0;
         for m in post_list.entries() {
             let manifest = m.load_manifest(t.file_io()).await.unwrap();
-            total += manifest.entries().len();
+            let n = manifest.entries().len();
+            assert!(
+                n <= 2,
+                "each rolled manifest should hold at most ~2 entries when target is just above bytes_per_entry"
+            );
+            total += n;
         }
         assert_eq!(total, 6);
     }
@@ -591,6 +576,15 @@ mod tests {
         let table = append_one(&catalog, table, data_file("a", 1, 100, 10)).await;
         let table = append_one(&catalog, table, data_file("b", 2, 200, 20)).await;
 
+        let pre_total_files_size = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .summary()
+            .additional_properties
+            .get("total-files-size")
+            .cloned();
+
         let tx = Transaction::new(&table);
         let mut commit = Arc::new(
             tx.rewrite_manifests()
@@ -612,9 +606,9 @@ mod tests {
         assert_eq!(s.get("entries-processed").unwrap(), "2");
         assert_eq!(s.get("manifests-replaced").unwrap(), "2");
         assert_eq!(s.get("manifests-kept").unwrap(), "0");
-        // Two distinct partitions → grouped into two new manifests.
         assert_eq!(s.get("manifests-created").unwrap(), "2");
         assert_eq!(s.get("total-records").unwrap(), "30");
+        assert_eq!(s.get("total-files-size").cloned(), pre_total_files_size);
     }
 
     #[tokio::test]
@@ -681,8 +675,8 @@ mod tests {
         let snap = table.metadata().current_snapshot().unwrap();
         assert_eq!(snap.parent_snapshot_id(), Some(pre_id));
         assert_eq!(snap.sequence_number(), pre_seq + 1);
+        assert_ne!(snap.snapshot_id(), pre_id);
 
-        // Each output manifest's entries must all share the same partition tuple.
         let post_list = table.manifest_list_reader(snap).load().await.unwrap();
         assert_eq!(
             post_list.entries().len(),

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -1,0 +1,706 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::spec::{
+    DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestFile,
+    ManifestListWriter, ManifestWriter, ManifestWriterBuilder, Operation, Snapshot,
+    SnapshotReference, SnapshotRetention, Struct, Summary,
+};
+use crate::table::Table;
+use crate::transaction::{ActionCommit, TransactionAction};
+use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
+
+const META_ROOT_PATH: &str = "metadata";
+const DEFAULT_TARGET_MANIFEST_SIZE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Rewrite the data manifests of a table's current snapshot.
+///
+/// Mirrors Java's `RewriteManifests`: groups live entries from existing data
+/// manifests bound to the current default partition spec by partition tuple
+/// and writes them into a smaller number of larger manifests, while
+/// preserving every entry's data file, snapshot id, and data/file sequence
+/// numbers (and, on v3, row lineage). Delete manifests and data manifests
+/// bound to non-default partition specs are kept unchanged. Produces a
+/// `Replace` snapshot.
+pub struct RewriteManifestsAction {
+    target_size_bytes: Option<u64>,
+    snapshot_properties: HashMap<String, String>,
+    commit_uuid: Option<Uuid>,
+    key_metadata: Option<Vec<u8>>,
+}
+
+impl RewriteManifestsAction {
+    pub(crate) fn new() -> Self {
+        Self {
+            target_size_bytes: None,
+            snapshot_properties: HashMap::new(),
+            commit_uuid: None,
+            key_metadata: None,
+        }
+    }
+
+    /// Override the target manifest file size in bytes used to roll a new
+    /// manifest. Defaults to 8 MiB to match the Java
+    /// `commit.manifest.target-size-bytes` default.
+    pub fn with_target_size_bytes(mut self, target_size_bytes: u64) -> Self {
+        self.target_size_bytes = Some(target_size_bytes);
+        self
+    }
+
+    /// Set the snapshot summary properties.
+    pub fn set_snapshot_properties(mut self, snapshot_properties: HashMap<String, String>) -> Self {
+        self.snapshot_properties = snapshot_properties;
+        self
+    }
+
+    /// Set commit UUID for the snapshot.
+    pub fn set_commit_uuid(mut self, commit_uuid: Uuid) -> Self {
+        self.commit_uuid = Some(commit_uuid);
+        self
+    }
+
+    /// Set encryption key metadata for newly written manifest files.
+    pub fn set_key_metadata(mut self, key_metadata: Vec<u8>) -> Self {
+        self.key_metadata = Some(key_metadata);
+        self
+    }
+}
+
+#[async_trait]
+impl TransactionAction for RewriteManifestsAction {
+    async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
+        let metadata = table.metadata();
+        let Some(current_snapshot) = metadata.current_snapshot() else {
+            return Err(Error::new(
+                ErrorKind::PreconditionFailed,
+                "RewriteManifests requires the table to have a current snapshot",
+            ));
+        };
+
+        let target_size_bytes = self
+            .target_size_bytes
+            .unwrap_or(DEFAULT_TARGET_MANIFEST_SIZE_BYTES);
+        let default_spec_id = metadata.default_partition_spec_id();
+        let format_version = metadata.format_version();
+
+        let manifest_list = current_snapshot
+            .load_manifest_list(table.file_io(), &table.metadata_ref())
+            .await?;
+
+        let mut kept: Vec<ManifestFile> = Vec::new();
+        let mut to_rewrite: Vec<ManifestFile> = Vec::new();
+        for manifest in manifest_list.entries() {
+            let is_data = manifest.content == ManifestContentType::Data;
+            let on_default_spec = manifest.partition_spec_id == default_spec_id;
+            let has_live = manifest.has_added_files() || manifest.has_existing_files();
+            if is_data && on_default_spec && has_live {
+                to_rewrite.push(manifest.clone());
+            } else {
+                kept.push(manifest.clone());
+            }
+        }
+
+        let single_below_target =
+            to_rewrite.len() == 1 && (to_rewrite[0].manifest_length as u64) <= target_size_bytes;
+        if to_rewrite.is_empty() || single_below_target {
+            return Ok(ActionCommit::new(vec![], vec![]));
+        }
+
+        let mut replaced_active_files: u64 = 0;
+        for m in &to_rewrite {
+            replaced_active_files += m.added_files_count.unwrap_or(0) as u64;
+            replaced_active_files += m.existing_files_count.unwrap_or(0) as u64;
+        }
+
+        let commit_uuid = self.commit_uuid.unwrap_or_else(Uuid::now_v7);
+        let snapshot_id = generate_unique_snapshot_id(table);
+
+        let mut grouped: Vec<Vec<crate::spec::ManifestEntry>> = Vec::new();
+        let mut group_index: HashMap<Struct, usize> = HashMap::new();
+        let mut entries_processed: u64 = 0;
+
+        for manifest_file in &to_rewrite {
+            let manifest = manifest_file.load_manifest(table.file_io()).await?;
+            for entry in manifest.entries() {
+                if !entry.is_alive() {
+                    continue;
+                }
+                let key = entry.data_file().partition.clone();
+                let idx = match group_index.get(&key) {
+                    Some(&i) => i,
+                    None => {
+                        let i = grouped.len();
+                        group_index.insert(key, i);
+                        grouped.push(Vec::new());
+                        i
+                    }
+                };
+                grouped[idx].push((**entry).clone());
+                entries_processed += 1;
+            }
+        }
+
+        if entries_processed != replaced_active_files {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Manifest list active file count ({replaced_active_files}) disagrees with manifest entry count ({entries_processed})"
+                ),
+            ));
+        }
+
+        for group in &mut grouped {
+            group.sort_by(|a, b| a.data_file().file_path.cmp(&b.data_file().file_path));
+        }
+
+        let mut counter: u64 = 0;
+        let mut new_manifests: Vec<ManifestFile> = Vec::new();
+
+        for group in grouped {
+            let mut writer = new_manifest_writer(
+                table,
+                &commit_uuid,
+                &mut counter,
+                self.key_metadata.clone(),
+                snapshot_id,
+            )?;
+            let mut accumulated: u64 = 0;
+            let mut min_first_row_id: Option<u64> = None;
+
+            for entry in group {
+                let entry_proxy_size = entry.data_file().file_size_in_bytes;
+                if accumulated > 0
+                    && accumulated.saturating_add(entry_proxy_size) > target_size_bytes
+                {
+                    let mut written = writer.write_manifest_file().await?;
+                    if format_version == FormatVersion::V3 {
+                        written.first_row_id = min_first_row_id;
+                    }
+                    new_manifests.push(written);
+                    writer = new_manifest_writer(
+                        table,
+                        &commit_uuid,
+                        &mut counter,
+                        self.key_metadata.clone(),
+                        snapshot_id,
+                    )?;
+                    accumulated = 0;
+                    min_first_row_id = None;
+                }
+                if let Some(frid) = entry.data_file().first_row_id
+                    && frid >= 0
+                {
+                    let frid_u = frid as u64;
+                    min_first_row_id = Some(min_first_row_id.map_or(frid_u, |m| m.min(frid_u)));
+                }
+                let snap_id = entry.snapshot_id().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        "Live manifest entry is missing snapshot_id",
+                    )
+                })?;
+                let seq = entry.sequence_number().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        "Live manifest entry is missing sequence_number",
+                    )
+                })?;
+                let file_seq = entry.file_sequence_number;
+                let data_file = entry.data_file().clone();
+                writer.add_existing_file(data_file, snap_id, seq, file_seq)?;
+                accumulated = accumulated.saturating_add(entry_proxy_size);
+            }
+            let mut written = writer.write_manifest_file().await?;
+            if format_version == FormatVersion::V3 {
+                written.first_row_id = min_first_row_id;
+            }
+            new_manifests.push(written);
+        }
+
+        let new_active_files: u64 = new_manifests
+            .iter()
+            .map(|m| {
+                m.added_files_count.unwrap_or(0) as u64 + m.existing_files_count.unwrap_or(0) as u64
+            })
+            .sum();
+        if new_active_files != replaced_active_files {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "Rewrite produced {new_active_files} active files, expected {replaced_active_files}"
+                ),
+            ));
+        }
+
+        let manifest_list_path = generate_manifest_list_file_path(table, snapshot_id, commit_uuid);
+        let next_seq_num = metadata.next_sequence_number();
+        let next_row_id = metadata.next_row_id();
+        let mut list_writer = match format_version {
+            FormatVersion::V1 => ManifestListWriter::v1(
+                table.file_io().new_output(manifest_list_path.clone())?,
+                snapshot_id,
+                metadata.current_snapshot_id(),
+            ),
+            FormatVersion::V2 => ManifestListWriter::v2(
+                table.file_io().new_output(manifest_list_path.clone())?,
+                snapshot_id,
+                metadata.current_snapshot_id(),
+                next_seq_num,
+            ),
+            FormatVersion::V3 => ManifestListWriter::v3(
+                table.file_io().new_output(manifest_list_path.clone())?,
+                snapshot_id,
+                metadata.current_snapshot_id(),
+                next_seq_num,
+                Some(next_row_id),
+            ),
+        };
+        let manifests_created = new_manifests.len();
+        let manifests_replaced = to_rewrite.len();
+        let manifests_kept = kept.len();
+        list_writer.add_manifests(new_manifests.into_iter().chain(kept.into_iter()))?;
+        list_writer.close().await?;
+
+        let mut additional_properties = HashMap::new();
+        for k in [
+            "total-data-files",
+            "total-delete-files",
+            "total-records",
+            "total-files-size",
+            "total-position-deletes",
+            "total-equality-deletes",
+        ] {
+            if let Some(v) = current_snapshot.summary().additional_properties.get(k) {
+                additional_properties.insert(k.to_string(), v.clone());
+            }
+        }
+        additional_properties.insert(
+            "manifests-created".to_string(),
+            manifests_created.to_string(),
+        );
+        additional_properties.insert(
+            "manifests-replaced".to_string(),
+            manifests_replaced.to_string(),
+        );
+        additional_properties.insert("manifests-kept".to_string(), manifests_kept.to_string());
+        additional_properties.insert(
+            "entries-processed".to_string(),
+            entries_processed.to_string(),
+        );
+        for (k, v) in &self.snapshot_properties {
+            additional_properties.insert(k.clone(), v.clone());
+        }
+        let summary = Summary {
+            operation: Operation::Replace,
+            additional_properties,
+        };
+
+        let commit_ts = chrono::Utc::now().timestamp_millis();
+        let snapshot_builder = Snapshot::builder()
+            .with_manifest_list(manifest_list_path)
+            .with_snapshot_id(snapshot_id)
+            .with_parent_snapshot_id(metadata.current_snapshot_id())
+            .with_sequence_number(next_seq_num)
+            .with_summary(summary)
+            .with_schema_id(metadata.current_schema_id())
+            .with_timestamp_ms(commit_ts);
+        let new_snapshot = match format_version {
+            FormatVersion::V3 => snapshot_builder.with_row_range(next_row_id, 0).build(),
+            _ => snapshot_builder.build(),
+        };
+
+        let updates = vec![
+            TableUpdate::AddSnapshot {
+                snapshot: new_snapshot,
+            },
+            TableUpdate::SetSnapshotRef {
+                ref_name: MAIN_BRANCH.to_string(),
+                reference: SnapshotReference::new(
+                    snapshot_id,
+                    SnapshotRetention::branch(None, None, None),
+                ),
+            },
+        ];
+        let requirements = vec![
+            TableRequirement::UuidMatch {
+                uuid: metadata.uuid(),
+            },
+            TableRequirement::RefSnapshotIdMatch {
+                r#ref: MAIN_BRANCH.to_string(),
+                snapshot_id: metadata.current_snapshot_id(),
+            },
+        ];
+        Ok(ActionCommit::new(updates, requirements))
+    }
+}
+
+fn new_manifest_writer(
+    table: &Table,
+    commit_uuid: &Uuid,
+    counter: &mut u64,
+    key_metadata: Option<Vec<u8>>,
+    snapshot_id: i64,
+) -> Result<ManifestWriter> {
+    let n = *counter;
+    *counter += 1;
+    let path = format!(
+        "{}/{}/{}-m{}.{}",
+        table.metadata().location(),
+        META_ROOT_PATH,
+        commit_uuid,
+        n,
+        DataFileFormat::Avro
+    );
+    let output = table.file_io().new_output(path)?;
+    let builder = ManifestWriterBuilder::new(
+        output,
+        Some(snapshot_id),
+        key_metadata,
+        table.metadata().current_schema().clone(),
+        table.metadata().default_partition_spec().as_ref().clone(),
+    );
+    Ok(match table.metadata().format_version() {
+        FormatVersion::V1 => builder.build_v1(),
+        FormatVersion::V2 => builder.build_v2_data(),
+        FormatVersion::V3 => builder.build_v3_data(),
+    })
+}
+
+fn generate_manifest_list_file_path(table: &Table, snapshot_id: i64, commit_uuid: Uuid) -> String {
+    format!(
+        "{}/{}/snap-{}-{}-{}.{}",
+        table.metadata().location(),
+        META_ROOT_PATH,
+        snapshot_id,
+        0,
+        commit_uuid,
+        DataFileFormat::Avro
+    )
+}
+
+fn generate_unique_snapshot_id(table: &Table) -> i64 {
+    let gen_id = || -> i64 {
+        let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
+        let id = (lhs ^ rhs) as i64;
+        if id < 0 { -id } else { id }
+    };
+    let mut id = gen_id();
+    while table.metadata().snapshots().any(|s| s.snapshot_id() == id) {
+        id = gen_id();
+    }
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::memory::tests::new_memory_catalog;
+    use crate::spec::{
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, Operation, Struct,
+    };
+    use crate::table::Table;
+    use crate::transaction::tests::{make_v2_minimal_table, make_v3_minimal_table_in_catalog};
+    use crate::transaction::{ApplyTransactionAction, Transaction, TransactionAction};
+    use crate::{Catalog, TableUpdate};
+
+    fn data_file(name: &str, partition: i64, size: u64, records: u64) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(format!("test/{name}.parquet"))
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(size)
+            .record_count(records)
+            .partition_spec_id(0)
+            .partition(Struct::from_iter([Some(Literal::long(partition))]))
+            .build()
+            .unwrap()
+    }
+
+    async fn append_one(catalog: &impl Catalog, table: Table, file: DataFile) -> Table {
+        let tx = Transaction::new(&table);
+        tx.fast_append()
+            .add_data_files(vec![file])
+            .apply(tx)
+            .unwrap()
+            .commit(catalog)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_no_current_snapshot_errors() {
+        let table = make_v2_minimal_table();
+        let tx = Transaction::new(&table);
+        let action = tx.rewrite_manifests();
+        let res = Arc::new(action).commit(&table).await;
+        assert!(res.is_err(), "expected PreconditionFailed without snapshot");
+    }
+
+    #[tokio::test]
+    async fn test_single_small_manifest_is_noop() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let table = append_one(&catalog, table, data_file("a", 1, 100, 1)).await;
+        let original_snapshot_id = table.metadata().current_snapshot_id();
+
+        let tx = Transaction::new(&table);
+        let action = tx.rewrite_manifests();
+        let mut commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = commit.take_updates();
+        assert!(updates.is_empty(), "single small manifest should be no-op");
+
+        let table = tx
+            .rewrite_manifests()
+            .apply(Transaction::new(&table))
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+        assert_eq!(
+            table.metadata().current_snapshot_id(),
+            original_snapshot_id,
+            "no-op should not change the current snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_manifest_merge_v2_preserves_sequence_numbers() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+
+        let table = append_one(&catalog, table, data_file("a", 1, 1_000, 10)).await;
+        let seq_a = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .sequence_number();
+        let table = append_one(&catalog, table, data_file("b", 1, 2_000, 20)).await;
+        let seq_b = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .sequence_number();
+        let table = append_one(&catalog, table, data_file("c", 2, 3_000, 30)).await;
+        let seq_c = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .sequence_number();
+        assert!(seq_a < seq_b && seq_b < seq_c);
+
+        let pre_manifest_count = table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap()
+            .entries()
+            .len();
+        assert_eq!(pre_manifest_count, 3);
+
+        let tx = Transaction::new(&table);
+        let table = tx
+            .rewrite_manifests()
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let snapshot = table.metadata().current_snapshot().unwrap();
+        assert_eq!(snapshot.summary().operation, Operation::Replace);
+
+        let post_list = snapshot
+            .load_manifest_list(table.file_io(), table.metadata())
+            .await
+            .unwrap();
+        let total_entries: usize = {
+            let mut n = 0;
+            for m in post_list.entries() {
+                let manifest = m.load_manifest(table.file_io()).await.unwrap();
+                n += manifest.entries().len();
+            }
+            n
+        };
+        assert_eq!(total_entries, 3, "all entries preserved across rewrite");
+
+        let mut seen_seqs: Vec<i64> = Vec::new();
+        for m in post_list.entries() {
+            let manifest = m.load_manifest(table.file_io()).await.unwrap();
+            for entry in manifest.entries() {
+                seen_seqs.push(entry.sequence_number().unwrap());
+            }
+        }
+        seen_seqs.sort();
+        assert_eq!(seen_seqs, vec![seq_a, seq_b, seq_c]);
+
+        assert!(post_list.entries().len() < pre_manifest_count);
+
+        let summary = &snapshot.summary().additional_properties;
+        assert_eq!(summary.get("total-records").unwrap(), "60");
+        assert_eq!(summary.get("total-data-files").unwrap(), "3");
+        assert_eq!(summary.get("entries-processed").unwrap(), "3");
+        assert_eq!(summary.get("manifests-replaced").unwrap(), "3");
+    }
+
+    #[tokio::test]
+    async fn test_target_size_rolls_multiple_manifests() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let mut t = table;
+        for i in 0..6 {
+            t = append_one(&catalog, t, data_file(&format!("f{i}"), 1, 10_000, 1)).await;
+        }
+
+        let tx = Transaction::new(&t);
+        let t = tx
+            .rewrite_manifests()
+            .with_target_size_bytes(15_000)
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        let post_list = t
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .load_manifest_list(t.file_io(), t.metadata())
+            .await
+            .unwrap();
+        assert!(
+            post_list.entries().len() > 1,
+            "rolling should produce multiple manifests when target is small"
+        );
+
+        let mut total = 0;
+        for m in post_list.entries() {
+            let manifest = m.load_manifest(t.file_io()).await.unwrap();
+            total += manifest.entries().len();
+        }
+        assert_eq!(total, 6);
+    }
+
+    #[tokio::test]
+    async fn test_v3_row_lineage_preserved() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let table = append_one(&catalog, table, data_file("a", 1, 100, 30)).await;
+        let table = append_one(&catalog, table, data_file("b", 1, 100, 17)).await;
+        let table = append_one(&catalog, table, data_file("c", 1, 100, 11)).await;
+
+        let pre_first_row_ids: Vec<Option<i64>> = {
+            let list = table
+                .metadata()
+                .current_snapshot()
+                .unwrap()
+                .load_manifest_list(table.file_io(), table.metadata())
+                .await
+                .unwrap();
+            let mut v = Vec::new();
+            for m in list.entries() {
+                let manifest = m.load_manifest(table.file_io()).await.unwrap();
+                for entry in manifest.entries() {
+                    v.push(entry.data_file().first_row_id);
+                }
+            }
+            v.sort();
+            v
+        };
+
+        let next_row_id_before = table.metadata().next_row_id();
+
+        let tx = Transaction::new(&table);
+        let table = tx
+            .rewrite_manifests()
+            .apply(tx)
+            .unwrap()
+            .commit(&catalog)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            table.metadata().next_row_id(),
+            next_row_id_before,
+            "rewrite must not consume new row ids"
+        );
+        let snap = table.metadata().current_snapshot().unwrap();
+        assert_eq!(snap.row_range(), Some((next_row_id_before, 0)));
+
+        let post_first_row_ids: Vec<Option<i64>> = {
+            let list = snap
+                .load_manifest_list(table.file_io(), table.metadata())
+                .await
+                .unwrap();
+            let mut v = Vec::new();
+            for m in list.entries() {
+                let manifest = m.load_manifest(table.file_io()).await.unwrap();
+                for entry in manifest.entries() {
+                    v.push(entry.data_file().first_row_id);
+                }
+            }
+            v.sort();
+            v
+        };
+        assert_eq!(pre_first_row_ids, post_first_row_ids);
+    }
+
+    #[tokio::test]
+    async fn test_summary_and_replace_operation() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let table = append_one(&catalog, table, data_file("a", 1, 100, 10)).await;
+        let table = append_one(&catalog, table, data_file("b", 2, 200, 20)).await;
+
+        let tx = Transaction::new(&table);
+        let mut commit = Arc::new(
+            tx.rewrite_manifests()
+                .set_snapshot_properties(HashMap::from([(
+                    "trigger".to_string(),
+                    "manual".to_string(),
+                )])),
+        )
+        .commit(&table)
+        .await
+        .unwrap();
+        let updates = commit.take_updates();
+        let snap = match &updates[0] {
+            TableUpdate::AddSnapshot { snapshot } => snapshot,
+            _ => unreachable!(),
+        };
+        let s = &snap.summary().additional_properties;
+        assert_eq!(snap.summary().operation, Operation::Replace);
+        assert_eq!(s.get("trigger").unwrap(), "manual");
+        assert_eq!(s.get("entries-processed").unwrap(), "2");
+        assert_eq!(s.get("manifests-replaced").unwrap(), "2");
+        assert_eq!(s.get("manifests-kept").unwrap(), "0");
+        // Two distinct partitions → grouped into two new manifests.
+        assert_eq!(s.get("manifests-created").unwrap(), "2");
+        assert_eq!(s.get("total-records").unwrap(), "30");
+    }
+}

--- a/crates/iceberg/src/transaction/rewrite_manifests.rs
+++ b/crates/iceberg/src/transaction/rewrite_manifests.rs
@@ -208,19 +208,23 @@ impl TransactionAction for RewriteManifestsAction {
         );
         let next_seq_num = metadata.next_sequence_number();
         let next_row_id = metadata.next_row_id();
-        let output = table.file_io().new_output(manifest_list_path.clone())?;
+        let writer = table
+            .file_io()
+            .new_output(manifest_list_path.clone())?
+            .writer()
+            .await?;
         let mut list_writer = match format_version {
             FormatVersion::V1 => {
-                ManifestListWriter::v1(output, snapshot_id, metadata.current_snapshot_id())
+                ManifestListWriter::v1(writer, snapshot_id, metadata.current_snapshot_id())
             }
             FormatVersion::V2 => ManifestListWriter::v2(
-                output,
+                writer,
                 snapshot_id,
                 metadata.current_snapshot_id(),
                 next_seq_num,
             ),
             FormatVersion::V3 => ManifestListWriter::v3(
-                output,
+                writer,
                 snapshot_id,
                 metadata.current_snapshot_id(),
                 next_seq_num,

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -147,7 +147,7 @@ impl<'a> SnapshotProducer<'a> {
     ) -> Self {
         Self {
             table,
-            snapshot_id: Self::generate_unique_snapshot_id(table),
+            snapshot_id: generate_unique_snapshot_id(table),
             commit_uuid,
             snapshot_properties,
             added_data_files,
@@ -232,10 +232,6 @@ impl<'a> SnapshotProducer<'a> {
         }
 
         Ok(())
-    }
-
-    fn generate_unique_snapshot_id(table: &Table) -> i64 {
-        generate_unique_snapshot_id(table)
     }
 
     fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -36,21 +36,26 @@ use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
 
-/// Generate a snapshot id that is not already used by any snapshot in `table`.
-///
-/// `i64::MIN` is masked off so the result is always representable as a positive
-/// `i64` (avoiding the `-i64::MIN` overflow that the previous `if id < 0 { -id }`
-/// branch would have hit).
 pub(crate) fn generate_unique_snapshot_id(table: &Table) -> i64 {
-    let gen_id = || -> i64 {
+    let generate_random_id = || -> i64 {
         let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
-        ((lhs ^ rhs) & (i64::MAX as u64)) as i64
+        let snapshot_id = (lhs ^ rhs) as i64;
+        if snapshot_id < 0 {
+            -snapshot_id
+        } else {
+            snapshot_id
+        }
     };
-    let mut id = gen_id();
-    while table.metadata().snapshots().any(|s| s.snapshot_id() == id) {
-        id = gen_id();
+    let mut snapshot_id = generate_random_id();
+
+    while table
+        .metadata()
+        .snapshots()
+        .any(|s| s.snapshot_id() == snapshot_id)
+    {
+        snapshot_id = generate_random_id();
     }
-    id
+    snapshot_id
 }
 
 /// A trait that defines how different table operations produce new snapshots.

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -36,6 +36,23 @@ use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
 const META_ROOT_PATH: &str = "metadata";
 
+/// Generate a snapshot id that is not already used by any snapshot in `table`.
+///
+/// `i64::MIN` is masked off so the result is always representable as a positive
+/// `i64` (avoiding the `-i64::MIN` overflow that the previous `if id < 0 { -id }`
+/// branch would have hit).
+pub(crate) fn generate_unique_snapshot_id(table: &Table) -> i64 {
+    let gen_id = || -> i64 {
+        let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
+        ((lhs ^ rhs) & (i64::MAX as u64)) as i64
+    };
+    let mut id = gen_id();
+    while table.metadata().snapshots().any(|s| s.snapshot_id() == id) {
+        id = gen_id();
+    }
+    id
+}
+
 /// A trait that defines how different table operations produce new snapshots.
 ///
 /// `SnapshotProduceOperation` is used by [`SnapshotProducer`] to customize snapshot creation
@@ -218,25 +235,7 @@ impl<'a> SnapshotProducer<'a> {
     }
 
     fn generate_unique_snapshot_id(table: &Table) -> i64 {
-        let generate_random_id = || -> i64 {
-            let (lhs, rhs) = Uuid::new_v4().as_u64_pair();
-            let snapshot_id = (lhs ^ rhs) as i64;
-            if snapshot_id < 0 {
-                -snapshot_id
-            } else {
-                snapshot_id
-            }
-        };
-        let mut snapshot_id = generate_random_id();
-
-        while table
-            .metadata()
-            .snapshots()
-            .any(|s| s.snapshot_id() == snapshot_id)
-        {
-            snapshot_id = generate_random_id();
-        }
-        snapshot_id
+        generate_unique_snapshot_id(table)
     }
 
     fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {


### PR DESCRIPTION
## Which issue does this PR close?

- Refs #1453 (architectural proposal — table maintenance operations).
- Tracking issue for unifying with `SnapshotProducer`: #2556.

## What changes are included in this PR?

Adds `RewriteManifestsAction`, exposed as `Transaction::rewrite_manifests()`, mirroring Java's `BaseRewriteManifests`:

- groups live `DataFile` entries by partition tuple within the default partition spec
- rolls new manifests by `target_size_bytes` (default 8 MiB, mirrors `commit.manifest.target-size-bytes`)
- preserves `sequence_number`, `file_sequence_number`, and (v3) `first_row_id` via `ManifestWriter::add_existing_file`
- carries forward `total-*` summary keys; emits `manifests-created`, `manifests-replaced`, `manifests-kept`, `entries-processed`
- commits a `Replace` snapshot

**Why a separate path from `SnapshotProducer`?** The producer cannot emit a `Replace` snapshot today: `update_snapshot_summaries` (`spec/snapshot_summary.rs:337-346`) rejects `Operation::Replace`, summary keys are driven by `added_data_files` only (`transaction/snapshot.rs:373-379`), and `ManifestProcess::process_manifests` is sync (blocks async manifest writes). Once those land, this action will migrate onto the unified path — tracked in #2556.

**Scope (Java-parity ceiling):** v1/v2/v3 format versions; knob set is `target_size_bytes` plus inherited `snapshot_properties` / `commit_uuid` / `key_metadata`. Out of scope: `rewrite_if` predicate, `cluster_by`, custom `spec_id` / `staging_location`, `iceberg-datafusion` SQL-procedure layer. Manifests bound to non-default specs and `DELETE` manifests pass through verbatim.

## Are these changes tested?

8 inline unit tests covering: missing current snapshot, single-small-manifest no-op, multi-manifest merge preserves sequence numbers (v2), target-size rolls multiple manifests, v3 row lineage + per-entry `(first_row_id, sequence_number, file_sequence_number)` preservation, summary + `Replace` operation, partition grouping + catalog commit, idempotency-after-consolidation. Tested on v2 and v3; the rewrite path is format-version-agnostic by construction (v1 uses the same `ManifestListWriter::v1` arm).

- `cargo test -p iceberg` (1304 passed, 0 failed)
- `cargo clippy -p iceberg --all-targets -- -D warnings`
- `cargo fmt --check`
- `make check-public-api`