### PR TITLE
Fix: replace --profile py-release with --release in Python release workflows

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -186,7 +186,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           working-directory: "bindings/python"
           command: build
-          args: --profile py-release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
+          args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.3"

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -122,7 +122,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           working-directory: "bindings/python"
           command: build
-          args: --profile py-release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
+          args: --release -o dist -i python3.12 # Explicitly set interpreter; manylinux containers have multiple Pythons and maturin may pick an older one
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:


### PR DESCRIPTION
Follow up to #2506, I noticed that "nightly pypi build" has been failing: https://github.com/apache/iceberg-rust/actions/workflows/release_python_nightly.yml

The `py-release` Cargo profile was moved from `Cargo.toml` into `pyproject.toml` as inline maturin `config` overrides on the built-in `release` profile. Update the workflow `args` to use `--release` accordingly.

## Changes
- `.github/workflows/release_python.yml`: `--profile py-release` → `--release`
- `.github/workflows/release_python_nightly.yml`: `--profile py-release` → `--release`

## Testing
Verified via nightly workflow run on fork: https://github.com/kevinjqliu/iceberg-rust/actions/runs/27474374224