### PR TITLE
chore(ci): migrate to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,13 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: publish
+    permissions:
+      contents: read
+      id-token: write  # Required for crates.io trusted publishing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -47,13 +47,16 @@ jobs:
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+        id: auth
+
       - name: Publish crates
         # Only publish if it's a tag and the tag is not a pre-release
         if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
-        run: cargo publish --workspace --all-features # zizmor: ignore[use-trusted-publishing] -- https://github.com/apache/iceberg-rust/issues/1539
+        run: cargo publish --workspace --all-features
         shell: bash
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   # Trigger Python release after crate publishing completes.
   # Only runs for tag pushes; for manual Python releases, use workflow_dispatch on release_python.yml directly.


### PR DESCRIPTION
## Which issue does this PR close?

This implements trusted publishing with crates.io, which closes #1539. I'd propose to close that issue after the first successful release.

## What changes are included in this PR?

This simply migrates the release workflow to use credentials obtained using trusted publishing.

This is the guide followed for the change: https://crates.io/docs/trusted-publishing

This change does not include the required changes on crates.io, which will need a committer to perform. I will add the remaining steps to #1539.

## Are these changes tested?

No. The changes will be verified with the first public release.