### PR TITLE
fix(ci): correct checkout version comment for zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
   check_standalone:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION

- Fixes the `ref-version-mismatch` zizmor finding in `ci.yml` line 122 where the version comment said `# v6` but the pinned hash resolves to tag `v6.0.2`
- This is currently failing the "GitHub Actions Security Analysis with zizmor" check on main

