### PR TITLE
ci: disable debuginfo and incremental in Rust CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
     strategy:
       max-parallel: 15
       matrix:
@@ -149,6 +152,9 @@ jobs:
   # optional functionality is properly gated behind feature flags.
   build_with_no_default_features:
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
     strategy:
       max-parallel: 15
       matrix:
@@ -174,6 +180,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
     strategy:
       max-parallel: 15
       matrix:
@@ -213,8 +222,6 @@ jobs:
       - name: Run tests
         shell: bash
         env:
-          # Disable debug info to speed up compilation and reduce artifact size
-          RUSTFLAGS: "-C debuginfo=0"
           # HuggingFace Hub integration tests self-skip when these are unset
           # (e.g. PRs from forks); see crates/storage/opendal/tests/file_io_hf_test.rs
           HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a CI maintenance change based on observed Rust build artifact size from debug info and incremental state.

## What changes are included in this PR?

This disables dev-profile debuginfo and incremental compilation for the Rust CI jobs where those artifacts do not provide practical value:

- `build`
- `build_with_no_default_features`
- `tests`

Concretely, this PR adds these job-level env vars:

```yaml
CARGO_PROFILE_DEV_DEBUG: "0"
CARGO_INCREMENTAL: "0"
```

It also removes the tests job's existing `RUSTFLAGS: "-C debuginfo=0"` override so debuginfo is disabled through the same Cargo profile mechanism across the affected jobs.

The `build` and `build_with_no_default_features` jobs are compile-verification jobs. They produce local Cargo outputs under `target/`, but those outputs are not uploaded, published, or consumed by the release publishing workflow. The `tests` job was already running without debuginfo, so this keeps the existing behavior while making the mechanism consistent.

In a local Linux A/B build, disabling both settings had the expected artifact-size impact:

| Metric | Baseline | With both env vars | Delta |
| --- | ---: | ---: | ---: |
| Wall time | 108s | 92s | -14.8% |
| `target/` size | 31 GiB | 6.5 GiB | -78.9% |

The wall-clock result is from a local Linux run, so it should not be read as a direct prediction for GitHub-hosted runners. The size result is the main motivation: smaller Rust build artifacts reduce pressure on the shared GitHub Actions cache budget.

Disabling incremental also avoids writing incremental state that is not useful for cold CI builds and is not cached by `swatinem/rust-cache`.

This also makes room for a follow-up cache improvement in the Python bindings CI. The maturin build is one of the largest remaining sources of CI runner demand, but caching its Rust artifacts needs enough cache budget headroom to be useful. Reducing the core Rust CI cache footprint first gives that follow-up a better chance of helping instead of immediately competing with oversized existing entries.

## Are these changes tested?

  - Not run locally; this is a GitHub Actions workflow-only change.
