### PR TITLE
Reject negative positional delete positions

### DIFF
--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -367,13 +367,6 @@ impl CachingDeleteFileLoader {
                     ));
                 }
 
-                if pos < 0 {
-                    return Err(Error::new(
-                        ErrorKind::DataInvalid,
-                        format!("negative position in delete file: {pos}"),
-                    ));
-                }
-
                 result
                     .entry(file_path.to_string())
                     .or_default()

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -361,6 +361,13 @@ impl CachingDeleteFileLoader {
                     ));
                 };
 
+                if pos < 0 {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("negative position in delete file: {pos}"),
+                    ));
+                }
+
                 result
                     .entry(file_path.to_string())
                     .or_default()
@@ -766,6 +773,22 @@ mod tests {
 
         let result = delete_filter.get_delete_vector(&file_scan_tasks[1]);
         assert!(result.is_none()); // no pos dels for file 3
+    }
+
+    #[tokio::test]
+    async fn test_parse_positional_deletes_rejects_negative_positions() {
+        let schema = crate::arrow::delete_filter::tests::create_pos_del_schema();
+        let file_path_col = Arc::new(StringArray::from_iter_values(vec!["data.parquet"]));
+        let pos_col = Arc::new(Int64Array::from_iter_values(vec![-1i64]));
+        let batch = RecordBatch::try_new(schema, vec![file_path_col, pos_col]).unwrap();
+        let stream = futures::stream::iter(vec![Ok(batch)]).boxed();
+
+        let err = CachingDeleteFileLoader::parse_positional_deletes_record_batch_stream(stream)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("negative position"));
     }
 
     /// Verifies that evolve_schema on partial-schema equality deletes works correctly

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -360,6 +360,12 @@ impl CachingDeleteFileLoader {
                         "null values in delete file",
                     ));
                 };
+                if pos < 0 {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("negative position in delete file {file_path}: {pos}"),
+                    ));
+                }
 
                 if pos < 0 {
                     return Err(Error::new(


### PR DESCRIPTION
## Summary

- Reject negative row positions while parsing positional delete files.
- Return `ErrorKind::DataInvalid` instead of casting negative `i64` values to huge `u64` positions.
- Add a focused regression test for `pos = -1`.

## Root cause

The positional-delete parser reads positions from an `Int64Array`, but inserted each value with `pos as u64`. That allowed malformed negative positions to wrap into very large row offsets instead of failing validation.

## Tests

- `cargo fmt --check`
- `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo test -p iceberg test_parse_positional_deletes_rejects_negative_positions --locked`
- `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo test -p iceberg arrow::caching_delete_file_loader::tests --locked`
