### PR TITLE
Use locked taplo-cli install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ nextest: install-cargo-nextest
 	cargo nextest run --all-targets --all-features --workspace
 
 install-taplo-cli:
-	cargo install taplo-cli@0.9.3
+	cargo install --locked taplo-cli@0.9.3
 
 fix-toml: install-taplo-cli
 	taplo fmt


### PR DESCRIPTION
## Summary

- Install `taplo-cli@0.9.3` with `--locked` in the Makefile.
- Keep the existing Taplo version while preventing transitive dependency drift during CI installs.

## Root cause

`cargo install taplo-cli@0.9.3` resolves dependencies at install time. After `time 0.3.48` was published, `taplo v0.13.2` can fail to compile with `E0119` during `make check-toml`. The original TOML formatting command used a locked install, and this restores that property for the pinned Taplo version.

## Tests

- `make check-toml`
