### PR TITLE
feat(avro): enable snappy codec support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rust-version = "1.92"
 aes = { version = "0.8", features = ["zeroize"] }
 aes-gcm = "0.10"
 anyhow = "1.0.72"
-apache-avro = { version = "0.21", features = ["zstandard"] }
+apache-avro = { version = "0.21", features = ["snappy", "zstandard"] }
 array-init = "2"
 arrow = "58"
 arrow-arith = "58"

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -161,7 +161,8 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
 
-    use serde_json::Value;
+    use apache_avro::{Codec, Writer, to_value};
+    use serde_json::{Value, to_vec};
     use tempfile::TempDir;
 
     use super::*;
@@ -286,6 +287,123 @@ mod tests {
         // The snapshot id is assigned when the entry is added to the manifest.
         entries[0].snapshot_id = Some(1);
         assert_eq!(actual_manifest, Manifest::new(metadata, entries));
+    }
+
+    #[test]
+    fn test_parse_snappy_manifest_v2() {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![Arc::new(NestedField::optional(
+                    1,
+                    "id",
+                    Type::Primitive(PrimitiveType::Long),
+                ))])
+                .build()
+                .unwrap(),
+        );
+        let partition_spec = PartitionSpec::builder(schema.clone())
+            .with_spec_id(0)
+            .build()
+            .unwrap();
+
+        for (manifest_content, file_content, file_path) in [
+            (
+                ManifestContentType::Data,
+                DataContentType::Data,
+                "s3://bucket/table/data/data.parquet",
+            ),
+            (
+                ManifestContentType::Deletes,
+                DataContentType::PositionDeletes,
+                "s3://bucket/table/data/delete.parquet",
+            ),
+        ] {
+            let metadata = ManifestMetadata {
+                schema_id: 0,
+                schema: schema.clone(),
+                partition_spec: partition_spec.clone(),
+                content: manifest_content,
+                format_version: FormatVersion::V2,
+            };
+            let entry = ManifestEntry {
+                status: ManifestStatus::Added,
+                snapshot_id: Some(1),
+                sequence_number: None,
+                file_sequence_number: None,
+                data_file: DataFile {
+                    content: file_content,
+                    file_path: file_path.to_string(),
+                    file_format: DataFileFormat::Parquet,
+                    partition: Struct::empty(),
+                    record_count: 1,
+                    file_size_in_bytes: 1024,
+                    column_sizes: HashMap::new(),
+                    value_counts: HashMap::new(),
+                    null_value_counts: HashMap::new(),
+                    nan_value_counts: HashMap::new(),
+                    lower_bounds: HashMap::new(),
+                    upper_bounds: HashMap::new(),
+                    key_metadata: None,
+                    split_offsets: None,
+                    equality_ids: None,
+                    sort_order_id: None,
+                    partition_spec_id: 0,
+                    first_row_id: None,
+                    referenced_data_file: None,
+                    content_offset: None,
+                    content_size_in_bytes: None,
+                },
+            };
+
+            let partition_type = metadata
+                .partition_spec
+                .partition_type(&metadata.schema)
+                .unwrap();
+            let avro_schema = manifest_schema_v2(&partition_type).unwrap();
+            let mut writer = Writer::with_codec(&avro_schema, Vec::new(), Codec::Snappy);
+            writer
+                .add_user_metadata("schema".to_string(), to_vec(&metadata.schema).unwrap())
+                .unwrap();
+            writer
+                .add_user_metadata(
+                    "schema-id".to_string(),
+                    metadata.schema.schema_id().to_string(),
+                )
+                .unwrap();
+            writer
+                .add_user_metadata(
+                    "partition-spec".to_string(),
+                    to_vec(&metadata.partition_spec.fields()).unwrap(),
+                )
+                .unwrap();
+            writer
+                .add_user_metadata(
+                    "partition-spec-id".to_string(),
+                    metadata.partition_spec.spec_id().to_string(),
+                )
+                .unwrap();
+            writer
+                .add_user_metadata(
+                    "format-version".to_string(),
+                    (metadata.format_version as u8).to_string(),
+                )
+                .unwrap();
+            writer
+                .add_user_metadata("content".to_string(), metadata.content.to_string())
+                .unwrap();
+            let value = to_value(
+                _serde::ManifestEntryV2::try_from(entry.clone(), &partition_type).unwrap(),
+            )
+            .unwrap()
+            .resolve(&avro_schema)
+            .unwrap();
+            writer.append(value).unwrap();
+            let bs = writer.into_inner().unwrap();
+
+            let parsed_manifest = Manifest::parse_avro(&bs).unwrap();
+
+            assert_eq!(parsed_manifest, Manifest::new(metadata, vec![entry]));
+        }
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/spec/manifest_list/mod.rs
+++ b/crates/iceberg/src/spec/manifest_list/mod.rs
@@ -93,8 +93,11 @@ impl ManifestList {
 mod test {
     use std::fs;
 
+    use apache_avro::{Codec, Writer};
     use tempfile::TempDir;
 
+    use super::_const_schema::MANIFEST_LIST_AVRO_SCHEMA_V2;
+    use super::_serde::ManifestFileV2;
     use super::*;
     use crate::io::FileIO;
     use crate::spec::{Datum, FieldSummary, ManifestContentType, ManifestFile};
@@ -215,6 +218,46 @@ mod test {
         writer.close().await.unwrap();
 
         let bs = fs::read(full_path).expect("read_file must succeed");
+
+        let parsed_manifest_list =
+            ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V2).unwrap();
+
+        assert_eq!(manifest_list, parsed_manifest_list);
+    }
+
+    #[test]
+    fn test_parse_snappy_manifest_list_v2() {
+        let manifest_list = ManifestList {
+            entries: vec![ManifestFile {
+                manifest_path: "s3a://icebergdata/demo/s1/t1/metadata/snappy-m0.avro".to_string(),
+                manifest_length: 6926,
+                partition_spec_id: 1,
+                content: ManifestContentType::Data,
+                sequence_number: 1,
+                min_sequence_number: 1,
+                added_snapshot_id: 377075049360453639,
+                added_files_count: Some(1),
+                existing_files_count: Some(0),
+                deleted_files_count: Some(0),
+                added_rows_count: Some(3),
+                existing_rows_count: Some(0),
+                deleted_rows_count: Some(0),
+                partitions: Some(vec![FieldSummary {
+                    contains_null: false,
+                    contains_nan: Some(false),
+                    lower_bound: Some(Datum::long(1).to_bytes().unwrap()),
+                    upper_bound: Some(Datum::long(1).to_bytes().unwrap()),
+                }]),
+                key_metadata: None,
+                first_row_id: None,
+            }],
+        };
+
+        let manifest_entry: ManifestFileV2 = manifest_list.entries[0].clone().try_into().unwrap();
+        let mut writer =
+            Writer::with_codec(&MANIFEST_LIST_AVRO_SCHEMA_V2, Vec::new(), Codec::Snappy);
+        writer.append_ser(manifest_entry).unwrap();
+        let bs = writer.into_inner().unwrap();
 
         let parsed_manifest_list =
             ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V2).unwrap();


### PR DESCRIPTION
- ## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- closes: #2574

```
Error: failed to load current manifest files for ...

Caused by:
    0: DataInvalid => Failure in conversion with avro, source: Codec 'snappy' is not supported/enabled
    1: Codec 'snappy' is not supported/enabled
```

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Some producers compress manifests with snappy instead of zstd - this PR just enables Snappy feature in apache-avro

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- external integration tests on snappy-compressed manifest files