### PR TITLE
bench(reader): add ArrowReader benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1382,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1672,11 +1711,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -3502,6 +3589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,6 +3855,7 @@ dependencies = [
  "bimap",
  "bytes",
  "chrono",
+ "criterion",
  "derive_builder",
  "expect-test",
  "fastnum",
@@ -4241,10 +4335,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -5158,6 +5272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5716,6 +5836,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,6 +6319,26 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "recursive"
@@ -7885,6 +8053,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ bytes = "1.11"
 cfg-if = "1"
 chrono = "0.4.41"
 clap = { version = "4.5.48", features = ["derive", "cargo"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 dashmap = "6"
 datafusion = "53.1.0"
 datafusion-cli = "53.0.0"

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -84,6 +84,7 @@ zeroize = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 expect-test = { workspace = true }
 iceberg_test_utils = { path = "../test_utils", features = ["tests"] }
 minijinja = { workspace = true }
@@ -97,3 +98,7 @@ tempfile = { workspace = true }
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["tap"]
+
+[[bench]]
+harness = false
+name = "arrow_reader"

--- a/crates/iceberg/benches/arrow_reader.rs
+++ b/crates/iceberg/benches/arrow_reader.rs
@@ -1,0 +1,417 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for [`ArrowReader`], focused on the per-`FileScanTask` overhead
+//! that dominates scans of tables with many small data files (see epic #2172).
+//!
+//! The files are written to a local temp directory and read back through the
+//! normal `FileIO` (local FS) path, so these measure CPU and per-task work
+//! (operator construction, metadata loading, schema resolution, projection /
+//! row-filter setup, stream wiring) rather than network latency. They give an
+//! in-repo, reproducible baseline against which I/O- and CPU-reuse
+//! optimizations can be measured.
+//!
+//! Run with: `cargo bench -p iceberg --bench arrow_reader`
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use futures::{TryStreamExt, stream};
+use iceberg::Runtime;
+use iceberg::arrow::ArrowReaderBuilder;
+use iceberg::expr::{Bind, Reference};
+use iceberg::io::FileIO;
+use iceberg::scan::{FileScanTask, FileScanTaskStream};
+use iceberg::spec::{
+    DataFileFormat, Datum, MappedField, NameMapping, NestedField, PrimitiveType, Schema, SchemaRef,
+    Type,
+};
+use parquet::arrow::{ArrowWriter, PARQUET_FIELD_ID_META_KEY};
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use tempfile::TempDir;
+use tokio::runtime::Runtime as TokioRuntime;
+
+/// Rows written into each generated Parquet data file. Kept small so the
+/// benchmark stresses per-file overhead (the regime epic #2172 targets) rather
+/// than column decoding throughput.
+const ROWS_PER_FILE: usize = 100;
+
+/// Build the Iceberg + Arrow schema pair used for every generated file:
+/// `(id: long, name: string)` with embedded Parquet field IDs, so the reader
+/// takes the "file has field IDs" fast path.
+fn schemas() -> (SchemaRef, arrow_schema::SchemaRef) {
+    let iceberg_schema = Arc::new(
+        Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+            ])
+            .build()
+            .unwrap(),
+    );
+
+    let arrow_schema = Arc::new(arrow_schema::Schema::new(vec![
+        arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false).with_metadata(
+            std::collections::HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "1".to_string(),
+            )]),
+        ),
+        arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, true).with_metadata(
+            std::collections::HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "2".to_string(),
+            )]),
+        ),
+    ]));
+
+    (iceberg_schema, arrow_schema)
+}
+
+/// Write `num_files` small Parquet files into `dir` and return their paths.
+fn write_files(
+    dir: &TempDir,
+    num_files: usize,
+    arrow_schema: &arrow_schema::SchemaRef,
+) -> Vec<String> {
+    let ids: ArrayRef = Arc::new(Int64Array::from_iter_values(0..ROWS_PER_FILE as i64));
+    let names: ArrayRef = Arc::new(StringArray::from_iter_values(
+        (0..ROWS_PER_FILE).map(|i| format!("row-{i}")),
+    ));
+    let batch =
+        RecordBatch::try_new(arrow_schema.clone(), vec![ids, names]).expect("build record batch");
+
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+
+    (0..num_files)
+        .map(|i| {
+            let path = format!("{}/data_{i}.parquet", dir.path().to_str().unwrap());
+            let file = std::fs::File::create(&path).expect("create parquet file");
+            let mut writer = ArrowWriter::try_new(file, arrow_schema.clone(), Some(props.clone()))
+                .expect("create arrow writer");
+            writer.write(&batch).expect("write batch");
+            writer.close().expect("close writer");
+            path
+        })
+        .collect()
+}
+
+/// Arrow schema WITHOUT embedded Parquet field IDs, simulating files migrated
+/// from Hive/Spark via `add_files`. Forces the reader's name-mapping branch.
+fn arrow_schema_without_field_ids() -> arrow_schema::SchemaRef {
+    Arc::new(arrow_schema::Schema::new(vec![
+        arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
+        arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, true),
+    ]))
+}
+
+/// Name mapping that assigns the table's field IDs by column name — what the
+/// reader applies when a file lacks embedded field IDs.
+fn name_mapping() -> Arc<NameMapping> {
+    Arc::new(NameMapping::new(vec![
+        MappedField::new(Some(1), vec!["id".to_string()], vec![]),
+        MappedField::new(Some(2), vec!["name".to_string()], vec![]),
+    ]))
+}
+
+/// Write a single Parquet file with many small row groups, so that byte-range
+/// splits select disjoint row-group sets — the same-file-split scenario that
+/// metadata caching (#2100 / item #5) targets.
+fn write_multi_row_group_file(
+    dir: &TempDir,
+    total_rows: usize,
+    rows_per_row_group: usize,
+    arrow_schema: &arrow_schema::SchemaRef,
+) -> String {
+    let ids: ArrayRef = Arc::new(Int64Array::from_iter_values(0..total_rows as i64));
+    let names: ArrayRef = Arc::new(StringArray::from_iter_values(
+        (0..total_rows).map(|i| format!("row-{i}")),
+    ));
+    let batch =
+        RecordBatch::try_new(arrow_schema.clone(), vec![ids, names]).expect("build record batch");
+
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .set_max_row_group_row_count(Some(rows_per_row_group))
+        .build();
+
+    let path = format!("{}/big.parquet", dir.path().to_str().unwrap());
+    let file = std::fs::File::create(&path).expect("create parquet file");
+    let mut writer =
+        ArrowWriter::try_new(file, arrow_schema.clone(), Some(props)).expect("create arrow writer");
+    writer.write(&batch).expect("write batch");
+    writer.close().expect("close writer");
+    path
+}
+
+/// Build a whole-file `FileScanTask` for each path (no predicate, no deletes —
+/// the projection-only path, which isolates per-task setup overhead).
+fn tasks_for(paths: &[String], schema: &SchemaRef) -> Vec<FileScanTask> {
+    paths.iter().map(|p| base_task(p, schema)).collect()
+}
+
+/// A whole-file projection-only task for a single path.
+fn base_task(path: &str, schema: &SchemaRef) -> FileScanTask {
+    let size = std::fs::metadata(path).expect("stat parquet file").len();
+    FileScanTask {
+        file_size_in_bytes: size,
+        start: 0,
+        length: size,
+        record_count: Some(ROWS_PER_FILE as u64),
+        data_file_path: path.to_string(),
+        data_file_format: DataFileFormat::Parquet,
+        schema: schema.clone(),
+        project_field_ids: vec![1, 2],
+        predicate: None,
+        deletes: vec![],
+        partition: None,
+        partition_spec: None,
+        name_mapping: None,
+        case_sensitive: false,
+    }
+}
+
+/// Like [`tasks_for`] but attaches a name mapping (migrated-table path).
+fn tasks_with_name_mapping(paths: &[String], schema: &SchemaRef) -> Vec<FileScanTask> {
+    let mapping = name_mapping();
+    paths
+        .iter()
+        .map(|p| FileScanTask {
+            name_mapping: Some(mapping.clone()),
+            ..base_task(p, schema)
+        })
+        .collect()
+}
+
+/// Build `num_splits` byte-range tasks over the SAME file, partitioning its
+/// length into contiguous ranges (mirroring how Iceberg Java splits a large
+/// file across partitions).
+fn same_file_split_tasks(path: &str, schema: &SchemaRef, num_splits: u64) -> Vec<FileScanTask> {
+    let size = std::fs::metadata(path).expect("stat parquet file").len();
+    let chunk = size.div_ceil(num_splits);
+    (0..num_splits)
+        .map(|i| {
+            let start = i * chunk;
+            let length = chunk.min(size.saturating_sub(start));
+            FileScanTask {
+                file_size_in_bytes: size,
+                start,
+                length,
+                record_count: None,
+                data_file_path: path.to_string(),
+                data_file_format: DataFileFormat::Parquet,
+                schema: schema.clone(),
+                project_field_ids: vec![1, 2],
+                predicate: None,
+                deletes: vec![],
+                partition: None,
+                partition_spec: None,
+                name_mapping: None,
+                case_sensitive: false,
+            }
+        })
+        .collect()
+}
+
+/// Like [`tasks_for`] but attaches a bound predicate (`id < total/2`),
+/// exercising row-filter and row-group-filtering setup per task.
+fn tasks_with_predicate(paths: &[String], schema: &SchemaRef) -> Vec<FileScanTask> {
+    let predicate = Reference::new("id")
+        .less_than(Datum::long(ROWS_PER_FILE as i64 / 2))
+        .bind(schema.clone(), true)
+        .expect("bind predicate");
+    paths
+        .iter()
+        .map(|p| FileScanTask {
+            predicate: Some(predicate.clone()),
+            ..base_task(p, schema)
+        })
+        .collect()
+}
+
+/// Read every task to completion, draining all record batches. `filtering`
+/// turns on row-group filtering and row selection (only meaningful when the
+/// tasks carry a predicate).
+async fn read_all(tasks: Vec<FileScanTask>, concurrency: usize, filtering: bool) {
+    let file_io = FileIO::new_with_fs();
+    let reader = ArrowReaderBuilder::new(file_io, Runtime::current())
+        .with_data_file_concurrency_limit(concurrency)
+        .with_row_group_filtering_enabled(filtering)
+        .with_row_selection_enabled(filtering)
+        .build();
+
+    let task_stream: FileScanTaskStream = Box::pin(stream::iter(tasks.into_iter().map(Ok)));
+
+    let batches: Vec<RecordBatch> = reader
+        .read(task_stream)
+        .expect("build read stream")
+        .stream()
+        .try_collect()
+        .await
+        .expect("read all batches");
+
+    criterion::black_box(batches);
+}
+
+/// Scans of many small files at a fixed concurrency. Throughput is reported in
+/// files/sec so the per-file overhead is directly visible across file counts.
+fn bench_many_small_files(c: &mut Criterion) {
+    let tokio = TokioRuntime::new().unwrap();
+    let (iceberg_schema, arrow_schema) = schemas();
+
+    let mut group = c.benchmark_group("many_small_files");
+    for num_files in [16usize, 64, 256] {
+        // Files are written once and reused across all samples for this size.
+        let dir = TempDir::new().unwrap();
+        let paths = write_files(&dir, num_files, &arrow_schema);
+
+        group.throughput(Throughput::Elements(num_files as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_files),
+            &num_files,
+            |b, _| {
+                b.to_async(&tokio).iter(|| {
+                    let tasks = tasks_for(&paths, &iceberg_schema);
+                    read_all(tasks, num_cpus_limit(), false)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// How concurrency affects throughput for a fixed corpus — exercises both the
+/// single-concurrency fast path and the buffered/flattened multi-task path.
+fn bench_concurrency(c: &mut Criterion) {
+    let tokio = TokioRuntime::new().unwrap();
+    let (iceberg_schema, arrow_schema) = schemas();
+
+    let num_files = 128usize;
+    let dir = TempDir::new().unwrap();
+    let paths = write_files(&dir, num_files, &arrow_schema);
+
+    let mut group = c.benchmark_group("concurrency");
+    group.throughput(Throughput::Elements(num_files as u64));
+    for concurrency in [1usize, 4, 16] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(&tokio).iter(|| {
+                    let tasks = tasks_for(&paths, &iceberg_schema);
+                    read_all(tasks, concurrency, false)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Migrated tables: files lack embedded field IDs, so each task must apply the
+/// name mapping and rebuild `ArrowReaderMetadata`. Compared against the
+/// field-ID fast path, this isolates the migrated-table schema-resolution cost.
+fn bench_migrated_table(c: &mut Criterion) {
+    let tokio = TokioRuntime::new().unwrap();
+    let (iceberg_schema, _) = schemas();
+    let arrow_schema = arrow_schema_without_field_ids();
+
+    let num_files = 128usize;
+    let dir = TempDir::new().unwrap();
+    let paths = write_files(&dir, num_files, &arrow_schema);
+
+    let mut group = c.benchmark_group("migrated_table");
+    group.throughput(Throughput::Elements(num_files as u64));
+    group.bench_function("name_mapping", |b| {
+        b.to_async(&tokio).iter(|| {
+            let tasks = tasks_with_name_mapping(&paths, &iceberg_schema);
+            read_all(tasks, num_cpus_limit(), false)
+        });
+    });
+    group.finish();
+}
+
+/// Same-file splits: one large multi-row-group file read as N byte-range
+/// tasks. Each task currently re-fetches the file's Parquet metadata
+/// independently — the scenario metadata caching (#2100 / item #5) targets.
+fn bench_same_file_splits(c: &mut Criterion) {
+    let tokio = TokioRuntime::new().unwrap();
+    let (iceberg_schema, arrow_schema) = schemas();
+
+    let total_rows = 100_000usize;
+    let rows_per_row_group = 2_000usize;
+    let dir = TempDir::new().unwrap();
+    let path = write_multi_row_group_file(&dir, total_rows, rows_per_row_group, &arrow_schema);
+
+    let mut group = c.benchmark_group("same_file_splits");
+    for num_splits in [1u64, 8, 32] {
+        group.throughput(Throughput::Elements(num_splits));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_splits),
+            &num_splits,
+            |b, &num_splits| {
+                b.to_async(&tokio).iter(|| {
+                    let tasks = same_file_split_tasks(&path, &iceberg_schema, num_splits);
+                    read_all(tasks, num_cpus_limit(), false)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Scans carrying a predicate, with row-group filtering and row selection
+/// enabled — exercises the per-task row-filter / field-id-map / row-group
+/// pruning setup that the projection-only benchmarks skip.
+fn bench_with_predicate(c: &mut Criterion) {
+    let tokio = TokioRuntime::new().unwrap();
+    let (iceberg_schema, arrow_schema) = schemas();
+
+    let num_files = 128usize;
+    let dir = TempDir::new().unwrap();
+    let paths = write_files(&dir, num_files, &arrow_schema);
+
+    let mut group = c.benchmark_group("with_predicate");
+    group.throughput(Throughput::Elements(num_files as u64));
+    group.bench_function("id_lt_half", |b| {
+        b.to_async(&tokio).iter(|| {
+            let tasks = tasks_with_predicate(&paths, &iceberg_schema);
+            read_all(tasks, num_cpus_limit(), true)
+        });
+    });
+    group.finish();
+}
+
+fn num_cpus_limit() -> usize {
+    std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(4)
+}
+
+criterion_group!(
+    benches,
+    bench_many_small_files,
+    bench_concurrency,
+    bench_migrated_table,
+    bench_same_file_splits,
+    bench_with_predicate,
+);
+criterion_main!(benches);

--- a/crates/iceberg/benches/arrow_reader.rs
+++ b/crates/iceberg/benches/arrow_reader.rs
@@ -25,6 +25,14 @@
 //! in-repo, reproducible baseline against which I/O- and CPU-reuse
 //! optimizations can be measured.
 //!
+//! The `same_file_splits` group additionally reports `ScanMetrics::bytes_read`
+//! as its throughput basis. Because that is a deterministic count (not a
+//! wall-clock sample), it surfaces redundant I/O directly: reading one file as
+//! N byte-range splits fetches the Parquet metadata N times, so total bytes
+//! read grows with the split count even though the file contents are identical.
+//! This is the cost that same-file metadata caching (proposed in #2172,
+//! attempted in #2100) targets, and is measurable even on the local FS.
+//!
 //! Run with: `cargo bench -p iceberg --bench arrow_reader`
 
 use std::sync::Arc;
@@ -272,6 +280,30 @@ async fn read_all(tasks: Vec<FileScanTask>, concurrency: usize, filtering: bool)
     criterion::black_box(batches);
 }
 
+/// Read every task to completion and return the total number of bytes fetched
+/// from storage (`ScanMetrics::bytes_read`). Unlike wall-clock time this is a
+/// deterministic measurement, which makes it the right tool for surfacing
+/// redundant I/O — e.g. the per-split metadata re-fetch that same-file metadata
+/// caching (proposed in #2172, attempted in #2100) targets.
+async fn read_all_bytes(tasks: Vec<FileScanTask>, concurrency: usize) -> u64 {
+    let file_io = FileIO::new_with_fs();
+    let reader = ArrowReaderBuilder::new(file_io, Runtime::current())
+        .with_data_file_concurrency_limit(concurrency)
+        .build();
+
+    let task_stream: FileScanTaskStream = Box::pin(stream::iter(tasks.into_iter().map(Ok)));
+
+    let result = reader.read(task_stream).expect("build read stream");
+    let metrics = result.metrics().clone();
+    let _: Vec<RecordBatch> = result
+        .stream()
+        .try_collect()
+        .await
+        .expect("read all batches");
+
+    metrics.bytes_read()
+}
+
 /// Scans of many small files at a fixed concurrency. Throughput is reported in
 /// files/sec so the per-file overhead is directly visible across file counts.
 fn bench_many_small_files(c: &mut Criterion) {
@@ -351,7 +383,8 @@ fn bench_migrated_table(c: &mut Criterion) {
 
 /// Same-file splits: one large multi-row-group file read as N byte-range
 /// tasks. Each task currently re-fetches the file's Parquet metadata
-/// independently — the scenario metadata caching (#2100 / item #5) targets.
+/// independently — the scenario same-file metadata caching (proposed in #2172,
+/// attempted in #2100) targets.
 fn bench_same_file_splits(c: &mut Criterion) {
     let tokio = TokioRuntime::new().unwrap();
     let (iceberg_schema, arrow_schema) = schemas();
@@ -360,10 +393,25 @@ fn bench_same_file_splits(c: &mut Criterion) {
     let rows_per_row_group = 2_000usize;
     let dir = TempDir::new().unwrap();
     let path = write_multi_row_group_file(&dir, total_rows, rows_per_row_group, &arrow_schema);
+    let file_size = std::fs::metadata(&path).expect("stat parquet file").len();
 
     let mut group = c.benchmark_group("same_file_splits");
     for num_splits in [1u64, 8, 32] {
-        group.throughput(Throughput::Elements(num_splits));
+        // Measure bytes_read once (deterministic) and report it as the
+        // benchmark's throughput basis, so criterions own output shows how
+        // total bytes fetched grows with the split count even though the file
+        // contents are identical — i.e. the redundant per-split metadata I/O.
+        let bytes_read = tokio.block_on(read_all_bytes(
+            same_file_split_tasks(&path, &iceberg_schema, num_splits),
+            num_cpus_limit(),
+        ));
+        eprintln!(
+            "same_file_splits/{num_splits}: bytes_read = {bytes_read} \
+             ({:.2}x file size of {file_size})",
+            bytes_read as f64 / file_size as f64
+        );
+
+        group.throughput(Throughput::Bytes(bytes_read));
         group.bench_with_input(
             BenchmarkId::from_parameter(num_splits),
             &num_splits,

--- a/crates/iceberg/benches/arrow_reader.rs
+++ b/crates/iceberg/benches/arrow_reader.rs
@@ -18,20 +18,39 @@
 //! Benchmarks for [`ArrowReader`], focused on the per-`FileScanTask` overhead
 //! that dominates scans of tables with many small data files (see epic #2172).
 //!
+//! # What this measures
+//!
 //! The files are written to a local temp directory and read back through the
-//! normal `FileIO` (local FS) path, so these measure CPU and per-task work
-//! (operator construction, metadata loading, schema resolution, projection /
-//! row-filter setup, stream wiring) rather than network latency. They give an
-//! in-repo, reproducible baseline against which I/O- and CPU-reuse
-//! optimizations can be measured.
+//! normal `FileIO` (local FS) path, so the time-based groups measure the CPU /
+//! decode / per-task setup path: metadata parsing, schema resolution,
+//! projection and row-filter setup, and stream wiring. After the first sample
+//! the files sit in the OS page cache, so these are *warm-cache* numbers, not
+//! cold first-touch reads.
+//!
+//! Every group asserts the expected total row count, so a change that reads
+//! fewer (or duplicated) rows fails loudly instead of reporting a bogus win.
+//!
+//! # What this cannot measure
+//!
+//! The local-FS `FileIO` has no credential-provider init, request signing,
+//! TLS, or network round-trips — the expensive parts of per-task object-store
+//! access. Consequently:
+//!
+//! - operator caching (#2177) will look near-flat here, and
+//! - the latency-hiding items (#2173, #2181) are not measurable at all.
+//!
+//! A flat local result for those must not be read as "the optimization does
+//! not help" — that misreading is part of why #2100 was closed. Likewise the
+//! schema is `Int64` + `Utf8` only: timestamp / decimal / nested / INT96
+//! column-decode regressions will not show up in these numbers.
 //!
 //! The `same_file_splits` group additionally reports `ScanMetrics::bytes_read`
 //! as its throughput basis. Because that is a deterministic count (not a
-//! wall-clock sample), it surfaces redundant I/O directly: reading one file as
-//! N byte-range splits fetches the Parquet metadata N times, so total bytes
-//! read grows with the split count even though the file contents are identical.
-//! This is the cost that same-file metadata caching (proposed in #2172,
-//! attempted in #2100) targets, and is measurable even on the local FS.
+//! wall-clock sample), it surfaces redundant I/O directly even on the local
+//! FS: reading one file as N byte-range splits fetches the Parquet metadata N
+//! times, so total bytes read grows with the split count even though the file
+//! contents are identical. This is the cost that same-file metadata caching
+//! (proposed in #2172, attempted in #2100) targets.
 //!
 //! Run with: `cargo bench -p iceberg --bench arrow_reader`
 
@@ -259,7 +278,16 @@ fn tasks_with_predicate(paths: &[String], schema: &SchemaRef) -> Vec<FileScanTas
 /// Read every task to completion, draining all record batches. `filtering`
 /// turns on row-group filtering and row selection (only meaningful when the
 /// tasks carry a predicate).
-async fn read_all(tasks: Vec<FileScanTask>, concurrency: usize, filtering: bool) {
+///
+/// Asserts that exactly `expected_rows` rows come back: a configuration that
+/// reads too few rows — or duplicates rows, like the sub-row-group-split bug
+/// in #2614 — would otherwise time faster and read as a performance win.
+async fn read_all(
+    tasks: Vec<FileScanTask>,
+    concurrency: usize,
+    filtering: bool,
+    expected_rows: usize,
+) {
     let file_io = FileIO::new_with_fs();
     let reader = ArrowReaderBuilder::new(file_io, Runtime::current())
         .with_data_file_concurrency_limit(concurrency)
@@ -277,6 +305,12 @@ async fn read_all(tasks: Vec<FileScanTask>, concurrency: usize, filtering: bool)
         .await
         .expect("read all batches");
 
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, expected_rows,
+        "benchmark read returned the wrong number of rows; timings would be meaningless"
+    );
+
     criterion::black_box(batches);
 }
 
@@ -285,7 +319,10 @@ async fn read_all(tasks: Vec<FileScanTask>, concurrency: usize, filtering: bool)
 /// deterministic measurement, which makes it the right tool for surfacing
 /// redundant I/O — e.g. the per-split metadata re-fetch that same-file metadata
 /// caching (proposed in #2172, attempted in #2100) targets.
-async fn read_all_bytes(tasks: Vec<FileScanTask>, concurrency: usize) -> u64 {
+///
+/// The same `expected_rows` assertion as [`read_all`] applies, so the byte
+/// counts always describe a correct read.
+async fn read_all_bytes(tasks: Vec<FileScanTask>, concurrency: usize, expected_rows: usize) -> u64 {
     let file_io = FileIO::new_with_fs();
     let reader = ArrowReaderBuilder::new(file_io, Runtime::current())
         .with_data_file_concurrency_limit(concurrency)
@@ -295,11 +332,17 @@ async fn read_all_bytes(tasks: Vec<FileScanTask>, concurrency: usize) -> u64 {
 
     let result = reader.read(task_stream).expect("build read stream");
     let metrics = result.metrics().clone();
-    let _: Vec<RecordBatch> = result
+    let batches: Vec<RecordBatch> = result
         .stream()
         .try_collect()
         .await
         .expect("read all batches");
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, expected_rows,
+        "benchmark read returned the wrong number of rows; byte counts would be meaningless"
+    );
 
     metrics.bytes_read()
 }
@@ -323,7 +366,7 @@ fn bench_many_small_files(c: &mut Criterion) {
             |b, _| {
                 b.to_async(&tokio).iter(|| {
                     let tasks = tasks_for(&paths, &iceberg_schema);
-                    read_all(tasks, num_cpus_limit(), false)
+                    read_all(tasks, num_cpus_limit(), false, num_files * ROWS_PER_FILE)
                 });
             },
         );
@@ -350,7 +393,7 @@ fn bench_concurrency(c: &mut Criterion) {
             |b, &concurrency| {
                 b.to_async(&tokio).iter(|| {
                     let tasks = tasks_for(&paths, &iceberg_schema);
-                    read_all(tasks, concurrency, false)
+                    read_all(tasks, concurrency, false, num_files * ROWS_PER_FILE)
                 });
             },
         );
@@ -375,7 +418,7 @@ fn bench_migrated_table(c: &mut Criterion) {
     group.bench_function("name_mapping", |b| {
         b.to_async(&tokio).iter(|| {
             let tasks = tasks_with_name_mapping(&paths, &iceberg_schema);
-            read_all(tasks, num_cpus_limit(), false)
+            read_all(tasks, num_cpus_limit(), false, num_files * ROWS_PER_FILE)
         });
     });
     group.finish();
@@ -404,6 +447,7 @@ fn bench_same_file_splits(c: &mut Criterion) {
         let bytes_read = tokio.block_on(read_all_bytes(
             same_file_split_tasks(&path, &iceberg_schema, num_splits),
             num_cpus_limit(),
+            total_rows,
         ));
         eprintln!(
             "same_file_splits/{num_splits}: bytes_read = {bytes_read} \
@@ -418,7 +462,9 @@ fn bench_same_file_splits(c: &mut Criterion) {
             |b, &num_splits| {
                 b.to_async(&tokio).iter(|| {
                     let tasks = same_file_split_tasks(&path, &iceberg_schema, num_splits);
-                    read_all(tasks, num_cpus_limit(), false)
+                    // `total_rows` doubles as the #2614 duplication guard: N splits
+                    // of one file must reassemble it exactly once.
+                    read_all(tasks, num_cpus_limit(), false, total_rows)
                 });
             },
         );
@@ -442,7 +488,13 @@ fn bench_with_predicate(c: &mut Criterion) {
     group.bench_function("id_lt_half", |b| {
         b.to_async(&tokio).iter(|| {
             let tasks = tasks_with_predicate(&paths, &iceberg_schema);
-            read_all(tasks, num_cpus_limit(), true)
+            // `id < ROWS_PER_FILE / 2` matches exactly half the rows per file.
+            read_all(
+                tasks,
+                num_cpus_limit(),
+                true,
+                num_files * (ROWS_PER_FILE / 2),
+            )
         });
     });
     group.finish();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2557.

## What changes are included in this PR?

Adds a criterion-based benchmark harness for the `ArrowReader` at `crates/iceberg/benches/arrow_reader.rs`. Until now there were no in-repo reader benchmarks, so every performance claim in the perf epic (#2172) had to be validated against external workloads. This harness writes Parquet files to a local temp dir and reads them back through the normal `FileIO` path, measuring the per-`FileScanTask` overhead that dominates scans of tables with many small files. Because it runs on the local FS, it isolates CPU / per-task work rather than network latency.

Benchmark groups, chosen to map onto the epic's code paths:

- **many_small_files** — scans 16/64/256 small files, reporting files/sec so per-file overhead is directly visible.
- **concurrency** — a fixed corpus read at concurrency 1/4/16, exercising both the single-concurrency fast path and the buffered/flattened multi-task path.
- **migrated_table** — files without embedded field IDs read via name mapping, isolating the migrated-table schema-resolution cost (#2176 path).
- **same_file_splits** — one multi-row-group file read as 1/8/32 byte-range tasks, surfacing the redundant per-split metadata fetch that the same-file metadata caching proposed in #2172 (attempted in #2100) targets.
- **with_predicate** — scans carrying a bound predicate with row-group filtering and row selection enabled, exercising the per-task row-filter setup.

This adds `criterion` (with the `async_tokio` feature) as a workspace dev-dependency and a `[[bench]]` entry to the `iceberg` crate.

### Measuring `bytes_read`, not just time

Wall-clock time on the local FS cannot show the benefit of optimizations that save *round-trips* (e.g. the metadata size hint #2173 or range coalescing #2181) — those need a latency-bearing backend, which is left as follow-up. But the same-file-split problem is different: its cost is redundant *bytes fetched*, not latency, so it is measurable even locally.

The `same_file_splits` group therefore reports `ScanMetrics::bytes_read` as its throughput basis (a deterministic count, not a sampled measurement) and prints the read amplification per split count. On a ~1.2 MiB file:

```
same_file_splits/1:  bytes_read = 1,694,258  (1.43x file size)
same_file_splits/8:  bytes_read = 5,529,051  (4.66x file size)
same_file_splits/32: bytes_read = 18,674,303 (15.72x file size)
```

Reading one file as 32 byte-range splits fetches ~15.7x the file size, because each split re-fetches the Parquet metadata independently. This is machine-independent evidence for the cost that same-file metadata caching targets — #2100 was closed partly because its author could not demonstrate a benefit on their workload (a ~1:1 task-to-file table, where same-file caching has nothing to hit); with this benchmark a caching implementation would show the amplification dropping back toward 1x.

Run with:

```
cargo bench -p iceberg --bench arrow_reader
```

## Are these changes tested?

This is a benchmark, not a code change. The harness compiles and runs (`cargo bench -p iceberg --bench arrow_reader`), and reuses the same Parquet-writing and reader-driving patterns as the existing reader unit tests. `cargo fmt` and `cargo clippy -p iceberg --benches` are clean.
