### PR TITLE
feat(transaction): default expiry to history.expire.* table properties

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2705,7 +2705,10 @@ pub iceberg::spec::TableProperties::commit_total_retry_timeout_ms: u64
 pub iceberg::spec::TableProperties::encryption_data_key_length: usize
 pub iceberg::spec::TableProperties::encryption_key_id: core::option::Option<alloc::string::String>
 pub iceberg::spec::TableProperties::gc_enabled: bool
+pub iceberg::spec::TableProperties::max_ref_age_ms: i64
+pub iceberg::spec::TableProperties::max_snapshot_age_ms: i64
 pub iceberg::spec::TableProperties::metadata_compression_codec: iceberg::compression::CompressionCodec
+pub iceberg::spec::TableProperties::min_snapshots_to_keep: usize
 pub iceberg::spec::TableProperties::write_datafusion_fanout_enabled: bool
 pub iceberg::spec::TableProperties::write_format_default: alloc::string::String
 pub iceberg::spec::TableProperties::write_target_file_size_bytes: usize
@@ -2735,10 +2738,16 @@ pub const iceberg::spec::TableProperties::PROPERTY_ENCRYPTION_KEY_ID: &str
 pub const iceberg::spec::TableProperties::PROPERTY_FORMAT_VERSION: &str
 pub const iceberg::spec::TableProperties::PROPERTY_GC_ENABLED: &str
 pub const iceberg::spec::TableProperties::PROPERTY_GC_ENABLED_DEFAULT: bool
+pub const iceberg::spec::TableProperties::PROPERTY_MAX_REF_AGE_MS: &str
+pub const iceberg::spec::TableProperties::PROPERTY_MAX_REF_AGE_MS_DEFAULT: i64
+pub const iceberg::spec::TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS: &str
+pub const iceberg::spec::TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS_DEFAULT: i64
 pub const iceberg::spec::TableProperties::PROPERTY_METADATA_COMPRESSION_CODEC: &str
 pub const iceberg::spec::TableProperties::PROPERTY_METADATA_COMPRESSION_CODEC_DEFAULT: &str
 pub const iceberg::spec::TableProperties::PROPERTY_METADATA_PREVIOUS_VERSIONS_MAX: &str
 pub const iceberg::spec::TableProperties::PROPERTY_METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT: usize
+pub const iceberg::spec::TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP: &str
+pub const iceberg::spec::TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP_DEFAULT: usize
 pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_ENABLED: &str
 pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_ENABLED_DEFAULT: bool
 pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_MAX_CHUNK_SIZE: &str

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -119,6 +119,12 @@ pub struct TableProperties {
     /// Whether garbage collection is enabled on drop.
     /// When `false`, data files will not be deleted when a table is dropped.
     pub gc_enabled: bool,
+    /// Default maximum age of a snapshot to keep when expiring snapshots.
+    pub max_snapshot_age_ms: i64,
+    /// Default minimum number of snapshots to keep per branch when expiring snapshots.
+    pub min_snapshots_to_keep: usize,
+    /// Default maximum age of a snapshot reference to keep when expiring snapshots.
+    pub max_ref_age_ms: i64,
     /// Whether content-defined chunking is enabled.
     /// `true` only when `write.parquet.content-defined-chunking.enabled = "true"`.
     pub cdc_enabled: bool,
@@ -239,6 +245,19 @@ impl TableProperties {
     /// Default value for gc.enabled
     pub const PROPERTY_GC_ENABLED_DEFAULT: bool = true;
 
+    /// Property key for the default maximum age of a snapshot to keep when expiring snapshots.
+    pub const PROPERTY_MAX_SNAPSHOT_AGE_MS: &str = "history.expire.max-snapshot-age-ms";
+    /// Default value for history.expire.max-snapshot-age-ms (5 days).
+    pub const PROPERTY_MAX_SNAPSHOT_AGE_MS_DEFAULT: i64 = 5 * 24 * 60 * 60 * 1000;
+    /// Property key for the default minimum number of snapshots to keep when expiring snapshots.
+    pub const PROPERTY_MIN_SNAPSHOTS_TO_KEEP: &str = "history.expire.min-snapshots-to-keep";
+    /// Default value for history.expire.min-snapshots-to-keep.
+    pub const PROPERTY_MIN_SNAPSHOTS_TO_KEEP_DEFAULT: usize = 1;
+    /// Property key for the default maximum age of a snapshot reference to keep when expiring.
+    pub const PROPERTY_MAX_REF_AGE_MS: &str = "history.expire.max-ref-age-ms";
+    /// Default value for history.expire.max-ref-age-ms (effectively never expire refs).
+    pub const PROPERTY_MAX_REF_AGE_MS_DEFAULT: i64 = i64::MAX;
+
     /// Enable content-defined chunking with parquet defaults (or per-property overrides).
     pub const PROPERTY_PARQUET_CDC_ENABLED: &str = "write.parquet.content-defined-chunking.enabled";
     /// Default value for content-defined chunking enabled.
@@ -316,6 +335,21 @@ impl TryFrom<&HashMap<String, String>> for TableProperties {
                 TableProperties::PROPERTY_GC_ENABLED,
                 TableProperties::PROPERTY_GC_ENABLED_DEFAULT,
             )?,
+            max_snapshot_age_ms: parse_property(
+                props,
+                TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS,
+                TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS_DEFAULT,
+            )?,
+            min_snapshots_to_keep: parse_property(
+                props,
+                TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP,
+                TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP_DEFAULT,
+            )?,
+            max_ref_age_ms: parse_property(
+                props,
+                TableProperties::PROPERTY_MAX_REF_AGE_MS,
+                TableProperties::PROPERTY_MAX_REF_AGE_MS_DEFAULT,
+            )?,
             cdc_enabled: parse_property(
                 props,
                 TableProperties::PROPERTY_PARQUET_CDC_ENABLED,
@@ -386,6 +420,40 @@ mod tests {
             table_properties.gc_enabled,
             TableProperties::PROPERTY_GC_ENABLED_DEFAULT
         );
+        assert_eq!(
+            table_properties.max_snapshot_age_ms,
+            TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS_DEFAULT
+        );
+        assert_eq!(
+            table_properties.min_snapshots_to_keep,
+            TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP_DEFAULT
+        );
+        assert_eq!(
+            table_properties.max_ref_age_ms,
+            TableProperties::PROPERTY_MAX_REF_AGE_MS_DEFAULT
+        );
+    }
+
+    #[test]
+    fn test_table_properties_history_expire_overrides() {
+        let props = HashMap::from([
+            (
+                TableProperties::PROPERTY_MAX_SNAPSHOT_AGE_MS.to_string(),
+                "1234".to_string(),
+            ),
+            (
+                TableProperties::PROPERTY_MIN_SNAPSHOTS_TO_KEEP.to_string(),
+                "7".to_string(),
+            ),
+            (
+                TableProperties::PROPERTY_MAX_REF_AGE_MS.to_string(),
+                "5678".to_string(),
+            ),
+        ]);
+        let table_properties = TableProperties::try_from(&props).unwrap();
+        assert_eq!(table_properties.max_snapshot_age_ms, 1234);
+        assert_eq!(table_properties.min_snapshots_to_keep, 7);
+        assert_eq!(table_properties.max_ref_age_ms, 5678);
     }
 
     #[test]

--- a/crates/iceberg/src/transaction/expire_snapshots.rs
+++ b/crates/iceberg/src/transaction/expire_snapshots.rs
@@ -21,13 +21,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 
-use crate::spec::{MAIN_BRANCH, SnapshotReference, SnapshotRetention, TableMetadata};
+use crate::spec::{
+    MAIN_BRANCH, SnapshotReference, SnapshotRetention, TableMetadata, TableProperties,
+};
 use crate::table::Table;
 use crate::transaction::action::{ActionCommit, TransactionAction};
 use crate::{Error, ErrorKind, Result, TableRequirement, TableUpdate};
-
-/// Default number of most recent snapshots to retain per branch when none is specified.
-const DEFAULT_RETAIN_LAST: usize = 1;
 
 /// A transaction action that removes snapshots from table metadata.
 ///
@@ -38,14 +37,16 @@ const DEFAULT_RETAIN_LAST: usize = 1;
 /// Selection follows Java `RemoveSnapshots`:
 /// - Explicit ids ([`expire_snapshot_ids`](Self::expire_snapshot_ids)) and age-based expiry are
 ///   combined: a snapshot is expired if it is named explicitly *or* selected by age.
-/// - Age-based expiry uses [`expire_older_than_ms`](Self::expire_older_than_ms) as the cutoff, or a
-///   per-branch `max_snapshot_age_ms` for that branch. Without either, age expires nothing.
+/// - Age-based expiry always runs. The cutoff is [`expire_older_than_ms`](Self::expire_older_than_ms)
+///   when set, a per-branch `max_snapshot_age_ms` for that branch, otherwise
+///   `now - history.expire.max-snapshot-age-ms` (default 5 days), matching Java's constructor default.
 /// - Expiry is computed per branch along each branch's ancestry: each branch keeps its most recent
-///   [`retain_last`](Self::retain_last) snapshots (default 1, with a per-ref `min_snapshots_to_keep`
-///   overriding it) plus any ancestor newer than the cutoff, so a shared ancestor reachable from a
-///   retained branch is never expired.
+///   [`retain_last`](Self::retain_last) snapshots — defaulting to `history.expire.min-snapshots-to-keep`,
+///   with a per-ref `min_snapshots_to_keep` overriding both — plus any ancestor newer than the cutoff,
+///   so a shared ancestor reachable from a retained branch is never expired.
 /// - Refs are aged out first: a non-`main` branch or tag whose head is older than its
-///   `max_ref_age_ms` is removed, and snapshots only that ref retained then become expirable.
+///   `max_ref_age_ms` (defaulting to `history.expire.max-ref-age-ms`) is removed, and snapshots only
+///   that ref retained then become expirable.
 /// - Heads of retained refs (including the current snapshot) are never expired, and naming one
 ///   explicitly is an error, since
 ///   [`remove_snapshots`](crate::spec::TableMetadataBuilder::remove_snapshots) would otherwise
@@ -67,6 +68,11 @@ impl ExpireSnapshotsAction {
 
     /// Expire these snapshot ids in addition to any age-based selection.
     ///
+    /// Age-based expiry runs by default (see the type-level docs), so a call that only names ids
+    /// still expires snapshots older than `history.expire.max-snapshot-age-ms`. Pin
+    /// [`expire_older_than_ms`](Self::expire_older_than_ms) to a very old timestamp to expire by id
+    /// alone.
+    ///
     /// Ids accumulate across calls (like [`add_data_files`](crate::transaction::Transaction::fast_append)).
     /// An id that is still referenced by a branch or tag cannot be expired and causes
     /// [`commit`](TransactionAction::commit) to fail.
@@ -82,7 +88,7 @@ impl ExpireSnapshotsAction {
     }
 
     /// Keep at least the `retain_last` most recent snapshots of each branch when expiring by age
-    /// (defaults to 1, must be at least 1).
+    /// (defaults to the table's `history.expire.min-snapshots-to-keep`, must be at least 1).
     ///
     /// This only bounds the age cutoff; it does not protect snapshots named via
     /// [`expire_snapshot_ids`](Self::expire_snapshot_ids). Setting it to 0 makes
@@ -93,7 +99,7 @@ impl ExpireSnapshotsAction {
     }
 
     /// Resolves the snapshots and refs to remove, following Java `RemoveSnapshots.internalApply`.
-    fn plan(&self, table: &Table) -> Result<ExpirePlan> {
+    fn plan(&self, table: &Table, properties: &TableProperties) -> Result<ExpirePlan> {
         // Matches Java `RemoveSnapshots.retainLast`, which requires at least one snapshot.
         if self.retain_last == Some(0) {
             return Err(Error::new(
@@ -104,19 +110,23 @@ impl ExpireSnapshotsAction {
 
         let metadata = table.metadata();
         let now = Utc::now().timestamp_millis();
-        // TODO: default the cutoff to `now - history.expire.max-snapshot-age-ms` and `default_min`
-        // to `history.expire.min-snapshots-to-keep`. Until then, without an explicit cutoff or a
-        // per-ref `max_snapshot_age_ms` age-based expiry keeps every snapshot.
-        let default_cutoff = self.older_than_ms.unwrap_or(i64::MIN);
-        let default_min_to_keep = self.retain_last.unwrap_or(DEFAULT_RETAIN_LAST);
+        // When a knob is not set explicitly, fall back to the table's `history.expire.*` properties,
+        // matching Java `RemoveSnapshots`' constructor. With the default `max-snapshot-age-ms` (5
+        // days) the age path always runs, so even an explicit-id-only call applies the default cutoff.
+        let default_cutoff = self
+            .older_than_ms
+            .unwrap_or_else(|| now.saturating_sub(properties.max_snapshot_age_ms));
+        let default_min_to_keep = self.retain_last.unwrap_or(properties.min_snapshots_to_keep);
 
-        // Ref aging: `main` is always kept; any other ref whose head is older than its own
-        // `max_ref_age_ms` is dropped, like Java's `computeRetainedRefs`.
-        // TODO: age refs without their own window against `history.expire.max-ref-age-ms`.
+        // Ref aging: `main` is always kept; any other ref whose head is older than its
+        // `max_ref_age_ms` (defaulting to `history.expire.max-ref-age-ms`) is dropped, like Java's
+        // `computeRetainedRefs`.
         let mut removed_ref_names: Vec<String> = vec![];
         let mut retained_refs: Vec<&SnapshotReference> = vec![];
         for (ref_name, snapshot_ref) in &metadata.refs {
-            if ref_name == MAIN_BRANCH || !Self::ref_aged_out(metadata, snapshot_ref, now) {
+            if ref_name == MAIN_BRANCH
+                || !Self::ref_aged_out(metadata, snapshot_ref, now, properties.max_ref_age_ms)
+            {
                 retained_refs.push(snapshot_ref);
             } else {
                 removed_ref_names.push(ref_name.clone());
@@ -206,21 +216,23 @@ impl ExpireSnapshotsAction {
         })
     }
 
-    /// Whether a non-main ref should be dropped because its head is older than its own
-    /// `max_ref_age_ms`. Refs without a window are never aged out.
-    fn ref_aged_out(metadata: &TableMetadata, snapshot_ref: &SnapshotReference, now: i64) -> bool {
+    /// Whether a non-main ref should be dropped because its head is older than its `max_ref_age_ms`,
+    /// defaulting to `default_max_ref_age_ms` (`history.expire.max-ref-age-ms`) when the ref sets no
+    /// window of its own. The default `i64::MAX` effectively never ages a ref out.
+    fn ref_aged_out(
+        metadata: &TableMetadata,
+        snapshot_ref: &SnapshotReference,
+        now: i64,
+        default_max_ref_age_ms: i64,
+    ) -> bool {
         let max_ref_age_ms = match snapshot_ref.retention {
             SnapshotRetention::Branch { max_ref_age_ms, .. }
             | SnapshotRetention::Tag { max_ref_age_ms } => max_ref_age_ms,
-        };
-        match (
-            max_ref_age_ms,
-            metadata.snapshot_by_id(snapshot_ref.snapshot_id),
-        ) {
-            (Some(max_ref_age_ms), Some(snapshot)) => {
-                now.saturating_sub(snapshot.timestamp_ms()) > max_ref_age_ms
-            }
-            _ => false,
+        }
+        .unwrap_or(default_max_ref_age_ms);
+        match metadata.snapshot_by_id(snapshot_ref.snapshot_id) {
+            Some(snapshot) => now.saturating_sub(snapshot.timestamp_ms()) > max_ref_age_ms,
+            None => false,
         }
     }
 
@@ -287,16 +299,17 @@ struct ExpirePlan {
 impl TransactionAction for ExpireSnapshotsAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {
         let metadata = table.metadata();
+        let properties = metadata.table_properties()?;
 
         // Expiring metadata defeats a user's explicit decision to disable GC (Java refuses too).
-        if !metadata.table_properties()?.gc_enabled {
+        if !properties.gc_enabled {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 "Cannot expire snapshots: gc.enabled is false",
             ));
         }
 
-        let plan = self.plan(table)?;
+        let plan = self.plan(table, &properties)?;
 
         if plan.ids_to_remove.is_empty() && plan.refs_to_remove.is_empty() {
             return Ok(ActionCommit::new(vec![], vec![]));
@@ -351,6 +364,9 @@ mod tests {
     const CURRENT_SNAPSHOT: i64 = 3055729675574597004;
     // Well after the minimal table's last-updated-ms, so synthetic snapshots pass timestamp checks.
     const TS: i64 = 1_700_000_000_000;
+    // A cutoff at the epoch makes age-based expiry a no-op (every snapshot is newer), isolating the
+    // explicit-id behavior under test now that the default cutoff (`now - 5 days`) always runs.
+    const NO_AGE_EXPIRY: i64 = 0;
 
     fn action() -> ExpireSnapshotsAction {
         ExpireSnapshotsAction::new()
@@ -431,8 +447,22 @@ mod tests {
 
     /// Builds a table from synthetic snapshots and refs on top of an empty base.
     fn table_with(snapshots: Vec<Snapshot>, refs: Vec<(&str, SnapshotReference)>) -> Table {
+        table_with_props(snapshots, refs, HashMap::new())
+    }
+
+    /// Like [`table_with`], but also seeds table properties (e.g. `history.expire.*` defaults).
+    fn table_with_props(
+        snapshots: Vec<Snapshot>,
+        refs: Vec<(&str, SnapshotReference)>,
+        properties: HashMap<String, String>,
+    ) -> Table {
         let base = make_v2_minimal_table();
-        let mut builder = base.metadata().clone().into_builder(None);
+        let mut builder = base
+            .metadata()
+            .clone()
+            .into_builder(None)
+            .set_properties(properties)
+            .unwrap();
         for snapshot in snapshots {
             builder = builder.add_snapshot(snapshot).unwrap();
         }
@@ -445,7 +475,12 @@ mod tests {
     #[tokio::test]
     async fn test_expire_explicit_snapshot_id() {
         assert_eq!(
-            removed_ids(action().expire_snapshot_ids(vec![OLD_SNAPSHOT])).await,
+            removed_ids(
+                action()
+                    .expire_snapshot_ids(vec![OLD_SNAPSHOT])
+                    .expire_older_than_ms(NO_AGE_EXPIRY)
+            )
+            .await,
             vec![OLD_SNAPSHOT]
         );
     }
@@ -453,9 +488,13 @@ mod tests {
     #[tokio::test]
     async fn test_explicit_unknown_id_is_ignored() {
         assert!(
-            removed_ids(action().expire_snapshot_ids(vec![42]))
-                .await
-                .is_empty()
+            removed_ids(
+                action()
+                    .expire_snapshot_ids(vec![42])
+                    .expire_older_than_ms(NO_AGE_EXPIRY)
+            )
+            .await
+            .is_empty()
         );
     }
 
@@ -618,12 +657,13 @@ mod tests {
             vec![(MAIN_BRANCH, branch(3, None))],
         );
 
-        // Two separate calls both take effect.
+        // Two separate calls both take effect (age expiry pinned off to isolate accumulation).
         let removed = expired(
             &table,
             action()
                 .expire_snapshot_ids(vec![1])
-                .expire_snapshot_ids(vec![2]),
+                .expire_snapshot_ids(vec![2])
+                .expire_older_than_ms(NO_AGE_EXPIRY),
         )
         .await;
         assert_eq!(removed, vec![1, 2]);
@@ -866,5 +906,93 @@ mod tests {
         // ancestor 3.
         let removed = expired(&table, action()).await;
         assert_eq!(removed, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_default_cutoff_expires_snapshots_older_than_max_age() {
+        let now = Utc::now().timestamp_millis();
+        let day_ms = 24 * 60 * 60 * 1000;
+        let table = table_with(
+            vec![
+                snapshot(1, None, 35, now - 10 * day_ms), // older than the default 5-day cutoff
+                snapshot(2, Some(1), 36, now - 1000),     // recent
+            ],
+            vec![(MAIN_BRANCH, branch(2, None))],
+        );
+
+        // No explicit cutoff: defaults to now - history.expire.max-snapshot-age-ms (5 days).
+        let removed = expired(&table, action()).await;
+        assert_eq!(removed, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_min_snapshots_to_keep_property_is_the_default_floor() {
+        let table = table_with_props(
+            vec![
+                snapshot(1, None, 35, TS + 1),
+                snapshot(2, Some(1), 36, TS + 2),
+                snapshot(3, Some(2), 37, TS + 3),
+            ],
+            vec![(MAIN_BRANCH, branch(3, None))],
+            HashMap::from([(
+                "history.expire.min-snapshots-to-keep".to_string(),
+                "3".to_string(),
+            )]),
+        );
+
+        // The snapshots predate the default cutoff, but the table's min-snapshots-to-keep=3 keeps
+        // the whole chain.
+        let removed = expired(&table, action()).await;
+        assert!(removed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_max_snapshot_age_ms_property_sets_the_cutoff() {
+        let now = Utc::now().timestamp_millis();
+        let day_ms = 24 * 60 * 60 * 1000;
+        // Snapshot 1 is 2 days old: the built-in 5-day default would keep it, but the table's
+        // 1-day history.expire.max-snapshot-age-ms expires it. This pins the cutoff to the property
+        // value rather than the hardcoded default.
+        let table = table_with_props(
+            vec![
+                snapshot(1, None, 35, now - 2 * day_ms),
+                snapshot(2, Some(1), 36, now - 1000),
+            ],
+            vec![(MAIN_BRANCH, branch(2, None))],
+            HashMap::from([(
+                "history.expire.max-snapshot-age-ms".to_string(),
+                day_ms.to_string(),
+            )]),
+        );
+
+        let removed = expired(&table, action()).await;
+        assert_eq!(removed, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_max_ref_age_ms_property_ages_out_ref_without_its_own_window() {
+        let now = Utc::now().timestamp_millis();
+        let day_ms = 24 * 60 * 60 * 1000;
+        // `old-tag` sets no max_ref_age_ms of its own, so it ages against the table's
+        // history.expire.max-ref-age-ms (1 day); its head is 10 days old, so the tag is dropped.
+        // Set the tag before main so the builder's last-updated bookkeeping stays monotonic.
+        let table = table_with_props(
+            vec![
+                snapshot(1, None, 35, now - 10 * day_ms),
+                snapshot(2, None, 36, now - 1000),
+            ],
+            vec![("old-tag", tag(1, None)), (MAIN_BRANCH, branch(2, None))],
+            HashMap::from([(
+                "history.expire.max-ref-age-ms".to_string(),
+                day_ms.to_string(),
+            )]),
+        );
+
+        let updates = updates_of(&table, action()).await;
+        assert_eq!(removed_refs(&updates), vec!["old-tag".to_string()]);
+        // Once the tag is gone, snapshot 1 (unreferenced and well past the default cutoff) expires.
+        assert!(updates.iter().any(
+            |u| matches!(u, TableUpdate::RemoveSnapshots { snapshot_ids } if snapshot_ids == &[1])
+        ));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #2145.

## What changes are included in this PR?

Defaults snapshot expiry to the table's `history.expire.*` properties when the corresponding knob is not set explicitly, completing the default fallback that #2591 deferred (its `plan()` carried two `TODO`s for exactly this).

- `TableProperties` gains three fields (and their consts/defaults), in the same shape as the existing `commit.retry.*` properties:
  - `history.expire.max-snapshot-age-ms` (default 5 days)
  - `history.expire.min-snapshots-to-keep` (default 1)
  - `history.expire.max-ref-age-ms` (default `i64::MAX`, i.e. never)
- `ExpireSnapshotsAction::plan()` now mirrors Java `RemoveSnapshots`' constructor:
  - the age cutoff defaults to `now - max-snapshot-age-ms`, so age-based selection **always runs** even for an explicit-id-only call (only file cleanup, out of scope here, keys off an explicit id in Java);
  - `retain_last` defaults to `min-snapshots-to-keep`;
  - refs without their own `max_ref_age_ms` age out against `max-ref-age-ms` (default never).

Defaults and names mirror Java's `TableProperties` (`MAX_SNAPSHOT_AGE_MS_DEFAULT = 5 days`, `MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1`, `MAX_REF_AGE_MS_DEFAULT = Long.MAX_VALUE`).

## Are these changes tested?

Yes — unit tests in `expire_snapshots.rs` (27 total, up from 25). Two new tests cover the always-on default cutoff (a >5-day-old snapshot is expired with no args while a recent one is kept) and the `history.expire.min-snapshots-to-keep` floor (the whole chain is retained despite age). Explicit-id-only tests pin the cutoff off to isolate that behavior now that the default age path always runs. `public-api.txt` regenerated for the new public fields/consts; clippy and fmt are clean.
