### PR TITLE
feat(catalog-rest): support vended storage credentials from REST responses

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
+use iceberg::io::{FileIO, FileIOBuilder, StorageCredential, StorageFactory};
 use iceberg::table::Table;
 use iceberg::{
     Catalog, CatalogBuilder, Error, ErrorKind, Namespace, NamespaceIdent, Result, Runtime,
@@ -340,6 +340,18 @@ impl RestCatalogConfig {
     }
 }
 
+/// Convert REST `storage-credentials` entries into core [`StorageCredential`]s
+/// that can be attached to a [`FileIO`] via its [`StorageConfig`](iceberg::io::StorageConfig).
+fn to_storage_credentials(
+    creds: Option<Vec<crate::types::StorageCredential>>,
+) -> Vec<StorageCredential> {
+    creds
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| StorageCredential::new(c.prefix, c.config))
+        .collect()
+}
+
 #[derive(Debug)]
 struct RestContext {
     client: HttpClient,
@@ -451,6 +463,7 @@ impl RestCatalog {
         &self,
         metadata_location: Option<&str>,
         extra_config: Option<HashMap<String, String>>,
+        credentials: Vec<StorageCredential>,
     ) -> Result<FileIO> {
         let mut props = self.context().await?.config.props.clone();
         if let Some(config) = extra_config {
@@ -483,7 +496,10 @@ impl RestCatalog {
                 )
             })?;
 
-        let file_io = FileIOBuilder::new(factory).with_props(props).build();
+        let file_io = FileIOBuilder::new(factory)
+            .with_props(props)
+            .with_storage_credentials(credentials)
+            .build();
 
         Ok(file_io)
     }
@@ -791,6 +807,7 @@ impl Catalog for RestCatalog {
             "Metadata location missing in `create_table` response!",
         ))?;
 
+        let credentials = to_storage_credentials(response.storage_credentials);
         let config = response
             .config
             .into_iter()
@@ -798,7 +815,7 @@ impl Catalog for RestCatalog {
             .collect();
 
         let file_io = self
-            .load_file_io(Some(metadata_location), Some(config))
+            .load_file_io(Some(metadata_location), Some(config), credentials)
             .await?;
 
         let table_builder = Table::builder()
@@ -848,6 +865,7 @@ impl Catalog for RestCatalog {
             }
         };
 
+        let credentials = to_storage_credentials(response.storage_credentials);
         let config = response
             .config
             .into_iter()
@@ -855,7 +873,11 @@ impl Catalog for RestCatalog {
             .collect();
 
         let file_io = self
-            .load_file_io(response.metadata_location.as_deref(), Some(config))
+            .load_file_io(
+                response.metadata_location.as_deref(),
+                Some(config),
+                credentials,
+            )
             .await?;
 
         let table_builder = Table::builder()
@@ -991,7 +1013,10 @@ impl Catalog for RestCatalog {
             "Metadata location missing in `register_table` response!",
         ))?;
 
-        let file_io = self.load_file_io(Some(metadata_location), None).await?;
+        let credentials = to_storage_credentials(response.storage_credentials);
+        let file_io = self
+            .load_file_io(Some(metadata_location), None, credentials)
+            .await?;
 
         Table::builder()
             .identifier(table_ident.clone())
@@ -1063,7 +1088,7 @@ impl Catalog for RestCatalog {
         };
 
         let file_io = self
-            .load_file_io(Some(&response.metadata_location), None)
+            .load_file_io(Some(&response.metadata_location), None, Vec::new())
             .await?;
 
         Table::builder()
@@ -2344,6 +2369,71 @@ mod tests {
 
         config_mock.assert_async().await;
         rename_table_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_load_table_applies_storage_credentials() {
+        let mut server = Server::new_async().await;
+
+        let config_mock = create_config_mock(&mut server).await;
+
+        // Inject a `storage-credentials` entry into the standard load-table response.
+        let mut body: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(format!(
+                "{}/testdata/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "load_table_response.json"
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        body["storage-credentials"] = json!([
+            {
+                "prefix": "s3://warehouse/database/table",
+                "config": {
+                    "s3.access-key-id": "VENDED_KEY",
+                    "s3.secret-access-key": "VENDED_SECRET",
+                    "s3.session-token": "VENDED_TOKEN"
+                }
+            }
+        ]);
+
+        let load_mock = server
+            .mock("GET", "/v1/namespaces/ns1/tables/test1")
+            .with_status(200)
+            .with_body(body.to_string())
+            .create_async()
+            .await;
+
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder().uri(server.url()).build(),
+            Some(Arc::new(LocalFsStorageFactory)),
+            Runtime::current(),
+        );
+
+        let table = catalog
+            .load_table(&TableIdent::new(
+                NamespaceIdent::new("ns1".to_string()),
+                "test1".to_string(),
+            ))
+            .await
+            .unwrap();
+
+        // The vended credential is carried on the table's FileIO config.
+        let creds = table.file_io().config().credentials();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].prefix, "s3://warehouse/database/table");
+
+        // And it is applied (wins) when resolving props for a data file under the prefix.
+        let resolved = table
+            .file_io()
+            .config()
+            .resolved_props("s3://warehouse/database/table/data/0.parquet");
+        assert_eq!(resolved.get("s3.access-key-id").unwrap(), "VENDED_KEY");
+        assert_eq!(resolved.get("s3.session-token").unwrap(), "VENDED_TOKEN");
+
+        config_mock.assert_async().await;
+        load_mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -22,7 +22,8 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt};
 
 use super::storage::{
-    LocalFsStorageFactory, MemoryStorageFactory, Storage, StorageConfig, StorageFactory,
+    LocalFsStorageFactory, MemoryStorageFactory, Storage, StorageConfig, StorageCredential,
+    StorageFactory,
 };
 use crate::Result;
 
@@ -216,6 +217,12 @@ impl FileIOBuilder {
         self.config = self
             .config
             .with_props(args.into_iter().map(|e| (e.0.to_string(), e.1.to_string())));
+        self
+    }
+
+    /// Attach per-prefix storage credentials (e.g. vended by a REST catalog).
+    pub fn with_storage_credentials(mut self, credentials: Vec<StorageCredential>) -> Self {
+        self.config = self.config.with_credentials(credentials);
         self
     }
 

--- a/crates/iceberg/src/io/storage/config/mod.rs
+++ b/crates/iceberg/src/io/storage/config/mod.rs
@@ -45,6 +45,30 @@ pub use oss::*;
 pub use s3::*;
 use serde::{Deserialize, Serialize};
 
+/// A storage credential scoped to a location prefix.
+///
+/// This mirrors the `storage-credentials` entries returned by an Iceberg REST
+/// catalog (see the REST spec). Each credential applies to objects whose path
+/// starts with `prefix`; when several credentials match a path, the one with
+/// the longest prefix should be preferred.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StorageCredential {
+    /// Storage location prefix this credential applies to (e.g. `s3://bucket/db/table`).
+    pub prefix: String,
+    /// Backend configuration carrying the credential (e.g. `s3.access-key-id`, ...).
+    pub config: HashMap<String, String>,
+}
+
+impl StorageCredential {
+    /// Create a new storage credential for the given location prefix.
+    pub fn new(prefix: impl Into<String>, config: HashMap<String, String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            config,
+        }
+    }
+}
+
 /// Configuration properties for storage backends.
 ///
 /// This struct contains only configuration properties without specifying
@@ -55,6 +79,9 @@ use serde::{Deserialize, Serialize};
 pub struct StorageConfig {
     /// Configuration properties for the storage backend
     props: HashMap<String, String>,
+    /// Per-prefix storage credentials, typically vended by a catalog.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    credentials: Vec<StorageCredential>,
 }
 
 impl StorageConfig {
@@ -62,6 +89,7 @@ impl StorageConfig {
     pub fn new() -> Self {
         Self {
             props: HashMap::new(),
+            credentials: Vec::new(),
         }
     }
 
@@ -71,12 +99,50 @@ impl StorageConfig {
     ///
     /// * `props` - Configuration properties for the storage backend
     pub fn from_props(props: HashMap<String, String>) -> Self {
-        Self { props }
+        Self {
+            props,
+            credentials: Vec::new(),
+        }
     }
 
     /// Get all configuration properties.
     pub fn props(&self) -> &HashMap<String, String> {
         &self.props
+    }
+
+    /// Get the per-prefix storage credentials.
+    pub fn credentials(&self) -> &[StorageCredential] {
+        &self.credentials
+    }
+
+    /// Attach per-prefix storage credentials (e.g. vended by a REST catalog).
+    ///
+    /// This is a builder-style method that returns `self` for chaining.
+    pub fn with_credentials(mut self, credentials: Vec<StorageCredential>) -> Self {
+        self.credentials = credentials;
+        self
+    }
+
+    /// Resolve the most specific credential for `location`.
+    ///
+    /// Returns the credential whose `prefix` is the longest match for the given
+    /// location, mirroring the selection rule from the Iceberg REST spec. Returns
+    /// `None` when no credential prefix matches.
+    pub fn resolve_credential(&self, location: &str) -> Option<&StorageCredential> {
+        self.credentials
+            .iter()
+            .filter(|c| location.starts_with(&c.prefix))
+            .max_by_key(|c| c.prefix.len())
+    }
+
+    /// Build the effective property map for `location`: base props overlaid with
+    /// the most specific matching credential's config (credential wins, per spec).
+    pub fn resolved_props(&self, location: &str) -> HashMap<String, String> {
+        let mut props = self.props.clone();
+        if let Some(cred) = self.resolve_credential(location) {
+            props.extend(cred.config.clone());
+        }
+        props
     }
 
     /// Get a specific configuration property by key.
@@ -222,6 +288,62 @@ mod tests {
         let config = StorageConfig::from_props(HashMap::new());
 
         assert!(config.props().is_empty());
+    }
+
+    #[test]
+    fn test_resolve_credential_longest_prefix_wins() {
+        let config = StorageConfig::new().with_credentials(vec![
+            StorageCredential::new(
+                "s3://bucket",
+                HashMap::from([("s3.access-key-id".to_string(), "broad".to_string())]),
+            ),
+            StorageCredential::new(
+                "s3://bucket/db/table",
+                HashMap::from([("s3.access-key-id".to_string(), "specific".to_string())]),
+            ),
+        ]);
+
+        let cred = config
+            .resolve_credential("s3://bucket/db/table/data/0.parquet")
+            .expect("a credential should match");
+        assert_eq!(cred.prefix, "s3://bucket/db/table");
+        assert_eq!(cred.config.get("s3.access-key-id").unwrap(), "specific");
+
+        // A path only under the broad prefix falls back to it.
+        let cred = config
+            .resolve_credential("s3://bucket/other/file.parquet")
+            .unwrap();
+        assert_eq!(cred.prefix, "s3://bucket");
+    }
+
+    #[test]
+    fn test_resolve_credential_no_match() {
+        let config = StorageConfig::new().with_credentials(vec![StorageCredential::new(
+            "s3://bucket-a",
+            HashMap::from([("s3.access-key-id".to_string(), "a".to_string())]),
+        )]);
+
+        assert!(config.resolve_credential("s3://bucket-b/x").is_none());
+    }
+
+    #[test]
+    fn test_resolved_props_credential_overrides_base() {
+        let config = StorageConfig::new()
+            .with_prop("s3.region", "us-east-1")
+            .with_prop("s3.access-key-id", "base")
+            .with_credentials(vec![StorageCredential::new(
+                "s3://bucket",
+                HashMap::from([("s3.access-key-id".to_string(), "vended".to_string())]),
+            )]);
+
+        let props = config.resolved_props("s3://bucket/db/table/data/0.parquet");
+        // Credential wins over base for the same key, base-only keys are preserved.
+        assert_eq!(props.get("s3.access-key-id").unwrap(), "vended");
+        assert_eq!(props.get("s3.region").unwrap(), "us-east-1");
+
+        // No matching credential: base props returned unchanged.
+        let props = config.resolved_props("gs://other/file");
+        assert_eq!(props.get("s3.access-key-id").unwrap(), "base");
     }
 
     #[test]

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -27,7 +27,7 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 use iceberg::io::{
     FileMetadata, FileRead, FileWrite, InputFile, OutputFile, Storage, StorageConfig,
-    StorageFactory,
+    StorageCredential, StorageFactory,
 };
 use iceberg::{Error, ErrorKind, Result};
 use serde::{Deserialize, Serialize};
@@ -188,6 +188,7 @@ impl StorageFactory for OpenDalResolvingStorageFactory {
     fn build(&self, config: &StorageConfig) -> Result<Arc<dyn Storage>> {
         Ok(Arc::new(OpenDalResolvingStorage {
             props: config.props().clone(),
+            credentials: config.credentials().to_vec(),
             storages: RwLock::new(HashMap::new()),
             #[cfg(feature = "opendal-s3")]
             customized_credential_load: self.customized_credential_load.clone(),
@@ -205,9 +206,16 @@ impl StorageFactory for OpenDalResolvingStorageFactory {
 pub struct OpenDalResolvingStorage {
     /// Configuration properties shared across all backends.
     props: HashMap<String, String>,
-    /// Cache of canonical scheme to storage mappings.
+    /// Per-prefix storage credentials (e.g. vended by a REST catalog).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    credentials: Vec<StorageCredential>,
+    /// Cache of resolution-key to storage mappings.
+    ///
+    /// The key is the canonical scheme when no credential matches, or the matched
+    /// credential prefix otherwise, so that different prefixes (with different
+    /// vended credentials) under the same scheme get distinct storage instances.
     #[serde(skip, default)]
-    storages: RwLock<HashMap<&'static str, Arc<OpenDalStorage>>>,
+    storages: RwLock<HashMap<String, Arc<OpenDalStorage>>>,
     /// Custom AWS credential loader for S3 storage.
     #[cfg(feature = "opendal-s3")]
     #[serde(skip)]
@@ -215,10 +223,26 @@ pub struct OpenDalResolvingStorage {
 }
 
 impl OpenDalResolvingStorage {
-    /// Resolve the storage for the given path by extracting the canonical scheme and
-    /// returning the cached or newly-created [`OpenDalStorage`].
+    /// Select the most specific (longest-prefix) credential matching `path`.
+    fn resolve_credential(&self, path: &str) -> Option<&StorageCredential> {
+        self.credentials
+            .iter()
+            .filter(|c| path.starts_with(&c.prefix))
+            .max_by_key(|c| c.prefix.len())
+    }
+
+    /// Resolve the storage for the given path by extracting the canonical scheme,
+    /// overlaying any matching vended credential, and returning the cached or
+    /// newly-created [`OpenDalStorage`].
     fn resolve(&self, path: &str) -> Result<Arc<OpenDalStorage>> {
         let scheme = extract_scheme(path)?;
+        let credential = self.resolve_credential(path);
+
+        // Cache key: matched credential prefix (most specific) or the scheme.
+        let cache_key = match credential {
+            Some(cred) => format!("{scheme}\u{0}{}", cred.prefix),
+            None => scheme.to_string(),
+        };
 
         // Fast path: check read lock first.
         {
@@ -226,7 +250,7 @@ impl OpenDalResolvingStorage {
                 .storages
                 .read()
                 .map_err(|_| Error::new(ErrorKind::Unexpected, "Storage cache lock poisoned"))?;
-            if let Some(storage) = cache.get(&scheme) {
+            if let Some(storage) = cache.get(&cache_key) {
                 return Ok(storage.clone());
             }
         }
@@ -238,18 +262,29 @@ impl OpenDalResolvingStorage {
             .map_err(|_| Error::new(ErrorKind::Unexpected, "Storage cache lock poisoned"))?;
 
         // Double-check after acquiring write lock.
-        if let Some(storage) = cache.get(&scheme) {
+        if let Some(storage) = cache.get(&cache_key) {
             return Ok(storage.clone());
         }
 
+        // Overlay the matching credential's config over the base props (credential
+        // wins, per the Iceberg REST spec preference for `storage-credentials`).
+        let props = match credential {
+            Some(cred) => {
+                let mut merged = self.props.clone();
+                merged.extend(cred.config.clone());
+                merged
+            }
+            None => self.props.clone(),
+        };
+
         let storage = build_storage_for_scheme(
             scheme,
-            &self.props,
+            &props,
             #[cfg(feature = "opendal-s3")]
             &self.customized_credential_load,
         )?;
         let storage = Arc::new(storage);
-        cache.insert(scheme, storage.clone());
+        cache.insert(cache_key, storage.clone());
         Ok(storage)
     }
 }
@@ -331,10 +366,74 @@ mod tests {
     fn empty_resolving_storage() -> OpenDalResolvingStorage {
         OpenDalResolvingStorage {
             props: HashMap::new(),
+            credentials: Vec::new(),
             storages: RwLock::new(HashMap::new()),
             #[cfg(feature = "opendal-s3")]
             customized_credential_load: None,
         }
+    }
+
+    #[cfg(feature = "opendal-s3")]
+    fn resolving_storage_with_credentials(
+        credentials: Vec<StorageCredential>,
+    ) -> OpenDalResolvingStorage {
+        OpenDalResolvingStorage {
+            props: HashMap::from([("s3.region".to_string(), "us-east-1".to_string())]),
+            credentials,
+            storages: RwLock::new(HashMap::new()),
+            customized_credential_load: None,
+        }
+    }
+
+    #[cfg(feature = "opendal-s3")]
+    #[test]
+    fn test_resolve_distinct_credentials_yield_distinct_storages() {
+        let storage = resolving_storage_with_credentials(vec![
+            StorageCredential::new(
+                "s3://bucket/db/t1",
+                HashMap::from([
+                    ("s3.access-key-id".to_string(), "k1".to_string()),
+                    ("s3.secret-access-key".to_string(), "s1".to_string()),
+                ]),
+            ),
+            StorageCredential::new(
+                "s3://bucket/db/t2",
+                HashMap::from([
+                    ("s3.access-key-id".to_string(), "k2".to_string()),
+                    ("s3.secret-access-key".to_string(), "s2".to_string()),
+                ]),
+            ),
+        ]);
+
+        let t1_a = storage.resolve("s3://bucket/db/t1/data/0.parquet").unwrap();
+        let t1_b = storage.resolve("s3://bucket/db/t1/data/1.parquet").unwrap();
+        let t2 = storage.resolve("s3://bucket/db/t2/data/0.parquet").unwrap();
+
+        // Same credential prefix -> shared cached storage.
+        assert!(
+            Arc::ptr_eq(&t1_a, &t1_b),
+            "paths under the same credential prefix should share a storage"
+        );
+        // Different credential prefix -> distinct storage instances.
+        assert!(
+            !Arc::ptr_eq(&t1_a, &t2),
+            "paths under different credential prefixes must not share a storage"
+        );
+    }
+
+    #[cfg(feature = "opendal-s3")]
+    #[test]
+    fn test_resolve_no_credential_falls_back_to_scheme_sharing() {
+        // With credentials present but a path that matches none, resolution falls
+        // back to scheme-level sharing (keyed by scheme, not prefix).
+        let storage = resolving_storage_with_credentials(vec![StorageCredential::new(
+            "s3://bucket/db/t1",
+            HashMap::from([("s3.access-key-id".to_string(), "k1".to_string())]),
+        )]);
+
+        let other_a = storage.resolve("s3://other/x.parquet").unwrap();
+        let other_b = storage.resolve("s3://other/y.parquet").unwrap();
+        assert!(Arc::ptr_eq(&other_a, &other_b));
     }
 
     #[cfg(feature = "opendal-s3")]


### PR DESCRIPTION
## Which issue does this PR close?

Prerequisite for #1690 (client support for server-side REST scan planning).

## What changes are included in this PR?

First-class support for the `storage-credentials` a REST catalog can vend, so
table reads use catalog-provided, per-location credentials instead of relying
only on static FileIO properties.

## Design

```
GET/POST → REST response carries `storage-credentials`
              [{ prefix: "s3://bucket/db/tbl", config: { <creds...> } }, ...]
                         │
   RestCatalog parses them ─► FileIOBuilder::with_storage_credentials(..)
                         │
   StorageConfig { props, credentials: Vec<StorageCredential> }
                         │  resolve_credential(location): longest-prefix match
                         ▼
   OpenDalResolvingStorageFactory picks the matching credential per object path
   at read time → builds the Operator with those creds
```

### Components

- **`StorageConfig`** now holds per-prefix `StorageCredential`s and exposes
  `resolve_credential(location)` (longest-prefix match) and `resolved_props(location)`.
- **`FileIOBuilder::with_storage_credentials`** attaches vended credentials to a
  `FileIO`.
- **`OpenDalResolvingStorageFactory`** selects the right credential for each
  object path when constructing the backend, so a single `FileIO` can span
  multiple credential prefixes.
- **REST catalog** parses `storage-credentials` from `LoadTableResult` and wires
  them into the table's `FileIO`.

### Why this is a prerequisite for scan planning

Server-side scan planning returns data files whose access is authorized by
credentials the server vends (in the load-table response and/or the scan-plan
response). The scan-planning client reads those files through a `FileIO` built
with `with_storage_credentials` + the resolving factory introduced here, so this
credential plumbing lands first as a standalone, independently-reviewable change.

## Are these changes tested?

Yes — unit tests for `StorageConfig` credential resolution (longest-prefix),
the resolving storage factory, and a REST-catalog test asserting `load_table`
attaches vended `storage-credentials` to the table `FileIO`.
