### PR TITLE
refactor(encryption) use `StandardKeyMetadata` from `EncryptedOutputFile` in `ManifestWriterBuilder`

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2079,7 +2079,7 @@ pub fn iceberg::spec::ManifestWriterBuilder::build_v2_deletes(self) -> iceberg::
 pub fn iceberg::spec::ManifestWriterBuilder::build_v3_data(self) -> iceberg::spec::ManifestWriter
 pub fn iceberg::spec::ManifestWriterBuilder::build_v3_deletes(self) -> iceberg::spec::ManifestWriter
 pub fn iceberg::spec::ManifestWriterBuilder::new(output: iceberg::io::OutputFile, snapshot_id: core::option::Option<i64>, key_metadata: core::option::Option<alloc::vec::Vec<u8>>, schema: iceberg::spec::SchemaRef, partition_spec: iceberg::spec::PartitionSpec) -> Self
-pub fn iceberg::spec::ManifestWriterBuilder::new_from_encrypted(encrypted_output: iceberg::encryption::EncryptedOutputFile, snapshot_id: core::option::Option<i64>, key_metadata: core::option::Option<alloc::vec::Vec<u8>>, schema: iceberg::spec::SchemaRef, partition_spec: iceberg::spec::PartitionSpec) -> Self
+pub fn iceberg::spec::ManifestWriterBuilder::new_from_encrypted(encrypted_output: iceberg::encryption::EncryptedOutputFile, snapshot_id: core::option::Option<i64>, schema: iceberg::spec::SchemaRef, partition_spec: iceberg::spec::PartitionSpec) -> iceberg::Result<Self>
 pub struct iceberg::spec::Map
 impl iceberg::spec::Map
 pub fn iceberg::spec::Map::get(&self, key: &iceberg::spec::Literal) -> core::option::Option<&core::option::Option<iceberg::spec::Literal>>

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -86,8 +86,7 @@ impl ManifestWriterBuilder {
         partition_spec: PartitionSpec,
     ) -> Result<Self> {
         let location = encrypted_output.location().to_owned();
-        let key_metadata = Some(encrypted_output.key_metadata().encode()?
-            .to_vec());
+        let key_metadata = Some(encrypted_output.key_metadata().encode()?.to_vec());
         Ok(Self {
             writer_future: Box::pin(async move { encrypted_output.writer().await }),
             location,

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -20,7 +20,6 @@ use std::future::Future;
 use std::pin::Pin;
 
 use apache_avro::{Writer as AvroWriter, to_value};
-use base64::encode;
 use bytes::Bytes;
 use itertools::Itertools;
 use serde_json::to_vec;
@@ -29,7 +28,7 @@ use super::{
     Datum, FormatVersion, ManifestContentType, PartitionSpec, PrimitiveType,
     UNASSIGNED_SEQUENCE_NUMBER,
 };
-use crate::encryption::{EncryptedOutputFile, StandardKeyMetadata};
+use crate::encryption::EncryptedOutputFile;
 use crate::error::Result;
 use crate::io::{FileWrite, OutputFile};
 use crate::spec::manifest::_serde::{ManifestEntryV1, ManifestEntryV2};

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -20,6 +20,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use apache_avro::{Writer as AvroWriter, to_value};
+use base64::encode;
 use bytes::Bytes;
 use itertools::Itertools;
 use serde_json::to_vec;
@@ -28,7 +29,7 @@ use super::{
     Datum, FormatVersion, ManifestContentType, PartitionSpec, PrimitiveType,
     UNASSIGNED_SEQUENCE_NUMBER,
 };
-use crate::encryption::EncryptedOutputFile;
+use crate::encryption::{EncryptedOutputFile, StandardKeyMetadata};
 use crate::error::Result;
 use crate::io::{FileWrite, OutputFile};
 use crate::spec::manifest::_serde::{ManifestEntryV1, ManifestEntryV2};
@@ -81,19 +82,20 @@ impl ManifestWriterBuilder {
     pub fn new_from_encrypted(
         encrypted_output: EncryptedOutputFile,
         snapshot_id: Option<i64>,
-        key_metadata: Option<Vec<u8>>,
         schema: SchemaRef,
         partition_spec: PartitionSpec,
-    ) -> Self {
+    ) -> Result<Self> {
         let location = encrypted_output.location().to_owned();
-        Self {
+        let key_metadata = Some(encrypted_output.key_metadata().encode()?
+            .to_vec());
+        Ok(Self {
             writer_future: Box::pin(async move { encrypted_output.writer().await }),
             location,
             snapshot_id,
             key_metadata,
             schema,
             partition_spec,
-        }
+        })
     }
 
     /// Build a [`ManifestWriter`] for format version 1.
@@ -124,6 +126,7 @@ impl ManifestWriterBuilder {
             .format_version(FormatVersion::V2)
             .content(ManifestContentType::Data)
             .build();
+
         ManifestWriter::new(
             self.writer_future,
             self.location,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
In https://github.com/apache/iceberg-rust/pull/2568 we introduced `new_from_encrypted` but the api isn't very ergonomic because `EncryptedOutputFile` has `StandardKeyMetadata` on it already so we don't need to pass in `key_metadata` also.

working towards #2034 

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->