### PR TITLE
chore(dev): bump iceberg-rest-fixture to 1.10.1

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -80,7 +80,7 @@ services:
   # REST Catalog - Apache Iceberg REST Catalog
   # =============================================================================
   rest:
-    image: apache/iceberg-rest-fixture:1.10.0
+    image: apache/iceberg-rest-fixture:1.10.1
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password


### PR DESCRIPTION
## What changes are included in this PR?

Bumps the integration-test REST catalog fixture in `dev/docker-compose.yaml`
from `1.10.0` to `1.10.1`, the latest published `apache/iceberg-rest-fixture`
release, so the integration tests run against the current patch fixture.

## Are these changes tested?

Covered by the existing Docker-based integration tests in CI.
