### PR TITLE
chore(ci): pin crates-io-auth-action to v1.0.4 with matching version comment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 
-      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
       - name: Publish crates


### PR DESCRIPTION
The `zizmor` CI audit fails with `ref-version-mismatch` on `.github/workflows/publish.yml`:

```
warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> ./.github/workflows/publish.yml:53
     - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
       is pointed to by tag v1.0.3
```

The pinned SHA `b7e9a28e` corresponds to tag `v1.0.3`, but the comment says `# v1` (the floating tag), so the comment and the pinned commit disagree.

This bumps the pin to `v1.0.4` (`bbd81622f20ce9e2dd9622e3218b975523e45bbe`) and makes the version comment match the pinned commit (from [ASF actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml))
