### PR TITLE
refactor!(writer): borrow TableMetadata in DefaultLocationGenerator::new

### DIFF
--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -1244,7 +1244,7 @@ mod tests {
         .unwrap();
 
         // Locations will be generated based on the table metadata, which will be using `s3://` for Amazon S3 Tables.
-        let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+        let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
         let file_name_generator = DefaultFileNameGenerator::new(
             "test".to_string(),
             None,

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3142,7 +3142,7 @@ impl iceberg::writer::file_writer::location_generator::FileNameGenerator for ice
 pub fn iceberg::writer::file_writer::location_generator::DefaultFileNameGenerator::generate_file_name(&self) -> alloc::string::String
 pub struct iceberg::writer::file_writer::location_generator::DefaultLocationGenerator
 impl iceberg::writer::file_writer::location_generator::DefaultLocationGenerator
-pub fn iceberg::writer::file_writer::location_generator::DefaultLocationGenerator::new(table_metadata: iceberg::spec::TableMetadata) -> iceberg::Result<Self>
+pub fn iceberg::writer::file_writer::location_generator::DefaultLocationGenerator::new(table_metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
 pub fn iceberg::writer::file_writer::location_generator::DefaultLocationGenerator::with_data_location(data_location: alloc::string::String) -> Self
 impl core::clone::Clone for iceberg::writer::file_writer::location_generator::DefaultLocationGenerator
 pub fn iceberg::writer::file_writer::location_generator::DefaultLocationGenerator::clone(&self) -> iceberg::writer::file_writer::location_generator::DefaultLocationGenerator

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -54,7 +54,7 @@ pub struct DefaultLocationGenerator {
 
 impl DefaultLocationGenerator {
     /// Create a new `DefaultLocationGenerator`.
-    pub fn new(table_metadata: TableMetadata) -> Result<Self> {
+    pub fn new(table_metadata: &TableMetadata) -> Result<Self> {
         let table_location = table_metadata.location();
         let prop = table_metadata.properties();
         let configured_data_location = prop
@@ -194,7 +194,7 @@ pub(crate) mod test {
 
         // test default data location
         let location_generator =
-            super::DefaultLocationGenerator::new(table_metadata.clone()).unwrap();
+            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/table/data/part-00000-test.parquet");
@@ -205,7 +205,7 @@ pub(crate) mod test {
             "s3://data.db/table/data_1".to_string(),
         );
         let location_generator =
-            super::DefaultLocationGenerator::new(table_metadata.clone()).unwrap();
+            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -218,7 +218,7 @@ pub(crate) mod test {
             "s3://data.db/table/data_2".to_string(),
         );
         let location_generator =
-            super::DefaultLocationGenerator::new(table_metadata.clone()).unwrap();
+            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -232,7 +232,7 @@ pub(crate) mod test {
             "s3://data.db/data_3".to_string(),
         );
         let location_generator =
-            super::DefaultLocationGenerator::new(table_metadata.clone()).unwrap();
+            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/data_3/part-00003-test.parquet");
@@ -302,7 +302,7 @@ pub(crate) mod test {
         };
 
         // Test with DefaultLocationGenerator
-        let default_location_gen = super::DefaultLocationGenerator::new(table_metadata).unwrap();
+        let default_location_gen = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location = default_location_gen.generate_location(Some(&partition_key), file_name);
         assert_eq!(
             location,

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -193,8 +193,7 @@ pub(crate) mod test {
         );
 
         // test default data location
-        let location_generator =
-            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/table/data/part-00000-test.parquet");
@@ -204,8 +203,7 @@ pub(crate) mod test {
             WRITE_FOLDER_STORAGE_LOCATION.to_string(),
             "s3://data.db/table/data_1".to_string(),
         );
-        let location_generator =
-            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -217,8 +215,7 @@ pub(crate) mod test {
             WRITE_DATA_LOCATION.to_string(),
             "s3://data.db/table/data_2".to_string(),
         );
-        let location_generator =
-            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -231,8 +228,7 @@ pub(crate) mod test {
             // invalid table location
             "s3://data.db/data_3".to_string(),
         );
-        let location_generator =
-            super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/data_3/part-00003-test.parquet");

--- a/crates/iceberg/src/writer/mod.rs
+++ b/crates/iceberg/src/writer/mod.rs
@@ -78,7 +78,7 @@
 //!     let table = catalog
 //!         .load_table(&TableIdent::from_strs(["hello", "world"])?)
 //!         .await?;
-//!     let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+//!     let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
 //!     let file_name_generator = DefaultFileNameGenerator::new(
 //!         "test".to_string(),
 //!         None,
@@ -207,7 +207,7 @@
 //!         table.metadata().current_schema().clone(),
 //!         Struct::from_iter(vec![Some(Literal::string("Seattle"))]),
 //!     );
-//!     let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+//!     let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
 //!     let file_name_generator = DefaultFileNameGenerator::new(
 //!         "test".to_string(),
 //!         None,
@@ -272,7 +272,7 @@
 //! #     .load("memory", HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), "file:///path/to/warehouse".to_string())]))
 //! #     .await?;
 //! # let table = catalog.load_table(&TableIdent::from_strs(["hello", "world"])?).await?;
-//! # let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+//! # let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
 //! # let file_name_generator = DefaultFileNameGenerator::new("test".to_string(), None, iceberg::spec::DataFileFormat::Parquet);
 //! # let parquet_writer_builder = ParquetWriterBuilder::new(WriterProperties::default(), table.metadata().current_schema().clone());
 //! # let rolling_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(
@@ -336,7 +336,7 @@
 //! #     .load("memory", HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), "file:///path/to/warehouse".to_string())]))
 //! #     .await?;
 //! # let table = catalog.load_table(&TableIdent::from_strs(["hello", "world"])?).await?;
-//! # let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+//! # let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
 //! # let file_name_generator = DefaultFileNameGenerator::new("test".to_string(), None, iceberg::spec::DataFileFormat::Parquet);
 //! # let parquet_writer_builder = ParquetWriterBuilder::new(WriterProperties::default(), table.metadata().current_schema().clone());
 //! # let rolling_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(

--- a/crates/integration_tests/tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/conflict_commit_test.rs
@@ -70,7 +70,7 @@ async fn test_append_data_file_conflict() {
             .try_into()
             .unwrap(),
     );
-    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+    let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
     let file_name_generator = DefaultFileNameGenerator::new(
         "test".to_string(),
         None,

--- a/crates/integrations/datafusion/src/physical_plan/write.rs
+++ b/crates/integrations/datafusion/src/physical_plan/write.rs
@@ -244,7 +244,7 @@ impl ExecutionPlan for IcebergWriteExec {
 
         let file_io = self.table.file_io().clone();
         // todo location_gen and file_name_gen should be configurable
-        let location_generator = DefaultLocationGenerator::new(self.table.metadata().clone())
+        let location_generator = DefaultLocationGenerator::new(self.table.metadata())
             .map_err(to_datafusion_error)?;
         // todo filename prefix/suffix should be configurable
         let file_name_generator =

--- a/crates/integrations/datafusion/src/physical_plan/write.rs
+++ b/crates/integrations/datafusion/src/physical_plan/write.rs
@@ -244,8 +244,8 @@ impl ExecutionPlan for IcebergWriteExec {
 
         let file_io = self.table.file_io().clone();
         // todo location_gen and file_name_gen should be configurable
-        let location_generator = DefaultLocationGenerator::new(self.table.metadata())
-            .map_err(to_datafusion_error)?;
+        let location_generator =
+            DefaultLocationGenerator::new(self.table.metadata()).map_err(to_datafusion_error)?;
         // todo filename prefix/suffix should be configurable
         let file_name_generator =
             DefaultFileNameGenerator::new(Uuid::now_v7().to_string(), None, file_format);


### PR DESCRIPTION
`DefaultLocationGenerator::new` took `TableMetadata` by value but only ever reads `.location()` and `.properties()` (both `&self` accessors).

Taking it by value forced every caller to deep-clone the whole `TableMetadata` just to satisfy the signature,.


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2605.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Change the parameter to `&TableMetadata` and drop the `.clone()` at each call site, eliminating an unnecessary deep clone on the write path.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

N/A