### PR TITLE
chore(ci): ignore pyo3 RUSTSEC-2026-0176 and -0177 in audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -43,4 +43,13 @@ ignore = [
   # Direct dependency upgraded to 0.9.3+. Transitive rand 0.8.5 remains
   # from reqsign/sqllogictest/rustc-hash — no 0.8.x patch exists.
   "RUSTSEC-2026-0097",
+  # pyo3 < 0.29: out-of-bounds read in PyList/PyTuple `nth`/`nth_back`, and
+  # missing `Sync` bound on `PyCFunction::new_closure` closures.
+  #
+  # Pulled only transitively through arrow's `pyarrow` feature
+  # (arrow-pyarrow), which still pins pyo3 ^0.28 in its latest release; no
+  # arrow build supports the patched pyo3 0.29 yet. Remove once arrow-pyarrow
+  # moves to pyo3 >=0.29.
+  "RUSTSEC-2026-0176",
+  "RUSTSEC-2026-0177",
 ]


### PR DESCRIPTION
These two advisories affect pyo3 < 0.29. pyo3 is pulled only transitively through arrow's `pyarrow` feature (arrow-pyarrow), whose latest release still pins pyo3 ^0.28, so no dependency upgrade can clear them yet. Ignore them, matching how the existing transitive advisories are handled, until arrow-pyarrow moves to pyo3 >=0.29.

## Which issue does this PR close?
Fix existing security audit fail

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->