### PR TITLE
ci: save Rust caches only from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -128,6 +130,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
@@ -162,6 +166,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build
         run: cargo build -p iceberg --no-default-features
@@ -192,6 +198,7 @@ jobs:
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.test-suite.name }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-nextest
         if: matrix.test-suite.name == 'default'

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a CI maintenance change based on observed GitHub Actions cache churn.

## What changes are included in this PR?

This keeps Rust cache restores enabled everywhere, but only saves new Rust caches from pushes to `main`.

For `pull_request` runs, GitHub creates caches under the PR merge ref (`refs/pull/.../merge`). Those caches have a narrow scope: they can help reruns of the same PR, but they cannot be restored by `main` or by other PRs. PRs can restore caches from their own scope and from the base/default branch, so the broadly useful caches are the ones saved from `main`.

In a recent cache audit, the repository cache was dominated by PR-scoped Rust caches while `main` had no large reusable Rust cache entries:

| Ref | Cache size |
| --- | ---: |
| `refs/pull/2667/merge` | ~7.9 GiB |
| `refs/pull/2668/merge` | ~6.3 GiB |
| `refs/heads/main` | ~34 KiB |

That churn has two costs:

| Cost | Impact |
| --- | --- |
| Cold PR builds after `main` caches are evicted | Keeping reusable `main` build caches is estimated to save roughly 2,000-2,500 GitHub Actions runner-minutes per week for the `CI / build` matrix alone. |
| PR cache uploads | In one recent successful PR run, this would have saved ~6.6 runner-minutes in the main `CI` workflow and ~10 seconds in the Public API workflow by skipping PR cache uploads. |

Concretely, this PR adds `save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}` to the existing `swatinem/rust-cache` steps in the main CI and Public API workflows.

## Are these changes tested?

- Not run locally; this is a GitHub Actions workflow-only change.
- The change uses the existing `swatinem/rust-cache` `save-if` option and does not alter the build, check, or test commands.
