### PR TITLE
feat(rest): add SigV4 auth manager for the REST catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,9 +3829,13 @@ name = "iceberg-catalog-rest"
 version = "0.10.1"
 dependencies = [
  "async-trait",
+ "aws-credential-types",
+ "aws-sigv4",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
+ "hmac 0.12.1",
  "http 1.5.0",
  "iceberg",
  "iceberg_test_utils",
@@ -3841,6 +3845,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "tokio",
  "tracing",
  "typed-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,7 +3891,9 @@ name = "iceberg-catalog-rest"
 version = "0.10.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
+ "futures",
  "http 1.4.2",
  "iceberg",
  "iceberg_test_utils",
@@ -3904,6 +3906,7 @@ dependencies = [
  "tokio",
  "typed-builder",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,7 +3907,6 @@ dependencies = [
  "tracing",
  "typed-builder",
  "uuid",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,6 +3904,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
+ "tracing",
  "typed-builder",
  "uuid",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ arrow-string = "59.2"
 as-any = "0.3.2"
 async-trait = "0.1.89"
 aws-config = "1.8.7"
+aws-credential-types = "1.2"
 aws-sdk-glue = { version = "1.85", default-features = false, features = [
   "default-https-client",
   "rt-tokio",
@@ -68,6 +69,10 @@ aws-sdk-glue = { version = "1.85", default-features = false, features = [
 aws-sdk-s3tables = { version = "1.28", default-features = false, features = [
   "default-https-client",
   "rt-tokio",
+] }
+aws-sigv4 = { version = "1.4", default-features = false, features = [
+  "sign-http",
+  "http1",
 ] }
 backon = "1.5.1"
 base64 = "0.22.1"
@@ -97,6 +102,7 @@ form_urlencoded = "1.2.2"
 fs-err = "3.1.0"
 futures = "0.3"
 hive_metastore = "0.2.0"
+hmac = "0.12"
 home = "0.5.12"
 http = "1.2"
 iceberg = { version = "0.10.0", path = "./crates/iceberg" }
@@ -140,6 +146,7 @@ serde_derive = "1.0.219"
 serde_json = "1.0.142"
 serde_repr = "0.1.16"
 serde_with = "3.4"
+sha2 = "0.10"
 sqllogictest = "0.29"
 sqlx = { version = "0.8.1", default-features = false }
 stacker = "0.1.20"

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -31,6 +31,9 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sigv4 = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 http = { workspace = true }
 iceberg = { workspace = true }
@@ -39,6 +42,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 typed-builder = { workspace = true }
@@ -47,6 +51,7 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
+hmac = { workspace = true }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
 # `stream` lets tests build a streaming body to exercise HttpRequestBody::Streaming.

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -43,7 +43,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-zeroize = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -36,13 +36,13 @@ http = { workspace = true }
 iceberg = { workspace = true }
 itertools = { workspace = true }
 reqwest = { workspace = true }
-zeroize = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -40,6 +40,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true }

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -36,6 +36,7 @@ http = { workspace = true }
 iceberg = { workspace = true }
 itertools = { workspace = true }
 reqwest = { workspace = true }
+zeroize = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -44,8 +45,12 @@ typed-builder = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+bytes = { workspace = true }
+futures = { workspace = true }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
+# `stream` lets tests build a streaming body to exercise AuthRequestBody::Streaming.
+reqwest = { workspace = true, features = ["stream"] }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -1,4 +1,11 @@
 pub mod iceberg_catalog_rest
+pub struct iceberg_catalog_rest::AuthRequest<'a>
+impl<'a> iceberg_catalog_rest::AuthRequest<'a>
+pub fn iceberg_catalog_rest::AuthRequest<'a>::body(&self) -> core::option::Option<&[u8]>
+pub fn iceberg_catalog_rest::AuthRequest<'a>::headers(&self) -> &http::header::map::HeaderMap
+pub fn iceberg_catalog_rest::AuthRequest<'a>::headers_mut(&mut self) -> &mut http::header::map::HeaderMap
+pub fn iceberg_catalog_rest::AuthRequest<'a>::method(&self) -> &http::method::Method
+pub fn iceberg_catalog_rest::AuthRequest<'a>::url_str(&self) -> &str
 pub struct iceberg_catalog_rest::CommitTableRequest
 pub iceberg_catalog_rest::CommitTableRequest::identifier: core::option::Option<iceberg::catalog::TableIdent>
 pub iceberg_catalog_rest::CommitTableRequest::requirements: alloc::vec::Vec<iceberg::catalog::TableRequirement>
@@ -175,6 +182,25 @@ impl serde_core::ser::Serialize for iceberg_catalog_rest::NamespaceResponse
 pub fn iceberg_catalog_rest::NamespaceResponse::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for iceberg_catalog_rest::NamespaceResponse
 pub fn iceberg_catalog_rest::NamespaceResponse::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub struct iceberg_catalog_rest::NoopAuthManager
+impl core::fmt::Debug for iceberg_catalog_rest::NoopAuthManager
+pub fn iceberg_catalog_rest::NoopAuthManager::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::NoopAuthManager
+pub fn iceberg_catalog_rest::NoopAuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, _props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub struct iceberg_catalog_rest::OAuth2Manager
+impl iceberg_catalog_rest::OAuth2Manager
+pub fn iceberg_catalog_rest::OAuth2Manager::new(token_endpoint: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn iceberg_catalog_rest::OAuth2Manager::with_client(self, client: reqwest::async_impl::client::Client) -> Self
+pub fn iceberg_catalog_rest::OAuth2Manager::with_credential(self, client_id: core::option::Option<alloc::string::String>, client_secret: alloc::string::String) -> Self
+pub fn iceberg_catalog_rest::OAuth2Manager::with_extra_headers(self, headers: http::header::map::HeaderMap) -> Self
+pub fn iceberg_catalog_rest::OAuth2Manager::with_extra_oauth_params(self, params: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
+pub fn iceberg_catalog_rest::OAuth2Manager::with_token(self, token: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::fmt::Debug for iceberg_catalog_rest::OAuth2Manager
+pub fn iceberg_catalog_rest::OAuth2Manager::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::OAuth2Manager
+pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg_catalog_rest::RegisterTableRequest
 pub iceberg_catalog_rest::RegisterTableRequest::metadata_location: alloc::string::String
 pub iceberg_catalog_rest::RegisterTableRequest::name: alloc::string::String
@@ -230,6 +256,7 @@ pub fn iceberg_catalog_rest::RestCatalog::update_namespace<'life0, 'life1, 'asyn
 pub fn iceberg_catalog_rest::RestCatalog::update_table<'life0, 'async_trait>(&'life0 self, commit: iceberg::catalog::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg_catalog_rest::RestCatalogBuilder
 impl iceberg_catalog_rest::RestCatalogBuilder
+pub fn iceberg_catalog_rest::RestCatalogBuilder::with_auth_manager(self, auth_manager: alloc::sync::Arc<dyn iceberg_catalog_rest::AuthManager>) -> Self
 pub fn iceberg_catalog_rest::RestCatalogBuilder::with_client(self, client: reqwest::async_impl::client::Client) -> Self
 impl core::default::Default for iceberg_catalog_rest::RestCatalogBuilder
 pub fn iceberg_catalog_rest::RestCatalogBuilder::default() -> Self
@@ -287,6 +314,22 @@ impl serde_core::ser::Serialize for iceberg_catalog_rest::UpdateNamespacePropert
 pub fn iceberg_catalog_rest::UpdateNamespacePropertiesResponse::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for iceberg_catalog_rest::UpdateNamespacePropertiesResponse
 pub fn iceberg_catalog_rest::UpdateNamespacePropertiesResponse::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const iceberg_catalog_rest::AUTH_TYPE_NONE: &str
+pub const iceberg_catalog_rest::AUTH_TYPE_OAUTH2: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_AUTH_TYPE: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_URI: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_WAREHOUSE: &str
+pub trait iceberg_catalog_rest::AuthManager: core::fmt::Debug + core::marker::Send + core::marker::Sync
+pub fn iceberg_catalog_rest::AuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn iceberg_catalog_rest::AuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::NoopAuthManager
+pub fn iceberg_catalog_rest::NoopAuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, _props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::OAuth2Manager
+pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub trait iceberg_catalog_rest::AuthSession: core::fmt::Debug + core::marker::Send + core::marker::Sync
+pub fn iceberg_catalog_rest::AuthSession::authenticate<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, request: &'life1 mut iceberg_catalog_rest::AuthRequest<'life2>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn iceberg_catalog_rest::AuthSession::invalidate<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::AuthSession::refresh<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait

--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -14,6 +14,24 @@ impl<'a> core::fmt::Debug for iceberg_catalog_rest::HttpRequestBody<'a>
 pub fn iceberg_catalog_rest::HttpRequestBody<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'a> core::marker::Copy for iceberg_catalog_rest::HttpRequestBody<'a>
 impl<'a> core::marker::StructuralPartialEq for iceberg_catalog_rest::HttpRequestBody<'a>
+pub enum iceberg_catalog_rest::PayloadHashMode
+pub iceberg_catalog_rest::PayloadHashMode::IcebergRest
+pub iceberg_catalog_rest::PayloadHashMode::StandardAws
+impl core::clone::Clone for iceberg_catalog_rest::PayloadHashMode
+pub fn iceberg_catalog_rest::PayloadHashMode::clone(&self) -> iceberg_catalog_rest::PayloadHashMode
+impl core::cmp::Eq for iceberg_catalog_rest::PayloadHashMode
+impl core::cmp::PartialEq for iceberg_catalog_rest::PayloadHashMode
+pub fn iceberg_catalog_rest::PayloadHashMode::eq(&self, other: &iceberg_catalog_rest::PayloadHashMode) -> bool
+impl core::fmt::Debug for iceberg_catalog_rest::PayloadHashMode
+pub fn iceberg_catalog_rest::PayloadHashMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for iceberg_catalog_rest::PayloadHashMode
+impl core::marker::StructuralPartialEq for iceberg_catalog_rest::PayloadHashMode
+pub struct iceberg_catalog_rest::AwsCredentials
+pub iceberg_catalog_rest::AwsCredentials::access_key_id: alloc::string::String
+pub iceberg_catalog_rest::AwsCredentials::secret_access_key: iceberg::sensitive::SensitiveString
+pub iceberg_catalog_rest::AwsCredentials::session_token: core::option::Option<iceberg::sensitive::SensitiveString>
+impl core::clone::Clone for iceberg_catalog_rest::AwsCredentials
+pub fn iceberg_catalog_rest::AwsCredentials::clone(&self) -> iceberg_catalog_rest::AwsCredentials
 pub struct iceberg_catalog_rest::CommitTableRequest
 pub iceberg_catalog_rest::CommitTableRequest::identifier: core::option::Option<iceberg::catalog::TableIdent>
 pub iceberg_catalog_rest::CommitTableRequest::requirements: alloc::vec::Vec<iceberg::catalog::TableRequirement>
@@ -331,6 +349,14 @@ impl core::default::Default for iceberg_catalog_rest::RestSessionCatalogBuilder
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::default() -> Self
 impl core::fmt::Debug for iceberg_catalog_rest::RestSessionCatalogBuilder
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct iceberg_catalog_rest::SigV4Signer
+impl iceberg_catalog_rest::SigV4Signer
+pub fn iceberg_catalog_rest::SigV4Signer::new(credentials: iceberg_catalog_rest::AwsCredentials, region: alloc::string::String, service: alloc::string::String, mode: iceberg_catalog_rest::PayloadHashMode) -> Self
+pub fn iceberg_catalog_rest::SigV4Signer::sign(&self, request: &mut reqwest::async_impl::request::Request) -> iceberg::error::Result<()>
+impl core::clone::Clone for iceberg_catalog_rest::SigV4Signer
+pub fn iceberg_catalog_rest::SigV4Signer::clone(&self) -> iceberg_catalog_rest::SigV4Signer
+impl core::fmt::Debug for iceberg_catalog_rest::SigV4Signer
+pub fn iceberg_catalog_rest::SigV4Signer::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct iceberg_catalog_rest::StorageCredential
 pub iceberg_catalog_rest::StorageCredential::config: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
 pub iceberg_catalog_rest::StorageCredential::prefix: alloc::string::String

--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -249,9 +249,6 @@ pub fn iceberg_catalog_rest::RenameTableRequest::serialize<__S>(&self, __seriali
 impl<'de> serde_core::de::Deserialize<'de> for iceberg_catalog_rest::RenameTableRequest
 pub fn iceberg_catalog_rest::RenameTableRequest::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub struct iceberg_catalog_rest::RestCatalog
-impl iceberg_catalog_rest::RestCatalog
-pub async fn iceberg_catalog_rest::RestCatalog::invalidate_token(&self) -> iceberg::error::Result<()>
-pub async fn iceberg_catalog_rest::RestCatalog::regenerate_token(&self) -> iceberg::error::Result<()>
 impl core::fmt::Debug for iceberg_catalog_rest::RestCatalog
 pub fn iceberg_catalog_rest::RestCatalog::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl iceberg::catalog::Catalog for iceberg_catalog_rest::RestCatalog
@@ -347,5 +344,3 @@ pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'asy
 pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg_catalog_rest::AuthSession: core::fmt::Debug + core::marker::Send + core::marker::Sync
 pub fn iceberg_catalog_rest::AuthSession::authenticate<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, request: &'life1 mut iceberg_catalog_rest::AuthRequest<'life2>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
-pub fn iceberg_catalog_rest::AuthSession::invalidate<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-pub fn iceberg_catalog_rest::AuthSession::refresh<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait

--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -349,6 +349,14 @@ impl core::default::Default for iceberg_catalog_rest::RestSessionCatalogBuilder
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::default() -> Self
 impl core::fmt::Debug for iceberg_catalog_rest::RestSessionCatalogBuilder
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct iceberg_catalog_rest::SigV4AuthManager
+impl iceberg_catalog_rest::SigV4AuthManager
+pub fn iceberg_catalog_rest::SigV4AuthManager::new(delegate: alloc::sync::Arc<dyn iceberg_catalog_rest::AuthManager>, signer: iceberg_catalog_rest::SigV4Signer) -> Self
+impl core::fmt::Debug for iceberg_catalog_rest::SigV4AuthManager
+pub fn iceberg_catalog_rest::SigV4AuthManager::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::SigV4AuthManager
+pub fn iceberg_catalog_rest::SigV4AuthManager::catalog_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn iceberg_catalog_rest::SigV4AuthManager::init_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub struct iceberg_catalog_rest::SigV4Signer
 impl iceberg_catalog_rest::SigV4Signer
 pub fn iceberg_catalog_rest::SigV4Signer::new(credentials: iceberg_catalog_rest::AwsCredentials, region: alloc::string::String, service: alloc::string::String, mode: iceberg_catalog_rest::PayloadHashMode) -> Self
@@ -405,8 +413,16 @@ impl<'de> serde_core::de::Deserialize<'de> for iceberg_catalog_rest::UpdateNames
 pub fn iceberg_catalog_rest::UpdateNamespacePropertiesResponse::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub const iceberg_catalog_rest::AUTH_TYPE_NONE: &str
 pub const iceberg_catalog_rest::AUTH_TYPE_OAUTH2: &str
+pub const iceberg_catalog_rest::AUTH_TYPE_SIGV4: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_ACCESS_KEY_ID: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_AUTH_TYPE: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SECRET_ACCESS_KEY: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SESSION_TOKEN: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SIGNING_NAME: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SIGNING_REGION: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE: &str
+pub const iceberg_catalog_rest::REST_CATALOG_PROP_SIGV4_ENABLED: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_URI: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_WAREHOUSE: &str
 pub trait iceberg_catalog_rest::AuthManager: core::fmt::Debug + core::marker::Send + core::marker::Sync
@@ -418,5 +434,8 @@ pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'life1, 'life
 impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::OAuth2Manager
 pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::SigV4AuthManager
+pub fn iceberg_catalog_rest::SigV4AuthManager::catalog_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn iceberg_catalog_rest::SigV4AuthManager::init_session<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, client: &'life1 iceberg_catalog_rest::HttpClient, props: &'life2 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub trait iceberg_catalog_rest::AuthSession: core::fmt::Debug + core::marker::Send + core::marker::Sync
 pub fn iceberg_catalog_rest::AuthSession::authenticate<'life0, 'life1, 'async_trait>(&'life0 self, request: &'life1 mut iceberg_catalog_rest::HttpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait

--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -1,10 +1,26 @@
 pub mod iceberg_catalog_rest
+pub enum iceberg_catalog_rest::AuthRequestBody<'a>
+pub iceberg_catalog_rest::AuthRequestBody::Buffered(&'a [u8])
+pub iceberg_catalog_rest::AuthRequestBody::Empty
+pub iceberg_catalog_rest::AuthRequestBody::Streaming
+impl<'a> iceberg_catalog_rest::AuthRequestBody<'a>
+pub fn iceberg_catalog_rest::AuthRequestBody<'a>::as_bytes(&self) -> core::option::Option<&'a [u8]>
+impl<'a> core::clone::Clone for iceberg_catalog_rest::AuthRequestBody<'a>
+pub fn iceberg_catalog_rest::AuthRequestBody<'a>::clone(&self) -> iceberg_catalog_rest::AuthRequestBody<'a>
+impl<'a> core::cmp::Eq for iceberg_catalog_rest::AuthRequestBody<'a>
+impl<'a> core::cmp::PartialEq for iceberg_catalog_rest::AuthRequestBody<'a>
+pub fn iceberg_catalog_rest::AuthRequestBody<'a>::eq(&self, other: &iceberg_catalog_rest::AuthRequestBody<'a>) -> bool
+impl<'a> core::fmt::Debug for iceberg_catalog_rest::AuthRequestBody<'a>
+pub fn iceberg_catalog_rest::AuthRequestBody<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for iceberg_catalog_rest::AuthRequestBody<'a>
+impl<'a> core::marker::StructuralPartialEq for iceberg_catalog_rest::AuthRequestBody<'a>
 pub struct iceberg_catalog_rest::AuthRequest<'a>
 impl<'a> iceberg_catalog_rest::AuthRequest<'a>
-pub fn iceberg_catalog_rest::AuthRequest<'a>::body(&self) -> core::option::Option<&[u8]>
+pub fn iceberg_catalog_rest::AuthRequest<'a>::body(&self) -> iceberg_catalog_rest::AuthRequestBody<'_>
 pub fn iceberg_catalog_rest::AuthRequest<'a>::headers(&self) -> &http::header::map::HeaderMap
 pub fn iceberg_catalog_rest::AuthRequest<'a>::headers_mut(&mut self) -> &mut http::header::map::HeaderMap
 pub fn iceberg_catalog_rest::AuthRequest<'a>::method(&self) -> &http::method::Method
+pub fn iceberg_catalog_rest::AuthRequest<'a>::new(inner: &'a mut reqwest::async_impl::request::Request) -> Self
 pub fn iceberg_catalog_rest::AuthRequest<'a>::url_str(&self) -> &str
 pub struct iceberg_catalog_rest::CommitTableRequest
 pub iceberg_catalog_rest::CommitTableRequest::identifier: core::option::Option<iceberg::catalog::TableIdent>
@@ -187,7 +203,7 @@ impl core::fmt::Debug for iceberg_catalog_rest::NoopAuthManager
 pub fn iceberg_catalog_rest::NoopAuthManager::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::NoopAuthManager
 pub fn iceberg_catalog_rest::NoopAuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, _props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
-pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg_catalog_rest::OAuth2Manager
 impl iceberg_catalog_rest::OAuth2Manager
 pub fn iceberg_catalog_rest::OAuth2Manager::new(token_endpoint: impl core::convert::Into<alloc::string::String>) -> Self
@@ -200,7 +216,7 @@ impl core::fmt::Debug for iceberg_catalog_rest::OAuth2Manager
 pub fn iceberg_catalog_rest::OAuth2Manager::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::OAuth2Manager
 pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
-pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg_catalog_rest::RegisterTableRequest
 pub iceberg_catalog_rest::RegisterTableRequest::metadata_location: alloc::string::String
 pub iceberg_catalog_rest::RegisterTableRequest::name: alloc::string::String
@@ -322,13 +338,13 @@ pub const iceberg_catalog_rest::REST_CATALOG_PROP_URI: &str
 pub const iceberg_catalog_rest::REST_CATALOG_PROP_WAREHOUSE: &str
 pub trait iceberg_catalog_rest::AuthManager: core::fmt::Debug + core::marker::Send + core::marker::Sync
 pub fn iceberg_catalog_rest::AuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
-pub fn iceberg_catalog_rest::AuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::AuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::NoopAuthManager
 pub fn iceberg_catalog_rest::NoopAuthManager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, _props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
-pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::NoopAuthManager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 impl iceberg_catalog_rest::AuthManager for iceberg_catalog_rest::OAuth2Manager
 pub fn iceberg_catalog_rest::OAuth2Manager::catalog_session<'life0, 'life1, 'async_trait>(&'life0 self, props: &'life1 std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
-pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::sync::Arc<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg_catalog_rest::OAuth2Manager::init_session<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<alloc::boxed::Box<dyn iceberg_catalog_rest::AuthSession>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg_catalog_rest::AuthSession: core::fmt::Debug + core::marker::Send + core::marker::Sync
 pub fn iceberg_catalog_rest::AuthSession::authenticate<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, request: &'life1 mut iceberg_catalog_rest::AuthRequest<'life2>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub fn iceberg_catalog_rest::AuthSession::invalidate<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iceberg::Result;
 pub use oauth2::OAuth2Manager;
-pub use sigv4::{AwsCredentials, PayloadHashMode, SigV4Signer};
+pub use sigv4::{AwsCredentials, PayloadHashMode, SigV4AuthManager, SigV4Signer};
 
 use crate::client::HttpClient;
 use crate::request::HttpRequest;
@@ -37,6 +37,8 @@ use crate::request::HttpRequest;
 pub const AUTH_TYPE_NONE: &str = "none";
 /// `rest.auth.type` value selecting OAuth2 token authentication.
 pub const AUTH_TYPE_OAUTH2: &str = "oauth2";
+/// `rest.auth.type` value selecting AWS SigV4 request signing.
+pub const AUTH_TYPE_SIGV4: &str = "sigv4";
 
 /// Creates the [`AuthSession`]s used to authenticate REST catalog requests.
 ///

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -19,6 +19,7 @@
 //! `AuthManager`/`AuthSession` API.
 
 mod oauth2;
+mod sigv4;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -27,6 +28,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iceberg::Result;
 pub use oauth2::OAuth2Manager;
+pub use sigv4::{AwsCredentials, PayloadHashMode, SigV4Signer};
 
 use crate::client::HttpClient;
 use crate::request::HttpRequest;

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -44,13 +44,17 @@ pub const AUTH_TYPE_OAUTH2: &str = "oauth2";
 pub trait AuthManager: Debug + Send + Sync {
     /// Session used for the initial `/v1/config` handshake, built from the
     /// user-supplied configuration.
-    async fn init_session(&self) -> Result<Arc<dyn AuthSession>>;
+    ///
+    /// Returns a [`Box`]: an init session is used once and released, unlike
+    /// the shared [`AuthManager::catalog_session`].
+    async fn init_session(&self) -> Result<Box<dyn AuthSession>>;
 
     /// Session used for all subsequent catalog requests, given the properties
     /// merged from the user configuration and the server's config response.
     ///
-    /// Implementations may carry state (e.g. a cached token) over from the
-    /// init session.
+    /// Returns an [`Arc`]: this session is shared by concurrent requests for
+    /// the rest of the catalog's lifetime. Implementations may carry state
+    /// (e.g. a cached token) over from the init session.
     async fn catalog_session(
         &self,
         props: &HashMap<String, String>,
@@ -67,7 +71,8 @@ pub struct AuthRequest<'a> {
 }
 
 impl<'a> AuthRequest<'a> {
-    pub(crate) fn new(inner: &'a mut Request) -> Self {
+    /// Wraps a request, e.g. to unit-test a custom [`AuthSession`].
+    pub fn new(inner: &'a mut Request) -> Self {
         Self { inner }
     }
 
@@ -91,9 +96,40 @@ impl<'a> AuthRequest<'a> {
         self.inner.headers_mut()
     }
 
-    /// The in-memory request body, or `None` for an empty or streaming body.
-    pub fn body(&self) -> Option<&[u8]> {
-        self.inner.body().and_then(|body| body.as_bytes())
+    /// The request body, distinguishing an absent body from a streaming one:
+    /// signers can sign [`AuthRequestBody::Empty`] (empty-payload hash) and
+    /// [`AuthRequestBody::Buffered`], but not [`AuthRequestBody::Streaming`].
+    pub fn body(&self) -> AuthRequestBody<'_> {
+        match self.inner.body() {
+            None => AuthRequestBody::Empty,
+            Some(body) => match body.as_bytes() {
+                Some(bytes) => AuthRequestBody::Buffered(bytes),
+                None => AuthRequestBody::Streaming,
+            },
+        }
+    }
+}
+
+/// The body of an [`AuthRequest`], as seen by authentication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthRequestBody<'a> {
+    /// No body is set.
+    Empty,
+    /// An in-memory body.
+    Buffered(&'a [u8]),
+    /// A streaming body, whose bytes are not available for e.g. signing.
+    Streaming,
+}
+
+impl<'a> AuthRequestBody<'a> {
+    /// The signable bytes: empty for [`Self::Empty`], the buffer for
+    /// [`Self::Buffered`], and `None` for [`Self::Streaming`].
+    pub fn as_bytes(&self) -> Option<&'a [u8]> {
+        match self {
+            AuthRequestBody::Empty => Some(&[]),
+            AuthRequestBody::Buffered(bytes) => Some(bytes),
+            AuthRequestBody::Streaming => None,
+        }
     }
 }
 
@@ -124,6 +160,32 @@ pub trait AuthSession: Debug + Send + Sync {
     }
 }
 
+/// A secret string: `Debug` prints `[REDACTED]` and the memory is zeroized on
+/// drop. String-shaped counterpart of the core crate's `SensitiveBytes`; note
+/// that copies formatted into requests (form bodies, header values) are owned
+/// by the HTTP stack and outlive this wrapper.
+#[derive(Clone)]
+pub(crate) struct SensitiveString(zeroize::Zeroizing<String>);
+
+impl SensitiveString {
+    /// The wrapped secret.
+    pub(crate) fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SensitiveString {
+    fn from(secret: String) -> Self {
+        Self(zeroize::Zeroizing::new(secret))
+    }
+}
+
+impl Debug for SensitiveString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
 /// [`AuthManager`] that performs no authentication.
 #[derive(Debug)]
 pub struct NoopAuthManager;
@@ -134,8 +196,8 @@ struct NoopSession;
 
 #[async_trait]
 impl AuthManager for NoopAuthManager {
-    async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
-        Ok(Arc::new(NoopSession))
+    async fn init_session(&self) -> Result<Box<dyn AuthSession>> {
+        Ok(Box::new(NoopSession))
     }
 
     async fn catalog_session(
@@ -150,5 +212,102 @@ impl AuthManager for NoopAuthManager {
 impl AuthSession for NoopSession {
     async fn authenticate(&self, _request: &mut AuthRequest<'_>) -> Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_static_token_session_lifecycle() {
+        // Token-only config: attach as-is; refresh keeps erroring (no
+        // credential to exchange); after invalidate, no auth is sent.
+        let manager = OAuth2Manager::new("http://localhost/unused").with_token("tok-static");
+        let session = manager.init_session().await.unwrap();
+        let client = Client::new();
+
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        session
+            .authenticate(&mut AuthRequest::new(&mut req))
+            .await
+            .unwrap();
+        assert_eq!(
+            req.headers().get("authorization").unwrap(),
+            "Bearer tok-static"
+        );
+
+        assert!(session.refresh().await.is_err());
+
+        session.invalidate().await.unwrap();
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        session
+            .authenticate(&mut AuthRequest::new(&mut req))
+            .await
+            .unwrap();
+        assert!(req.headers().get("authorization").is_none());
+    }
+
+    #[test]
+    fn test_sensitive_string_redacts_debug() {
+        let secret = SensitiveString::from("s3cret-value".to_string());
+        assert_eq!(format!("{secret:?}"), "[REDACTED]");
+
+        // Containers can safely derive Debug around it.
+        #[derive(Debug)]
+        #[allow(dead_code)]
+        struct Holder {
+            secret: SensitiveString,
+        }
+        let rendered = format!("{:?}", Holder { secret });
+        assert!(!rendered.contains("s3cret-value"), "leaked: {rendered}");
+        assert!(rendered.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_auth_request_body_states() {
+        let client = Client::new();
+
+        // No body at all.
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        let auth_req = AuthRequest::new(&mut req);
+        let body = auth_req.body();
+        assert_eq!(body, AuthRequestBody::Empty);
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
+
+        // An in-memory body.
+        let mut req = client
+            .post("https://rest.example.com/v1/namespaces")
+            .body("{}")
+            .build()
+            .unwrap();
+        let auth_req = AuthRequest::new(&mut req);
+        let body = auth_req.body();
+        assert_eq!(body, AuthRequestBody::Buffered(b"{}"));
+        assert_eq!(body.as_bytes(), Some(b"{}" as &[u8]));
+
+        // A streaming body: bytes are unavailable, so it must not sign as empty.
+        let mut req = client
+            .post("https://rest.example.com/v1/namespaces")
+            .body(reqwest::Body::wrap_stream(futures::stream::once(async {
+                Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"chunk"))
+            })))
+            .build()
+            .unwrap();
+        let auth_req = AuthRequest::new(&mut req);
+        let body = auth_req.body();
+        assert_eq!(body, AuthRequestBody::Streaming);
+        assert_eq!(body.as_bytes(), None);
     }
 }

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -138,26 +138,6 @@ impl<'a> AuthRequestBody<'a> {
 pub trait AuthSession: Debug + Send + Sync {
     /// Applies authentication to the request (adds headers, signs, ...).
     async fn authenticate(&self, request: &mut AuthRequest<'_>) -> Result<()>;
-
-    /// Drops any cached credentials so the next request re-authenticates.
-    ///
-    /// Backs the existing [`RestCatalog::invalidate_token`] API; not part of
-    /// the intended extension surface, and the default no-op is usually fine.
-    ///
-    /// [`RestCatalog::invalidate_token`]: crate::RestCatalog::invalidate_token
-    async fn invalidate(&self) -> Result<()> {
-        Ok(())
-    }
-
-    /// Proactively refreshes cached credentials (e.g. re-exchanges an OAuth2
-    /// client credential for a new token), leaving them intact on failure.
-    ///
-    /// Like [`Self::invalidate`], backs [`RestCatalog::regenerate_token`].
-    ///
-    /// [`RestCatalog::regenerate_token`]: crate::RestCatalog::regenerate_token
-    async fn refresh(&self) -> Result<()> {
-        Ok(())
-    }
 }
 
 /// A secret string: `Debug` prints `[REDACTED]` and the memory is zeroized on
@@ -222,14 +202,12 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_static_token_session_lifecycle() {
-        // Token-only config: attach as-is; refresh keeps erroring (no
-        // credential to exchange); after invalidate, no auth is sent.
+    async fn test_static_token_session_attaches_token() {
+        // Token-only config: the token is attached as-is.
         let manager = OAuth2Manager::new("http://localhost/unused").with_token("tok-static");
         let session = manager.init_session().await.unwrap();
-        let client = Client::new();
 
-        let mut req = client
+        let mut req = Client::new()
             .get("https://rest.example.com/v1/config")
             .build()
             .unwrap();
@@ -241,19 +219,6 @@ mod tests {
             req.headers().get("authorization").unwrap(),
             "Bearer tok-static"
         );
-
-        assert!(session.refresh().await.is_err());
-
-        session.invalidate().await.unwrap();
-        let mut req = client
-            .get("https://rest.example.com/v1/config")
-            .build()
-            .unwrap();
-        session
-            .authenticate(&mut AuthRequest::new(&mut req))
-            .await
-            .unwrap();
-        assert!(req.headers().get("authorization").is_none());
     }
 
     #[test]

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -140,32 +140,6 @@ pub trait AuthSession: Debug + Send + Sync {
     async fn authenticate(&self, request: &mut AuthRequest<'_>) -> Result<()>;
 }
 
-/// A secret string: `Debug` prints `[REDACTED]` and the memory is zeroized on
-/// drop. String-shaped counterpart of the core crate's `SensitiveBytes`; note
-/// that copies formatted into requests (form bodies, header values) are owned
-/// by the HTTP stack and outlive this wrapper.
-#[derive(Clone)]
-pub(crate) struct SensitiveString(zeroize::Zeroizing<String>);
-
-impl SensitiveString {
-    /// The wrapped secret.
-    pub(crate) fn expose(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for SensitiveString {
-    fn from(secret: String) -> Self {
-        Self(zeroize::Zeroizing::new(secret))
-    }
-}
-
-impl Debug for SensitiveString {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("[REDACTED]")
-    }
-}
-
 /// [`AuthManager`] that performs no authentication.
 #[derive(Debug)]
 pub struct NoopAuthManager;
@@ -219,22 +193,6 @@ mod tests {
             req.headers().get("authorization").unwrap(),
             "Bearer tok-static"
         );
-    }
-
-    #[test]
-    fn test_sensitive_string_redacts_debug() {
-        let secret = SensitiveString::from("s3cret-value".to_string());
-        assert_eq!(format!("{secret:?}"), "[REDACTED]");
-
-        // Containers can safely derive Debug around it.
-        #[derive(Debug)]
-        #[allow(dead_code)]
-        struct Holder {
-            secret: SensitiveString,
-        }
-        let rendered = format!("{:?}", Holder { secret });
-        assert!(!rendered.contains("s3cret-value"), "leaked: {rendered}");
-        assert!(rendered.contains("[REDACTED]"));
     }
 
     #[test]

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Pluggable authentication for the REST catalog, mirroring Iceberg Java's
+//! `AuthManager`/`AuthSession` API.
+
+mod oauth2;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use http::{HeaderMap, Method};
+use iceberg::Result;
+pub use oauth2::OAuth2Manager;
+use reqwest::Request;
+
+/// `rest.auth.type` value disabling authentication.
+pub const AUTH_TYPE_NONE: &str = "none";
+/// `rest.auth.type` value selecting OAuth2 token authentication.
+pub const AUTH_TYPE_OAUTH2: &str = "oauth2";
+
+/// Creates the [`AuthSession`]s used to authenticate REST catalog requests.
+///
+/// A manager is created once per catalog, either from the `rest.auth.type`
+/// property or injected through `RestCatalogBuilder::with_auth_manager`, and
+/// lives for the lifetime of the catalog.
+#[async_trait]
+pub trait AuthManager: Debug + Send + Sync {
+    /// Session used for the initial `/v1/config` handshake, built from the
+    /// user-supplied configuration.
+    async fn init_session(&self) -> Result<Arc<dyn AuthSession>>;
+
+    /// Session used for all subsequent catalog requests, given the properties
+    /// merged from the user configuration and the server's config response.
+    ///
+    /// Implementations may carry state (e.g. a cached token) over from the
+    /// init session.
+    async fn catalog_session(
+        &self,
+        props: &HashMap<String, String>,
+    ) -> Result<Arc<dyn AuthSession>>;
+}
+
+/// An outgoing REST request being authenticated by an [`AuthSession`].
+///
+/// Wraps the request so authentication implementations depend only on the
+/// stable `http` crate and standard types, not on the concrete HTTP client the
+/// REST catalog uses internally.
+pub struct AuthRequest<'a> {
+    inner: &'a mut Request,
+}
+
+impl<'a> AuthRequest<'a> {
+    pub(crate) fn new(inner: &'a mut Request) -> Self {
+        Self { inner }
+    }
+
+    /// The request method.
+    pub fn method(&self) -> &Method {
+        self.inner.method()
+    }
+
+    /// The request URL, as a string (scheme, host, path and query).
+    pub fn url_str(&self) -> &str {
+        self.inner.url().as_str()
+    }
+
+    /// The request headers.
+    pub fn headers(&self) -> &HeaderMap {
+        self.inner.headers()
+    }
+
+    /// The mutable request headers, e.g. to add an `Authorization` header.
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        self.inner.headers_mut()
+    }
+
+    /// The in-memory request body, or `None` for an empty or streaming body.
+    pub fn body(&self) -> Option<&[u8]> {
+        self.inner.body().and_then(|body| body.as_bytes())
+    }
+}
+
+/// Authenticates outgoing REST catalog requests.
+#[async_trait]
+pub trait AuthSession: Debug + Send + Sync {
+    /// Applies authentication to the request (adds headers, signs, ...).
+    async fn authenticate(&self, request: &mut AuthRequest<'_>) -> Result<()>;
+
+    /// Drops any cached credentials so the next request re-authenticates.
+    ///
+    /// Exists to back the pre-existing [`RestCatalog::invalidate_token`] API
+    /// and has no counterpart in Java's `AuthSession`. Implementations are
+    /// expected to manage credential lifetime inside [`Self::authenticate`];
+    /// this is not part of the intended extension surface, and the default
+    /// no-op is fine for most managers.
+    ///
+    /// [`RestCatalog::invalidate_token`]: crate::RestCatalog::invalidate_token
+    async fn invalidate(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Proactively refreshes cached credentials (e.g. re-exchanges an OAuth2
+    /// client credential for a new token), leaving them intact on failure.
+    ///
+    /// Like [`Self::invalidate`], this backs the pre-existing
+    /// [`RestCatalog::regenerate_token`] API rather than being part of the
+    /// intended extension surface.
+    ///
+    /// [`RestCatalog::regenerate_token`]: crate::RestCatalog::regenerate_token
+    async fn refresh(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// [`AuthManager`] that performs no authentication.
+#[derive(Debug)]
+pub struct NoopAuthManager;
+
+/// [`AuthSession`] that performs no authentication.
+#[derive(Debug)]
+struct NoopSession;
+
+#[async_trait]
+impl AuthManager for NoopAuthManager {
+    async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
+        Ok(Arc::new(NoopSession))
+    }
+
+    async fn catalog_session(
+        &self,
+        _props: &HashMap<String, String>,
+    ) -> Result<Arc<dyn AuthSession>> {
+        Ok(Arc::new(NoopSession))
+    }
+}
+
+#[async_trait]
+impl AuthSession for NoopSession {
+    async fn authenticate(&self, _request: &mut AuthRequest<'_>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -105,11 +105,8 @@ pub trait AuthSession: Debug + Send + Sync {
 
     /// Drops any cached credentials so the next request re-authenticates.
     ///
-    /// Exists to back the pre-existing [`RestCatalog::invalidate_token`] API
-    /// and has no counterpart in Java's `AuthSession`. Implementations are
-    /// expected to manage credential lifetime inside [`Self::authenticate`];
-    /// this is not part of the intended extension surface, and the default
-    /// no-op is fine for most managers.
+    /// Backs the existing [`RestCatalog::invalidate_token`] API; not part of
+    /// the intended extension surface, and the default no-op is usually fine.
     ///
     /// [`RestCatalog::invalidate_token`]: crate::RestCatalog::invalidate_token
     async fn invalidate(&self) -> Result<()> {
@@ -119,9 +116,7 @@ pub trait AuthSession: Debug + Send + Sync {
     /// Proactively refreshes cached credentials (e.g. re-exchanges an OAuth2
     /// client credential for a new token), leaving them intact on failure.
     ///
-    /// Like [`Self::invalidate`], this backs the pre-existing
-    /// [`RestCatalog::regenerate_token`] API rather than being part of the
-    /// intended extension surface.
+    /// Like [`Self::invalidate`], backs [`RestCatalog::regenerate_token`].
     ///
     /// [`RestCatalog::regenerate_token`]: crate::RestCatalog::regenerate_token
     async fn refresh(&self) -> Result<()> {

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -26,7 +26,7 @@ use reqwest::header::HeaderMap;
 use reqwest::{Client, Method};
 use tokio::sync::Mutex;
 
-use super::{AuthManager, AuthRequest, AuthSession};
+use super::{AuthManager, AuthRequest, AuthSession, SensitiveString};
 use crate::catalog::{
     REST_CATALOG_PROP_URI, RestCatalogConfig, credential_from_props, default_token_endpoint,
     explicit_headers_from_props,
@@ -38,7 +38,7 @@ use crate::types::{ErrorResponse, TokenResponse};
 struct OAuth2Params {
     extra_headers: HeaderMap,
     token_endpoint: String,
-    credential: Option<(Option<String>, String)>,
+    credential: Option<(Option<String>, SensitiveString)>,
     extra_oauth_params: HashMap<String, String>,
 }
 
@@ -50,7 +50,7 @@ struct OAuth2Params {
 /// across sessions so it survives the config handshake.
 pub struct OAuth2Manager {
     client: Client,
-    token: Arc<Mutex<Option<String>>>,
+    token: Arc<Mutex<Option<SensitiveString>>>,
     init_params: OAuth2Params,
     /// True when the token endpoint was derived from the catalog URI (not
     /// explicitly configured): it is then recomputed from the merged URI in
@@ -83,13 +83,13 @@ impl OAuth2Manager {
 
     /// Sets a bearer token used directly (takes precedence over `credential`).
     pub fn with_token(mut self, token: impl Into<String>) -> Self {
-        self.token = Arc::new(Mutex::new(Some(token.into())));
+        self.token = Arc::new(Mutex::new(Some(SensitiveString::from(token.into()))));
         self
     }
 
     /// Sets the client credential exchanged for a token at the token endpoint.
     pub fn with_credential(mut self, client_id: Option<String>, client_secret: String) -> Self {
-        self.init_params.credential = Some((client_id, client_secret));
+        self.init_params.credential = Some((client_id, client_secret.into()));
         self
     }
 
@@ -116,11 +116,11 @@ impl OAuth2Manager {
     pub(crate) fn from_config(cfg: &RestCatalogConfig) -> Result<Self> {
         Ok(Self {
             client: cfg.client(),
-            token: Arc::new(Mutex::new(cfg.token())),
+            token: Arc::new(Mutex::new(cfg.token().map(SensitiveString::from))),
             init_params: OAuth2Params {
                 extra_headers: cfg.extra_headers()?,
                 token_endpoint: cfg.get_token_endpoint(),
-                credential: cfg.credential(),
+                credential: cfg.credential().map(|(id, secret)| (id, secret.into())),
                 extra_oauth_params: cfg.extra_oauth_params(),
             },
             endpoint_is_default: cfg.explicit_oauth2_server_uri().is_none(),
@@ -138,12 +138,8 @@ impl Debug for OAuth2Manager {
 
 #[async_trait]
 impl AuthManager for OAuth2Manager {
-    async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
-        Ok(Arc::new(OAuth2Session {
-            client: self.client.clone(),
-            token: self.token.clone(),
-            params: self.init_params.clone(),
-        }))
+    async fn init_session(&self) -> Result<Box<dyn AuthSession>> {
+        Ok(self.build_session(self.init_params.clone()))
     }
 
     async fn catalog_session(
@@ -152,7 +148,7 @@ impl AuthManager for OAuth2Manager {
     ) -> Result<Arc<dyn AuthSession>> {
         // The server config may carry a new token (or restate the user's).
         if let Some(token) = props.get("token") {
-            *self.token.lock().await = Some(token.clone());
+            *self.token.lock().await = Some(SensitiveString::from(token.clone()));
         }
 
         // Explicit property overrides merge ONTO the manager's options, so an
@@ -178,63 +174,136 @@ impl AuthManager for OAuth2Manager {
             _ => self.init_params.token_endpoint.clone(),
         };
 
-        Ok(Arc::new(OAuth2Session {
-            client: self.client.clone(),
-            token: self.token.clone(),
-            params: OAuth2Params {
+        Ok(Arc::from(
+            self.build_session(OAuth2Params {
                 extra_headers,
                 token_endpoint,
                 credential: credential_from_props(props)
+                    .map(|(id, secret)| (id, secret.into()))
                     .or_else(|| self.init_params.credential.clone()),
                 extra_oauth_params,
-            },
-        }))
+            }),
+        ))
     }
 }
 
-/// [`AuthSession`] adding a `Authorization: Bearer <token>` header.
-struct OAuth2Session {
-    client: Client,
-    /// Cached bearer token, shared with the owning [`OAuth2Manager`].
-    token: Arc<Mutex<Option<String>>>,
-    params: OAuth2Params,
+impl OAuth2Manager {
+    /// Builds the session matching the configured mode:
+    ///
+    /// - a `credential` yields a [`ClientCredentialsSession`] (its token cache
+    ///   pre-seeded when a `token` is also set, and the token then takes
+    ///   precedence until invalidated);
+    /// - otherwise a [`StaticTokenSession`], which attaches the configured
+    ///   token as-is — or nothing when none is set.
+    ///
+    /// Both share the manager's token cell, so a cached token survives the
+    /// config handshake and `invalidate` is observed by later sessions.
+    fn build_session(&self, params: OAuth2Params) -> Box<dyn AuthSession> {
+        match params.credential {
+            Some(credential) => Box::new(ClientCredentialsSession {
+                client: self.client.clone(),
+                token: self.token.clone(),
+                credential,
+                token_endpoint: params.token_endpoint,
+                extra_headers: params.extra_headers,
+                extra_oauth_params: params.extra_oauth_params,
+            }),
+            None => Box::new(StaticTokenSession {
+                token: self.token.clone(),
+            }),
+        }
+    }
 }
 
-impl Debug for OAuth2Session {
+/// Attaches `token` as a `Authorization: Bearer <token>` header, marked
+/// sensitive so `Debug`-formatted requests redact it.
+fn attach_bearer(req: &mut AuthRequest<'_>, token: &SensitiveString) -> Result<()> {
+    let mut value: http::HeaderValue =
+        format!("Bearer {}", token.expose()).parse().map_err(|e| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "Invalid token received from catalog server!",
+            )
+            .with_source(e)
+        })?;
+    value.set_sensitive(true);
+    req.headers_mut().insert(http::header::AUTHORIZATION, value);
+    Ok(())
+}
+
+/// [`AuthSession`] for a pre-configured bearer token: attaches it as-is and
+/// cannot obtain a new one (there is no credential to exchange).
+#[derive(Debug)]
+struct StaticTokenSession {
+    /// Shared with the owning [`OAuth2Manager`].
+    token: Arc<Mutex<Option<SensitiveString>>>,
+}
+
+#[async_trait]
+impl AuthSession for StaticTokenSession {
+    async fn authenticate(&self, req: &mut AuthRequest<'_>) -> Result<()> {
+        // After `invalidate` there is nothing to fall back to: no auth is sent.
+        match self.token.lock().await.clone() {
+            Some(token) => attach_bearer(req, &token),
+            None => Ok(()),
+        }
+    }
+
+    async fn invalidate(&self) -> Result<()> {
+        *self.token.lock().await = None;
+        Ok(())
+    }
+
+    async fn refresh(&self) -> Result<()> {
+        Err(Error::new(
+            ErrorKind::DataInvalid,
+            "Credential must be provided for authentication",
+        ))
+    }
+}
+
+/// [`AuthSession`] implementing the OAuth2 client-credentials flow: exchanges
+/// the credential for a token at the token endpoint and caches it.
+///
+/// # TODO: Support automatic token refreshing.
+struct ClientCredentialsSession {
+    client: Client,
+    /// Cached bearer token, shared with the owning [`OAuth2Manager`].
+    token: Arc<Mutex<Option<SensitiveString>>>,
+    credential: (Option<String>, SensitiveString),
+    token_endpoint: String,
+    extra_headers: HeaderMap,
+    extra_oauth_params: HashMap<String, String>,
+}
+
+impl Debug for ClientCredentialsSession {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OAuth2Session")
-            .field("token_endpoint", &self.params.token_endpoint)
+        f.debug_struct("ClientCredentialsSession")
+            .field("token_endpoint", &self.token_endpoint)
             .finish_non_exhaustive()
     }
 }
 
-impl OAuth2Session {
+impl ClientCredentialsSession {
     async fn exchange_credential_for_token(&self) -> Result<String> {
-        // Credential must exist here.
-        let (client_id, client_secret) = self.params.credential.as_ref().ok_or_else(|| {
-            Error::new(
-                ErrorKind::DataInvalid,
-                "Credential must be provided for authentication",
-            )
-        })?;
+        let (client_id, client_secret) = &self.credential;
 
         let mut params = HashMap::with_capacity(4);
         params.insert("grant_type", "client_credentials");
         if let Some(client_id) = client_id {
             params.insert("client_id", client_id);
         }
-        params.insert("client_secret", client_secret);
+        params.insert("client_secret", client_secret.expose());
         params.extend(
-            self.params
-                .extra_oauth_params
+            self.extra_oauth_params
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str())),
         );
 
         let mut auth_req = self
             .client
-            .request(Method::POST, &self.params.token_endpoint)
-            .headers(self.params.extra_headers.clone())
+            .request(Method::POST, &self.token_endpoint)
+            .headers(self.extra_headers.clone())
             .form(&params)
             .build()?;
         // extra headers add content-type application/json header it's necessary to override it with proper type
@@ -282,51 +351,27 @@ impl OAuth2Session {
 }
 
 #[async_trait]
-impl AuthSession for OAuth2Session {
-    /// Adds a bearer token to the authorization header.
-    ///
-    /// Three modes:
-    ///
-    /// 1. **No authentication** - Skip when both `credential` and `token` are missing.
-    /// 2. **Token authentication** - Use the provided `token` directly.
-    /// 3. **OAuth authentication** - Exchange `credential` for a token, cache it, then use it.
-    ///
-    /// When both `credential` and `token` are present, `token` takes precedence.
-    ///
-    /// # TODO: Support automatic token refreshing.
+impl AuthSession for ClientCredentialsSession {
+    /// Uses the cached token when present (a configured `token` takes
+    /// precedence over the credential until invalidated); otherwise exchanges
+    /// the credential for a token, caches it, then uses it.
     async fn authenticate(&self, req: &mut AuthRequest<'_>) -> Result<()> {
-        // Clone the token from lock without holding the lock for entire function.
-        let token = self.token.lock().await.clone();
-
-        if self.params.credential.is_none() && token.is_none() {
-            return Ok(());
-        }
-
-        // Either use the provided token or exchange credential for token, cache and use that
-        let token = match token {
-            Some(token) => token,
-            None => {
-                let token = self.exchange_credential_for_token().await?;
-                // Update token so that we use it for next request instead of
-                // exchanging credential for token from the server again
-                *self.token.lock().await = Some(token.clone());
-                token
+        // The lock is held across the exchange: waiters reuse a successful
+        // result, and retry themselves after a failure.
+        let token = {
+            let mut token = self.token.lock().await;
+            match &*token {
+                Some(token) => token.clone(),
+                None => {
+                    let new_token =
+                        SensitiveString::from(self.exchange_credential_for_token().await?);
+                    *token = Some(new_token.clone());
+                    new_token
+                }
             }
         };
 
-        // Insert token in request.
-        req.headers_mut().insert(
-            http::header::AUTHORIZATION,
-            format!("Bearer {token}").parse().map_err(|e| {
-                Error::new(
-                    ErrorKind::DataInvalid,
-                    "Invalid token received from catalog server!",
-                )
-                .with_source(e)
-            })?,
-        );
-
-        Ok(())
+        attach_bearer(req, &token)
     }
 
     /// Invalidate the current token without generating a new one. On the next
@@ -344,7 +389,7 @@ impl AuthSession for OAuth2Session {
     /// an error and leave the current token unchanged.
     async fn refresh(&self) -> Result<()> {
         let new_token = self.exchange_credential_for_token().await?;
-        *self.token.lock().await = Some(new_token);
+        *self.token.lock().await = Some(new_token.into());
         Ok(())
     }
 }

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -1,0 +1,353 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use http::StatusCode;
+use iceberg::{Error, ErrorKind, Result};
+use reqwest::header::HeaderMap;
+use reqwest::{Client, Method};
+use tokio::sync::Mutex;
+
+use super::{AuthManager, AuthRequest, AuthSession};
+use crate::catalog::{
+    REST_CATALOG_PROP_URI, RestCatalogConfig, credential_from_props, default_token_endpoint,
+    explicit_headers_from_props,
+};
+use crate::types::{ErrorResponse, TokenResponse};
+
+/// Per-phase OAuth2 parameters (init vs. post-handshake catalog phase).
+#[derive(Clone)]
+struct OAuth2Params {
+    extra_headers: HeaderMap,
+    token_endpoint: String,
+    credential: Option<(Option<String>, String)>,
+    extra_oauth_params: HashMap<String, String>,
+}
+
+/// [`AuthManager`] implementing the OAuth2 client-credentials flow used by
+/// Iceberg REST catalogs.
+///
+/// A configured `token` is used directly; otherwise `credential` is exchanged
+/// for a token at the token endpoint and cached. The cached token is shared
+/// across sessions so it survives the config handshake.
+pub struct OAuth2Manager {
+    client: Client,
+    token: Arc<Mutex<Option<String>>>,
+    init_params: OAuth2Params,
+    /// True when the token endpoint was derived from the catalog URI (not
+    /// explicitly configured): it is then recomputed from the merged URI in
+    /// [`Self::catalog_session`], since `/v1/config` may override the URI.
+    endpoint_is_default: bool,
+}
+
+impl OAuth2Manager {
+    /// Creates a manager exchanging credentials at `token_endpoint`, with no
+    /// token or credential configured. Combine with the `with_*` methods:
+    ///
+    /// ```rust,ignore
+    /// let manager = OAuth2Manager::new("https://auth.example.com/v1/oauth/tokens")
+    ///     .with_credential(Some("client-id".into()), "client-secret".into());
+    /// ```
+    pub fn new(token_endpoint: impl Into<String>) -> Self {
+        Self {
+            client: Client::default(),
+            token: Arc::new(Mutex::new(None)),
+            init_params: OAuth2Params {
+                extra_headers: HeaderMap::new(),
+                token_endpoint: token_endpoint.into(),
+                credential: None,
+                // Same default as the configuration path (and the
+                // pre-AuthManager client): the Iceberg catalog scope.
+                extra_oauth_params: HashMap::from([("scope".to_string(), "catalog".to_string())]),
+            },
+            endpoint_is_default: false,
+        }
+    }
+
+    /// Sets a bearer token used directly (takes precedence over `credential`).
+    pub fn with_token(mut self, token: impl Into<String>) -> Self {
+        self.token = Arc::new(Mutex::new(Some(token.into())));
+        self
+    }
+
+    /// Sets the client credential exchanged for a token at the token endpoint.
+    pub fn with_credential(mut self, client_id: Option<String>, client_secret: String) -> Self {
+        self.init_params.credential = Some((client_id, client_secret));
+        self
+    }
+
+    /// Sets the HTTP client used for token requests.
+    pub fn with_client(mut self, client: Client) -> Self {
+        self.client = client;
+        self
+    }
+
+    /// Sets extra headers sent with token requests.
+    pub fn with_extra_headers(mut self, headers: HeaderMap) -> Self {
+        self.init_params.extra_headers = headers;
+        self
+    }
+
+    /// Adds extra OAuth2 form parameters (e.g. `scope`, `audience`), merged
+    /// onto the defaults: provide a `scope` entry to replace the default
+    /// `catalog` scope.
+    pub fn with_extra_oauth_params(mut self, params: HashMap<String, String>) -> Self {
+        self.init_params.extra_oauth_params.extend(params);
+        self
+    }
+
+    pub(crate) fn from_config(cfg: &RestCatalogConfig) -> Result<Self> {
+        Ok(Self {
+            client: cfg.client(),
+            token: Arc::new(Mutex::new(cfg.token())),
+            init_params: OAuth2Params {
+                extra_headers: cfg.extra_headers()?,
+                token_endpoint: cfg.get_token_endpoint(),
+                credential: cfg.credential(),
+                extra_oauth_params: cfg.extra_oauth_params(),
+            },
+            endpoint_is_default: cfg.explicit_oauth2_server_uri().is_none(),
+        })
+    }
+}
+
+impl Debug for OAuth2Manager {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2Manager")
+            .field("token_endpoint", &self.init_params.token_endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl AuthManager for OAuth2Manager {
+    async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
+        Ok(Arc::new(OAuth2Session {
+            client: self.client.clone(),
+            token: self.token.clone(),
+            params: self.init_params.clone(),
+        }))
+    }
+
+    async fn catalog_session(
+        &self,
+        props: &HashMap<String, String>,
+    ) -> Result<Arc<dyn AuthSession>> {
+        // The server config may carry a new token (or restate the user's).
+        if let Some(token) = props.get("token") {
+            *self.token.lock().await = Some(token.clone());
+        }
+
+        // Explicit property overrides are merged ONTO the manager's configured
+        // options: an injected manager keeps its token endpoint, extra headers
+        // and OAuth params unless a property explicitly overrides them.
+        let mut extra_headers = self.init_params.extra_headers.clone();
+        extra_headers.extend(explicit_headers_from_props(props)?);
+
+        let mut extra_oauth_params = self.init_params.extra_oauth_params.clone();
+        for key in ["scope", "audience", "resource"] {
+            if let Some(value) = props.get(key) {
+                extra_oauth_params.insert(key.to_string(), value.to_string());
+            }
+        }
+
+        let token_endpoint = match props.get("oauth2-server-uri") {
+            Some(uri) if !uri.is_empty() => uri.clone(),
+            // The built-in manager's default endpoint follows the merged
+            // catalog URI (a `/v1/config` override may have changed it);
+            // injected managers keep their explicitly configured endpoint.
+            _ if self.endpoint_is_default => props
+                .get(REST_CATALOG_PROP_URI)
+                .map(|uri| default_token_endpoint(uri))
+                .unwrap_or_else(|| self.init_params.token_endpoint.clone()),
+            _ => self.init_params.token_endpoint.clone(),
+        };
+
+        Ok(Arc::new(OAuth2Session {
+            client: self.client.clone(),
+            token: self.token.clone(),
+            params: OAuth2Params {
+                extra_headers,
+                token_endpoint,
+                credential: credential_from_props(props)
+                    .or_else(|| self.init_params.credential.clone()),
+                extra_oauth_params,
+            },
+        }))
+    }
+}
+
+/// [`AuthSession`] adding a `Authorization: Bearer <token>` header.
+struct OAuth2Session {
+    client: Client,
+    /// Cached bearer token, shared with the owning [`OAuth2Manager`].
+    token: Arc<Mutex<Option<String>>>,
+    params: OAuth2Params,
+}
+
+impl Debug for OAuth2Session {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2Session")
+            .field("token_endpoint", &self.params.token_endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OAuth2Session {
+    async fn exchange_credential_for_token(&self) -> Result<String> {
+        // Credential must exist here.
+        let (client_id, client_secret) = self.params.credential.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "Credential must be provided for authentication",
+            )
+        })?;
+
+        let mut params = HashMap::with_capacity(4);
+        params.insert("grant_type", "client_credentials");
+        if let Some(client_id) = client_id {
+            params.insert("client_id", client_id);
+        }
+        params.insert("client_secret", client_secret);
+        params.extend(
+            self.params
+                .extra_oauth_params
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        );
+
+        let mut auth_req = self
+            .client
+            .request(Method::POST, &self.params.token_endpoint)
+            .headers(self.params.extra_headers.clone())
+            .form(&params)
+            .build()?;
+        // extra headers add content-type application/json header it's necessary to override it with proper type
+        // note that form call doesn't add content-type header if already present
+        auth_req.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
+        let auth_url = auth_req.url().clone();
+        let auth_resp = self.client.execute(auth_req).await?;
+
+        let auth_res: TokenResponse = if auth_resp.status() == StatusCode::OK {
+            let text = auth_resp
+                .bytes()
+                .await
+                .map_err(|err| err.with_url(auth_url.clone()))?;
+            Ok(serde_json::from_slice(&text).map_err(|e| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    "Failed to parse response from rest catalog server!",
+                )
+                .with_context("operation", "auth")
+                .with_context("url", auth_url.to_string())
+                .with_context("json", String::from_utf8_lossy(&text))
+                .with_source(e)
+            })?)
+        } else {
+            let code = auth_resp.status();
+            let text = auth_resp
+                .bytes()
+                .await
+                .map_err(|err| err.with_url(auth_url.clone()))?;
+            let e: ErrorResponse = serde_json::from_slice(&text).map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "Received unexpected response")
+                    .with_context("code", code.to_string())
+                    .with_context("operation", "auth")
+                    .with_context("url", auth_url.to_string())
+                    .with_context("json", String::from_utf8_lossy(&text))
+                    .with_source(e)
+            })?;
+            Err(Error::from(e))
+        }?;
+        Ok(auth_res.access_token)
+    }
+}
+
+#[async_trait]
+impl AuthSession for OAuth2Session {
+    /// Adds a bearer token to the authorization header.
+    ///
+    /// Three modes:
+    ///
+    /// 1. **No authentication** - Skip when both `credential` and `token` are missing.
+    /// 2. **Token authentication** - Use the provided `token` directly.
+    /// 3. **OAuth authentication** - Exchange `credential` for a token, cache it, then use it.
+    ///
+    /// When both `credential` and `token` are present, `token` takes precedence.
+    ///
+    /// # TODO: Support automatic token refreshing.
+    async fn authenticate(&self, req: &mut AuthRequest<'_>) -> Result<()> {
+        // Clone the token from lock without holding the lock for entire function.
+        let token = self.token.lock().await.clone();
+
+        if self.params.credential.is_none() && token.is_none() {
+            return Ok(());
+        }
+
+        // Either use the provided token or exchange credential for token, cache and use that
+        let token = match token {
+            Some(token) => token,
+            None => {
+                let token = self.exchange_credential_for_token().await?;
+                // Update token so that we use it for next request instead of
+                // exchanging credential for token from the server again
+                *self.token.lock().await = Some(token.clone());
+                token
+            }
+        };
+
+        // Insert token in request.
+        req.headers_mut().insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().map_err(|e| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "Invalid token received from catalog server!",
+                )
+                .with_source(e)
+            })?,
+        );
+
+        Ok(())
+    }
+
+    /// Invalidate the current token without generating a new one. On the next
+    /// request, the session will attempt to generate a new token.
+    async fn invalidate(&self) -> Result<()> {
+        *self.token.lock().await = None;
+        Ok(())
+    }
+
+    /// Invalidate the current token and set a new one. Generates a new token
+    /// before invalidating the current one, meaning the old token will be used
+    /// until this function acquires the lock and overwrites the token.
+    ///
+    /// If credential is invalid, or the request fails, this method will return
+    /// an error and leave the current token unchanged.
+    async fn refresh(&self) -> Result<()> {
+        let new_token = self.exchange_credential_for_token().await?;
+        *self.token.lock().await = Some(new_token);
+        Ok(())
+    }
+}

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -74,8 +74,7 @@ impl OAuth2Manager {
                 extra_headers: HeaderMap::new(),
                 token_endpoint: token_endpoint.into(),
                 credential: None,
-                // Same default as the configuration path (and the
-                // pre-AuthManager client): the Iceberg catalog scope.
+                // Same default as the configuration path: the catalog scope.
                 extra_oauth_params: HashMap::from([("scope".to_string(), "catalog".to_string())]),
             },
             endpoint_is_default: false,
@@ -156,9 +155,8 @@ impl AuthManager for OAuth2Manager {
             *self.token.lock().await = Some(token.clone());
         }
 
-        // Explicit property overrides are merged ONTO the manager's configured
-        // options: an injected manager keeps its token endpoint, extra headers
-        // and OAuth params unless a property explicitly overrides them.
+        // Explicit property overrides merge ONTO the manager's options, so an
+        // injected manager keeps whatever a property doesn't override.
         let mut extra_headers = self.init_params.extra_headers.clone();
         extra_headers.extend(explicit_headers_from_props(props)?);
 
@@ -171,9 +169,8 @@ impl AuthManager for OAuth2Manager {
 
         let token_endpoint = match props.get("oauth2-server-uri") {
             Some(uri) if !uri.is_empty() => uri.clone(),
-            // The built-in manager's default endpoint follows the merged
-            // catalog URI (a `/v1/config` override may have changed it);
-            // injected managers keep their explicitly configured endpoint.
+            // A default endpoint follows the merged catalog URI (which
+            // `/v1/config` may have overridden); explicit ones are kept.
             _ if self.endpoint_is_default => props
                 .get(REST_CATALOG_PROP_URI)
                 .map(|uri| default_token_endpoint(uri))

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -219,7 +219,11 @@ fn attach_bearer(req: &mut HttpRequest, token: &SensitiveString) -> Result<()> {
             .with_source(e)
         })?;
     value.set_sensitive(true);
-    req.headers_mut().insert(http::header::AUTHORIZATION, value);
+    // Java's `OAuth2Util.AuthSession` puts the header only if absent, leaving a
+    // configured `header.authorization` in place.
+    if !req.headers().contains_key(http::header::AUTHORIZATION) {
+        req.headers_mut().insert(http::header::AUTHORIZATION, value);
+    }
     Ok(())
 }
 

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -192,12 +192,12 @@ impl OAuth2Manager {
     ///
     /// - a `credential` yields a [`ClientCredentialsSession`] (its token cache
     ///   pre-seeded when a `token` is also set, and the token then takes
-    ///   precedence until invalidated);
+    ///   precedence over the credential);
     /// - otherwise a [`StaticTokenSession`], which attaches the configured
     ///   token as-is — or nothing when none is set.
     ///
     /// Both share the manager's token cell, so a cached token survives the
-    /// config handshake and `invalidate` is observed by later sessions.
+    /// config handshake.
     fn build_session(&self, params: OAuth2Params) -> Box<dyn AuthSession> {
         match params.credential {
             Some(credential) => Box::new(ClientCredentialsSession {
@@ -242,23 +242,10 @@ struct StaticTokenSession {
 #[async_trait]
 impl AuthSession for StaticTokenSession {
     async fn authenticate(&self, req: &mut AuthRequest<'_>) -> Result<()> {
-        // After `invalidate` there is nothing to fall back to: no auth is sent.
         match self.token.lock().await.clone() {
             Some(token) => attach_bearer(req, &token),
             None => Ok(()),
         }
-    }
-
-    async fn invalidate(&self) -> Result<()> {
-        *self.token.lock().await = None;
-        Ok(())
-    }
-
-    async fn refresh(&self) -> Result<()> {
-        Err(Error::new(
-            ErrorKind::DataInvalid,
-            "Credential must be provided for authentication",
-        ))
     }
 }
 
@@ -353,8 +340,8 @@ impl ClientCredentialsSession {
 #[async_trait]
 impl AuthSession for ClientCredentialsSession {
     /// Uses the cached token when present (a configured `token` takes
-    /// precedence over the credential until invalidated); otherwise exchanges
-    /// the credential for a token, caches it, then uses it.
+    /// precedence over the credential); otherwise exchanges the credential
+    /// for a token, caches it, then uses it.
     async fn authenticate(&self, req: &mut AuthRequest<'_>) -> Result<()> {
         // The lock is held across the exchange: waiters reuse a successful
         // result, and retry themselves after a failure.
@@ -372,24 +359,5 @@ impl AuthSession for ClientCredentialsSession {
         };
 
         attach_bearer(req, &token)
-    }
-
-    /// Invalidate the current token without generating a new one. On the next
-    /// request, the session will attempt to generate a new token.
-    async fn invalidate(&self) -> Result<()> {
-        *self.token.lock().await = None;
-        Ok(())
-    }
-
-    /// Invalidate the current token and set a new one. Generates a new token
-    /// before invalidating the current one, meaning the old token will be used
-    /// until this function acquires the lock and overwrites the token.
-    ///
-    /// If credential is invalid, or the request fails, this method will return
-    /// an error and leave the current token unchanged.
-    async fn refresh(&self) -> Result<()> {
-        let new_token = self.exchange_credential_for_token().await?;
-        *self.token.lock().await = Some(new_token.into());
-        Ok(())
     }
 }

--- a/crates/catalog/rest/src/auth/oauth2.rs
+++ b/crates/catalog/rest/src/auth/oauth2.rs
@@ -21,12 +21,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::StatusCode;
-use iceberg::{Error, ErrorKind, Result};
+use iceberg::{Credential, Error, ErrorKind, Result};
 use reqwest::header::HeaderMap;
 use reqwest::{Client, Method};
 use tokio::sync::Mutex;
 
-use super::{AuthManager, AuthRequest, AuthSession, SensitiveString};
+use super::{AuthManager, AuthRequest, AuthSession};
 use crate::catalog::{
     REST_CATALOG_PROP_URI, RestCatalogConfig, credential_from_props, default_token_endpoint,
     explicit_headers_from_props,
@@ -38,7 +38,7 @@ use crate::types::{ErrorResponse, TokenResponse};
 struct OAuth2Params {
     extra_headers: HeaderMap,
     token_endpoint: String,
-    credential: Option<(Option<String>, SensitiveString)>,
+    credential: Option<(Option<String>, Credential)>,
     extra_oauth_params: HashMap<String, String>,
 }
 
@@ -50,7 +50,7 @@ struct OAuth2Params {
 /// across sessions so it survives the config handshake.
 pub struct OAuth2Manager {
     client: Client,
-    token: Arc<Mutex<Option<SensitiveString>>>,
+    token: Arc<Mutex<Option<Credential>>>,
     init_params: OAuth2Params,
     /// True when the token endpoint was derived from the catalog URI (not
     /// explicitly configured): it is then recomputed from the merged URI in
@@ -83,7 +83,7 @@ impl OAuth2Manager {
 
     /// Sets a bearer token used directly (takes precedence over `credential`).
     pub fn with_token(mut self, token: impl Into<String>) -> Self {
-        self.token = Arc::new(Mutex::new(Some(SensitiveString::from(token.into()))));
+        self.token = Arc::new(Mutex::new(Some(Credential::from(token.into()))));
         self
     }
 
@@ -116,7 +116,7 @@ impl OAuth2Manager {
     pub(crate) fn from_config(cfg: &RestCatalogConfig) -> Result<Self> {
         Ok(Self {
             client: cfg.client(),
-            token: Arc::new(Mutex::new(cfg.token().map(SensitiveString::from))),
+            token: Arc::new(Mutex::new(cfg.token().map(Credential::from))),
             init_params: OAuth2Params {
                 extra_headers: cfg.extra_headers()?,
                 token_endpoint: cfg.get_token_endpoint(),
@@ -148,7 +148,7 @@ impl AuthManager for OAuth2Manager {
     ) -> Result<Arc<dyn AuthSession>> {
         // The server config may carry a new token (or restate the user's).
         if let Some(token) = props.get("token") {
-            *self.token.lock().await = Some(SensitiveString::from(token.clone()));
+            *self.token.lock().await = Some(Credential::from(token.clone()));
         }
 
         // Explicit property overrides merge ONTO the manager's options, so an
@@ -217,7 +217,7 @@ impl OAuth2Manager {
 
 /// Attaches `token` as a `Authorization: Bearer <token>` header, marked
 /// sensitive so `Debug`-formatted requests redact it.
-fn attach_bearer(req: &mut AuthRequest<'_>, token: &SensitiveString) -> Result<()> {
+fn attach_bearer(req: &mut AuthRequest<'_>, token: &Credential) -> Result<()> {
     let mut value: http::HeaderValue =
         format!("Bearer {}", token.expose()).parse().map_err(|e| {
             Error::new(
@@ -236,7 +236,7 @@ fn attach_bearer(req: &mut AuthRequest<'_>, token: &SensitiveString) -> Result<(
 #[derive(Debug)]
 struct StaticTokenSession {
     /// Shared with the owning [`OAuth2Manager`].
-    token: Arc<Mutex<Option<SensitiveString>>>,
+    token: Arc<Mutex<Option<Credential>>>,
 }
 
 #[async_trait]
@@ -256,8 +256,8 @@ impl AuthSession for StaticTokenSession {
 struct ClientCredentialsSession {
     client: Client,
     /// Cached bearer token, shared with the owning [`OAuth2Manager`].
-    token: Arc<Mutex<Option<SensitiveString>>>,
-    credential: (Option<String>, SensitiveString),
+    token: Arc<Mutex<Option<Credential>>>,
+    credential: (Option<String>, Credential),
     token_endpoint: String,
     extra_headers: HeaderMap,
     extra_oauth_params: HashMap<String, String>,
@@ -350,8 +350,7 @@ impl AuthSession for ClientCredentialsSession {
             match &*token {
                 Some(token) => token.clone(),
                 None => {
-                    let new_token =
-                        SensitiveString::from(self.exchange_credential_for_token().await?);
+                    let new_token = Credential::from(self.exchange_credential_for_token().await?);
                     *token = Some(new_token.clone());
                     new_token
                 }

--- a/crates/catalog/rest/src/auth/sigv4/mod.rs
+++ b/crates/catalog/rest/src/auth/sigv4/mod.rs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! AWS SigV4 request signing for the REST catalog.
+
+mod signer;
+
+pub use signer::{AwsCredentials, PayloadHashMode, SigV4Signer};

--- a/crates/catalog/rest/src/auth/sigv4/mod.rs
+++ b/crates/catalog/rest/src/auth/sigv4/mod.rs
@@ -15,8 +15,218 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! AWS SigV4 request signing for the REST catalog.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use iceberg::Result;
+use reqwest::header::{AUTHORIZATION, HeaderName};
 
 mod signer;
 
 pub use signer::{AwsCredentials, PayloadHashMode, SigV4Signer};
+
+use super::{AuthManager, AuthSession, HttpRequest};
+use crate::catalog::sigv4_signer_from_props;
+use crate::client::HttpClient;
+
+/// Header the delegate's `Authorization` is relocated to before signing, so
+/// token-based auth composes with SigV4, which needs `Authorization` for the
+/// signature itself. Iceberg Java relocates with the `Original-` prefix.
+const RELOCATED_AUTH_HEADER: HeaderName = HeaderName::from_static("original-authorization");
+
+/// [`AuthManager`] that SigV4-signs every request, wrapping a delegate
+/// manager whose authentication (e.g. an OAuth2 bearer token) is relocated to
+/// `Original-Authorization` and included in the signature.
+///
+/// An injected HTTP client must not follow redirects (a signed request can't
+/// be transparently re-followed) nor set default headers that change the
+/// signed set (e.g. `Host`, `x-amz-*`): those apply after signing.
+#[derive(Debug)]
+pub struct SigV4AuthManager {
+    delegate: Arc<dyn AuthManager>,
+    signer: SigV4Signer,
+    /// True when the signer was built from catalog properties:
+    /// [`Self::catalog_session`] then rebuilds it from the merged props.
+    signer_from_config: bool,
+}
+
+impl SigV4AuthManager {
+    /// Creates a SigV4 manager signing with `signer` on top of `delegate`.
+    ///
+    /// The signer is kept as-is — its credentials and payload mode exist
+    /// nowhere in the properties, so signing properties never replace it.
+    pub fn new(delegate: Arc<dyn AuthManager>, signer: SigV4Signer) -> Self {
+        Self {
+            delegate,
+            signer,
+            signer_from_config: false,
+        }
+    }
+
+    /// A manager whose signer derives from catalog properties; the merged
+    /// `/v1/config` properties rebuild it.
+    pub(crate) fn from_config_signer(delegate: Arc<dyn AuthManager>, signer: SigV4Signer) -> Self {
+        Self {
+            delegate,
+            signer,
+            signer_from_config: true,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthManager for SigV4AuthManager {
+    async fn init_session(
+        &self,
+        client: &HttpClient,
+        props: &HashMap<String, String>,
+    ) -> Result<Box<dyn AuthSession>> {
+        Ok(Box::new(SigV4Session {
+            delegate: Arc::from(self.delegate.init_session(client, props).await?),
+            signer: self.signer.clone(),
+        }))
+    }
+
+    async fn catalog_session(
+        &self,
+        client: &HttpClient,
+        props: &HashMap<String, String>,
+    ) -> Result<Arc<dyn AuthSession>> {
+        // A config-built signer follows the merged properties; an injected
+        // one is kept as-is (see [`Self::new`]).
+        let signer = if self.signer_from_config {
+            sigv4_signer_from_props(props)?
+        } else {
+            self.signer.clone()
+        };
+        Ok(Arc::new(SigV4Session {
+            delegate: self.delegate.catalog_session(client, props).await?,
+            signer,
+        }))
+    }
+}
+
+/// [`AuthSession`] applying the delegate's auth, then SigV4-signing.
+#[derive(Debug)]
+struct SigV4Session {
+    delegate: Arc<dyn AuthSession>,
+    signer: SigV4Signer,
+}
+
+#[async_trait]
+impl AuthSession for SigV4Session {
+    async fn authenticate(&self, request: &mut HttpRequest) -> Result<()> {
+        self.delegate.authenticate(request).await?;
+        // Every value moves, and an existing `Original-Authorization` is kept:
+        // Java groups them into one list rather than replacing.
+        let relocated: Vec<_> = request
+            .headers()
+            .get_all(AUTHORIZATION)
+            .iter()
+            .cloned()
+            .collect();
+        if !relocated.is_empty() {
+            request.headers_mut().remove(AUTHORIZATION);
+            for mut auth in relocated {
+                // Force-mark it: a delegate (or `header.authorization`) may
+                // have supplied a non-sensitive value.
+                auth.set_sensitive(true);
+                request.headers_mut().append(RELOCATED_AUTH_HEADER, auth);
+            }
+        }
+        self.signer.sign(request.inner_mut())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iceberg::sensitive::SensitiveString;
+    use reqwest::header::HeaderValue;
+
+    use super::*;
+    use crate::HttpRequest;
+
+    fn test_session(session_token: Option<&str>) -> SigV4Session {
+        SigV4Session {
+            delegate: Arc::new(crate::auth::NoopSession),
+            signer: SigV4Signer::new(
+                AwsCredentials {
+                    access_key_id: "AKIDEXAMPLE".into(),
+                    secret_access_key: "secret".to_string().into(),
+                    session_token: session_token.map(|t| SensitiveString::from(t.to_string())),
+                },
+                "us-east-1".into(),
+                "execute-api".into(),
+                PayloadHashMode::IcebergRest,
+            ),
+        }
+    }
+
+    fn request_with(headers: &[(&'static str, &str)]) -> HttpRequest {
+        let mut builder = reqwest::Client::new().get("https://rest.example.com/v1/config");
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        HttpRequest::new(builder.build().unwrap())
+    }
+
+    #[tokio::test]
+    async fn relocation_keeps_an_existing_original_authorization() {
+        // Java collects both values under `Original-Authorization` instead of
+        // replacing one with the other.
+        let mut request = request_with(&[
+            ("original-authorization", "credential-A"),
+            ("authorization", "credential-B"),
+        ]);
+
+        test_session(None).authenticate(&mut request).await.unwrap();
+
+        let relocated: Vec<_> = request
+            .headers()
+            .get_all("original-authorization")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(relocated, ["credential-A", "credential-B"]);
+        // The signature replaces `authorization`, it does not leave the original.
+        assert!(
+            request
+                .headers()
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("AWS4-HMAC-SHA256 ")
+        );
+    }
+
+    #[tokio::test]
+    async fn conflicting_signer_headers_are_relocated_not_dropped() {
+        // Java relocates an original whose value differs from the signed one.
+        let mut request = request_with(&[
+            ("x-amz-date", "19700101T000000Z"),
+            ("x-amz-security-token", "caller-token"),
+        ]);
+
+        test_session(Some("signer-token"))
+            .authenticate(&mut request)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get("original-x-amz-date").unwrap(),
+            "19700101T000000Z"
+        );
+        let token = request
+            .headers()
+            .get("original-x-amz-security-token")
+            .unwrap();
+        assert_eq!(token, "caller-token");
+        assert!(token.is_sensitive());
+        assert_eq!(
+            request.headers().get("x-amz-security-token").unwrap(),
+            HeaderValue::from_static("signer-token")
+        );
+    }
+}

--- a/crates/catalog/rest/src/auth/sigv4/signer.rs
+++ b/crates/catalog/rest/src/auth/sigv4/signer.rs
@@ -1,0 +1,978 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use chrono::{DateTime, Utc};
+#[cfg(test)]
+use hmac::{Hmac, Mac};
+use iceberg::sensitive::SensitiveString;
+use iceberg::{Error, ErrorKind, Result};
+use sha2::{Digest, Sha256};
+
+/// Hex SHA-256 of the empty string.
+const EMPTY_BODY_HEX_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/// How the payload hash is encoded in the `x-amz-content-sha256` header.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PayloadHashMode {
+    /// Iceberg Java's RESTSigV4 style: base64 header for non-empty bodies, hex
+    /// for empty; the canonical request always uses hex.
+    IcebergRest,
+    /// Standard AWS SigV4 style: hex everywhere (e.g. AWS Glue).
+    StandardAws,
+}
+
+/// Derives the AWS SigV4 signing key.
+#[cfg(test)]
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key).expect("HMAC takes a key of any size");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn hex_sha256(data: &[u8]) -> String {
+    encode_hex(&Sha256::digest(data))
+}
+
+#[cfg(test)]
+fn hex_hmac_sha256(key: &[u8], data: &[u8]) -> String {
+    encode_hex(&hmac_sha256(key, data))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    base64::engine::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
+}
+
+#[cfg(test)]
+fn signing_key(secret: &str, date: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+/// Computes the value of the `x-amz-content-sha256` header.
+fn content_sha256_header(body: &[u8], mode: PayloadHashMode) -> String {
+    match mode {
+        PayloadHashMode::StandardAws => hex_sha256(body),
+        PayloadHashMode::IcebergRest => {
+            if body.is_empty() {
+                EMPTY_BODY_HEX_SHA256.to_string()
+            } else {
+                base64_encode(&Sha256::digest(body))
+            }
+        }
+    }
+}
+
+/// Static AWS-style credentials used for SigV4 signing of catalog requests.
+#[derive(Clone)]
+pub struct AwsCredentials {
+    /// AWS access key id.
+    pub access_key_id: String,
+    /// AWS secret access key.
+    pub secret_access_key: SensitiveString,
+    /// Optional STS session token.
+    pub session_token: Option<SensitiveString>,
+}
+
+/// AWS SigV4 signer following Iceberg Java's `RESTSigV4AuthSession`: it adds the
+/// required amz headers and signs all request headers except a small blacklist.
+#[derive(Clone)]
+pub struct SigV4Signer {
+    credentials: AwsCredentials,
+    region: String,
+    service: String,
+    mode: PayloadHashMode,
+}
+
+impl SigV4Signer {
+    /// Creates a new SigV4 signer.
+    pub fn new(
+        credentials: AwsCredentials,
+        region: String,
+        service: String,
+        mode: PayloadHashMode,
+    ) -> Self {
+        Self {
+            credentials,
+            region,
+            service,
+            mode,
+        }
+    }
+
+    /// Signs `request` in place, rewriting it where signing requires it: an
+    /// existing `Authorization` moves to `Original-Authorization` and is signed
+    /// over, userinfo is dropped from the URL, and a `+` in the query becomes
+    /// `%20`.
+    ///
+    /// That last one means a `+` is taken to be an encoded space, which is what
+    /// `RequestBuilder::query` writes; encode a literal plus as `%2B`. AWS
+    /// requires spaces as `%20` in a signed URL either way.
+    ///
+    /// Note that `aws_sigv4` traces the request it is given, so `RUST_LOG` at
+    /// trace level will print these headers.
+    pub fn sign(&self, request: &mut reqwest::Request) -> Result<()> {
+        self.sign_at(request, Utc::now())
+    }
+
+    fn sign_at(&self, request: &mut reqwest::Request, now: DateTime<Utc>) -> Result<()> {
+        use aws_sigv4::http_request::{
+            PayloadChecksumKind, PercentEncodingMode, SignableBody, SignableRequest,
+            SigningSettings, UriPathNormalizationMode, sign,
+        };
+        use aws_sigv4::sign::v4;
+
+        let body: Vec<u8> = match request.body() {
+            None => Vec::new(),
+            Some(b) => b
+                .as_bytes()
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::FeatureUnsupported,
+                        "cannot sign a streaming request body",
+                    )
+                })?
+                .to_vec(),
+        };
+        let content_header = content_sha256_header(&body, self.mode);
+
+        // Renamed before signing, as Java's `convertHeaders` does, so a
+        // delegate's bearer token travels along and is signed over.
+        let displaced_authorization: Vec<_> = request
+            .headers()
+            .get_all(reqwest::header::AUTHORIZATION)
+            .iter()
+            .cloned()
+            .collect();
+        if !displaced_authorization.is_empty() {
+            request.headers_mut().remove(reqwest::header::AUTHORIZATION);
+            for mut value in displaced_authorization {
+                value.set_sensitive(true);
+                request.headers_mut().append(RELOCATED_AUTHORIZATION, value);
+            }
+        }
+
+        // Relocated after signing, as Java does, so the `Original-` copy is
+        // not itself signed.
+        let displaced_content_hash: Vec<_> = request
+            .headers()
+            .get_all("x-amz-content-sha256")
+            .iter()
+            .filter(|v| v.as_bytes() != content_header.as_bytes())
+            .cloned()
+            .collect();
+        request
+            .headers_mut()
+            .insert("x-amz-content-sha256", content_header.parse().unwrap());
+
+        // The wire Host never carries userinfo, so signing it would mismatch
+        // and would feed the password to the HMAC. `RequestBuilder` strips it,
+        // a hand-built request does not.
+        if !request.url().username().is_empty() || request.url().password().is_some() {
+            let url = request.url_mut();
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+        }
+
+        // Verifiers disagree on `+` in a query — a literal under RFC 3986, a
+        // space under form encoding — and reqwest writes spaces as `+`. Rewrite
+        // it so the wire and the canonical request agree either way.
+        if let Some(query) = request.url().query().filter(|q| q.contains('+')) {
+            let unambiguous = query.replace('+', "%20");
+            request.url_mut().set_query(Some(&unambiguous));
+        }
+
+        let mut settings = SigningSettings::default();
+        // `Aws4Signer` defaults: normalize the path and double-encode it.
+        settings.percent_encoding_mode = PercentEncodingMode::Double;
+        settings.uri_path_normalization_mode = UriPathNormalizationMode::Enabled;
+        // The header is ours to set: IcebergRest mode puts base64 there,
+        // while the signer hashes the body in hex for the canonical request.
+        settings.payload_checksum_kind = PayloadChecksumKind::NoHeader;
+        // Java's `AbstractAws4Signer` ignores these too; the crate's defaults
+        // do not.
+        let mut excluded = settings.excluded_headers.take().unwrap_or_default();
+        excluded.extend([
+            "expect".into(),
+            "connection".into(),
+            "x-forwarded-for".into(),
+        ]);
+        settings.excluded_headers = Some(excluded);
+
+        let identity = aws_credential_types::Credentials::new(
+            self.credentials.access_key_id.clone(),
+            self.credentials.secret_access_key.expose().to_string(),
+            self.credentials
+                .session_token
+                .as_ref()
+                .map(|t| t.expose().to_string()),
+            None,
+            "iceberg-rest",
+        )
+        .into();
+        let params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&self.region)
+            .name(&self.service)
+            .time(now.into())
+            .settings(settings)
+            .build()
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to build SigV4 params").with_source(e)
+            })?
+            .into();
+
+        let headers: Vec<(&str, &str)> = request
+            .headers()
+            .iter()
+            .filter_map(|(n, v)| v.to_str().ok().map(|v| (n.as_str(), v)))
+            .collect();
+        let signable = SignableRequest::new(
+            request.method().as_str(),
+            request.url().as_str(),
+            headers.into_iter(),
+            SignableBody::Bytes(&body),
+        )
+        .map_err(|e| {
+            Error::new(ErrorKind::DataInvalid, "request is not signable").with_source(e)
+        })?;
+
+        let (instructions, _signature) = sign(signable, &params)
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "SigV4 signing failed").with_source(e))?
+            .into_parts();
+
+        let (signed_headers, _params) = instructions.into_parts();
+        let h = request.headers_mut();
+        for mut value in displaced_content_hash {
+            // The original may carry a credential.
+            value.set_sensitive(true);
+            h.append(RELOCATED_CONTENT_SHA256, value);
+        }
+        for header in signed_headers {
+            let name: reqwest::header::HeaderName = header.name().parse().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "invalid signed header name").with_source(e)
+            })?;
+            // Moved aside rather than dropped, as Java does.
+            if let Some(relocated) = relocated_name(name.as_str()) {
+                relocate_conflicting(h, name.as_str(), header.value(), relocated);
+            }
+            let mut value: reqwest::header::HeaderValue = header.value().parse().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "invalid signed header value").with_source(e)
+            })?;
+            if name == reqwest::header::AUTHORIZATION || name == "x-amz-security-token" {
+                value.set_sensitive(true);
+            }
+            h.insert(name, value);
+        }
+        Ok(())
+    }
+}
+
+const RELOCATED_AUTHORIZATION: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static("original-authorization");
+const RELOCATED_AMZ_DATE: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static("original-x-amz-date");
+const RELOCATED_CONTENT_SHA256: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static("original-x-amz-content-sha256");
+const RELOCATED_SECURITY_TOKEN: reqwest::header::HeaderName =
+    reqwest::header::HeaderName::from_static("original-x-amz-security-token");
+
+/// The `Original-<name>` counterpart of a header the signer generates.
+fn relocated_name(name: &str) -> Option<reqwest::header::HeaderName> {
+    match name {
+        "x-amz-date" => Some(RELOCATED_AMZ_DATE),
+        "x-amz-content-sha256" => Some(RELOCATED_CONTENT_SHA256),
+        "x-amz-security-token" => Some(RELOCATED_SECURITY_TOKEN),
+        _ => None,
+    }
+}
+
+/// Moves `name`'s current values to `Original-<name>` when they differ from the
+/// value about to be signed, so a caller's header is not silently dropped
+/// (Java's `RESTSigV4AuthSession.updateRequestHeaders`).
+fn relocate_conflicting(
+    headers: &mut reqwest::header::HeaderMap,
+    name: &str,
+    signed: &str,
+    relocated: reqwest::header::HeaderName,
+) {
+    let conflicting: Vec<_> = headers
+        .get_all(name)
+        .iter()
+        .filter(|value| value.as_bytes() != signed.as_bytes())
+        .cloned()
+        .collect();
+    for mut value in conflicting {
+        // The original may carry a credential (e.g. a session token).
+        value.set_sensitive(true);
+        headers.append(relocated.clone(), value);
+    }
+}
+
+impl std::fmt::Debug for SigV4Signer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SigV4Signer")
+            .field("region", &self.region)
+            .field("service", &self.service)
+            .field("mode", &self.mode)
+            .field("access_key_id", &self.credentials.access_key_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_HEX: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn signing_rewrites_an_ambiguous_plus_out_of_the_query() {
+        use chrono::TimeZone;
+
+        // reqwest writes a space as `+`, which verifiers read either as a
+        // literal plus or as a space. Signing rewrites it to `%20`.
+        let mut request = reqwest::Client::new()
+            .get("https://rest.example.com/v1/namespaces")
+            .query(&[("parent", "my ns")])
+            .build()
+            .unwrap();
+        assert!(request.url().query().unwrap().contains("my+ns"));
+
+        let signer = SigV4Signer::new(
+            AwsCredentials {
+                access_key_id: "ak".to_string(),
+                secret_access_key: "sk".to_string().into(),
+                session_token: None,
+            },
+            "us-east-1".to_string(),
+            "execute-api".to_string(),
+            PayloadHashMode::StandardAws,
+        );
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+        signer.sign_at(&mut request, now).unwrap();
+
+        // The request that goes out no longer carries the ambiguous form.
+        let query = request.url().query().unwrap();
+        assert!(!query.contains('+'), "{query}");
+        assert!(query.contains("my%20ns"), "{query}");
+        assert_signature_is(
+            &request,
+            "b7bb5a323a1ce0ace18454171084deef2dac44c933c3949771fc70179d3cce2b",
+        );
+    }
+
+    #[test]
+    fn content_sha256_header_iceberg_mode() {
+        let v = content_sha256_header(b"hello", PayloadHashMode::IcebergRest);
+        assert_eq!(v, "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=");
+        let e = content_sha256_header(b"", PayloadHashMode::IcebergRest);
+        assert_eq!(e, EMPTY_HEX);
+    }
+
+    #[test]
+    fn content_sha256_header_standard_mode() {
+        let v = content_sha256_header(b"hello", PayloadHashMode::StandardAws);
+        assert_eq!(
+            v,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    /// The signature the previous hand-rolled signer produced for this case,
+    /// pinned so a change in canonicalization is caught.
+    fn assert_signature_is(req: &reqwest::Request, expected: &str) {
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(auth.ends_with(&format!("Signature={expected}")), "{auth}");
+    }
+
+    fn test_signer(mode: PayloadHashMode) -> SigV4Signer {
+        SigV4Signer::new(
+            AwsCredentials {
+                access_key_id: "ak".to_string(),
+                secret_access_key: "sk".to_string().into(),
+                session_token: None,
+            },
+            "us-east-1".to_string(),
+            "execute-api".to_string(),
+            mode,
+        )
+    }
+
+    #[test]
+    fn userinfo_is_stripped_before_signing() {
+        use chrono::TimeZone;
+
+        // `HttpRequest::new` is public, so a hand-built request can carry
+        // userinfo that the wire Host never has.
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://user:pw@rest.example.com/v1/config"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(req.url().username(), "user");
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+
+        assert_eq!(req.url().username(), "");
+        assert_eq!(req.url().password(), None);
+        assert_signature_is(
+            &req,
+            "0f4a3487bcff9dd16bf0a42d06c24dc49b2366e8a928dc9666f8424cf5b306b3",
+        );
+    }
+
+    #[test]
+    fn a_doubled_slash_in_the_path_is_normalized() {
+        use chrono::TimeZone;
+
+        // A catalog URI with a trailing slash produces `//v1/...`; the signed
+        // path has to collapse it the way `Aws4Signer` does.
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://rest.example.com//v1//config".parse().unwrap(),
+        );
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+
+        assert_signature_is(
+            &req,
+            "0f4a3487bcff9dd16bf0a42d06c24dc49b2366e8a928dc9666f8424cf5b306b3",
+        );
+    }
+
+    #[test]
+    fn caller_headers_the_signer_overwrites_are_relocated() {
+        use chrono::TimeZone;
+
+        // Java's `updateRequestHeaders` moves a conflicting caller value to
+        // `Original-<name>` rather than dropping it, credentials included.
+        let signer = SigV4Signer::new(
+            AwsCredentials {
+                access_key_id: "ak".to_string(),
+                secret_access_key: "sk".to_string().into(),
+                session_token: Some("signer-token".to_string().into()),
+            },
+            "us-east-1".to_string(),
+            "execute-api".to_string(),
+            PayloadHashMode::StandardAws,
+        );
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header("authorization", "Bearer caller-token")
+            .header("x-amz-date", "19700101T000000Z")
+            .header("x-amz-security-token", "caller-session")
+            .header("x-amz-content-sha256", "caller-hash")
+            .build()
+            .unwrap();
+
+        signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap();
+
+        let h = req.headers();
+        assert_eq!(
+            h.get("original-authorization").unwrap(),
+            "Bearer caller-token"
+        );
+        assert_eq!(h.get("original-x-amz-date").unwrap(), "19700101T000000Z");
+        assert_eq!(
+            h.get("original-x-amz-content-sha256").unwrap(),
+            "caller-hash"
+        );
+        let token = h.get("original-x-amz-security-token").unwrap();
+        assert_eq!(token, "caller-session");
+        // Relocated originals may be credentials themselves.
+        assert!(token.is_sensitive());
+        assert!(
+            h.get("original-x-amz-content-sha256")
+                .unwrap()
+                .is_sensitive()
+        );
+        // And the signer's own values took their place.
+        assert!(
+            h.get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("AWS4-HMAC-SHA256 ")
+        );
+        assert_eq!(h.get("x-amz-security-token").unwrap(), "signer-token");
+    }
+
+    #[test]
+    fn an_existing_authorization_is_never_signed() {
+        use chrono::TimeZone;
+
+        // `authorization` must stay out of `SignedHeaders`: the signer replaces
+        // it, so signing the caller's value would guarantee a mismatch. The
+        // crate's own defaults carry that exclusion.
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header("authorization", "Bearer caller-token")
+            .header("user-agent", "example/1.0")
+            .build()
+            .unwrap();
+
+        signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap();
+
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let signed = auth
+            .split("SignedHeaders=")
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .next()
+            .unwrap();
+        for excluded in ["authorization", "user-agent"] {
+            assert!(!signed.split(';').any(|h| h == excluded), "{signed}");
+        }
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_not_signed() {
+        use chrono::TimeZone;
+
+        // A proxy or an HTTP/2 hop may drop or rewrite these, so signing them
+        // would make the request fail verification. Java's `AbstractAws4Signer`
+        // ignores them too.
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header("expect", "100-continue")
+            .header("connection", "keep-alive")
+            .header("x-forwarded-for", "203.0.113.7")
+            .header("x-tenant", "acme")
+            .build()
+            .unwrap();
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let signed = auth
+            .split("SignedHeaders=")
+            .nth(1)
+            .unwrap()
+            .split(',')
+            .next()
+            .unwrap();
+        for skipped in ["expect", "connection", "x-forwarded-for"] {
+            assert!(!signed.split(';').any(|h| h == skipped), "{signed}");
+        }
+        // An ordinary caller header is still signed.
+        assert!(signed.split(';').any(|h| h == "x-tenant"), "{signed}");
+        assert_signature_is(
+            &req,
+            "f938221412ed6b55cf3db380ce6ded476419ad3d7db4c76d932031c98465ce79",
+        );
+    }
+
+    #[test]
+    fn signed_credentials_are_marked_sensitive() {
+        use chrono::TimeZone;
+
+        // Both carry a credential, so a `Debug`-formatted request must not
+        // print them.
+        let signer = SigV4Signer::new(
+            AwsCredentials {
+                access_key_id: "ak".to_string(),
+                secret_access_key: "sk".to_string().into(),
+                session_token: Some("session-token".to_string().into()),
+            },
+            "us-east-1".to_string(),
+            "execute-api".to_string(),
+            PayloadHashMode::StandardAws,
+        );
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+
+        signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap();
+
+        assert!(req.headers().get("authorization").unwrap().is_sensitive());
+        assert!(
+            req.headers()
+                .get("x-amz-security-token")
+                .unwrap()
+                .is_sensitive()
+        );
+        let debug = format!("{req:?}");
+        assert!(!debug.contains("session-token"), "{debug}");
+    }
+
+    #[test]
+    fn a_caller_content_hash_is_relocated_not_dropped() {
+        use chrono::TimeZone;
+
+        // The signer overwrites `x-amz-content-sha256`; the caller's value
+        // moves aside instead of vanishing, after signing as Java does.
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header("x-amz-content-sha256", "caller-supplied")
+            .build()
+            .unwrap();
+
+        signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            req.headers().get("original-x-amz-content-sha256").unwrap(),
+            "caller-supplied"
+        );
+        assert_eq!(
+            req.headers().get("x-amz-content-sha256").unwrap(),
+            EMPTY_HEX
+        );
+    }
+
+    #[test]
+    fn signs_with_a_non_default_service_and_session_token() {
+        use chrono::TimeZone;
+
+        // What a non-AWS S3-compatible catalog vends: its own signing name
+        // rather than `execute-api`, its own region, and STS credentials.
+        let signer = SigV4Signer::new(
+            AwsCredentials {
+                access_key_id: "STS.EXAMPLEACCESSKEYID".into(),
+                secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                    .to_string()
+                    .into(),
+                session_token: Some("example-session-token".to_string().into()),
+            },
+            "us-east-1".into(),
+            "custom-service".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let mut req = reqwest::Client::new()
+            .get("https://catalog.example.com/v1/config?warehouse=my-catalog")
+            .build()
+            .unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 8, 26, 12, 0, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+
+        assert_signature_is(
+            &req,
+            "6b7065e5f44da4f5c3654126b8d5fe29599905afb6b98f4de65b6ec6e1be783f",
+        );
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            auth.contains("/us-east-1/custom-service/aws4_request"),
+            "{auth}"
+        );
+        assert_eq!(
+            req.headers().get("x-amz-security-token").unwrap(),
+            "example-session-token"
+        );
+    }
+
+    #[test]
+    fn signing_key_and_signature_match_aws_vector() {
+        let secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        let date = "20150830";
+        let region = "us-east-1";
+        let service = "service";
+        let key = signing_key(secret, date, region, service);
+
+        let string_to_sign = "AWS4-HMAC-SHA256\n\
+20150830T123600Z\n\
+20150830/us-east-1/service/aws4_request\n\
+bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63";
+        let sig = hex_hmac_sha256(&key, string_to_sign.as_bytes());
+        assert_eq!(
+            sig,
+            "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+        );
+    }
+
+    #[test]
+    fn signs_request_iceberg_mode() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: Some("SESSIONTOKEN".to_string().into()),
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "glue".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .post("https://rest.example.com/v1/namespaces")
+            .body("{}")
+            .build()
+            .unwrap();
+
+        signer.sign(&mut req).unwrap();
+
+        let h = req.headers();
+        assert!(
+            h.get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
+        );
+        assert!(h.contains_key("x-amz-date"));
+        assert_eq!(h.get("x-amz-security-token").unwrap(), "SESSIONTOKEN");
+        let csha = h.get("x-amz-content-sha256").unwrap().to_str().unwrap();
+        assert_eq!(csha, "RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o=");
+    }
+
+    /// Empty body uses the hex constant and existing headers are signed too
+    /// (mirrors Java's `TestRESTSigV4AuthSession::authenticateWithoutBody`).
+    #[test]
+    fn signs_empty_body_and_all_headers() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: None,
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "glue".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .header("content-type", "application/json")
+            .header("content-encoding", "gzip")
+            .build()
+            .unwrap();
+
+        signer.sign(&mut req).unwrap();
+
+        let h = req.headers();
+        assert_eq!(h.get("x-amz-content-sha256").unwrap(), EMPTY_HEX);
+        assert!(!h.contains_key("x-amz-security-token"));
+        let auth = h.get("authorization").unwrap().to_str().unwrap();
+        assert!(auth.starts_with("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"));
+        assert!(auth.contains(
+            "SignedHeaders=content-encoding;content-type;host;x-amz-content-sha256;x-amz-date"
+        ));
+    }
+
+    /// The signed `host` must include an explicit non-default port, matching
+    /// what reqwest/hyper put on the wire and what the AWS SDK signs.
+    #[test]
+    fn iceberg_mode_signs_the_hex_payload_hash_not_the_base64_header() {
+        // The IcebergRest split: `x-amz-content-sha256` carries base64, but the
+        // canonical request must hash in hex. A body is required to tell them
+        // apart — every other signing test uses an empty one, where the header
+        // is the hex constant and the two values coincide.
+        //
+        // Java has no counterpart: there the split lives inside the AWS SDK
+        // (`SignerChecksumParams` puts a base64 checksum in the header while
+        // `Aws4Signer` canonicalizes hex), so `TestRESTSigV4Signer` only checks
+        // that the header is present. Reimplementing the signer makes the
+        // invariant ours to keep.
+        use chrono::TimeZone;
+
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: None,
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "execute-api".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let body = br#"{"namespace":["ns"]}"#;
+        let mut req = reqwest::Client::new()
+            .post("https://rest.example.com/v1/namespaces")
+            .body(body.to_vec())
+            .build()
+            .unwrap();
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+
+        // The header carries base64 while the pinned signature covers hex.
+        assert_eq!(
+            req.headers().get("x-amz-content-sha256").unwrap(),
+            content_sha256_header(body, PayloadHashMode::IcebergRest).as_str()
+        );
+        assert_ne!(
+            req.headers().get("x-amz-content-sha256").unwrap(),
+            hex_sha256(body).as_str()
+        );
+        assert_signature_is(
+            &req,
+            "c68682c26cab6a781256f83b0076f50014f4922c3907f4ff09c204a74d61fc1d",
+        );
+    }
+
+    #[test]
+    fn signs_host_with_non_default_port() {
+        use chrono::TimeZone;
+
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: None,
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "glue".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .get("https://rest.example.com:8181/v1/config")
+            .build()
+            .unwrap();
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+        assert_signature_is(
+            &req,
+            "f7801a4ecac5fe6dcc4ee385223428ec4833f21d0c2fc10d2fb00694b2c0def7",
+        );
+    }
+
+    /// AWS SDK v2 parity (`doubleUrlEncode`): the canonical URI encodes the
+    /// serialized path once more — literal `,` becomes `%2C`, an encoded
+    /// `%2C` becomes `%252C` — while plain paths stay byte-identical.
+    #[test]
+    fn canonical_uri_is_aws_double_encoded() {
+        use chrono::TimeZone;
+
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: None,
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "glue".into(),
+            PayloadHashMode::IcebergRest,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .get("https://rest.example.com/v1/namespaces/a%2Cb/tables/x,y")
+            .build()
+            .unwrap();
+        let now = Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap();
+
+        signer.sign_at(&mut req, now).unwrap();
+        assert_signature_is(
+            &req,
+            "4d966b6fc2dfb62be5a603e4e07e5dc85b2af1c7e6a181c5646bfbf38ddfa543",
+        );
+    }
+
+    #[test]
+    fn signs_request_standard_mode_uses_hex_header() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                .to_string()
+                .into(),
+            session_token: None,
+        };
+        let signer = SigV4Signer::new(
+            creds,
+            "us-east-1".into(),
+            "glue".into(),
+            PayloadHashMode::StandardAws,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .post("https://rest.example.com/v1/namespaces")
+            .body("hello")
+            .build()
+            .unwrap();
+
+        signer.sign(&mut req).unwrap();
+
+        // StandardAws keeps the header in hex.
+        assert_eq!(
+            req.headers().get("x-amz-content-sha256").unwrap(),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+}

--- a/crates/catalog/rest/src/auth/sigv4/signer.rs
+++ b/crates/catalog/rest/src/auth/sigv4/signer.rs
@@ -29,8 +29,8 @@ const EMPTY_BODY_HEX_SHA256: &str =
 /// How the payload hash is encoded in the `x-amz-content-sha256` header.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PayloadHashMode {
-    /// Iceberg Java's RESTSigV4 style: base64 header for non-empty bodies, hex
-    /// for empty; the canonical request always uses hex.
+    /// Iceberg Java's RESTSigV4 style: base64 header when there is a body, hex
+    /// when there is none; the canonical request always uses hex.
     IcebergRest,
     /// Standard AWS SigV4 style: hex everywhere (e.g. AWS Glue).
     StandardAws,
@@ -69,17 +69,15 @@ fn signing_key(secret: &str, date: &str, region: &str, service: &str) -> Vec<u8>
     hmac_sha256(&k_service, b"aws4_request")
 }
 
-/// Computes the value of the `x-amz-content-sha256` header.
-fn content_sha256_header(body: &[u8], mode: PayloadHashMode) -> String {
+/// Computes the value of the `x-amz-content-sha256` header. `None` is a request
+/// with no body at all, which the two modes disagree about.
+fn content_sha256_header(body: Option<&[u8]>, mode: PayloadHashMode) -> String {
     match mode {
-        PayloadHashMode::StandardAws => hex_sha256(body),
-        PayloadHashMode::IcebergRest => {
-            if body.is_empty() {
-                EMPTY_BODY_HEX_SHA256.to_string()
-            } else {
-                base64_encode(&Sha256::digest(body))
-            }
-        }
+        PayloadHashMode::StandardAws => hex_sha256(body.unwrap_or_default()),
+        PayloadHashMode::IcebergRest => match body {
+            None => EMPTY_BODY_HEX_SHA256.to_string(),
+            Some(body) => base64_encode(&Sha256::digest(body)),
+        },
     }
 }
 
@@ -129,8 +127,8 @@ impl SigV4Signer {
     /// `RequestBuilder::query` writes; encode a literal plus as `%2B`. AWS
     /// requires spaces as `%20` in a signed URL either way.
     ///
-    /// Note that `aws_sigv4` traces the request it is given, so `RUST_LOG` at
-    /// trace level will print these headers.
+    /// Fails rather than sign a request whose body is streaming or whose
+    /// headers are not UTF-8, since neither can be canonicalized faithfully.
     pub fn sign(&self, request: &mut reqwest::Request) -> Result<()> {
         self.sign_at(request, Utc::now())
     }
@@ -141,20 +139,24 @@ impl SigV4Signer {
             SigningSettings, UriPathNormalizationMode, sign,
         };
         use aws_sigv4::sign::v4;
+        use tracing::subscriber::NoSubscriber;
 
-        let body: Vec<u8> = match request.body() {
-            None => Vec::new(),
-            Some(b) => b
-                .as_bytes()
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::FeatureUnsupported,
-                        "cannot sign a streaming request body",
-                    )
-                })?
-                .to_vec(),
+        // An absent body is not the same as an empty one: Java branches on
+        // `encodedBody() == null`, so a present-but-empty body is hashed.
+        let body: Option<Vec<u8>> = match request.body() {
+            None => None,
+            Some(b) => Some(
+                b.as_bytes()
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorKind::FeatureUnsupported,
+                            "cannot sign a streaming request body",
+                        )
+                    })?
+                    .to_vec(),
+            ),
         };
-        let content_header = content_sha256_header(&body, self.mode);
+        let content_header = content_sha256_header(body.as_deref(), self.mode);
 
         // Renamed before signing, as Java's `convertHeaders` does, so a
         // delegate's bearer token travels along and is signed over.
@@ -242,22 +244,40 @@ impl SigV4Signer {
             })?
             .into();
 
+        // Skipping a header that is not UTF-8 would leave it unsigned but still
+        // on the wire, which AWS rejects for `x-amz-*` and is hard to diagnose.
         let headers: Vec<(&str, &str)> = request
             .headers()
             .iter()
-            .filter_map(|(n, v)| v.to_str().ok().map(|v| (n.as_str(), v)))
-            .collect();
+            .map(|(n, v)| {
+                let v = v.to_str().map_err(|e| {
+                    Error::new(
+                        ErrorKind::DataInvalid,
+                        format!("cannot sign non-UTF-8 header value for `{n}`"),
+                    )
+                    .with_source(e)
+                })?;
+                Ok((n.as_str(), v))
+            })
+            .collect::<Result<_>>()?;
         let signable = SignableRequest::new(
             request.method().as_str(),
             request.url().as_str(),
             headers.into_iter(),
-            SignableBody::Bytes(&body),
+            SignableBody::Bytes(body.as_deref().unwrap_or_default()),
         )
         .map_err(|e| {
             Error::new(ErrorKind::DataInvalid, "request is not signable").with_source(e)
         })?;
 
-        let (instructions, _signature) = sign(signable, &params)
+        // `aws_sigv4` traces the request it signs, and its redaction list covers
+        // `authorization` but not the `Original-` copy we just made, so a
+        // delegate's bearer token would be printed verbatim at trace level.
+        // Signing is synchronous and logs nothing else worth keeping, so mute
+        // it for the call.
+        let signed =
+            tracing::subscriber::with_default(NoSubscriber::default(), || sign(signable, &params));
+        let (instructions, _signature) = signed
             .map_err(|e| Error::new(ErrorKind::Unexpected, "SigV4 signing failed").with_source(e))?
             .into_parts();
 
@@ -384,15 +404,27 @@ mod tests {
 
     #[test]
     fn content_sha256_header_iceberg_mode() {
-        let v = content_sha256_header(b"hello", PayloadHashMode::IcebergRest);
+        let v = content_sha256_header(Some(b"hello"), PayloadHashMode::IcebergRest);
         assert_eq!(v, "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=");
-        let e = content_sha256_header(b"", PayloadHashMode::IcebergRest);
+        let e = content_sha256_header(None, PayloadHashMode::IcebergRest);
         assert_eq!(e, EMPTY_HEX);
+    }
+
+    /// Java branches on `encodedBody() == null`, so a body that is present but
+    /// empty is hashed like any other rather than taking the absent-body path.
+    #[test]
+    fn content_sha256_header_separates_an_empty_body_from_an_absent_one() {
+        let empty = content_sha256_header(Some(b""), PayloadHashMode::IcebergRest);
+        assert_eq!(empty, "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=");
+        assert_ne!(
+            empty,
+            content_sha256_header(None, PayloadHashMode::IcebergRest)
+        );
     }
 
     #[test]
     fn content_sha256_header_standard_mode() {
-        let v = content_sha256_header(b"hello", PayloadHashMode::StandardAws);
+        let v = content_sha256_header(Some(b"hello"), PayloadHashMode::StandardAws);
         assert_eq!(
             v,
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
@@ -422,6 +454,90 @@ mod tests {
             "execute-api".to_string(),
             mode,
         )
+    }
+
+    /// Collects every event field a subscriber would have been handed.
+    #[derive(Clone, Default)]
+    struct CapturedLog(std::sync::Arc<std::sync::Mutex<String>>);
+
+    impl tracing::field::Visit for CapturedLog {
+        fn record_debug(&mut self, _: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.lock().unwrap().push_str(&format!("{value:?}"));
+        }
+    }
+
+    impl tracing::Subscriber for CapturedLog {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::Id {
+            tracing::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::Id, _: &tracing::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            event.record(&mut self.clone());
+        }
+        fn enter(&self, _: &tracing::Id) {}
+        fn exit(&self, _: &tracing::Id) {}
+    }
+
+    /// `aws_sigv4` traces the headers it is given, and its redaction list does
+    /// not cover the `Original-` copy of a relocated bearer token.
+    #[test]
+    fn signing_does_not_trace_a_relocated_bearer_token() {
+        use chrono::TimeZone;
+
+        const TOKEN: &str = "Bearer topsecretdelegatetoken";
+        let signer = test_signer(PayloadHashMode::IcebergRest);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header(reqwest::header::AUTHORIZATION, TOKEN)
+            .build()
+            .unwrap();
+
+        let log = CapturedLog::default();
+        tracing::subscriber::with_default(log.clone(), || {
+            signer
+                .sign_at(
+                    &mut req,
+                    Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+                )
+                .unwrap();
+            // Without this the assertion below would pass even if nothing was
+            // ever captured.
+            tracing::trace!(canary = "subscriber-is-live");
+        });
+
+        let captured = log.0.lock().unwrap().clone();
+        assert!(captured.contains("subscriber-is-live"), "captured nothing");
+        assert!(!captured.contains(TOKEN), "{captured}");
+        // The token still travels, it is just not logged.
+        assert_eq!(req.headers().get(RELOCATED_AUTHORIZATION).unwrap(), TOKEN);
+    }
+
+    #[test]
+    fn a_non_utf8_header_value_is_rejected_rather_than_left_unsigned() {
+        use chrono::TimeZone;
+
+        let signer = test_signer(PayloadHashMode::IcebergRest);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header(
+                "x-amz-meta-tenant",
+                reqwest::header::HeaderValue::from_bytes(b"acme\xfa").unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let err = signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("x-amz-meta-tenant"), "{err}");
     }
 
     #[test]
@@ -571,6 +687,44 @@ mod tests {
         for excluded in ["authorization", "user-agent"] {
             assert!(!signed.split(';').any(|h| h == excluded), "{signed}");
         }
+        // The relocated copy, on the other hand, is signed over — that is the
+        // point of renaming it before signing rather than after.
+        assert!(
+            signed.split(';').any(|h| h == "original-authorization"),
+            "{signed}"
+        );
+    }
+
+    /// Java groups all `Authorization` values under the relocated name, so
+    /// repeated credentials must survive together and stay redacted.
+    #[test]
+    fn every_repeated_authorization_is_relocated_and_kept_sensitive() {
+        use chrono::TimeZone;
+
+        let signer = test_signer(PayloadHashMode::StandardAws);
+        let mut req = reqwest::Client::new()
+            .get("https://rest.example.com/v1/config")
+            .header("authorization", "Bearer first")
+            .header("authorization", "Bearer second")
+            .build()
+            .unwrap();
+
+        signer
+            .sign_at(
+                &mut req,
+                Utc.with_ymd_and_hms(2015, 8, 30, 12, 36, 0).unwrap(),
+            )
+            .unwrap();
+
+        let relocated: Vec<_> = req
+            .headers()
+            .get_all(RELOCATED_AUTHORIZATION)
+            .iter()
+            .collect();
+        assert_eq!(relocated.len(), 2, "{relocated:?}");
+        assert_eq!(relocated[0], "Bearer first");
+        assert_eq!(relocated[1], "Bearer second");
+        assert!(relocated.iter().all(|v| v.is_sensitive()), "{relocated:?}");
     }
 
     #[test]
@@ -868,7 +1022,7 @@ bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63";
         // The header carries base64 while the pinned signature covers hex.
         assert_eq!(
             req.headers().get("x-amz-content-sha256").unwrap(),
-            content_sha256_header(body, PayloadHashMode::IcebergRest).as_str()
+            content_sha256_header(Some(body), PayloadHashMode::IcebergRest).as_str()
         );
         assert_ne!(
             req.headers().get("x-amz-content-sha256").unwrap(),

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use iceberg::encryption::kms::{KeyManagementClient, KmsClientFactory};
@@ -38,6 +38,7 @@ use reqwest::{Client, Method, StatusCode, Url};
 use tokio::sync::OnceCell;
 use typed_builder::TypedBuilder;
 
+use crate::auth::{AUTH_TYPE_NONE, AUTH_TYPE_OAUTH2, AuthManager, NoopAuthManager, OAuth2Manager};
 use crate::client::{
     HttpClient, deserialize_catalog_response, deserialize_unexpected_catalog_error,
 };
@@ -54,6 +55,8 @@ pub const REST_CATALOG_PROP_URI: &str = "uri";
 pub const REST_CATALOG_PROP_WAREHOUSE: &str = "warehouse";
 /// Disable header redaction in error logs (defaults to false for security)
 pub const REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str = "disable-header-redaction";
+/// Authentication scheme: `none` or `oauth2` (default).
+pub const REST_CATALOG_PROP_AUTH_TYPE: &str = "rest.auth.type";
 
 const ICEBERG_REST_SPEC_VERSION: &str = "0.14.1";
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -77,6 +80,8 @@ impl Default for RestCatalogBuilder {
                 warehouse: None,
                 props: HashMap::new(),
                 client: None,
+                default_client: Arc::new(OnceLock::new()),
+                auth_manager: None,
             },
             storage_factory: None,
             kms_client_factory: None,
@@ -161,6 +166,12 @@ impl RestCatalogBuilder {
         self.config.client = Some(client);
         self
     }
+
+    /// Injects a custom auth manager, overriding the `rest.auth.type` configuration.
+    pub fn with_auth_manager(mut self, auth_manager: Arc<dyn AuthManager>) -> Self {
+        self.config.auth_manager = Some(auth_manager);
+        self
+    }
 }
 
 /// Rest catalog configuration.
@@ -179,6 +190,15 @@ pub(crate) struct RestCatalogConfig {
 
     #[builder(default)]
     client: Option<Client>,
+
+    /// Lazily-created default HTTP client, shared through clones of this
+    /// config so OAuth and catalog traffic reuse one connection pool
+    /// (matching the single-client behavior before the AuthManager refactor).
+    #[builder(default)]
+    default_client: Arc<OnceLock<Client>>,
+
+    #[builder(default)]
+    auth_manager: Option<Arc<dyn AuthManager>>,
 }
 
 impl RestCatalogConfig {
@@ -195,11 +215,13 @@ impl RestCatalogConfig {
     }
 
     pub(crate) fn get_token_endpoint(&self) -> String {
-        if let Some(oauth2_uri) = self.props.get("oauth2-server-uri") {
-            oauth2_uri.to_string()
-        } else {
-            [&self.uri, PATH_V1, "oauth", "tokens"].join("/")
-        }
+        self.explicit_oauth2_server_uri()
+            .unwrap_or_else(|| default_token_endpoint(&self.uri))
+    }
+
+    /// The `oauth2-server-uri` property, only when explicitly configured.
+    pub(crate) fn explicit_oauth2_server_uri(&self) -> Option<String> {
+        self.props.get("oauth2-server-uri").cloned()
     }
 
     fn namespaces_endpoint(&self) -> String {
@@ -231,9 +253,13 @@ impl RestCatalogConfig {
         ])
     }
 
-    /// Get the client from the config.
-    pub(crate) fn client(&self) -> Option<Client> {
-        self.client.clone()
+    /// The HTTP client: the configured one, or a lazily-created default that
+    /// is shared across every user of this config (and its clones), so token
+    /// and catalog requests keep sharing one connection pool.
+    pub(crate) fn client(&self) -> Client {
+        self.client
+            .clone()
+            .unwrap_or_else(|| self.default_client.get_or_init(Client::default).clone())
     }
 
     /// Get the token from the config.
@@ -245,89 +271,32 @@ impl RestCatalogConfig {
 
     /// Get the credentials from the config. The client can use these credentials to fetch a new
     /// token.
-    ///
-    /// ## Output
-    ///
-    /// - `None`: No credential is set.
-    /// - `Some(None, client_secret)`: No client_id is set, use client_secret directly.
-    /// - `Some(Some(client_id), client_secret)`: Both client_id and client_secret are set.
     pub(crate) fn credential(&self) -> Option<(Option<String>, String)> {
-        let cred = self.props.get("credential")?;
-
-        match cred.split_once(':') {
-            Some((client_id, client_secret)) => {
-                Some((Some(client_id.to_string()), client_secret.to_string()))
-            }
-            None => Some((None, cred.to_string())),
-        }
+        credential_from_props(&self.props)
     }
 
-    /// Get the extra headers from config, which includes:
-    ///
-    /// - `content-type`
-    /// - `x-client-version`
-    /// - `user-agent`
-    /// - All headers specified by `header.xxx` in props.
+    /// Get the extra headers from config, see [`extra_headers_from_props`].
     pub(crate) fn extra_headers(&self) -> Result<HeaderMap> {
-        let mut headers = HeaderMap::from_iter([
-            (
-                header::CONTENT_TYPE,
-                HeaderValue::from_static("application/json"),
-            ),
-            (
-                HeaderName::from_static("x-client-version"),
-                HeaderValue::from_static(ICEBERG_REST_SPEC_VERSION),
-            ),
-            (
-                header::USER_AGENT,
-                HeaderValue::from_str(&format!("iceberg-rs/{CARGO_PKG_VERSION}")).unwrap(),
-            ),
-        ]);
-
-        for (key, value) in self
-            .props
-            .iter()
-            .filter_map(|(k, v)| k.strip_prefix("header.").map(|k| (k, v)))
-        {
-            headers.insert(
-                HeaderName::from_str(key).map_err(|e| {
-                    Error::new(
-                        ErrorKind::DataInvalid,
-                        format!("Invalid header name: {key}"),
-                    )
-                    .with_source(e)
-                })?,
-                HeaderValue::from_str(value).map_err(|e| {
-                    Error::new(
-                        ErrorKind::DataInvalid,
-                        format!("Invalid header value: {value}"),
-                    )
-                    .with_source(e)
-                })?,
-            );
-        }
-
-        Ok(headers)
+        extra_headers_from_props(&self.props)
     }
 
     /// Get the optional OAuth headers from the config.
     pub(crate) fn extra_oauth_params(&self) -> HashMap<String, String> {
-        let mut params = HashMap::new();
+        oauth_params_from_props(&self.props)
+    }
 
-        if let Some(scope) = self.props.get("scope") {
-            params.insert("scope".to_string(), scope.to_string());
-        } else {
-            params.insert("scope".to_string(), "catalog".to_string());
-        }
-
-        let optional_params = ["audience", "resource"];
-        for param_name in optional_params {
-            if let Some(value) = self.props.get(param_name) {
-                params.insert(param_name.to_string(), value.to_string());
-            }
-        }
-
-        params
+    /// The properties handed to [`AuthManager::catalog_session`], with the
+    /// resolved token endpoint made explicit.
+    pub(crate) fn auth_props(&self) -> HashMap<String, String> {
+        // `oauth2-server-uri` stays absent unless explicitly configured, so an
+        // injected manager keeps its own token endpoint instead of having a
+        // synthesized `<catalog>/v1/oauth/tokens` forced onto it (posting a
+        // client secret to the wrong host). The resolved catalog `uri` (which
+        // a `/v1/config` override may have changed) IS passed, so the built-in
+        // manager can recompute its default endpoint from it.
+        let mut props = self.props.clone();
+        props.insert(REST_CATALOG_PROP_URI.to_string(), self.uri.clone());
+        props
     }
 
     /// Check if header redaction is disabled in error logs.
@@ -341,6 +310,32 @@ impl RestCatalogConfig {
             .unwrap_or(false)
     }
 
+    /// The configured auth scheme: explicit `rest.auth.type` or the default
+    /// `oauth2` (which behaves as no auth when neither `token` nor
+    /// `credential` is set).
+    fn auth_type(&self) -> String {
+        self.props
+            .get(REST_CATALOG_PROP_AUTH_TYPE)
+            .cloned()
+            .unwrap_or_else(|| AUTH_TYPE_OAUTH2.to_string())
+    }
+
+    /// Resolves the auth manager: a `with_auth_manager` override wins,
+    /// otherwise one is built from the `rest.auth.type` configuration.
+    pub(crate) fn resolve_auth_manager(&self) -> Result<Arc<dyn AuthManager>> {
+        if let Some(auth_manager) = &self.auth_manager {
+            return Ok(auth_manager.clone());
+        }
+        match self.auth_type().as_str() {
+            AUTH_TYPE_NONE => Ok(Arc::new(NoopAuthManager)),
+            AUTH_TYPE_OAUTH2 => Ok(Arc::new(OAuth2Manager::from_config(self)?)),
+            other => Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!("unknown '{REST_CATALOG_PROP_AUTH_TYPE}': {other}"),
+            )),
+        }
+    }
+
     /// Merge the `RestCatalogConfig` with the a [`CatalogConfig`] (fetched from the REST server).
     pub(crate) fn merge_with_config(mut self, mut config: CatalogConfig) -> Self {
         if let Some(uri) = config.overrides.remove("uri") {
@@ -349,11 +344,118 @@ impl RestCatalogConfig {
 
         let mut props = config.defaults;
         props.extend(self.props);
+        // The client-side warehouse was moved off the props by the builder;
+        // restore it between defaults and overrides so managers receive the
+        // resolved value via `auth_props` with the standard precedence
+        // (server default < client < server override).
+        if let Some(warehouse) = &self.warehouse {
+            props.insert(REST_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.clone());
+        }
         props.extend(config.overrides);
 
         self.props = props;
         self
     }
+}
+
+/// Parses the `credential` property.
+///
+/// ## Output
+///
+/// - `None`: No credential is set.
+/// - `Some(None, client_secret)`: No client_id is set, use client_secret directly.
+/// - `Some(Some(client_id), client_secret)`: Both client_id and client_secret are set.
+pub(crate) fn credential_from_props(
+    props: &HashMap<String, String>,
+) -> Option<(Option<String>, String)> {
+    let cred = props.get("credential")?;
+
+    match cred.split_once(':') {
+        Some((client_id, client_secret)) => {
+            Some((Some(client_id.to_string()), client_secret.to_string()))
+        }
+        None => Some((None, cred.to_string())),
+    }
+}
+
+/// The extra headers added to each request, which include:
+///
+/// - `content-type`
+/// - `x-client-version`
+/// - `user-agent`
+/// - All headers specified by `header.xxx` in props.
+pub(crate) fn extra_headers_from_props(props: &HashMap<String, String>) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::from_iter([
+        (
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        ),
+        (
+            HeaderName::from_static("x-client-version"),
+            HeaderValue::from_static(ICEBERG_REST_SPEC_VERSION),
+        ),
+        (
+            header::USER_AGENT,
+            HeaderValue::from_str(&format!("iceberg-rs/{CARGO_PKG_VERSION}")).unwrap(),
+        ),
+    ]);
+
+    headers.extend(explicit_headers_from_props(props)?);
+
+    Ok(headers)
+}
+
+/// The default OAuth2 token endpoint for a catalog `uri`.
+pub(crate) fn default_token_endpoint(uri: &str) -> String {
+    [uri, PATH_V1, "oauth", "tokens"].join("/")
+}
+
+/// Only the headers explicitly configured via `header.xxx` props (no defaults).
+pub(crate) fn explicit_headers_from_props(props: &HashMap<String, String>) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for (key, value) in props
+        .iter()
+        .filter_map(|(k, v)| k.strip_prefix("header.").map(|k| (k, v)))
+    {
+        headers.insert(
+            HeaderName::from_str(key).map_err(|e| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    format!("Invalid header name: {key}"),
+                )
+                .with_source(e)
+            })?,
+            HeaderValue::from_str(value).map_err(|e| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    format!("Invalid header value: {value}"),
+                )
+                .with_source(e)
+            })?,
+        );
+    }
+
+    Ok(headers)
+}
+
+/// The optional OAuth parameters added to each authentication request.
+pub(crate) fn oauth_params_from_props(props: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut params = HashMap::new();
+
+    if let Some(scope) = props.get("scope") {
+        params.insert("scope".to_string(), scope.to_string());
+    } else {
+        params.insert("scope".to_string(), "catalog".to_string());
+    }
+
+    let optional_params = ["audience", "resource"];
+    for param_name in optional_params {
+        if let Some(value) = props.get(param_name) {
+            params.insert(param_name.to_string(), value.to_string());
+        }
+    }
+
+    params
 }
 
 #[derive(Debug)]
@@ -432,7 +534,7 @@ impl RestCatalog {
     async fn context(&self) -> Result<&RestContext> {
         self.ctx
             .get_or_try_init(|| async {
-                let client = HttpClient::new(&self.user_config)?;
+                let client = HttpClient::new(&self.user_config).await?;
                 let catalog_config = RestCatalog::load_config(&client, &self.user_config).await?;
                 // Use the advertised endpoints as-is, falling back to
                 // `DEFAULT_ENDPOINTS` when absent or empty.
@@ -443,7 +545,7 @@ impl RestCatalog {
                     _ => crate::endpoint::DEFAULT_ENDPOINTS.clone(),
                 };
                 let config = self.user_config.clone().merge_with_config(catalog_config);
-                let client = client.update_with(&config)?;
+                let client = client.update_with(&config).await?;
 
                 Ok(RestContext {
                     config,
@@ -549,7 +651,7 @@ impl RestCatalog {
     /// Invalidate the current token without generating a new one. On the next request, the client
     /// will attempt to generate a new token.
     pub async fn invalidate_token(&self) -> Result<()> {
-        self.context().await?.client.invalidate_token().await
+        self.context().await?.client.session().invalidate().await
     }
 
     /// Invalidate the current token and set a new one. Generates a new token before invalidating
@@ -559,7 +661,7 @@ impl RestCatalog {
     /// If credential is invalid, or the request fails, this method will return an error and leave
     /// the current token unchanged.
     pub async fn regenerate_token(&self) -> Result<()> {
-        self.context().await?.client.regenerate_token().await
+        self.context().await?.client.session().refresh().await
     }
 }
 
@@ -1465,9 +1567,18 @@ mod tests {
         let oauth_mock =
             create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 200)
                 .await;
+        // The next request re-exchanges the credential and sends the new token.
+        let ns_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header("authorization", "Bearer ey000000000001")
+            .with_body(r#"{"namespaces": []}"#)
+            .create_async()
+            .await;
         catalog.invalidate_token().await.unwrap();
-        let token = catalog.context().await.unwrap().client.token().await;
+        catalog.list_namespaces(None).await.unwrap();
         oauth_mock.assert_async().await;
+        ns_mock.assert_async().await;
+        let token = catalog.context().await.unwrap().client.token().await;
         assert_eq!(token, Some("ey000000000001".to_string()));
     }
 
@@ -1499,8 +1610,10 @@ mod tests {
             create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 500)
                 .await;
         catalog.invalidate_token().await.unwrap();
-        let token = catalog.context().await.unwrap().client.token().await;
+        // The failed re-exchange surfaces as an error and no token is cached.
+        assert!(catalog.list_namespaces(None).await.is_err());
         oauth_mock.assert_async().await;
+        let token = catalog.context().await.unwrap().client.token().await;
         assert_eq!(token, None);
     }
 
@@ -1763,6 +1876,404 @@ mod tests {
 
         config_mock.assert_async().await;
         list_ns_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_auth_type_none_disables_auth() {
+        // An explicit `rest.auth.type=none` wins over a configured token.
+        let props = HashMap::from([
+            (REST_CATALOG_PROP_AUTH_TYPE.to_string(), "none".to_string()),
+            ("token".to_string(), "some-oauth-token".to_string()),
+        ]);
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+
+        let session = config
+            .resolve_auth_manager()
+            .unwrap()
+            .init_session()
+            .await
+            .unwrap();
+        let mut req = Client::new()
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        session
+            .authenticate(&mut crate::auth::AuthRequest::new(&mut req))
+            .await
+            .unwrap();
+        assert!(req.headers().get("authorization").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_header_prop_overrides_token_on_the_wire() {
+        // Pre-AuthManager behavior, preserved: extra headers are applied after
+        // authentication, so a user-configured `header.authorization` wins
+        // over a configured token.
+        let mut server = Server::new_async().await;
+        let config_mock = create_config_mock(&mut server).await;
+        let list_ns_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header("authorization", "Basic xyz")
+            .with_body(r#"{"namespaces": []}"#)
+            .create_async()
+            .await;
+
+        let props = HashMap::from([
+            ("token".to_string(), "some-oauth-token".to_string()),
+            ("header.authorization".to_string(), "Basic xyz".to_string()),
+        ]);
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .props(props)
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        catalog.list_namespaces(None).await.unwrap();
+        config_mock.assert_async().await;
+        list_ns_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_builtin_oauth_endpoint_follows_uri_override() {
+        // When `/v1/config` overrides `uri` (and no explicit `oauth2-server-uri`
+        // is set), the built-in manager's default token endpoint must follow
+        // the merged URI: a refresh after the handshake posts to the new host.
+        let mut bootstrap = Server::new_async().await;
+        let mut overridden = Server::new_async().await;
+
+        let config_mock = bootstrap
+            .mock("GET", "/v1/config")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"overrides": {{"uri": "{}"}}, "defaults": {{}}}}"#,
+                overridden.url()
+            ))
+            .create_async()
+            .await;
+        // Handshake exchange still uses the bootstrap-derived default.
+        let bootstrap_oauth_mock =
+            create_oauth_mock_with_path(&mut bootstrap, "/v1/oauth/tokens", "tok-boot", 200).await;
+        // The refresh must follow the overridden URI.
+        let overridden_oauth_mock =
+            create_oauth_mock_with_path(&mut overridden, "/v1/oauth/tokens", "tok-new", 200).await;
+
+        let props = HashMap::from([("credential".to_string(), "client1:secret1".to_string())]);
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(bootstrap.url())
+                .props(props)
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        catalog.context().await.unwrap();
+        catalog.regenerate_token().await.unwrap();
+
+        config_mock.assert_async().await;
+        bootstrap_oauth_mock.assert_async().await;
+        overridden_oauth_mock.assert_async().await;
+        let token = catalog.context().await.unwrap().client.token().await;
+        assert_eq!(token, Some("tok-new".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_injected_oauth_manager_keeps_endpoint_and_options() {
+        // An injected OAuth2Manager must keep its own token endpoint, extra
+        // headers and OAuth params across the config handshake: only explicit
+        // properties may override them, never synthesized defaults.
+        let mut server = Server::new_async().await;
+        let config_mock = create_config_mock(&mut server).await;
+
+        // The catalog-host default endpoint must never see the credential.
+        let default_endpoint_mock = server
+            .mock("POST", "/v1/oauth/tokens")
+            .expect(0)
+            .create_async()
+            .await;
+        // Both exchanges (handshake + regenerate) hit the injected endpoint,
+        // carrying the injected header and OAuth param.
+        let custom_endpoint_mock = server
+            .mock("POST", "/custom/oauth/tokens")
+            .match_header("x-tenant", "t1")
+            // The default catalog scope must survive alongside the injected
+            // audience (with_extra_oauth_params merges onto the defaults).
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex("scope=catalog".to_string()),
+                mockito::Matcher::Regex("audience=aud-1".to_string()),
+            ]))
+            .with_status(200)
+            .with_body(
+                r#"{
+                "access_token": "ey000000000000",
+                "token_type": "Bearer",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "expires_in": 86400
+                }"#,
+            )
+            .expect(2)
+            .create_async()
+            .await;
+
+        let manager = OAuth2Manager::new(format!("{}/custom/oauth/tokens", server.url()))
+            .with_credential(Some("client1".to_string()), "secret1".to_string())
+            .with_extra_headers(HeaderMap::from_iter([(
+                HeaderName::from_static("x-tenant"),
+                HeaderValue::from_static("t1"),
+            )]))
+            .with_extra_oauth_params(HashMap::from([(
+                "audience".to_string(),
+                "aud-1".to_string(),
+            )]));
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .auth_manager(Some(Arc::new(manager)))
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        // Handshake performs the first exchange; regenerate the second — both
+        // must use the injected endpoint/options.
+        catalog.context().await.unwrap();
+        catalog.regenerate_token().await.unwrap();
+
+        config_mock.assert_async().await;
+        custom_endpoint_mock.assert_async().await;
+        default_endpoint_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_catalog_session_receives_resolved_warehouse() {
+        use tokio::sync::Mutex as AsyncMutex;
+
+        use crate::auth::AuthSession;
+
+        // A custom manager must receive the resolved warehouse in the props
+        // handed to `catalog_session`, with the standard precedence:
+        // server default < client-side warehouse < server override.
+        #[derive(Debug)]
+        struct PlainSession;
+        #[async_trait]
+        impl AuthSession for PlainSession {
+            async fn authenticate(
+                &self,
+                _request: &mut crate::auth::AuthRequest<'_>,
+            ) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        #[derive(Debug)]
+        struct CapturingManager(Arc<AsyncMutex<Option<HashMap<String, String>>>>);
+        #[async_trait]
+        impl AuthManager for CapturingManager {
+            async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
+                Ok(Arc::new(PlainSession))
+            }
+            async fn catalog_session(
+                &self,
+                props: &HashMap<String, String>,
+            ) -> Result<Arc<dyn AuthSession>> {
+                *self.0.lock().await = Some(props.clone());
+                Ok(Arc::new(PlainSession))
+            }
+        }
+
+        // Client warehouse wins over a server default.
+        let mut server = Server::new_async().await;
+        let config_mock = server
+            .mock("GET", "/v1/config")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "warehouse".to_string(),
+                "client-wh".to_string(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"defaults": {"warehouse": "default-wh"}, "overrides": {}}"#)
+            .create_async()
+            .await;
+        let captured = Arc::new(AsyncMutex::new(None));
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .warehouse("client-wh".to_string())
+                .auth_manager(Some(Arc::new(CapturingManager(captured.clone()))))
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+        catalog.context().await.unwrap();
+        config_mock.assert_async().await;
+        let props = captured.lock().await.clone().unwrap();
+        assert_eq!(
+            props.get("warehouse").map(String::as_str),
+            Some("client-wh")
+        );
+
+        // A server override wins over the client warehouse.
+        let mut server = Server::new_async().await;
+        let config_mock = server
+            .mock("GET", "/v1/config")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "warehouse".to_string(),
+                "client-wh".to_string(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"defaults": {}, "overrides": {"warehouse": "override-wh"}}"#)
+            .create_async()
+            .await;
+        let captured = Arc::new(AsyncMutex::new(None));
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .warehouse("client-wh".to_string())
+                .auth_manager(Some(Arc::new(CapturingManager(captured.clone()))))
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+        catalog.context().await.unwrap();
+        config_mock.assert_async().await;
+        let props = captured.lock().await.clone().unwrap();
+        assert_eq!(
+            props.get("warehouse").map(String::as_str),
+            Some("override-wh")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_session_dropped_before_catalog_session() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use crate::auth::AuthSession;
+
+        // A manager whose init session guards a one-shot resource (released on
+        // drop) must see it released before `catalog_session` is invoked.
+        #[derive(Debug)]
+        struct GuardSession(Arc<AtomicBool>);
+        impl Drop for GuardSession {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        #[async_trait]
+        impl AuthSession for GuardSession {
+            async fn authenticate(
+                &self,
+                _request: &mut crate::auth::AuthRequest<'_>,
+            ) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        #[derive(Debug)]
+        struct PlainSession;
+        #[async_trait]
+        impl AuthSession for PlainSession {
+            async fn authenticate(
+                &self,
+                _request: &mut crate::auth::AuthRequest<'_>,
+            ) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        #[derive(Debug)]
+        struct GuardManager(Arc<AtomicBool>);
+        #[async_trait]
+        impl AuthManager for GuardManager {
+            async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
+                Ok(Arc::new(GuardSession(self.0.clone())))
+            }
+            async fn catalog_session(
+                &self,
+                _props: &HashMap<String, String>,
+            ) -> Result<Arc<dyn AuthSession>> {
+                if !self.0.load(Ordering::SeqCst) {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "init session must be dropped before catalog_session",
+                    ));
+                }
+                Ok(Arc::new(PlainSession))
+            }
+        }
+
+        let mut server = Server::new_async().await;
+        let config_mock = create_config_mock(&mut server).await;
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .auth_manager(Some(Arc::new(GuardManager(dropped.clone()))))
+                .build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        catalog.context().await.unwrap();
+        config_mock.assert_async().await;
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_unknown_auth_type_is_rejected() {
+        let props = HashMap::from([(
+            REST_CATALOG_PROP_AUTH_TYPE.to_string(),
+            "kerberos".to_string(),
+        )]);
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+
+        let err = config.resolve_auth_manager().unwrap_err();
+        assert!(err.message().contains(REST_CATALOG_PROP_AUTH_TYPE));
+    }
+
+    #[test]
+    fn test_with_auth_manager_overrides_config() {
+        // A custom auth manager takes precedence over `rest.auth.type`.
+        #[derive(Debug)]
+        struct StubAuthManager;
+        #[async_trait]
+        impl AuthManager for StubAuthManager {
+            async fn init_session(&self) -> Result<Arc<dyn crate::auth::AuthSession>> {
+                unimplemented!()
+            }
+            async fn catalog_session(
+                &self,
+                _props: &HashMap<String, String>,
+            ) -> Result<Arc<dyn crate::auth::AuthSession>> {
+                unimplemented!()
+            }
+        }
+
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([(
+                REST_CATALOG_PROP_AUTH_TYPE.to_string(),
+                "kerberos".to_string(),
+            )]))
+            .auth_manager(Some(Arc::new(StubAuthManager)))
+            .build();
+
+        // The unknown auth type is never consulted.
+        assert!(config.resolve_auth_manager().is_ok());
     }
 
     #[tokio::test]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -289,11 +289,8 @@ impl RestCatalogConfig {
     /// resolved token endpoint made explicit.
     pub(crate) fn auth_props(&self) -> HashMap<String, String> {
         // `oauth2-server-uri` stays absent unless explicitly configured, so an
-        // injected manager keeps its own token endpoint instead of having a
-        // synthesized `<catalog>/v1/oauth/tokens` forced onto it (posting a
-        // client secret to the wrong host). The resolved catalog `uri` (which
-        // a `/v1/config` override may have changed) IS passed, so the built-in
-        // manager can recompute its default endpoint from it.
+        // injected manager keeps its own endpoint. The resolved `uri` IS passed
+        // so the built-in manager can recompute its default from it.
         let mut props = self.props.clone();
         props.insert(REST_CATALOG_PROP_URI.to_string(), self.uri.clone());
         props
@@ -344,10 +341,8 @@ impl RestCatalogConfig {
 
         let mut props = config.defaults;
         props.extend(self.props);
-        // The client-side warehouse was moved off the props by the builder;
-        // restore it between defaults and overrides so managers receive the
-        // resolved value via `auth_props` with the standard precedence
-        // (server default < client < server override).
+        // The builder moved the client warehouse off the props; restore it
+        // between defaults and overrides (default < client < override).
         if let Some(warehouse) = &self.warehouse {
             props.insert(REST_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.clone());
         }

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -56,7 +56,9 @@ pub const REST_CATALOG_PROP_WAREHOUSE: &str = "warehouse";
 /// Disable header redaction in error logs and `Debug` output (defaults to
 /// false for security)
 pub const REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str = "disable-header-redaction";
-/// Authentication scheme: `none` or `oauth2` (default).
+/// Authentication scheme: `none` or `oauth2`. When unset, `oauth2` is used
+/// if a `token`, `credential` or `oauth2-server-uri` is configured, `none`
+/// otherwise.
 pub const REST_CATALOG_PROP_AUTH_TYPE: &str = "rest.auth.type";
 
 const ICEBERG_REST_SPEC_VERSION: &str = "0.14.1";
@@ -346,14 +348,24 @@ impl RestCatalogConfig {
             .unwrap_or(false)
     }
 
-    /// The configured auth scheme: explicit `rest.auth.type` or the default
-    /// `oauth2` (which behaves as no auth when neither `token` nor
-    /// `credential` is set).
+    /// The configured auth scheme: explicit `rest.auth.type` when set;
+    /// otherwise `oauth2` when a `token`, `credential` or `oauth2-server-uri`
+    /// is configured (preserving pre-`rest.auth.type` setups), `none` when
+    /// none is.
     fn auth_type(&self) -> String {
         self.props
             .get(REST_CATALOG_PROP_AUTH_TYPE)
             .cloned()
-            .unwrap_or_else(|| AUTH_TYPE_OAUTH2.to_string())
+            .unwrap_or_else(|| {
+                if self.token().is_some()
+                    || self.credential().is_some()
+                    || self.explicit_oauth2_server_uri().is_some()
+                {
+                    AUTH_TYPE_OAUTH2.to_string()
+                } else {
+                    AUTH_TYPE_NONE.to_string()
+                }
+            })
     }
 
     /// Resolves the auth manager: a `with_auth_manager` override wins,
@@ -367,7 +379,11 @@ impl RestCatalogConfig {
             AUTH_TYPE_OAUTH2 => Ok(Arc::new(OAuth2Manager::from_config(self)?)),
             other => Err(Error::new(
                 ErrorKind::DataInvalid,
-                format!("unknown '{REST_CATALOG_PROP_AUTH_TYPE}': {other}"),
+                format!(
+                    "unknown '{REST_CATALOG_PROP_AUTH_TYPE}': {other}; use \
+                     `RestCatalogBuilder::with_auth_manager` to inject a \
+                     custom auth manager"
+                ),
             )),
         }
     }
@@ -681,28 +697,6 @@ impl RestCatalog {
         let file_io = FileIOBuilder::new(factory).with_props(props).build();
 
         Ok(file_io)
-    }
-
-    /// Invalidate the current token without generating a new one. On the next request, the client
-    /// will attempt to generate a new token.
-    ///
-    /// Sessions that don't manage a token (e.g. with `rest.auth.type` `none`,
-    /// or a custom [`AuthManager`]) may treat this as a no-op.
-    pub async fn invalidate_token(&self) -> Result<()> {
-        self.context().await?.client.session().invalidate().await
-    }
-
-    /// Invalidate the current token and set a new one. Generates a new token before invalidating
-    /// the current token, meaning the old token will be used until this function acquires the lock
-    /// and overwrites the token.
-    ///
-    /// If credential is invalid, or the request fails, this method will return an error and leave
-    /// the current token unchanged.
-    ///
-    /// Errors when the session has no credential to exchange (e.g. a static
-    /// token); a custom [`AuthManager`]'s session may treat this as a no-op.
-    pub async fn regenerate_token(&self) -> Result<()> {
-        self.context().await?.client.session().refresh().await
     }
 }
 
@@ -1582,152 +1576,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_invalidate_token() {
-        let mut server = Server::new_async().await;
-        let oauth_mock = create_oauth_mock(&mut server).await;
-        let config_mock = create_config_mock(&mut server).await;
-
-        let mut props = HashMap::new();
-        props.insert("credential".to_string(), "client1:secret1".to_string());
-
-        let catalog = RestCatalog::new(
-            RestCatalogConfig::builder()
-                .uri(server.url())
-                .props(props)
-                .build(),
-            Some(Arc::new(LocalFsStorageFactory)),
-            Runtime::current(),
-            None,
-        );
-
-        let token = catalog.context().await.unwrap().client.token().await;
-        oauth_mock.assert_async().await;
-        config_mock.assert_async().await;
-        assert_eq!(token, Some("ey000000000000".to_string()));
-
-        let oauth_mock =
-            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 200)
-                .await;
-        // The next request re-exchanges the credential and sends the new token.
-        let ns_mock = server
-            .mock("GET", "/v1/namespaces")
-            .match_header("authorization", "Bearer ey000000000001")
-            .with_body(r#"{"namespaces": []}"#)
-            .create_async()
-            .await;
-        catalog.invalidate_token().await.unwrap();
-        catalog.list_namespaces(None).await.unwrap();
-        oauth_mock.assert_async().await;
-        ns_mock.assert_async().await;
-        let token = catalog.context().await.unwrap().client.token().await;
-        assert_eq!(token, Some("ey000000000001".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_invalidate_token_failing_request() {
-        let mut server = Server::new_async().await;
-        let oauth_mock = create_oauth_mock(&mut server).await;
-        let config_mock = create_config_mock(&mut server).await;
-
-        let mut props = HashMap::new();
-        props.insert("credential".to_string(), "client1:secret1".to_string());
-
-        let catalog = RestCatalog::new(
-            RestCatalogConfig::builder()
-                .uri(server.url())
-                .props(props)
-                .build(),
-            Some(Arc::new(LocalFsStorageFactory)),
-            Runtime::current(),
-            None,
-        );
-
-        let token = catalog.context().await.unwrap().client.token().await;
-        oauth_mock.assert_async().await;
-        config_mock.assert_async().await;
-        assert_eq!(token, Some("ey000000000000".to_string()));
-
-        let oauth_mock =
-            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 500)
-                .await;
-        catalog.invalidate_token().await.unwrap();
-        // The failed re-exchange surfaces as an error and no token is cached.
-        assert!(catalog.list_namespaces(None).await.is_err());
-        oauth_mock.assert_async().await;
-        let token = catalog.context().await.unwrap().client.token().await;
-        assert_eq!(token, None);
-    }
-
-    #[tokio::test]
-    async fn test_regenerate_token() {
-        let mut server = Server::new_async().await;
-        let oauth_mock = create_oauth_mock(&mut server).await;
-        let config_mock = create_config_mock(&mut server).await;
-
-        let mut props = HashMap::new();
-        props.insert("credential".to_string(), "client1:secret1".to_string());
-
-        let catalog = RestCatalog::new(
-            RestCatalogConfig::builder()
-                .uri(server.url())
-                .props(props)
-                .build(),
-            Some(Arc::new(LocalFsStorageFactory)),
-            Runtime::current(),
-            None,
-        );
-
-        let token = catalog.context().await.unwrap().client.token().await;
-        oauth_mock.assert_async().await;
-        config_mock.assert_async().await;
-        assert_eq!(token, Some("ey000000000000".to_string()));
-
-        let oauth_mock =
-            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 200)
-                .await;
-        catalog.regenerate_token().await.unwrap();
-        oauth_mock.assert_async().await;
-        let token = catalog.context().await.unwrap().client.token().await;
-        assert_eq!(token, Some("ey000000000001".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_regenerate_token_failing_request() {
-        let mut server = Server::new_async().await;
-        let oauth_mock = create_oauth_mock(&mut server).await;
-        let config_mock = create_config_mock(&mut server).await;
-
-        let mut props = HashMap::new();
-        props.insert("credential".to_string(), "client1:secret1".to_string());
-
-        let catalog = RestCatalog::new(
-            RestCatalogConfig::builder()
-                .uri(server.url())
-                .props(props)
-                .build(),
-            Some(Arc::new(LocalFsStorageFactory)),
-            Runtime::current(),
-            None,
-        );
-
-        let token = catalog.context().await.unwrap().client.token().await;
-        oauth_mock.assert_async().await;
-        config_mock.assert_async().await;
-        assert_eq!(token, Some("ey000000000000".to_string()));
-
-        let oauth_mock =
-            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "ey000000000001", 500)
-                .await;
-        let invalidate_result = catalog.regenerate_token().await;
-        assert!(invalidate_result.is_err());
-        oauth_mock.assert_async().await;
-        let token = catalog.context().await.unwrap().client.token().await;
-
-        // original token is left intact
-        assert_eq!(token, Some("ey000000000000".to_string()));
-    }
-
-    #[tokio::test]
     async fn test_http_headers() {
         let server = Server::new_async().await;
         let mut props = HashMap::new();
@@ -1985,9 +1833,9 @@ mod tests {
     async fn test_builtin_oauth_endpoint_follows_uri_override() {
         // When `/v1/config` overrides `uri` (and no explicit `oauth2-server-uri`
         // is set), the built-in manager's default token endpoint must follow
-        // the merged URI: a refresh after the handshake posts to the new host.
+        // the merged URI.
         let mut bootstrap = Server::new_async().await;
-        let mut overridden = Server::new_async().await;
+        let overridden = Server::new_async().await;
 
         let config_mock = bootstrap
             .mock("GET", "/v1/config")
@@ -2001,9 +1849,6 @@ mod tests {
         // Handshake exchange still uses the bootstrap-derived default.
         let bootstrap_oauth_mock =
             create_oauth_mock_with_path(&mut bootstrap, "/v1/oauth/tokens", "tok-boot", 200).await;
-        // The refresh must follow the overridden URI.
-        let overridden_oauth_mock =
-            create_oauth_mock_with_path(&mut overridden, "/v1/oauth/tokens", "tok-new", 200).await;
 
         let props = HashMap::from([("credential".to_string(), "client1:secret1".to_string())]);
         let catalog = RestCatalog::new(
@@ -2016,14 +1861,13 @@ mod tests {
             None,
         );
 
-        catalog.context().await.unwrap();
-        catalog.regenerate_token().await.unwrap();
-
+        let context = catalog.context().await.unwrap();
         config_mock.assert_async().await;
         bootstrap_oauth_mock.assert_async().await;
-        overridden_oauth_mock.assert_async().await;
-        let token = catalog.context().await.unwrap().client.token().await;
-        assert_eq!(token, Some("tok-new".to_string()));
+        // The catalog session's endpoint follows the overridden URI (visible
+        // via the session's Debug, which prints its token endpoint).
+        let session_debug = format!("{:?}", context.client.session());
+        assert!(session_debug.contains(&format!("{}/v1/oauth/tokens", overridden.url())));
     }
 
     #[tokio::test]
@@ -2068,21 +1912,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_seeded_token_with_credential_exchanges_once_after_invalidate() {
-        // The seeded token is attached without an exchange; after
-        // invalidate() the credential is exchanged exactly once.
+    async fn test_seeded_token_takes_precedence_over_credential() {
+        // token + credential: the seeded token is attached without any
+        // credential exchange.
         let mut server = Server::new_async().await;
-        // create_oauth_mock_with_path expects exactly 1 hit.
-        let oauth_mock =
-            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "tok-new", 200).await;
+        let oauth_mock = server
+            .mock("POST", "/v1/oauth/tokens")
+            .expect(0)
+            .create_async()
+            .await;
 
         let manager = OAuth2Manager::new(format!("{}/v1/oauth/tokens", server.url()))
             .with_token("tok-seed")
             .with_credential(Some("client1".to_string()), "secret1".to_string());
         let session = manager.init_session().await.unwrap();
 
-        let client = Client::new();
-        let mut req = client
+        let mut req = Client::new()
             .get("https://rest.example.com/v1/config")
             .build()
             .unwrap();
@@ -2095,20 +1940,6 @@ mod tests {
             "Bearer tok-seed"
         );
 
-        session.invalidate().await.unwrap();
-        let mut req = client
-            .get("https://rest.example.com/v1/config")
-            .build()
-            .unwrap();
-        session
-            .authenticate(&mut crate::auth::AuthRequest::new(&mut req))
-            .await
-            .unwrap();
-        assert_eq!(
-            req.headers().get("authorization").unwrap(),
-            "Bearer tok-new"
-        );
-
         oauth_mock.assert_async().await;
     }
 
@@ -2118,7 +1949,14 @@ mod tests {
         // headers and OAuth params across the config handshake: only explicit
         // properties may override them, never synthesized defaults.
         let mut server = Server::new_async().await;
-        let config_mock = create_config_mock(&mut server).await;
+        // The server vends the credential, so the exchange runs through the
+        // post-handshake catalog session (exercising its property merging).
+        let config_mock = server
+            .mock("GET", "/v1/config")
+            .with_status(200)
+            .with_body(r#"{"defaults": {"credential": "client1:secret1"}, "overrides": {}}"#)
+            .create_async()
+            .await;
 
         // The catalog-host default endpoint must never see the credential.
         let default_endpoint_mock = server
@@ -2126,8 +1964,8 @@ mod tests {
             .expect(0)
             .create_async()
             .await;
-        // Both exchanges (handshake + regenerate) hit the injected endpoint,
-        // carrying the injected header and OAuth param.
+        // The exchange hits the injected endpoint, carrying the injected
+        // header and OAuth param.
         let custom_endpoint_mock = server
             .mock("POST", "/custom/oauth/tokens")
             .match_header("x-tenant", "t1")
@@ -2146,12 +1984,16 @@ mod tests {
                 "expires_in": 86400
                 }"#,
             )
-            .expect(2)
+            .create_async()
+            .await;
+        let ns_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header("authorization", "Bearer ey000000000000")
+            .with_body(r#"{"namespaces": []}"#)
             .create_async()
             .await;
 
         let manager = OAuth2Manager::new(format!("{}/custom/oauth/tokens", server.url()))
-            .with_credential(Some("client1".to_string()), "secret1".to_string())
             .with_extra_headers(HeaderMap::from_iter([(
                 HeaderName::from_static("x-tenant"),
                 HeaderValue::from_static("t1"),
@@ -2170,14 +2012,12 @@ mod tests {
             None,
         );
 
-        // Handshake performs the first exchange; regenerate the second — both
-        // must use the injected endpoint/options.
-        catalog.context().await.unwrap();
-        catalog.regenerate_token().await.unwrap();
+        catalog.list_namespaces(None).await.unwrap();
 
         config_mock.assert_async().await;
         custom_endpoint_mock.assert_async().await;
         default_endpoint_mock.assert_async().await;
+        ns_mock.assert_async().await;
     }
 
     #[tokio::test]
@@ -2384,6 +2224,38 @@ mod tests {
         assert!(!out.contains("cs-secret"));
         assert!(out.contains("[REDACTED]"));
         assert!(out.contains("wh1"));
+    }
+
+    #[test]
+    fn test_auth_type_defaults() {
+        // Unset `rest.auth.type`: `oauth2` when any OAuth material is
+        // configured (existing setups keep working), `none` otherwise.
+        let bare = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .build();
+        assert!(format!("{:?}", bare.resolve_auth_manager().unwrap()).contains("NoopAuthManager"));
+
+        let with_token = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([("token".to_string(), "tok".to_string())]))
+            .build();
+        assert!(
+            format!("{:?}", with_token.resolve_auth_manager().unwrap()).contains("OAuth2Manager")
+        );
+
+        // An explicit OAuth endpoint is oauth2 intent too: the manager can
+        // still pick up a server-supplied token from `/v1/config`.
+        let with_endpoint = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([(
+                "oauth2-server-uri".to_string(),
+                "http://auth.example.com/tokens".to_string(),
+            )]))
+            .build();
+        assert!(
+            format!("{:?}", with_endpoint.resolve_auth_manager().unwrap())
+                .contains("OAuth2Manager")
+        );
     }
 
     #[test]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use iceberg::encryption::kms::{KeyManagementClient, KmsClientFactory};
 use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
+use iceberg::sensitive::SensitiveString;
 use iceberg::table::Table;
 use iceberg::{
     Catalog, CatalogBuilder, Error, ErrorKind, Namespace, NamespaceIdent, Result, Runtime,
@@ -39,7 +40,10 @@ use reqwest::{Client, Method, StatusCode, Url};
 use tokio::sync::OnceCell;
 use typed_builder::TypedBuilder;
 
-use crate::auth::{AUTH_TYPE_NONE, AUTH_TYPE_OAUTH2, AuthManager, NoopAuthManager, OAuth2Manager};
+use crate::auth::{
+    AUTH_TYPE_NONE, AUTH_TYPE_OAUTH2, AUTH_TYPE_SIGV4, AuthManager, AwsCredentials,
+    NoopAuthManager, OAuth2Manager, PayloadHashMode, SigV4AuthManager, SigV4Signer,
+};
 use crate::client::{
     HttpClient, deserialize_catalog_response, deserialize_unexpected_catalog_error,
 };
@@ -59,10 +63,28 @@ pub const REST_CATALOG_PROP_WAREHOUSE: &str = "warehouse";
 /// Disable header redaction in error logs and `Debug` output (defaults to
 /// false for security)
 pub const REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str = "disable-header-redaction";
-/// Authentication scheme: `none` or `oauth2`. When unset, `oauth2` is used
-/// if a `token`, `credential` or `oauth2-server-uri` is configured, `none`
-/// otherwise.
+/// Authentication scheme: `none`, `oauth2` or `sigv4`. When unset: `sigv4`
+/// if `rest.sigv4-enabled` is true, `oauth2` if a `token`, `credential` or
+/// `oauth2-server-uri` is configured, `none` otherwise.
 pub const REST_CATALOG_PROP_AUTH_TYPE: &str = "rest.auth.type";
+
+/// Enable AWS SigV4 request signing for the REST catalog.
+pub const REST_CATALOG_PROP_SIGV4_ENABLED: &str = "rest.sigv4-enabled";
+/// SigV4 signing service name (defaults to `execute-api`, as Iceberg Java).
+pub const REST_CATALOG_PROP_SIGNING_NAME: &str = "rest.signing-name";
+/// SigV4 signing region (required for SigV4 signing; falls back to the
+/// `AWS_REGION`/`AWS_DEFAULT_REGION` env vars).
+pub const REST_CATALOG_PROP_SIGNING_REGION: &str = "rest.signing-region";
+/// SigV4 access key id (set together with the secret; otherwise the
+/// `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars are used).
+pub const REST_CATALOG_PROP_ACCESS_KEY_ID: &str = "rest.access-key-id";
+/// SigV4 secret access key (see [`REST_CATALOG_PROP_ACCESS_KEY_ID`]).
+pub const REST_CATALOG_PROP_SECRET_ACCESS_KEY: &str = "rest.secret-access-key";
+/// SigV4 session token (optional; from the env only with env credentials).
+pub const REST_CATALOG_PROP_SESSION_TOKEN: &str = "rest.session-token";
+/// Auth scheme SigV4 wraps: `oauth2` (the default; attaches nothing until a
+/// token or credential is available) or `none` to disable delegate auth.
+pub const REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE: &str = "rest.auth.sigv4.delegate-auth-type";
 
 const ICEBERG_REST_SPEC_VERSION: &str = "0.14.1";
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -256,9 +278,22 @@ impl RestCatalogConfig {
     /// is shared across every user of this config (and its clones), so token
     /// and catalog requests keep sharing one connection pool.
     pub(crate) fn client(&self) -> Client {
-        self.client
-            .clone()
-            .unwrap_or_else(|| self.default_client.get_or_init(Client::default).clone())
+        self.client.clone().unwrap_or_else(|| {
+            self.default_client
+                .get_or_init(|| {
+                    // A signed request can't be transparently re-followed
+                    // (Java re-signs every hop), and reqwest's cross-origin
+                    // strip list doesn't know relocated or custom auth
+                    // headers. Surface the 3xx instead; an injected client
+                    // should disable redirects too.
+                    if self.signs_requests() {
+                        no_redirect_client()
+                    } else {
+                        Client::default()
+                    }
+                })
+                .clone()
+        })
     }
 
     /// Get the token from the config.
@@ -295,6 +330,33 @@ impl RestCatalogConfig {
             .unwrap_or(false)
     }
 
+    /// Pre-builds the shared default client without redirect following. The
+    /// catalog calls this for an injected [`AuthManager`], which may sign and
+    /// which this config cannot see (see [`Self::signs_requests`]).
+    pub(crate) fn disable_client_redirects(&self) {
+        if self.client.is_none() {
+            self.default_client.get_or_init(no_redirect_client);
+        }
+    }
+
+    /// Whether the configured auth signs requests, so the default client must
+    /// not follow redirects.
+    fn signs_requests(&self) -> bool {
+        self.sigv4_enabled()
+            || self
+                .props
+                .get(REST_CATALOG_PROP_AUTH_TYPE)
+                .is_some_and(|auth_type| auth_type.eq_ignore_ascii_case(AUTH_TYPE_SIGV4))
+    }
+
+    /// The deprecated `rest.sigv4-enabled` switch.
+    fn sigv4_enabled(&self) -> bool {
+        self.props
+            .get(REST_CATALOG_PROP_SIGV4_ENABLED)
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+
     /// Merge the `RestCatalogConfig` with the a [`CatalogConfig`] (fetched from the REST server).
     pub(crate) fn merge_with_config(mut self, mut config: CatalogConfig) -> Self {
         if let Some(uri) = config.overrides.remove(REST_CATALOG_PROP_URI) {
@@ -313,6 +375,95 @@ impl RestCatalogConfig {
         self.props = props;
         self
     }
+}
+
+/// Builds a [`SigV4Signer`] from the SigV4 properties (credentials fall back
+/// to the standard `AWS_*` environment variables).
+///
+/// Runs on the user properties at construction and on the merged properties
+/// after the config handshake, so server-supplied values are honored.
+/// A client that surfaces a 3xx instead of re-sending a signed request: Java
+/// re-signs every hop, and reqwest's cross-origin strip list doesn't know
+/// relocated or custom auth headers.
+fn no_redirect_client() -> Client {
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("failed to build default HTTP client")
+}
+
+pub(crate) fn sigv4_signer_from_props(props: &HashMap<String, String>) -> Result<SigV4Signer> {
+    let non_blank = |value: &String| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
+    // Credentials already fall back to the environment; the region does too, so
+    // a config that works with Iceberg Java's default region provider works here.
+    let region = props
+        .get(REST_CATALOG_PROP_SIGNING_REGION)
+        .and_then(non_blank)
+        .or_else(|| {
+            ["AWS_REGION", "AWS_DEFAULT_REGION"]
+                .iter()
+                .find_map(|key| std::env::var(key).ok().as_ref().and_then(non_blank))
+        })
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                format!("'{REST_CATALOG_PROP_SIGNING_REGION}' is required for SigV4 signing"),
+            )
+        })?;
+    let name = props
+        .get(REST_CATALOG_PROP_SIGNING_NAME)
+        .and_then(non_blank)
+        // Iceberg Java's REST_SIGNING_NAME_DEFAULT.
+        .unwrap_or_else(|| "execute-api".to_string());
+
+    // Blank values are treated as absent rather than as usable credentials.
+    let prop = |key: &str| props.get(key).and_then(non_blank);
+    let env = |key: &str| std::env::var(key).ok().as_ref().and_then(non_blank);
+
+    // The credential tuple comes from ONE source: mixing an explicit key with
+    // ambient environment credentials would cross principals.
+    let credentials = match (
+        prop(REST_CATALOG_PROP_ACCESS_KEY_ID),
+        prop(REST_CATALOG_PROP_SECRET_ACCESS_KEY),
+    ) {
+        (Some(access_key_id), Some(secret_access_key)) => AwsCredentials {
+            access_key_id,
+            secret_access_key: secret_access_key.into(),
+            session_token: prop(REST_CATALOG_PROP_SESSION_TOKEN).map(SensitiveString::from),
+        },
+        (None, None) => match (env("AWS_ACCESS_KEY_ID"), env("AWS_SECRET_ACCESS_KEY")) {
+            (Some(access_key_id), Some(secret_access_key)) => AwsCredentials {
+                access_key_id,
+                secret_access_key: secret_access_key.into(),
+                session_token: env("AWS_SESSION_TOKEN").map(SensitiveString::from),
+            },
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!(
+                        "missing SigV4 credentials: set '{REST_CATALOG_PROP_ACCESS_KEY_ID}'/'{REST_CATALOG_PROP_SECRET_ACCESS_KEY}' or the AWS_* env vars"
+                    ),
+                ));
+            }
+        },
+        _ => {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "'{REST_CATALOG_PROP_ACCESS_KEY_ID}' and '{REST_CATALOG_PROP_SECRET_ACCESS_KEY}' must be set together"
+                ),
+            ));
+        }
+    };
+    Ok(SigV4Signer::new(
+        credentials,
+        region,
+        name,
+        PayloadHashMode::IcebergRest,
+    ))
 }
 
 /// Parses the `credential` property.
@@ -763,6 +914,14 @@ impl RestSessionCatalog {
     /// `credential` or `oauth2-server-uri` is configured (preserving
     /// pre-`rest.auth.type` setups), `none` when none is.
     fn auth_type(config: &RestCatalogConfig) -> String {
+        // The legacy switch wins over `rest.auth.type`, as it does in Java.
+        if config.sigv4_enabled() {
+            tracing::warn!(
+                "'{REST_CATALOG_PROP_SIGV4_ENABLED}' is deprecated; set \
+                 '{REST_CATALOG_PROP_AUTH_TYPE}={AUTH_TYPE_SIGV4}' instead"
+            );
+            return AUTH_TYPE_SIGV4.to_string();
+        }
         config
             .props
             .get(REST_CATALOG_PROP_AUTH_TYPE)
@@ -800,6 +959,32 @@ impl RestSessionCatalog {
         match auth_type.as_str() {
             AUTH_TYPE_NONE => Ok(Arc::new(NoopAuthManager)),
             AUTH_TYPE_OAUTH2 => Ok(Arc::new(OAuth2Manager::from_config(config)?)),
+            AUTH_TYPE_SIGV4 => {
+                // SigV4 signs on top of a delegate auth (Java parity). The
+                // delegate defaults to OAuth2 even without a token/credential:
+                // it attaches nothing then, but still picks up a token the
+                // server's config response supplies.
+                let delegate_auth_type = config
+                    .props
+                    .get(REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE)
+                    .map(|auth_type| auth_type.to_ascii_lowercase());
+                let delegate: Arc<dyn AuthManager> = match delegate_auth_type.as_deref() {
+                    Some(AUTH_TYPE_NONE) => Arc::new(NoopAuthManager),
+                    Some(AUTH_TYPE_OAUTH2) | None => Arc::new(OAuth2Manager::from_config(config)?),
+                    Some(other) => {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!(
+                                "unknown '{REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE}': {other}"
+                            ),
+                        ));
+                    }
+                };
+                Ok(Arc::new(SigV4AuthManager::from_config_signer(
+                    delegate,
+                    sigv4_signer_from_props(&config.props)?,
+                )))
+            }
             other => Err(Error::new(
                 ErrorKind::DataInvalid,
                 format!(
@@ -815,6 +1000,11 @@ impl RestSessionCatalog {
     async fn client(&self) -> Result<&RestClient> {
         self.client
             .get_or_try_init(|| async {
+                // An injected manager may sign requests, which the config
+                // cannot see; a signed request must not be re-followed.
+                if self.auth_manager.is_some() {
+                    self.user_config.disable_client_redirects();
+                }
                 RestClient::init(&self.user_config, self.resolve_auth_manager()?).await
             })
             .await
@@ -2177,6 +2367,161 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sigv4_signature_survives_a_configured_authorization_header() {
+        // Why authentication runs after the client's extra headers: applying
+        // them afterwards would overwrite the signature with the configured
+        // `header.authorization`, and the request would go out unsigned.
+        let mut server = Server::new_async().await;
+        let config_mock = create_config_mock(&mut server).await;
+        let list_ns_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header(
+                "authorization",
+                mockito::Matcher::Regex("^AWS4-HMAC-SHA256 ".to_string()),
+            )
+            .match_header("original-authorization", "Basic gateway")
+            .with_body(r#"{"namespaces": []}"#)
+            .create_async()
+            .await;
+
+        let mut props = sigv4_props();
+        props.insert(
+            "header.authorization".to_string(),
+            "Basic gateway".to_string(),
+        );
+        let catalog = RestCatalog::new(
+            SessionContext::empty(),
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .props(props)
+                .build(),
+            None,
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        catalog.list_namespaces(None).await.unwrap();
+        config_mock.assert_async().await;
+        list_ns_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_signs_requests() {
+        let mut server = Server::new_async().await;
+
+        let config_mock = create_config_mock(&mut server).await;
+
+        // With sigv4 enabled, requests must carry an AWS SigV4 Authorization header.
+        let list_ns_mock = server
+            .mock("GET", "/v1/namespaces")
+            .match_header(
+                "authorization",
+                mockito::Matcher::Regex("^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/".to_string()),
+            )
+            .with_body(r#"{"namespaces": []}"#)
+            .create_async()
+            .await;
+
+        let props = HashMap::from([
+            (
+                REST_CATALOG_PROP_SIGV4_ENABLED.to_string(),
+                "true".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_REGION.to_string(),
+                "us-east-1".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_NAME.to_string(),
+                "glue".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_ACCESS_KEY_ID.to_string(),
+                "AKIDEXAMPLE".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SECRET_ACCESS_KEY.to_string(),
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            ),
+        ]);
+        let catalog = RestCatalog::new(
+            SessionContext::empty(),
+            RestCatalogConfig::builder()
+                .uri(server.url())
+                .props(props)
+                .build(),
+            None,
+            None,
+            Runtime::current(),
+            None,
+        );
+
+        let namespaces = catalog.list_namespaces(None).await.unwrap();
+        assert!(namespaces.is_empty());
+
+        config_mock.assert_async().await;
+        list_ns_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_composes_with_token_auth() {
+        // SigV4 signs on top of token auth: the bearer token is relocated to
+        // `Original-Authorization` and the signature takes `Authorization`.
+        let props = HashMap::from([
+            (
+                REST_CATALOG_PROP_SIGV4_ENABLED.to_string(),
+                "true".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_REGION.to_string(),
+                "us-east-1".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_NAME.to_string(),
+                "glue".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_ACCESS_KEY_ID.to_string(),
+                "AKIDEXAMPLE".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SECRET_ACCESS_KEY.to_string(),
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            ),
+            ("token".to_string(), "some-oauth-token".to_string()),
+        ]);
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+
+        let session = test_catalog(config)
+            .resolve_auth_manager()
+            .unwrap()
+            .init_session(&test_client(), &HashMap::new())
+            .await
+            .unwrap();
+        let mut req = HttpRequest::new(
+            Client::new()
+                .get("https://rest.example.com/v1/config")
+                .build()
+                .unwrap(),
+        );
+        session.authenticate(&mut req).await.unwrap();
+
+        let headers = req.headers();
+        assert_eq!(
+            headers.get("original-authorization").unwrap(),
+            "Bearer some-oauth-token"
+        );
+        let auth = headers.get("authorization").unwrap().to_str().unwrap();
+        assert!(auth.starts_with("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"));
+        // The relocated token is part of the signature.
+        assert!(auth.contains("original-authorization"));
+    }
+
+    #[tokio::test]
     async fn test_auth_type_none_disables_auth() {
         // An explicit `rest.auth.type=none` wins over a configured token.
         let props = HashMap::from([
@@ -2206,9 +2551,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_header_prop_overrides_token_on_the_wire() {
-        // Pre-AuthManager behavior, preserved: extra headers are applied after
-        // authentication, so a user-configured `header.authorization` wins
-        // over a configured token.
+        // Authentication runs after the extra headers, yet a configured
+        // `header.authorization` still wins: the OAuth2 session only sets the
+        // header when absent, as Java's `OAuth2Util.AuthSession` does.
         let mut server = Server::new_async().await;
         let config_mock = create_config_mock(&mut server).await;
         let list_ns_mock = server
@@ -2890,6 +3235,328 @@ mod tests {
 
         let err = test_catalog(config).resolve_auth_manager().unwrap_err();
         assert!(err.message().contains(REST_CATALOG_PROP_AUTH_TYPE));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_sigv4_switch_wins_over_auth_type() {
+        // Java's AuthManagers gives the deprecated switch precedence, so a
+        // config carrying both still signs.
+        let mut props = sigv4_props();
+        props.insert(
+            REST_CATALOG_PROP_AUTH_TYPE.to_string(),
+            AUTH_TYPE_OAUTH2.to_string(),
+        );
+        props.insert(
+            REST_CATALOG_PROP_SIGV4_ENABLED.to_string(),
+            "true".to_string(),
+        );
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+        assert!(
+            format!("{:?}", test_catalog(config).resolve_auth_manager().unwrap())
+                .contains("SigV4AuthManager")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_signing_props_resolution() {
+        // Missing region.
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([(
+                REST_CATALOG_PROP_SIGV4_ENABLED.to_string(),
+                "true".to_string(),
+            )]))
+            .build();
+        let err = test_catalog(config).resolve_auth_manager().unwrap_err();
+        assert!(err.message().contains(REST_CATALOG_PROP_SIGNING_REGION));
+
+        // The signing name defaults to `execute-api` (Iceberg Java parity).
+        let mut props = sigv4_props();
+        props.remove(REST_CATALOG_PROP_SIGNING_NAME);
+        let signer = sigv4_signer_from_props(&props).unwrap();
+        assert!(format!("{signer:?}").contains("execute-api"));
+
+        // An access key without its secret is rejected, never mixed with
+        // environment credentials.
+        let mut props = sigv4_props();
+        props.remove(REST_CATALOG_PROP_SECRET_ACCESS_KEY);
+        let err = sigv4_signer_from_props(&props).unwrap_err();
+        assert!(err.message().contains("must be set together"));
+
+        // A blank value is absent, not a usable credential.
+        let mut props = sigv4_props();
+        props.insert(
+            REST_CATALOG_PROP_ACCESS_KEY_ID.to_string(),
+            "  ".to_string(),
+        );
+        let err = sigv4_signer_from_props(&props).unwrap_err();
+        assert!(err.message().contains("must be set together"));
+    }
+
+    #[test]
+    fn test_sigv4_prop_names_match_iceberg_java() {
+        // Iceberg Java's AwsProperties values; renaming any of these breaks
+        // portable configurations.
+        assert_eq!(REST_CATALOG_PROP_SIGNING_NAME, "rest.signing-name");
+        assert_eq!(REST_CATALOG_PROP_SIGNING_REGION, "rest.signing-region");
+        assert_eq!(REST_CATALOG_PROP_ACCESS_KEY_ID, "rest.access-key-id");
+        assert_eq!(
+            REST_CATALOG_PROP_SECRET_ACCESS_KEY,
+            "rest.secret-access-key"
+        );
+        assert_eq!(REST_CATALOG_PROP_SESSION_TOKEN, "rest.session-token");
+    }
+
+    #[tokio::test]
+    async fn test_injected_manager_does_not_follow_redirects() {
+        // An injected manager may sign, and the config cannot see it, so the
+        // catalog has to disable redirects on its behalf. Following the 302
+        // would fail against the unreachable target instead of surfacing it.
+        let mut server = Server::new_async().await;
+        let redirect_mock = server
+            .mock("GET", "/v1/config")
+            .with_status(302)
+            .with_header("location", "http://localhost:1/nowhere")
+            .create_async()
+            .await;
+
+        let catalog = RestCatalog::new(
+            SessionContext::empty(),
+            RestCatalogConfig::builder().uri(server.url()).build(),
+            Some(Arc::new(NoopAuthManager)),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+            None,
+        );
+
+        let err = catalog.list_namespaces(None).await.unwrap_err().to_string();
+        assert!(err.contains("302"), "{err}");
+        redirect_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_default_client_does_not_follow_redirects() {
+        // The default client must surface the 3xx instead of re-sending a
+        // stale signature (and relocated auth headers) to the target.
+        let mut server = Server::new_async().await;
+        let redirect_mock = server
+            .mock("GET", "/v1/config")
+            .with_status(302)
+            .with_header("location", "http://localhost/nowhere")
+            .expect(3)
+            .create_async()
+            .await;
+
+        let config = RestCatalogConfig::builder()
+            .uri(server.url())
+            .props(sigv4_props())
+            .build();
+        let response = config
+            .client()
+            .get(format!("{}/v1/config", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 302);
+
+        // Same for an injected manager, which the config cannot see.
+        let config = RestCatalogConfig::builder().uri(server.url()).build();
+        config.disable_client_redirects();
+        let response = config
+            .client()
+            .get(format!("{}/v1/config", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 302);
+
+        // Same for the deprecated switch.
+        let config = RestCatalogConfig::builder()
+            .uri(server.url())
+            .props(HashMap::from([(
+                REST_CATALOG_PROP_SIGV4_ENABLED.to_string(),
+                "true".to_string(),
+            )]))
+            .build();
+        let response = config
+            .client()
+            .get(format!("{}/v1/config", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 302);
+
+        redirect_mock.assert_async().await;
+    }
+
+    fn sigv4_props() -> HashMap<String, String> {
+        HashMap::from([
+            (
+                REST_CATALOG_PROP_AUTH_TYPE.to_string(),
+                AUTH_TYPE_SIGV4.to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_REGION.to_string(),
+                "us-east-1".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SIGNING_NAME.to_string(),
+                "execute-api".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_ACCESS_KEY_ID.to_string(),
+                "ak".to_string(),
+            ),
+            (
+                REST_CATALOG_PROP_SECRET_ACCESS_KEY.to_string(),
+                "sk".to_string(),
+            ),
+        ])
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_delegate_auth_type_explicit() {
+        // `none` forces a Noop delegate even when a token is configured.
+        let mut props = sigv4_props();
+        props.insert("token".to_string(), "tok".to_string());
+        props.insert(
+            REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE.to_string(),
+            AUTH_TYPE_NONE.to_string(),
+        );
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+        let manager = test_catalog(config).resolve_auth_manager().unwrap();
+        assert!(format!("{manager:?}").contains("NoopAuthManager"));
+
+        // `oauth2` forces an OAuth2 delegate even without a token/credential.
+        let mut props = sigv4_props();
+        props.insert(
+            REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE.to_string(),
+            AUTH_TYPE_OAUTH2.to_string(),
+        );
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+        let manager = test_catalog(config).resolve_auth_manager().unwrap();
+        assert!(format!("{manager:?}").contains("OAuth2Manager"));
+
+        // Unknown delegate types are rejected.
+        let mut props = sigv4_props();
+        props.insert(
+            REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE.to_string(),
+            "kerberos".to_string(),
+        );
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(props)
+            .build();
+        let err = test_catalog(config).resolve_auth_manager().unwrap_err();
+        assert!(
+            err.message()
+                .contains(REST_CATALOG_PROP_SIGV4_DELEGATE_AUTH_TYPE)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_catalog_session_rebuilds_signer_from_merged_props() {
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(sigv4_props())
+            .build();
+        let manager = test_catalog(config).resolve_auth_manager().unwrap();
+
+        // A config-built signer follows the merged props: a server-supplied
+        // signing default/override is honored.
+        let mut merged = sigv4_props();
+        merged.insert(
+            REST_CATALOG_PROP_SIGNING_REGION.to_string(),
+            "eu-west-1".to_string(),
+        );
+        let session = manager
+            .catalog_session(&test_client(), &merged)
+            .await
+            .unwrap();
+        assert!(format!("{session:?}").contains("eu-west-1"));
+
+        // An injected signer is never rebuilt from the merged props: signing
+        // must keep its credentials, region and payload-hash mode.
+        let manager = SigV4AuthManager::new(
+            Arc::new(NoopAuthManager),
+            SigV4Signer::new(
+                AwsCredentials {
+                    access_key_id: "injected-ak".to_string(),
+                    secret_access_key: "injected-sk".to_string().into(),
+                    session_token: None,
+                },
+                "us-west-2".to_string(),
+                "execute-api".to_string(),
+                PayloadHashMode::StandardAws,
+            ),
+        );
+        let session = manager
+            .catalog_session(&test_client(), &merged)
+            .await
+            .unwrap();
+
+        let mut req = HttpRequest::new(
+            Client::new()
+                .post("https://rest.example.com/v1/namespaces")
+                .body("{}")
+                .build()
+                .unwrap(),
+        );
+        session.authenticate(&mut req).await.unwrap();
+        let authorization = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(authorization.contains("Credential=injected-ak/"));
+        assert!(authorization.contains("/us-west-2/execute-api/"));
+        // StandardAws keeps the hex payload hash (IcebergRest would base64 it).
+        assert_eq!(
+            req.headers().get("x-amz-content-sha256").unwrap(),
+            "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_default_delegate_picks_up_server_token() {
+        // The delegate defaults to OAuth2 even without a token/credential:
+        // a server-supplied token is attached, not dropped by a Noop.
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(sigv4_props())
+            .build();
+        let manager = test_catalog(config).resolve_auth_manager().unwrap();
+        assert!(format!("{manager:?}").contains("OAuth2Manager"));
+
+        let mut merged = sigv4_props();
+        merged.insert("token".to_string(), "srv-tok".to_string());
+        let session = manager
+            .catalog_session(&test_client(), &merged)
+            .await
+            .unwrap();
+
+        let mut req = HttpRequest::new(
+            Client::new()
+                .get("https://rest.example.com/v1/namespaces")
+                .build()
+                .unwrap(),
+        );
+        session.authenticate(&mut req).await.unwrap();
+        let relocated = req.headers().get("original-authorization").unwrap();
+        assert_eq!(relocated, "Bearer srv-tok");
+        // The delegate's value may not be marked, so relocation marks it.
+        assert!(relocated.is_sensitive());
+        assert!(req.headers().contains_key("authorization"));
     }
 
     #[tokio::test]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -53,7 +53,8 @@ use crate::types::{
 pub const REST_CATALOG_PROP_URI: &str = "uri";
 /// REST catalog warehouse location
 pub const REST_CATALOG_PROP_WAREHOUSE: &str = "warehouse";
-/// Disable header redaction in error logs (defaults to false for security)
+/// Disable header redaction in error logs and `Debug` output (defaults to
+/// false for security)
 pub const REST_CATALOG_PROP_DISABLE_HEADER_REDACTION: &str = "disable-header-redaction";
 /// Authentication scheme: `none` or `oauth2` (default).
 pub const REST_CATALOG_PROP_AUTH_TYPE: &str = "rest.auth.type";
@@ -175,7 +176,7 @@ impl RestCatalogBuilder {
 }
 
 /// Rest catalog configuration.
-#[derive(Clone, Debug, TypedBuilder)]
+#[derive(Clone, TypedBuilder)]
 pub(crate) struct RestCatalogConfig {
     #[builder(default, setter(strip_option))]
     name: Option<String>,
@@ -199,6 +200,44 @@ pub(crate) struct RestCatalogConfig {
 
     #[builder(default)]
     auth_manager: Option<Arc<dyn AuthManager>>,
+}
+
+/// Property keys whose values are secrets, or may embed them (headers,
+/// connection strings, keys like `adls.account-key` or `s3.sse.key`).
+fn is_sensitive_prop(key: &str) -> bool {
+    key.contains("token")
+        || key.contains("credential")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("key")
+        || key.contains("connection-string")
+        || key.starts_with("header.")
+}
+
+/// Redacts secret property values: this config is printed by
+/// [`RestCatalog`]'s derived `Debug`.
+impl std::fmt::Debug for RestCatalogConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let props: HashMap<&str, &str> = self
+            .props
+            .iter()
+            .map(|(key, value)| {
+                let value = if is_sensitive_prop(key) {
+                    "[REDACTED]"
+                } else {
+                    value.as_str()
+                };
+                (key.as_str(), value)
+            })
+            .collect();
+        f.debug_struct("RestCatalogConfig")
+            .field("name", &self.name)
+            .field("uri", &self.uri)
+            .field("warehouse", &self.warehouse)
+            .field("props", &props)
+            .field("auth_manager", &self.auth_manager)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RestCatalogConfig {
@@ -286,7 +325,7 @@ impl RestCatalogConfig {
     }
 
     /// The properties handed to [`AuthManager::catalog_session`], with the
-    /// resolved token endpoint made explicit.
+    /// resolved catalog `uri` made explicit.
     pub(crate) fn auth_props(&self) -> HashMap<String, String> {
         // `oauth2-server-uri` stays absent unless explicitly configured, so an
         // injected manager keeps its own endpoint. The resolved `uri` IS passed
@@ -423,7 +462,8 @@ pub(crate) fn explicit_headers_from_props(props: &HashMap<String, String>) -> Re
             HeaderValue::from_str(value).map_err(|e| {
                 Error::new(
                     ErrorKind::DataInvalid,
-                    format!("Invalid header value: {value}"),
+                    // The value itself is omitted: it may be a secret.
+                    format!("Invalid value for header: {key}"),
                 )
                 .with_source(e)
             })?,
@@ -645,6 +685,9 @@ impl RestCatalog {
 
     /// Invalidate the current token without generating a new one. On the next request, the client
     /// will attempt to generate a new token.
+    ///
+    /// Sessions that don't manage a token (e.g. with `rest.auth.type` `none`,
+    /// or a custom [`AuthManager`]) may treat this as a no-op.
     pub async fn invalidate_token(&self) -> Result<()> {
         self.context().await?.client.session().invalidate().await
     }
@@ -655,6 +698,9 @@ impl RestCatalog {
     ///
     /// If credential is invalid, or the request fails, this method will return an error and leave
     /// the current token unchanged.
+    ///
+    /// Errors when the session has no credential to exchange (e.g. a static
+    /// token); a custom [`AuthManager`]'s session may treat this as a no-op.
     pub async fn regenerate_token(&self) -> Result<()> {
         self.context().await?.client.session().refresh().await
     }
@@ -1981,6 +2027,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_authenticate_single_token_exchange() {
+        // Concurrent requests that all find no cached token must trigger ONE
+        // credential exchange (the lock is held across it), not one each.
+        let mut server = Server::new_async().await;
+        // create_oauth_mock_with_path expects exactly 1 hit.
+        let oauth_mock =
+            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "tok-once", 200).await;
+
+        let manager = OAuth2Manager::new(format!("{}/v1/oauth/tokens", server.url()))
+            .with_credential(Some("client1".to_string()), "secret1".to_string());
+        let session: Arc<dyn crate::auth::AuthSession> =
+            Arc::from(manager.init_session().await.unwrap());
+
+        let client = Client::new();
+        let attempts = (0..8).map(|_| {
+            let session = session.clone();
+            let client = client.clone();
+            async move {
+                let mut req = client
+                    .get("https://rest.example.com/v1/config")
+                    .build()
+                    .unwrap();
+                session
+                    .authenticate(&mut crate::auth::AuthRequest::new(&mut req))
+                    .await
+                    .unwrap();
+                req.headers()
+                    .get("authorization")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            }
+        });
+        let bearers = futures::future::join_all(attempts).await;
+
+        oauth_mock.assert_async().await;
+        assert!(bearers.iter().all(|b| b == "Bearer tok-once"));
+    }
+
+    #[tokio::test]
+    async fn test_seeded_token_with_credential_exchanges_once_after_invalidate() {
+        // The seeded token is attached without an exchange; after
+        // invalidate() the credential is exchanged exactly once.
+        let mut server = Server::new_async().await;
+        // create_oauth_mock_with_path expects exactly 1 hit.
+        let oauth_mock =
+            create_oauth_mock_with_path(&mut server, "/v1/oauth/tokens", "tok-new", 200).await;
+
+        let manager = OAuth2Manager::new(format!("{}/v1/oauth/tokens", server.url()))
+            .with_token("tok-seed")
+            .with_credential(Some("client1".to_string()), "secret1".to_string());
+        let session = manager.init_session().await.unwrap();
+
+        let client = Client::new();
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        session
+            .authenticate(&mut crate::auth::AuthRequest::new(&mut req))
+            .await
+            .unwrap();
+        assert_eq!(
+            req.headers().get("authorization").unwrap(),
+            "Bearer tok-seed"
+        );
+
+        session.invalidate().await.unwrap();
+        let mut req = client
+            .get("https://rest.example.com/v1/config")
+            .build()
+            .unwrap();
+        session
+            .authenticate(&mut crate::auth::AuthRequest::new(&mut req))
+            .await
+            .unwrap();
+        assert_eq!(
+            req.headers().get("authorization").unwrap(),
+            "Bearer tok-new"
+        );
+
+        oauth_mock.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn test_injected_oauth_manager_keeps_endpoint_and_options() {
         // An injected OAuth2Manager must keep its own token endpoint, extra
         // headers and OAuth params across the config handshake: only explicit
@@ -2073,8 +2205,8 @@ mod tests {
         struct CapturingManager(Arc<AsyncMutex<Option<HashMap<String, String>>>>);
         #[async_trait]
         impl AuthManager for CapturingManager {
-            async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
-                Ok(Arc::new(PlainSession))
+            async fn init_session(&self) -> Result<Box<dyn AuthSession>> {
+                Ok(Box::new(PlainSession))
             }
             async fn catalog_session(
                 &self,
@@ -2189,8 +2321,8 @@ mod tests {
         struct GuardManager(Arc<AtomicBool>);
         #[async_trait]
         impl AuthManager for GuardManager {
-            async fn init_session(&self) -> Result<Arc<dyn AuthSession>> {
-                Ok(Arc::new(GuardSession(self.0.clone())))
+            async fn init_session(&self) -> Result<Box<dyn AuthSession>> {
+                Ok(Box::new(GuardSession(self.0.clone())))
             }
             async fn catalog_session(
                 &self,
@@ -2226,6 +2358,35 @@ mod tests {
     }
 
     #[test]
+    fn test_config_debug_redacts_secrets() {
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([
+                ("token".to_string(), "tok-secret".to_string()),
+                ("credential".to_string(), "id:cred-secret".to_string()),
+                ("header.authorization".to_string(), "Basic xyz".to_string()),
+                ("adls.account-key".to_string(), "adls-secret".to_string()),
+                ("s3.sse.key".to_string(), "sse-secret".to_string()),
+                (
+                    "adls.connection-string".to_string(),
+                    "cs-secret".to_string(),
+                ),
+                ("warehouse".to_string(), "wh1".to_string()),
+            ]))
+            .build();
+
+        let out = format!("{config:?}");
+        assert!(!out.contains("tok-secret"));
+        assert!(!out.contains("cred-secret"));
+        assert!(!out.contains("Basic xyz"));
+        assert!(!out.contains("adls-secret"));
+        assert!(!out.contains("sse-secret"));
+        assert!(!out.contains("cs-secret"));
+        assert!(out.contains("[REDACTED]"));
+        assert!(out.contains("wh1"));
+    }
+
+    #[test]
     fn test_unknown_auth_type_is_rejected() {
         let props = HashMap::from([(
             REST_CATALOG_PROP_AUTH_TYPE.to_string(),
@@ -2247,7 +2408,7 @@ mod tests {
         struct StubAuthManager;
         #[async_trait]
         impl AuthManager for StubAuthManager {
-            async fn init_session(&self) -> Result<Arc<dyn crate::auth::AuthSession>> {
+            async fn init_session(&self) -> Result<Box<dyn crate::auth::AuthSession>> {
                 unimplemented!()
             }
             async fn catalog_session(

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -374,7 +374,16 @@ impl RestCatalogConfig {
         if let Some(auth_manager) = &self.auth_manager {
             return Ok(auth_manager.clone());
         }
-        match self.auth_type().as_str() {
+        let auth_type = self.auth_type();
+        // Java parity (`AuthManagers`): make the inference visible so users
+        // configure the type explicitly.
+        if auth_type == AUTH_TYPE_OAUTH2 && !self.props.contains_key(REST_CATALOG_PROP_AUTH_TYPE) {
+            tracing::warn!(
+                "Inferring {REST_CATALOG_PROP_AUTH_TYPE}={AUTH_TYPE_OAUTH2} from the configured \
+                 OAuth properties; set it explicitly to avoid this warning"
+            );
+        }
+        match auth_type.as_str() {
             AUTH_TYPE_NONE => Ok(Arc::new(NoopAuthManager)),
             AUTH_TYPE_OAUTH2 => Ok(Arc::new(OAuth2Manager::from_config(self)?)),
             other => Err(Error::new(

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -3326,7 +3326,7 @@ mod tests {
         let catalog = RestCatalog::new(
             SessionContext::empty(),
             RestCatalogConfig::builder().uri(server.url()).build(),
-            Some(Arc::new(NoopAuthManager)),
+            Some(Box::new(NoopAuthManager)),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -42,9 +42,14 @@ pub(crate) struct HttpClient {
 
 impl Debug for HttpClient {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // The inner client is omitted: an injected one may carry secrets in
+        // its default headers.
         f.debug_struct("HttpClient")
-            .field("client", &self.client)
-            .field("extra_headers", &self.extra_headers)
+            .field(
+                // `header.*` values may hold secrets (e.g. `authorization`).
+                "extra_headers",
+                &format_headers_redacted(&self.extra_headers, self.disable_header_redaction),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -53,7 +58,7 @@ impl HttpClient {
     /// Create a new http client.
     pub async fn new(cfg: &RestCatalogConfig) -> Result<Self> {
         let auth_manager = cfg.resolve_auth_manager()?;
-        let session = auth_manager.init_session().await?;
+        let session = Arc::from(auth_manager.init_session().await?);
         Ok(HttpClient {
             client: cfg.client(),
             extra_headers: cfg.extra_headers()?,
@@ -170,20 +175,21 @@ pub(crate) async fn deserialize_catalog_response<R: DeserializeOwned>(
     })
 }
 
-/// Headers that contain sensitive information and should be excluded from logs.
-const SENSITIVE_HEADERS: &[&str] = &[
-    "authorization",
-    "proxy-authorization",
-    "set-cookie",
-    "cookie",
-    "x-api-key",
-    "x-auth-token",
-];
-
-/// Returns true if the header name is considered sensitive.
+/// Returns true if the header may carry a secret (matched by substring, so
+/// e.g. `x-client-secret` is covered along with `authorization`).
 fn is_sensitive_header(name: &str) -> bool {
     let name_lower = name.to_lowercase();
-    SENSITIVE_HEADERS.iter().any(|h| name_lower == *h)
+    [
+        "auth",
+        "token",
+        "secret",
+        "key",
+        "password",
+        "cookie",
+        "credential",
+    ]
+    .iter()
+    .any(|pattern| name_lower.contains(pattern))
 }
 
 /// Redacts sensitive headers and returns a debug-formatted string.
@@ -263,6 +269,31 @@ mod tests {
         assert!(result.contains("application/json"));
         assert!(result.contains("x-request-id"));
         assert!(result.contains("abc123"));
+    }
+
+    #[tokio::test]
+    async fn test_http_client_debug_redacts_headers() {
+        let config = RestCatalogConfig::builder()
+            .uri("http://localhost".to_string())
+            .props(HashMap::from([
+                ("header.authorization".to_string(), "Basic xyz".to_string()),
+                (
+                    "header.x-client-secret".to_string(),
+                    "shh-secret".to_string(),
+                ),
+                (
+                    "header.x-client-credential".to_string(),
+                    "cred-value".to_string(),
+                ),
+            ]))
+            .build();
+        let client = HttpClient::new(&config).await.unwrap();
+
+        let out = format!("{client:?}");
+        assert!(!out.contains("Basic xyz"));
+        assert!(!out.contains("shh-secret"));
+        assert!(!out.contains("cred-value"));
+        assert!(out.contains("[REDACTED]"));
     }
 
     #[test]

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -103,6 +103,7 @@ impl HttpClient {
     }
 
     /// The session authenticating requests in the current phase.
+    #[cfg(test)]
     pub(crate) fn session(&self) -> &Arc<dyn AuthSession> {
         &self.session
     }

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -17,34 +17,27 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 
-use http::StatusCode;
 use iceberg::{Error, ErrorKind, Result};
 use reqwest::header::HeaderMap;
 use reqwest::{Client, IntoUrl, Method, Request, RequestBuilder, Response};
 use serde::de::DeserializeOwned;
-use tokio::sync::Mutex;
 
 use crate::RestCatalogConfig;
-use crate::types::{ErrorResponse, TokenResponse};
+use crate::auth::{AuthManager, AuthRequest, AuthSession};
 
 pub(crate) struct HttpClient {
     client: Client,
 
-    /// The token to be used for authentication.
-    ///
-    /// It's possible to fetch the token from the server while needed.
-    token: Mutex<Option<String>>,
-    /// The token endpoint to be used for authentication.
-    token_endpoint: String,
-    /// The credential to be used for authentication.
-    credential: Option<(Option<String>, String)>,
     /// Extra headers to be added to each request.
     extra_headers: HeaderMap,
-    /// Extra oauth parameters to be added to each authentication request.
-    extra_oauth_params: HashMap<String, String>,
     /// Whether to disable header redaction in error logs (defaults to false for security).
     disable_header_redaction: bool,
+    /// The auth manager living for the lifetime of the catalog.
+    auth_manager: Arc<dyn AuthManager>,
+    /// The session authenticating requests in the current phase.
+    session: Arc<dyn AuthSession>,
 }
 
 impl Debug for HttpClient {
@@ -58,16 +51,15 @@ impl Debug for HttpClient {
 
 impl HttpClient {
     /// Create a new http client.
-    pub fn new(cfg: &RestCatalogConfig) -> Result<Self> {
-        let extra_headers = cfg.extra_headers()?;
+    pub async fn new(cfg: &RestCatalogConfig) -> Result<Self> {
+        let auth_manager = cfg.resolve_auth_manager()?;
+        let session = auth_manager.init_session().await?;
         Ok(HttpClient {
-            client: cfg.client().unwrap_or_default(),
-            token: Mutex::new(cfg.token()),
-            token_endpoint: cfg.get_token_endpoint(),
-            credential: cfg.credential(),
-            extra_headers,
-            extra_oauth_params: cfg.extra_oauth_params(),
+            client: cfg.client(),
+            extra_headers: cfg.extra_headers()?,
             disable_header_redaction: cfg.disable_header_redaction(),
+            auth_manager,
+            session,
         })
     }
 
@@ -75,172 +67,66 @@ impl HttpClient {
     ///
     /// If cfg carries new value, we will use cfg instead.
     /// Otherwise, we will keep the old value.
-    pub fn update_with(self, cfg: &RestCatalogConfig) -> Result<Self> {
+    ///
+    /// The auth manager is kept; it derives a new session from the merged
+    /// properties (carrying over state such as a cached token).
+    pub async fn update_with(self, cfg: &RestCatalogConfig) -> Result<Self> {
+        let HttpClient {
+            // The same client comes back from `cfg.client()` below: the config
+            // clone shares the lazily-created default (or the user's client).
+            client: _,
+            extra_headers: current_headers,
+            disable_header_redaction: _,
+            auth_manager,
+            session: init_session,
+        } = self;
+        // Release the init-phase session before deriving the catalog session,
+        // so a manager whose init session guards a one-shot resource (released
+        // on drop) can build its catalog session without deadlocking.
+        drop(init_session);
+
         let extra_headers = (!cfg.extra_headers()?.is_empty())
             .then(|| cfg.extra_headers())
             .transpose()?
-            .unwrap_or(self.extra_headers);
+            .unwrap_or(current_headers);
+        let session = auth_manager.catalog_session(&cfg.auth_props()).await?;
         Ok(HttpClient {
-            client: cfg.client().unwrap_or(self.client),
-            token: Mutex::new(cfg.token().or_else(|| self.token.into_inner())),
-            token_endpoint: if !cfg.get_token_endpoint().is_empty() {
-                cfg.get_token_endpoint()
-            } else {
-                self.token_endpoint
-            },
-            credential: cfg.credential().or(self.credential),
+            client: cfg.client(),
             extra_headers,
-            extra_oauth_params: if !cfg.extra_oauth_params().is_empty() {
-                cfg.extra_oauth_params()
-            } else {
-                self.extra_oauth_params
-            },
             disable_header_redaction: cfg.disable_header_redaction(),
+            auth_manager,
+            session,
         })
     }
 
-    /// This API is testing only to assert the token.
+    /// The session authenticating requests in the current phase.
+    pub(crate) fn session(&self) -> &Arc<dyn AuthSession> {
+        &self.session
+    }
+
+    /// Testing only: the bearer token the current session would attach.
+    ///
+    /// Authenticates a throwaway request (never sent — `authenticate` only
+    /// mutates it) and reads the header back, so this works for any
+    /// [`AuthSession`] without the trait carrying a test-only method.
     #[cfg(test)]
     pub(crate) async fn token(&self) -> Option<String> {
-        let mut req = self
-            .request(Method::GET, &self.token_endpoint)
+        let mut request = self
+            .client
+            .request(Method::GET, "http://localhost/token-probe")
             .build()
-            .unwrap();
-        self.authenticate(&mut req).await.ok();
-        self.token.lock().await.clone()
-    }
-
-    async fn exchange_credential_for_token(&self) -> Result<String> {
-        // Credential must exist here.
-        let (client_id, client_secret) = self.credential.as_ref().ok_or_else(|| {
-            Error::new(
-                ErrorKind::DataInvalid,
-                "Credential must be provided for authentication",
-            )
-        })?;
-
-        let mut params = HashMap::with_capacity(4);
-        params.insert("grant_type", "client_credentials");
-        if let Some(client_id) = client_id {
-            params.insert("client_id", client_id);
-        }
-        params.insert("client_secret", client_secret);
-        params.extend(
-            self.extra_oauth_params
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.as_str())),
-        );
-
-        let mut auth_req = self
-            .request(Method::POST, &self.token_endpoint)
-            .form(&params)
-            .build()?;
-        // extra headers add content-type application/json header it's necessary to override it with proper type
-        // note that form call doesn't add content-type header if already present
-        auth_req.headers_mut().insert(
-            http::header::CONTENT_TYPE,
-            http::HeaderValue::from_static("application/x-www-form-urlencoded"),
-        );
-        let auth_url = auth_req.url().clone();
-        let auth_resp = self.client.execute(auth_req).await?;
-
-        let auth_res: TokenResponse = if auth_resp.status() == StatusCode::OK {
-            let text = auth_resp
-                .bytes()
-                .await
-                .map_err(|err| err.with_url(auth_url.clone()))?;
-            Ok(serde_json::from_slice(&text).map_err(|e| {
-                Error::new(
-                    ErrorKind::Unexpected,
-                    "Failed to parse response from rest catalog server!",
-                )
-                .with_context("operation", "auth")
-                .with_context("url", auth_url.to_string())
-                .with_context("json", String::from_utf8_lossy(&text))
-                .with_source(e)
-            })?)
-        } else {
-            let code = auth_resp.status();
-            let text = auth_resp
-                .bytes()
-                .await
-                .map_err(|err| err.with_url(auth_url.clone()))?;
-            let e: ErrorResponse = serde_json::from_slice(&text).map_err(|e| {
-                Error::new(ErrorKind::Unexpected, "Received unexpected response")
-                    .with_context("code", code.to_string())
-                    .with_context("operation", "auth")
-                    .with_context("url", auth_url.to_string())
-                    .with_context("json", String::from_utf8_lossy(&text))
-                    .with_source(e)
-            })?;
-            Err(Error::from(e))
-        }?;
-        Ok(auth_res.access_token)
-    }
-
-    /// Invalidate the current token without generating a new one. On the next request, the client
-    /// will attempt to generate a new token.
-    pub(crate) async fn invalidate_token(&self) -> Result<()> {
-        *self.token.lock().await = None;
-        Ok(())
-    }
-
-    /// Invalidate the current token and set a new one. Generates a new token before invalidating
-    /// the current token, meaning the old token will be used until this function acquires the lock
-    /// and overwrites the token.
-    ///
-    /// If credential is invalid, or the request fails, this method will return an error and leave
-    /// the current token unchanged.
-    pub(crate) async fn regenerate_token(&self) -> Result<()> {
-        let new_token = self.exchange_credential_for_token().await?;
-        *self.token.lock().await = Some(new_token.clone());
-        Ok(())
-    }
-
-    /// Authenticates the request by adding a bearer token to the authorization header.
-    ///
-    /// This method supports three authentication modes:
-    ///
-    /// 1. **No authentication** - Skip authentication when both `credential` and `token` are missing.
-    /// 2. **Token authentication** - Use the provided `token` directly for authentication.
-    /// 3. **OAuth authentication** - Exchange `credential` for a token, cache it, then use it for authentication.
-    ///
-    /// When both `credential` and `token` are present, `token` takes precedence.
-    ///
-    /// # TODO: Support automatic token refreshing.
-    async fn authenticate(&self, req: &mut Request) -> Result<()> {
-        // Clone the token from lock without holding the lock for entire function.
-        let token = self.token.lock().await.clone();
-
-        if self.credential.is_none() && token.is_none() {
-            return Ok(());
-        }
-
-        // Either use the provided token or exchange credential for token, cache and use that
-        let token = match token {
-            Some(token) => token,
-            None => {
-                let token = self.exchange_credential_for_token().await?;
-                // Update token so that we use it for next request instead of
-                // exchanging credential for token from the server again
-                *self.token.lock().await = Some(token.clone());
-                token
-            }
-        };
-
-        // Insert token in request.
-        req.headers_mut().insert(
-            http::header::AUTHORIZATION,
-            format!("Bearer {token}").parse().map_err(|e| {
-                Error::new(
-                    ErrorKind::DataInvalid,
-                    "Invalid token received from catalog server!",
-                )
-                .with_source(e)
-            })?,
-        );
-
-        Ok(())
+            .ok()?;
+        self.session
+            .authenticate(&mut AuthRequest::new(&mut request))
+            .await
+            .ok()?;
+        request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)?
+            .to_str()
+            .ok()?
+            .strip_prefix("Bearer ")
+            .map(str::to_string)
     }
 
     #[inline]
@@ -250,17 +136,16 @@ impl HttpClient {
             .headers(self.extra_headers.clone())
     }
 
-    /// Executes the given `Request` and returns a `Response`.
-    pub async fn execute(&self, mut request: Request) -> Result<Response> {
-        request.headers_mut().extend(self.extra_headers.clone());
-        Ok(self.client.execute(request).await?)
-    }
-
     // Queries the Iceberg REST catalog after authentication with the given `Request` and
     // returns a `Response`.
     pub async fn query_catalog(&self, mut request: Request) -> Result<Response> {
-        self.authenticate(&mut request).await?;
-        self.execute(request).await
+        // Authenticate first, then apply extra headers, so a configured
+        // `header.authorization` keeps overriding a token (unchanged behavior).
+        self.session
+            .authenticate(&mut AuthRequest::new(&mut request))
+            .await?;
+        request.headers_mut().extend(self.extra_headers.clone());
+        Ok(self.client.execute(request).await?)
     }
 
     /// Returns whether header redaction is disabled for this client.

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -179,11 +179,14 @@ impl HttpClient {
     /// Sends `request` to the Iceberg REST catalog, authenticated by this
     /// client's session.
     pub(crate) async fn query_catalog(&self, mut request: HttpRequest) -> Result<HttpResponse> {
-        // Authenticate first, then apply extra headers, so a configured
-        // `header.authorization` keeps overriding a token (unchanged behavior).
-        self.auth_session.authenticate(&mut request).await?;
-        let mut request = request.into_inner();
+        // Authenticate last: extending afterwards would let a configured
+        // `header.authorization` overwrite a SigV4 signature and send the
+        // request unsigned. A configured header still wins over a token,
+        // because the OAuth2 session only sets one when absent, as Java's
+        // `OAuth2Util.AuthSession` does.
         request.headers_mut().extend(self.extra_headers.clone());
+        self.auth_session.authenticate(&mut request).await?;
+        let request = request.into_inner();
         HttpResponse::read(self.client.execute(request).await?).await
     }
 

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -72,17 +72,15 @@ impl HttpClient {
     /// properties (carrying over state such as a cached token).
     pub async fn update_with(self, cfg: &RestCatalogConfig) -> Result<Self> {
         let HttpClient {
-            // The same client comes back from `cfg.client()` below: the config
-            // clone shares the lazily-created default (or the user's client).
+            // `cfg.client()` below returns this same shared client.
             client: _,
             extra_headers: current_headers,
             disable_header_redaction: _,
             auth_manager,
             session: init_session,
         } = self;
-        // Release the init-phase session before deriving the catalog session,
-        // so a manager whose init session guards a one-shot resource (released
-        // on drop) can build its catalog session without deadlocking.
+        // Release the init session first, so a manager whose init session
+        // guards a one-shot resource can build its catalog session.
         drop(init_session);
 
         let extra_headers = (!cfg.extra_headers()?.is_empty())
@@ -106,9 +104,9 @@ impl HttpClient {
 
     /// Testing only: the bearer token the current session would attach.
     ///
-    /// Authenticates a throwaway request (never sent — `authenticate` only
-    /// mutates it) and reads the header back, so this works for any
-    /// [`AuthSession`] without the trait carrying a test-only method.
+    /// Authenticates a throwaway request (never sent) and reads the header
+    /// back, so it works for any [`AuthSession`] without a test-only trait
+    /// method.
     #[cfg(test)]
     pub(crate) async fn token(&self) -> Option<String> {
         let mut request = self

--- a/crates/catalog/rest/src/lib.rs
+++ b/crates/catalog/rest/src/lib.rs
@@ -51,11 +51,13 @@
 
 #![deny(missing_docs)]
 
+mod auth;
 mod catalog;
 mod client;
 mod endpoint;
 mod types;
 
+pub use auth::*;
 pub use catalog::*;
 pub use endpoint::Endpoint;
 pub use types::*;

--- a/crates/catalog/rest/src/request.rs
+++ b/crates/catalog/rest/src/request.rs
@@ -43,6 +43,14 @@ impl HttpRequest {
         Ok(Self::new(builder.build()?))
     }
 
+    /// The wrapped request, for crate-internal consumers that need the
+    /// concrete client type (e.g. handing it to [`SigV4Signer::sign`]).
+    ///
+    /// [`SigV4Signer::sign`]: crate::SigV4Signer::sign
+    pub(crate) fn inner_mut(&mut self) -> &mut Request {
+        &mut self.inner
+    }
+
     /// The wrapped request, for the client that sends it.
     pub(crate) fn into_inner(self) -> Request {
         self.inner


### PR DESCRIPTION
  ## Which issue does this PR close?

  Follow-up to [#2838](https://github.com/apache/iceberg-rust/pull/2838), split from the [#2815](https://github.com/apache/iceberg-rust/pull/2815) prototype per review.

  ## What changes are included in this PR?

  SigV4 as a `SigV4AuthManager` wrapping a delegate auth manager, per [#2838](https://github.com/apache/iceberg-rust/pull/2838)'s design:

  - The delegate authenticates first (e.g. an OAuth2 bearer); its `Authorization` is relocated to `Original-Authorization` (Java convention) and included in the signature, then the request is SigV4-signed.
  - `SigV4Signer` follows AWS canonical-request rules with Java parity (path normalization + double encoding, all-headers-minus-blacklist, `IcebergRest`/`StandardAws` payload-hash modes).
  - Properties match Java's `AwsProperties` (`rest.signing-region`, `rest.signing-name` default `execute-api`, `rest.access-key-id`/`rest.secret-access-key`/`rest.session-token`, single-source credential resolution). Delegate defaults to `oauth2`; an injected signer is never rebuilt from server properties.

  Three behavior changes worth calling out, all for Java parity:

  -  Authentication is applied **after** the client's extra headers. Applying them afterwards would let a configured `header.authorization` overwrite the SigV4 signature and send the request unsigned; running auth last lets the session relocate that header to `Original-Authorization` and sign over it. A configured header still wins over an OAuth2 token, because that session only sets one when absent — as Java's`OAuth2Util.AuthSession` does.
  - A signer-generated header that conflicts with a caller's (`x-amz-date`, `x-amz-content-sha256`, `x-amz-security-token`) is relocated to `Original-*` rather than dropped, matching Java's `updateRequestHeaders`. Relocated values are marked sensitive.
  - The default client does not follow redirects when SigV4 is configured or an auth manager is injected: a signed request can't be transparently re-followed, and reqwest's cross-origin strip list doesn't know `Original-Authorization` or `x-amz-security-token`.
   - `rest.signing-region` falls back to `AWS_REGION`/`AWS_DEFAULT_REGION`, matching the credential properties below and Iceberg Java's default region resolution.