### PR TITLE
chore: Bump MSRV to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ version = "0.9.0"
 license = "Apache-2.0"
 repository = "https://github.com/apache/iceberg-rust"
 # Check the MSRV policy in README.md before changing this
-rust-version = "1.92"
+rust-version = "1.94"
 
 [workspace.dependencies]
 aes = { version = "0.8", features = ["zeroize"] }

--- a/crates/iceberg/src/arrow/reader/row_filter.rs
+++ b/crates/iceberg/src/arrow/reader/row_filter.rs
@@ -230,8 +230,8 @@ mod tests {
         table_location: String,
         reader: ArrowReader,
     ) -> Vec<Option<String>> {
-        let tasks = Box::pin(futures::stream::iter(
-            vec![Ok(FileScanTask::builder()
+        let tasks = {
+            let task = FileScanTask::builder()
                 .with_file_size_in_bytes(
                     std::fs::metadata(format!("{table_location}/1.parquet"))
                         .unwrap()
@@ -245,9 +245,9 @@ mod tests {
                 .with_project_field_ids(vec![1])
                 .with_predicate(Some(predicate.bind(schema, true).unwrap()))
                 .with_case_sensitive(false)
-                .build())]
-            .into_iter(),
-        )) as FileScanTaskStream;
+                .build();
+            Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream
+        };
 
         let result = reader
             .read(tasks)

--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -53,7 +53,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> Deserialize<'de> for LogicalExpre
     where D: serde::Deserializer<'de> {
         let inputs = Vec::<Box<T>>::deserialize(deserializer)?;
         Ok(LogicalExpression::new(
-            array_init::from_iter(inputs.into_iter()).ok_or_else(|| {
+            array_init::from_iter(inputs).ok_or_else(|| {
                 serde::de::Error::custom(format!("Failed to deserialize LogicalExpression: the len of inputs is not match with the len of LogicalExpression {N}"))
             })?,
         ))

--- a/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
@@ -736,28 +736,22 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
                 }
 
                 match (min, max) {
-                    (Some(min), Some(max)) => {
+                    (Some(min), Some(max))
                         if literals
                             .iter()
-                            .all(|datum| datum.lt(&min) || datum.gt(&max))
-                        {
-                            // if all values are outside the bounds, rows cannot match.
-                            return Ok(false);
-                        }
+                            .all(|datum| datum.lt(&min) || datum.gt(&max)) =>
+                    {
+                        // if all values are outside the bounds, no rows can match
+                        return Ok(false);
                     }
-                    (Some(min), _) => {
-                        if !literals.iter().any(|datum| datum.ge(&min)) {
-                            // if none of the values are greater than the min bound, rows cant match
-                            return Ok(false);
-                        }
+                    (Some(min), _) if !literals.iter().any(|datum| datum.ge(&min)) => {
+                        // if no values are within the min bound, no rows can match
+                        return Ok(false);
                     }
-                    (_, Some(max)) => {
-                        if !literals.iter().any(|datum| datum.le(&max)) {
-                            // if all values are greater than upper bound, rows cannot match.
-                            return Ok(false);
-                        }
+                    (_, Some(max)) if !literals.iter().any(|datum| datum.le(&max)) => {
+                        // if no values are within the max bound, no rows can match
+                        return Ok(false);
                     }
-
                     _ => {}
                 }
 

--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -573,7 +573,7 @@ impl Literal {
                     {
                         Ok(Some(Literal::Map(Map::from_iter(
                             keys.into_iter()
-                                .zip(values.into_iter())
+                                .zip(values)
                                 .map(|(key, value)| {
                                     Ok((
                                         Literal::try_from_json(key, &map.key_field.field_type)

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -72,7 +72,7 @@ impl IcebergCatalogProvider {
 
         let schemas: HashMap<String, Arc<dyn SchemaProvider>> = schema_names
             .into_iter()
-            .zip(providers.into_iter())
+            .zip(providers)
             .map(|(name, provider)| {
                 let provider = Arc::new(provider) as Arc<dyn SchemaProvider>;
                 (name, provider)

--- a/crates/integrations/datafusion/src/schema.rs
+++ b/crates/integrations/datafusion/src/schema.rs
@@ -81,7 +81,7 @@ impl IcebergSchemaProvider {
         .await?;
 
         let tables = Arc::new(DashMap::new());
-        for (name, provider) in table_names.into_iter().zip(providers.into_iter()) {
+        for (name, provider) in table_names.into_iter().zip(providers) {
             tables.insert(name, Arc::new(provider));
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -20,5 +20,5 @@
 #
 # The channel is exactly same day for our MSRV.
 [toolchain]
-channel = "nightly-2025-10-27"
+channel = "nightly-2026-03-05"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?

N/A

Updating MSRV ahead of 0.10 release. #2527

## What changes are included in this PR?

Bump the MSRV for the crates, as well as the Rust toolchain used for Clippy and Rustfmt checks.

New Clippy warnings are addressed in this PR.

## Are these changes tested?

No additional checks beyond CI.