### PR TITLE
chore: Move dependency list generation from a release task to a PR author responsibility

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Dependencies
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/DEPENDENCIES.rust.tsv"
+      - ".github/workflows/dependencies.yml"
+
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/DEPENDENCIES.rust.tsv"
+      - ".github/workflows/dependencies.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_DENY_VERSION: "0.19.9"
+
+permissions: {}
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny@$CARGO_DENY_VERSION
+
+      - name: Generate dependency lists
+        run: dev/release/dependencies.sh generate
+
+      - name: Check dependency lists are up-to-date
+        run: |
+          if ! git diff --exit-code -- '**/DEPENDENCIES.rust.tsv'; then
+            echo ""
+            echo "ERROR: DEPENDENCIES.rust.tsv files are out of date."
+            echo "This CI check uses cargo-deny $CARGO_DENY_VERSION."
+            echo ""
+            echo "To fix this locally:"
+            echo "  cargo install --locked cargo-deny@$CARGO_DENY_VERSION"
+            echo "  dev/release/dependencies.sh generate"
+            echo ""
+            echo "Then commit the updated DEPENDENCIES.rust.tsv files."
+            exit 1
+          fi

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -3,210 +3,277 @@ abi_stable@0.11.3		X									X
 abi_stable_derive@0.11.3		X									X						
 abi_stable_shared@0.11.0		X									X						
 adler2@2.0.1	X	X									X						
+aead@0.5.2		X									X						
+aes@0.8.4		X									X						
+aes-gcm@0.10.3		X									X						
 ahash@0.8.12		X									X						
-aho-corasick@1.1.3											X				X		
+aho-corasick@1.1.4											X				X		
 alloc-no-stdlib@2.0.4					X												
 alloc-stdlib@0.2.2					X												
 allocator-api2@0.2.21		X									X						
 android_system_properties@0.1.5		X									X						
-anyhow@1.0.100		X									X						
+anstream@1.0.0		X									X						
+anstyle@1.0.14		X									X						
+anstyle-parse@1.0.0		X									X						
+anstyle-query@1.1.5		X									X						
+anstyle-wincon@3.0.11		X									X						
+anyhow@1.0.102		X									X						
 apache-avro@0.21.0		X															
-ar_archive_writer@0.2.0			X														
+approx@0.5.1		X															
+ar_archive_writer@0.5.1			X														
 array-init@2.1.0		X									X						
 arrayref@0.3.9				X													
 arrayvec@0.7.6		X									X						
-arrow@57.1.0		X															
-arrow-arith@57.1.0		X															
-arrow-array@57.1.0		X															
-arrow-buffer@57.1.0		X															
-arrow-cast@57.1.0		X															
-arrow-csv@57.1.0		X															
-arrow-data@57.1.0		X															
-arrow-ipc@57.1.0		X															
-arrow-json@57.1.0		X															
-arrow-ord@57.1.0		X															
-arrow-pyarrow@57.1.0		X															
-arrow-row@57.1.0		X															
-arrow-schema@57.1.0		X															
-arrow-select@57.1.0		X															
-arrow-string@57.1.0		X															
+arrow@58.1.0		X															
+arrow-arith@58.3.0		X															
+arrow-array@58.3.0		X									X						
+arrow-buffer@58.3.0		X															
+arrow-cast@58.3.0		X															
+arrow-csv@58.1.0		X															
+arrow-data@58.3.0		X															
+arrow-ipc@58.1.0		X															
+arrow-json@58.1.0		X															
+arrow-ord@58.3.0		X															
+arrow-pyarrow@58.3.0		X															
+arrow-row@58.1.0		X															
+arrow-schema@58.3.0		X															
+arrow-select@58.3.0		X															
+arrow-string@58.3.0		X															
 as-any@0.3.2		X									X						
 as_derive_utils@0.11.0		X									X						
-async-compression@0.4.36		X									X						
+async-compression@0.4.41		X									X						
 async-ffi@0.5.0											X						
-async-lock@3.4.1		X									X						
+async-lock@3.4.2		X									X						
 async-trait@0.1.89		X									X						
 atoi@2.0.0											X						
 atomic-waker@1.1.2		X									X						
 autocfg@1.5.0		X									X						
+aws-lc-rs@1.16.2		X							X								
+aws-lc-sys@0.39.0		X			X				X		X	X					
 backon@1.6.0		X															
 base64@0.22.1		X									X						
-bigdecimal@0.4.9		X									X						
+base64ct@1.8.3		X									X						
+bigdecimal@0.4.10		X									X						
 bimap@0.6.3		X									X						
-bitflags@2.10.0		X									X						
+bitflags@2.11.0		X									X						
 blake2@0.10.6		X									X						
-blake3@1.8.2		X	X				X										
+blake3@1.8.3		X	X				X										
 block-buffer@0.10.4		X									X						
+block-buffer@0.12.0		X									X						
+block-padding@0.3.3		X									X						
 bnum@0.12.1		X									X						
-bon@3.8.1		X									X						
-bon-macros@3.8.1		X									X						
+bon@3.9.1		X									X						
+bon-macros@3.9.1		X									X						
 brotli@8.0.2					X						X						
 brotli-decompressor@5.0.0					X						X						
-bumpalo@3.19.0		X									X						
-bytemuck@1.24.0		X									X					X	
+bstr@1.12.1		X									X						
+bumpalo@3.20.2		X									X						
+bytemuck@1.25.0		X									X					X	
+bytemuck_derive@1.10.2		X									X					X	
 byteorder@1.5.0											X				X		
-bytes@1.11.0											X						
+bytes@1.11.1											X						
 bzip2@0.6.1		X									X						
-cc@1.2.43		X									X						
+cbc@0.1.2		X									X						
+cc@1.2.57		X									X						
+cfg-if@0.1.10		X									X						
 cfg-if@1.0.4		X									X						
-chrono@0.4.42		X									X						
+chacha20@0.10.0		X									X						
+chrono@0.4.44		X									X						
 chrono-tz@0.10.4		X									X						
-comfy-table@7.1.2											X						
-compression-codecs@0.4.35		X									X						
+cipher@0.4.4		X									X						
+clap@4.6.0		X									X						
+clap_builder@4.6.0		X									X						
+clap_derive@4.6.0		X									X						
+clap_lex@1.1.0		X									X						
+cmake@0.1.57		X									X						
+colorchoice@1.0.5		X									X						
+colored@3.1.1													X				
+combine@4.6.7											X						
+comfy-table@7.2.2											X						
+compression-codecs@0.4.37		X									X						
 compression-core@0.4.31		X									X						
 concurrent-queue@2.5.0		X									X						
+const-oid@0.10.2		X									X						
 const-oid@0.9.6		X									X						
 const-random@0.1.18		X									X						
 const-random-macro@0.1.16		X									X						
+const-str@1.1.0											X						
 const_panic@0.2.15																X	
-constant_time_eq@0.3.1		X					X					X					
+constant_time_eq@0.4.2		X					X					X					
+core-foundation@0.10.1		X									X						
+core-foundation@0.9.4		X									X						
 core-foundation-sys@0.8.7		X									X						
 core_extensions@1.5.4		X									X						
 core_extensions_proc_macros@1.5.4		X									X						
+countio@0.3.0											X						
 cpufeatures@0.2.17		X									X						
+cpufeatures@0.3.0		X									X						
 crc32c@0.6.8		X									X						
 crc32fast@1.5.0		X									X						
 crossbeam-channel@0.5.15		X									X						
 crossbeam-epoch@0.9.18		X									X						
 crossbeam-utils@0.8.21		X									X						
 crunchy@0.2.4											X						
-crypto-common@0.1.6		X									X						
+crypto-common@0.1.7		X									X						
+crypto-common@0.2.2		X									X						
 csv@1.4.0											X				X		
 csv-core@0.1.13											X				X		
+ctor@0.6.3		X									X						
+ctor@1.0.7		X									X						
+ctor-proc-macro@0.0.7		X									X						
+ctr@0.9.2		X									X						
 darling@0.20.11											X						
-darling@0.21.3											X						
+darling@0.23.0											X						
 darling_core@0.20.11											X						
-darling_core@0.21.3											X						
+darling_core@0.23.0											X						
 darling_macro@0.20.11											X						
-darling_macro@0.21.3											X						
-dashmap@6.1.0											X						
-datafusion@52.2.0		X															
-datafusion-catalog@52.2.0		X															
-datafusion-catalog-listing@52.2.0		X															
-datafusion-common@52.2.0		X															
-datafusion-common-runtime@52.2.0		X															
-datafusion-datasource@52.2.0		X															
-datafusion-datasource-arrow@52.2.0		X															
-datafusion-datasource-csv@52.2.0		X															
-datafusion-datasource-json@52.2.0		X															
-datafusion-datasource-parquet@52.2.0		X															
-datafusion-doc@52.2.0		X															
-datafusion-execution@52.2.0		X															
-datafusion-expr@52.2.0		X															
-datafusion-expr-common@52.2.0		X															
-datafusion-ffi@52.1.0		X															
-datafusion-functions@52.2.0		X															
-datafusion-functions-aggregate@52.2.0		X															
-datafusion-functions-aggregate-common@52.2.0		X															
-datafusion-functions-nested@52.2.0		X															
-datafusion-functions-table@52.2.0		X															
-datafusion-functions-window@52.2.0		X															
-datafusion-functions-window-common@52.2.0		X															
-datafusion-macros@52.2.0		X															
-datafusion-optimizer@52.2.0		X															
-datafusion-physical-expr@52.2.0		X															
-datafusion-physical-expr-adapter@52.2.0		X															
-datafusion-physical-expr-common@52.2.0		X															
-datafusion-physical-optimizer@52.2.0		X															
-datafusion-physical-plan@52.2.0		X															
-datafusion-proto@52.1.0		X															
-datafusion-proto-common@52.1.0		X															
-datafusion-pruning@52.2.0		X															
-datafusion-session@52.2.0		X															
-datafusion-sql@52.2.0		X															
+darling_macro@0.23.0											X						
+dashmap@6.2.1											X						
+datafusion@53.1.0		X															
+datafusion-catalog@53.1.0		X															
+datafusion-catalog-listing@53.1.0		X															
+datafusion-common@53.1.0		X															
+datafusion-common-runtime@53.1.0		X															
+datafusion-datasource@53.1.0		X															
+datafusion-datasource-arrow@53.1.0		X															
+datafusion-datasource-csv@53.1.0		X															
+datafusion-datasource-json@53.1.0		X															
+datafusion-datasource-parquet@53.1.0		X															
+datafusion-doc@53.1.0		X															
+datafusion-execution@53.1.0		X															
+datafusion-expr@53.1.0		X															
+datafusion-expr-common@53.1.0		X															
+datafusion-ffi@53.1.0		X															
+datafusion-functions@53.1.0		X															
+datafusion-functions-aggregate@53.1.0		X															
+datafusion-functions-aggregate-common@53.1.0		X															
+datafusion-functions-nested@53.1.0		X															
+datafusion-functions-table@53.1.0		X															
+datafusion-functions-window@53.1.0		X															
+datafusion-functions-window-common@53.1.0		X															
+datafusion-macros@53.1.0		X															
+datafusion-optimizer@53.1.0		X															
+datafusion-physical-expr@53.1.0		X															
+datafusion-physical-expr-adapter@53.1.0		X															
+datafusion-physical-expr-common@53.1.0		X															
+datafusion-physical-optimizer@53.1.0		X															
+datafusion-physical-plan@53.1.0		X															
+datafusion-proto@53.1.0		X															
+datafusion-proto-common@53.1.0		X															
+datafusion-pruning@53.1.0		X															
+datafusion-session@53.1.0		X															
+datafusion-sql@53.1.0		X															
+der@0.7.10		X									X						
+deranged@0.5.8		X									X						
 derive_builder@0.20.2		X									X						
 derive_builder_core@0.20.2		X									X						
 derive_builder_macro@0.20.2		X									X						
 digest@0.10.7		X									X						
+digest@0.11.3		X									X						
+dirs@6.0.0		X									X						
+dirs-sys@0.5.0		X									X						
 displaydoc@0.2.5		X									X						
-dissimilar@1.0.10		X															
+dissimilar@1.0.11		X															
+dlv-list@0.5.2		X									X						
+dtor@0.1.1		X									X						
+dtor-proc-macro@0.0.6		X									X						
+dunce@1.0.5		X					X					X					
 either@1.15.0		X									X						
 equivalent@1.0.2		X									X						
-erased-serde@0.4.9		X									X						
+erased-serde@0.4.10		X									X						
 errno@0.3.14		X									X						
 event-listener@5.4.1		X									X						
 event-listener-strategy@0.5.4		X									X						
 expect-test@1.5.1		X									X						
 fastnum@0.7.4		X									X						
 fastrand@2.3.0		X									X						
-find-msvc-tools@0.1.4		X									X						
+find-msvc-tools@0.1.9		X									X						
 fixedbitset@0.5.7		X									X						
-flatbuffers@25.9.23		X															
-flate2@1.1.5		X									X						
+flatbuffers@25.12.19		X															
+flate2@1.1.9		X									X						
 fnv@1.0.7		X									X						
 foldhash@0.1.5																X	
 foldhash@0.2.0																X	
 form_urlencoded@1.2.2		X									X						
-futures@0.3.31		X									X						
-futures-channel@0.3.31		X									X						
-futures-core@0.3.31		X									X						
-futures-executor@0.3.31		X									X						
-futures-io@0.3.31		X									X						
-futures-macro@0.3.31		X									X						
-futures-sink@0.3.31		X									X						
-futures-task@0.3.31		X									X						
-futures-util@0.3.31		X									X						
+fs_extra@1.3.0											X						
+futures@0.3.32		X									X						
+futures-channel@0.3.32		X									X						
+futures-core@0.3.32		X									X						
+futures-executor@0.3.32		X									X						
+futures-io@0.3.32		X									X						
+futures-macro@0.3.32		X									X						
+futures-sink@0.3.32		X									X						
+futures-task@0.3.32		X									X						
+futures-util@0.3.32		X									X						
+gearhash@0.1.3		X									X						
 generational-arena@0.2.9													X				
-generic-array@0.14.9											X						
-getrandom@0.2.16		X									X						
+generic-array@0.14.7											X						
+getrandom@0.2.17		X									X						
 getrandom@0.3.4		X									X						
+getrandom@0.4.2		X									X						
+ghash@0.5.1		X									X						
+git-version@0.3.9				X													
+git-version-macro@0.3.9				X													
 glob@0.3.3		X									X						
 gloo-timers@0.3.0		X									X						
 half@2.7.1		X									X						
 hashbrown@0.14.5		X									X						
 hashbrown@0.15.5		X									X						
 hashbrown@0.16.1		X									X						
+hashbrown@0.17.1		X									X						
+heapify@0.2.0		X									X						
 heck@0.5.0		X									X						
 hex@0.4.3		X									X						
+hf-xet@1.5.2		X															
 hmac@0.12.1		X									X						
-home@0.5.11		X									X						
-http@1.3.1		X									X						
+http@1.4.0		X									X						
 http-body@1.0.1											X						
 http-body-util@0.1.3											X						
 httparse@1.10.1		X									X						
 humantime@2.3.0		X									X						
-hyper@1.7.0											X						
+hybrid-array@0.4.12		X									X						
+hyper@1.8.1											X						
 hyper-rustls@0.27.7		X							X		X						
-hyper-util@0.1.17											X						
-iana-time-zone@0.1.64		X									X						
+hyper-util@0.1.20											X						
+iana-time-zone@0.1.65		X									X						
 iana-time-zone-haiku@0.1.2		X									X						
 iceberg@0.9.0		X															
 iceberg-datafusion@0.9.0		X															
 iceberg-storage-opendal@0.9.0		X															
-icu_collections@2.1.0														X			
-icu_locale_core@2.1.0														X			
-icu_normalizer@2.1.0														X			
-icu_normalizer_data@2.1.0														X			
-icu_properties@2.1.0														X			
-icu_properties_data@2.1.0														X			
-icu_provider@2.1.0														X			
+iceberg_test_utils@0.9.0		X															
+icu_collections@2.1.1														X			
+icu_locale_core@2.1.1														X			
+icu_normalizer@2.1.1														X			
+icu_normalizer_data@2.1.1														X			
+icu_properties@2.1.2														X			
+icu_properties_data@2.1.2														X			
+icu_provider@2.1.1														X			
 ident_case@1.0.1		X									X						
 idna@1.1.0		X									X						
 idna_adapter@1.2.1		X									X						
-indexmap@2.12.1		X									X						
-indoc@2.0.7		X									X						
+indexmap@2.13.0		X									X						
+inout@0.1.4		X									X						
 integer-encoding@3.0.4											X						
 inventory@0.3.22		X									X						
-ipnet@2.11.0		X									X						
-iri-string@0.7.8		X									X						
+ipnet@2.12.0		X									X						
+iri-string@0.7.11		X									X						
+is_terminal_polyfill@1.70.2		X									X						
 itertools@0.13.0		X									X						
 itertools@0.14.0		X									X						
-itoa@1.0.15		X									X						
-jiff@0.2.16											X				X		
-jiff-tzdb@0.1.5											X				X		
+itoa@1.0.18		X									X						
+jiff@0.2.23											X				X		
+jiff-tzdb@0.1.6											X				X		
 jiff-tzdb-platform@0.1.3											X				X		
+jni@0.22.4		X									X						
+jni-macros@0.22.4		X									X						
+jni-sys@0.4.1		X									X						
+jni-sys-macros@0.4.1		X									X						
 jobserver@0.1.34		X									X						
-js-sys@0.3.82		X									X						
+js-sys@0.3.91		X									X						
+jsonwebtoken@10.3.0											X						
+konst@0.4.3																X	
+konst_proc_macros@0.4.1																X	
+lazy_static@1.5.0		X									X						
 lexical-core@1.0.6		X									X						
 lexical-parse-float@1.0.6		X									X						
 lexical-parse-integer@1.0.6		X									X						
@@ -214,92 +281,157 @@ lexical-util@1.0.7		X									X
 lexical-write-float@1.0.6		X									X						
 lexical-write-integer@1.0.6		X									X						
 libbz2-rs-sys@0.2.2																	X
-libc@0.2.177		X									X						
+libc@0.2.183		X									X						
 libloading@0.7.4									X								
-liblzma@0.4.5		X									X						
-liblzma-sys@0.4.4		X									X						
-libm@0.2.15											X						
-libz-rs-sys@0.5.2																X	
-linux-raw-sys@0.11.0		X	X								X						
+liblzma@0.4.6		X									X						
+liblzma-sys@0.4.5		X									X						
+libm@0.2.16											X						
+libredox@0.1.14											X						
+link-section@0.18.1		X									X						
+linktime-proc-macro@0.2.0		X									X						
+linux-raw-sys@0.12.1		X	X								X						
 litemap@0.8.1														X			
 lock_api@0.4.14		X									X						
-log@0.4.28		X									X						
-lz4_flex@0.12.0											X						
+log@0.4.29		X									X						
+lz4_flex@0.13.0											X						
+matchers@0.2.0											X						
 md-5@0.10.6		X									X						
-memchr@2.7.6											X				X		
-memoffset@0.9.1											X						
+md-5@0.11.0		X									X						
+mea@0.6.3		X															
+memchr@2.8.0											X				X		
 miniz_oxide@0.8.9		X									X					X	
-mio@1.1.0											X						
-moka@0.12.11		X									X						
+mio@1.2.0											X						
+moka@0.12.15		X									X						
+more-asserts@0.3.1		X					X				X				X		
 murmur3@0.5.2		X									X						
+ntapi@0.4.3		X									X						
+nu-ansi-term@0.50.3											X						
 num-bigint@0.4.6		X									X						
+num-bigint-dig@0.8.6		X									X						
 num-complex@0.4.6		X									X						
+num-conv@0.2.0		X									X						
 num-integer@0.1.46		X									X						
+num-iter@0.1.45		X									X						
 num-traits@0.2.19		X									X						
-object@0.32.2		X									X						
-object_store@0.12.4		X									X						
-once_cell@1.21.3		X									X						
-opendal@0.55.0		X															
+objc2-core-foundation@0.3.2		X									X					X	
+objc2-io-kit@0.3.2		X									X					X	
+objc2-system-configuration@0.3.2		X									X					X	
+object@0.37.3		X									X						
+object_store@0.13.2		X									X						
+once_cell@1.21.4		X									X						
+once_cell_polyfill@1.70.2		X									X						
+oneshot@0.1.13		X									X						
+opaque-debug@0.3.1		X									X						
+opendal@0.57.0		X															
+opendal-core@0.57.0		X															
+opendal-layer-concurrent-limit@0.57.0		X															
+opendal-layer-logging@0.57.0		X															
+opendal-layer-retry@0.57.0		X															
+opendal-layer-timeout@0.57.0		X															
+opendal-service-azdls@0.57.0		X															
+opendal-service-azure-common@0.57.0		X															
+opendal-service-fs@0.57.0		X															
+opendal-service-gcs@0.57.0		X															
+opendal-service-hf@0.57.0		X															
+opendal-service-oss@0.57.0		X															
+opendal-service-s3@0.57.0		X															
+openssl-probe@0.2.1		X									X						
+option-ext@0.2.0													X				
 ordered-float@2.10.1											X						
 ordered-float@4.6.0											X						
+ordered-multimap@0.7.3											X						
+os_str_bytes@6.6.1		X									X						
 parking@2.2.1		X									X						
 parking_lot@0.12.5		X									X						
 parking_lot_core@0.9.12		X									X						
-parquet@57.1.0		X															
+parquet@58.1.0		X															
 paste@1.0.15		X									X						
+pbkdf2@0.12.2		X									X						
+pem@3.0.6											X						
+pem-rfc7468@0.7.0		X									X						
 percent-encoding@2.3.2		X									X						
 petgraph@0.8.3		X									X						
 phf@0.12.1											X						
 phf_shared@0.12.1											X						
-pin-project-lite@0.2.16		X									X						
+pin-project@1.1.11		X									X						
+pin-project-internal@1.1.11		X									X						
+pin-project-lite@0.2.17		X									X						
 pin-utils@0.1.0		X									X						
+pkcs1@0.7.5		X									X						
+pkcs5@0.7.1		X									X						
+pkcs8@0.10.2		X									X						
 pkg-config@0.3.32		X									X						
-portable-atomic@1.11.1		X									X						
-portable-atomic-util@0.2.4		X									X						
+polyval@0.6.2		X									X						
+portable-atomic@1.13.1		X									X						
+portable-atomic-util@0.2.6		X									X						
 potential_utf@0.1.4														X			
+powerfmt@0.2.0		X									X						
 ppv-lite86@0.2.21		X									X						
 prettyplease@0.2.37		X									X						
-proc-macro2@1.0.103		X									X						
-prost@0.14.1		X															
-prost-derive@0.14.1		X															
-psm@0.1.28		X									X						
+proc-macro2@1.0.106		X									X						
+prost@0.14.3		X															
+prost-derive@0.14.3		X															
+psm@0.1.30		X									X						
 pyiceberg_core_rust@0.9.0		X															
-pyo3@0.26.0		X									X						
-pyo3-build-config@0.26.0		X									X						
-pyo3-ffi@0.26.0		X									X						
-pyo3-macros@0.26.0		X									X						
-pyo3-macros-backend@0.26.0		X									X						
+pyo3@0.28.3		X									X						
+pyo3-build-config@0.28.3		X									X						
+pyo3-ffi@0.28.3		X									X						
+pyo3-macros@0.28.3		X									X						
+pyo3-macros-backend@0.28.3		X									X						
 quad-rand@0.2.3											X						
-quick-xml@0.38.3											X						
-quote@1.0.41		X									X						
+quick-xml@0.39.4											X						
+quote@1.0.45		X									X						
 r-efi@5.3.0		X								X	X						
+r-efi@6.0.0		X								X	X						
+rand@0.10.1		X									X						
 rand@0.8.5		X									X						
-rand@0.9.2		X									X						
+rand@0.9.4		X									X						
 rand_chacha@0.3.1		X									X						
 rand_chacha@0.9.0		X									X						
+rand_core@0.10.0		X									X						
 rand_core@0.6.4		X									X						
-rand_core@0.9.3		X									X						
+rand_core@0.9.5		X									X						
 recursive@0.1.1											X						
 recursive-proc-macro-impl@0.1.1											X						
+redb@3.1.3		X									X						
 redox_syscall@0.5.18											X						
-regex@1.12.2		X									X						
-regex-automata@0.4.13		X									X						
-regex-lite@0.1.8		X									X						
-regex-syntax@0.8.8		X									X						
+redox_users@0.5.2											X						
+regex@1.12.3		X									X						
+regex-automata@0.4.14		X									X						
+regex-lite@0.1.9		X									X						
+regex-syntax@0.8.10		X									X						
 repr_offset@0.2.2																X	
-reqsign@0.16.5		X															
-reqwest@0.12.24		X									X						
+reqsign-aliyun-oss@3.0.0		X															
+reqsign-aws-v4@3.0.0		X															
+reqsign-azure-storage@3.0.0		X															
+reqsign-core@3.0.0		X															
+reqsign-file-read-tokio@3.0.0		X															
+reqsign-google@3.0.0		X															
+reqwest@0.12.28		X									X						
+reqwest@0.13.3		X									X						
+reqwest-middleware@0.5.2		X									X						
 ring@0.17.14		X							X								
-roaring@0.11.2		X									X						
+roaring@0.11.3		X									X						
+rsa@0.9.10		X									X						
+rust-ini@0.21.3											X						
 rustc_version@0.4.1		X									X						
-rustix@1.1.2		X	X								X						
-rustls@0.23.34		X							X		X						
-rustls-pki-types@1.13.0		X									X						
-rustls-webpki@0.103.7									X								
+rustix@1.1.4		X	X								X						
+rustls@0.23.37		X							X		X						
+rustls-native-certs@0.8.3		X							X		X						
+rustls-pki-types@1.14.0		X									X						
+rustls-platform-verifier@0.7.0		X									X						
+rustls-platform-verifier-android@0.1.1		X									X						
+rustls-webpki@0.103.13									X								
 rustversion@1.0.22		X									X						
-ryu@1.0.20		X				X											
+ryu@1.0.23		X				X											
+safe-transmute@0.11.3											X						
+salsa20@0.10.2		X									X						
 same-file@1.0.6											X				X		
+schannel@0.1.29											X						
 scopeguard@1.2.0		X									X						
+scrypt@0.11.0		X									X						
+security-framework@3.7.0		X									X						
+security-framework-sys@2.17.0		X									X						
 semver@1.0.27		X									X						
 seq-macro@0.3.6		X									X						
 serde@1.0.228		X									X						
@@ -307,54 +439,76 @@ serde-big-array@0.5.1		X									X
 serde_bytes@0.11.19		X									X						
 serde_core@1.0.228		X									X						
 serde_derive@1.0.228		X									X						
-serde_json@1.0.145		X									X						
+serde_json@1.0.149		X									X						
 serde_repr@0.1.20		X									X						
 serde_urlencoded@0.7.1		X									X						
-serde_with@3.15.1		X									X						
-serde_with_macros@3.15.1		X									X						
+serde_with@3.21.0		X									X						
+serde_with_macros@3.21.0		X									X						
 sha1@0.10.6		X									X						
 sha2@0.10.9		X									X						
+sha2-asm@0.6.4											X						
+sharded-slab@0.1.7											X						
+shellexpand@3.1.2		X									X						
 shlex@1.3.0		X									X						
-simd-adler32@0.3.7											X						
+signature@2.2.0		X									X						
+simd-adler32@0.3.8											X						
+simd_cesu8@1.1.1		X									X						
 simdutf8@0.1.5		X									X						
-siphasher@1.0.1		X									X						
-slab@0.4.11											X						
+simple_asn1@0.6.4									X								
+siphasher@1.0.2		X									X						
+slab@0.4.12											X						
 smallvec@1.15.1		X									X						
 snap@1.1.1					X												
-socket2@0.6.1		X									X						
-sqlparser@0.59.0		X															
-sqlparser_derive@0.3.0		X															
+socket2@0.6.3		X									X						
+spin@0.9.8											X						
+spki@0.7.3		X									X						
+sqlparser@0.61.0		X															
+sqlparser_derive@0.5.0		X															
 stable_deref_trait@1.2.1		X									X						
-stacker@0.1.22		X									X						
+stacker@0.1.23		X									X						
+static_assertions@1.1.0		X									X						
+statrs@0.18.0											X						
 strsim@0.11.1											X						
-strum@0.26.3											X						
 strum@0.27.2											X						
-strum_macros@0.26.4											X						
 strum_macros@0.27.2											X						
 subtle@2.6.1					X												
+symlink@0.1.0		X									X						
 syn@1.0.109		X									X						
-syn@2.0.113		X									X						
+syn@2.0.117		X									X						
 sync_wrapper@1.0.2		X															
 synstructure@0.13.2											X						
+sysinfo@0.38.4											X						
+system-configuration@0.7.0		X									X						
+system-configuration-sys@0.6.0		X									X						
 tagptr@0.2.0		X									X						
-target-lexicon@0.13.3			X														
-tempfile@3.23.0		X									X						
-thiserror@2.0.17		X									X						
-thiserror-impl@2.0.17		X									X						
+target-lexicon@0.13.5			X														
+tempfile@3.27.0		X									X						
+thiserror@2.0.18		X									X						
+thiserror-impl@2.0.18		X									X						
+thread_local@1.1.9		X									X						
 thrift@0.17.0		X															
+time@0.3.47		X									X						
+time-core@0.1.8		X									X						
+time-macros@0.2.27		X									X						
 tiny-keccak@2.0.2							X										
 tinystr@0.8.2														X			
-tokio@1.48.0											X						
-tokio-macros@2.6.0											X						
+tokio@1.52.1											X						
+tokio-macros@2.7.0											X						
+tokio-retry@0.3.1											X						
 tokio-rustls@0.26.4		X									X						
+tokio-stream@0.1.18											X						
 tokio-util@0.7.18											X						
-tower@0.5.2											X						
-tower-http@0.6.6											X						
+tower@0.5.3											X						
+tower-http@0.6.8											X						
 tower-layer@0.3.3											X						
 tower-service@0.3.3											X						
-tracing@0.1.41											X						
-tracing-attributes@0.1.30											X						
-tracing-core@0.1.34											X						
+tracing@0.1.44											X						
+tracing-appender@0.2.5											X						
+tracing-attributes@0.1.31											X						
+tracing-core@0.1.36											X						
+tracing-log@0.2.0											X						
+tracing-serde@0.2.0											X						
+tracing-subscriber@0.3.23											X						
 try-lock@0.2.5											X						
 tstr@0.2.4																X	
 tstr_proc_macros@0.2.2																X	
@@ -363,77 +517,105 @@ typed-arena@2.0.2											X
 typed-builder@0.20.1		X									X						
 typed-builder-macro@0.20.1		X									X						
 typeid@1.0.3		X									X						
-typenum@1.19.0		X									X						
+typenum@1.20.1		X									X						
 typetag@0.2.21		X									X						
 typetag-impl@0.2.21		X									X						
-typewit@1.14.2																X	
-unicode-ident@1.0.20		X									X			X			
+typewit@1.15.2																X	
+unicode-ident@1.0.24		X									X			X			
 unicode-segmentation@1.12.0		X									X						
 unicode-width@0.2.2		X									X						
-unindent@0.2.4		X									X						
+universal-hash@0.5.1		X									X						
+untrusted@0.7.1									X								
 untrusted@0.9.0									X								
-url@2.5.7		X									X						
+url@2.5.8		X									X						
+urlencoding@2.1.3											X						
 utf8_iter@1.0.4		X									X						
-uuid@1.19.0		X									X						
+utf8parse@0.2.2		X									X						
+uuid@1.23.0		X									X						
 version_check@0.9.5		X									X						
 walkdir@2.5.0											X				X		
 want@0.3.1											X						
 wasi@0.11.1+wasi-snapshot-preview1		X	X								X						
-wasip2@1.0.1+wasi-0.2.4		X	X								X						
-wasm-bindgen@0.2.105		X									X						
-wasm-bindgen-futures@0.4.55		X									X						
-wasm-bindgen-macro@0.2.105		X									X						
-wasm-bindgen-macro-support@0.2.105		X									X						
-wasm-bindgen-shared@0.2.105		X									X						
-wasm-streams@0.4.2		X									X						
-web-sys@0.3.82		X									X						
+wasi@0.14.7+wasi-0.2.4		X	X								X						
+wasip2@1.0.2+wasi-0.2.9		X	X								X						
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X						
+wasite@1.0.2		X				X					X						
+wasm-bindgen@0.2.114		X									X						
+wasm-bindgen-futures@0.4.64		X									X						
+wasm-bindgen-macro@0.2.114		X									X						
+wasm-bindgen-macro-support@0.2.114		X									X						
+wasm-bindgen-shared@0.2.114		X									X						
+wasm-streams@0.5.0		X									X						
+web-sys@0.3.91		X									X						
 web-time@1.1.0		X									X						
-webpki-roots@1.0.3								X									
+webpki-root-certs@1.0.7								X									
+whoami@2.1.1		X				X					X						
 winapi@0.3.9		X									X						
 winapi-i686-pc-windows-gnu@0.4.0		X									X						
 winapi-util@0.1.11											X				X		
 winapi-x86_64-pc-windows-gnu@0.4.0		X									X						
+windows@0.62.2		X									X						
+windows-collections@0.3.2		X									X						
 windows-core@0.62.2		X									X						
+windows-future@0.3.2		X									X						
 windows-implement@0.60.2		X									X						
 windows-interface@0.59.3		X									X						
 windows-link@0.2.1		X									X						
+windows-numerics@0.3.1		X									X						
+windows-registry@0.6.1		X									X						
 windows-result@0.4.1		X									X						
 windows-strings@0.5.1		X									X						
+windows-sys@0.48.0		X									X						
 windows-sys@0.52.0		X									X						
 windows-sys@0.59.0		X									X						
 windows-sys@0.60.2		X									X						
 windows-sys@0.61.2		X									X						
+windows-targets@0.48.5		X									X						
 windows-targets@0.52.6		X									X						
 windows-targets@0.53.5		X									X						
+windows-threading@0.2.1		X									X						
+windows_aarch64_gnullvm@0.48.5		X									X						
 windows_aarch64_gnullvm@0.52.6		X									X						
 windows_aarch64_gnullvm@0.53.1		X									X						
+windows_aarch64_msvc@0.48.5		X									X						
 windows_aarch64_msvc@0.52.6		X									X						
 windows_aarch64_msvc@0.53.1		X									X						
+windows_i686_gnu@0.48.5		X									X						
 windows_i686_gnu@0.52.6		X									X						
 windows_i686_gnu@0.53.1		X									X						
 windows_i686_gnullvm@0.52.6		X									X						
 windows_i686_gnullvm@0.53.1		X									X						
+windows_i686_msvc@0.48.5		X									X						
 windows_i686_msvc@0.52.6		X									X						
 windows_i686_msvc@0.53.1		X									X						
+windows_x86_64_gnu@0.48.5		X									X						
 windows_x86_64_gnu@0.52.6		X									X						
 windows_x86_64_gnu@0.53.1		X									X						
+windows_x86_64_gnullvm@0.48.5		X									X						
 windows_x86_64_gnullvm@0.52.6		X									X						
 windows_x86_64_gnullvm@0.53.1		X									X						
+windows_x86_64_msvc@0.48.5		X									X						
 windows_x86_64_msvc@0.52.6		X									X						
 windows_x86_64_msvc@0.53.1		X									X						
-wit-bindgen@0.46.0		X	X								X						
+wit-bindgen@0.51.0		X	X								X						
 writeable@0.6.2														X			
+xattr@1.6.1		X									X						
+xet-client@1.5.2		X															
+xet-core-structures@1.5.2		X															
+xet-data@1.5.2		X															
+xet-runtime@1.5.2		X															
 yoke@0.8.1														X			
 yoke-derive@0.8.1														X			
-zerocopy@0.8.27		X		X							X						
-zerocopy-derive@0.8.27		X		X							X						
+zerocopy@0.8.47		X		X							X						
+zerocopy-derive@0.8.47		X		X							X						
 zerofrom@0.1.6														X			
 zerofrom-derive@0.1.6														X			
 zeroize@1.8.2		X									X						
 zerotrie@0.2.3														X			
 zerovec@0.11.5														X			
 zerovec-derive@0.11.2														X			
-zlib-rs@0.5.2																X	
+zlib-rs@0.6.3																X	
+zmij@1.0.21											X						
 zstd@0.13.3											X						
 zstd-safe@7.2.4		X									X						
 zstd-sys@2.0.16+zstd.1.5.7		X									X						

--- a/crates/catalog/glue/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/glue/DEPENDENCIES.rust.tsv
@@ -1,380 +1,429 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-lock@3.4.2		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-aws-config@1.8.14		X												
-aws-credential-types@1.2.13		X												
-aws-runtime@1.7.1		X												
-aws-sdk-glue@1.139.0		X												
-aws-sdk-sso@1.95.0		X												
-aws-sdk-ssooidc@1.97.0		X												
-aws-sdk-sts@1.99.0		X												
-aws-sigv4@1.4.1		X												
-aws-smithy-async@1.2.14		X												
-aws-smithy-http@0.63.6		X												
-aws-smithy-http-client@1.1.12		X												
-aws-smithy-json@0.62.5		X												
-aws-smithy-observability@0.2.6		X												
-aws-smithy-query@0.60.15		X												
-aws-smithy-runtime@1.10.3		X												
-aws-smithy-runtime-api@1.11.6		X												
-aws-smithy-types@1.4.6		X												
-aws-smithy-xml@0.60.15		X												
-aws-types@1.3.13		X												
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-base64-simd@0.8.0											X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-bytes-utils@0.1.4		X									X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation@0.10.1		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-deranged@0.5.8		X									X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-errno@0.3.14		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-fnv@1.0.7		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-h2@0.3.27											X			
-h2@0.4.13											X			
-half@2.7.1		X									X			
-hashbrown@0.16.1		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@0.2.12		X									X			
-http@1.4.0		X									X			
-http-body@0.4.6											X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-httpdate@1.0.3		X									X			
-hyper@0.14.32											X			
-hyper@1.8.1											X			
-hyper-rustls@0.24.2		X							X		X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-catalog-glue@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-indexmap@2.13.0		X									X			
-integer-encoding@3.0.4											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-murmur3@0.5.2		X									X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-conv@0.2.0		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-openssl-probe@0.2.1		X									X			
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-outref@0.5.2											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-powerfmt@0.2.0		X									X			
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.21.12		X							X		X			
-rustls@0.23.37		X							X		X			
-rustls-native-certs@0.8.3		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.101.7									X					
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-schannel@0.1.28											X			
-scopeguard@1.2.0		X									X			
-sct@0.7.1		X							X		X			
-security-framework@3.7.0		X									X			
-security-framework-sys@2.17.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-signal-hook-registry@1.4.8		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.5.10		X									X			
-socket2@0.6.2		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-time@0.3.47		X									X			
-time-core@0.1.8		X									X			
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.24.1		X									X			
-tokio-rustls@0.26.4		X									X			
-tokio-util@0.7.18											X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-attributes@0.1.31											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-urlencoding@2.1.3											X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-version_check@0.9.5		X									X			
-vsimd@0.8.0											X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-xmlparser@0.13.6		X									X			
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aead@0.5.2		X									X				
+aes@0.8.4		X									X				
+aes-gcm@0.10.3		X									X				
+ahash@0.8.12		X									X				
+aho-corasick@1.1.4											X			X	
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+android_system_properties@0.1.5		X									X				
+anyhow@1.0.102		X									X				
+apache-avro@0.21.0		X													
+array-init@2.1.0		X									X				
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X									X				
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X									X				
+async-lock@3.4.2		X									X				
+async-trait@0.1.89		X									X				
+atoi@2.0.0											X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-config@1.8.15		X													
+aws-credential-types@1.2.14		X													
+aws-lc-rs@1.16.2		X							X						
+aws-lc-sys@0.39.0		X			X				X		X	X			
+aws-runtime@1.7.2		X													
+aws-sdk-glue@1.142.1		X													
+aws-sdk-sso@1.97.0		X													
+aws-sdk-ssooidc@1.99.0		X													
+aws-sdk-sts@1.101.0		X													
+aws-sigv4@1.4.2		X													
+aws-smithy-async@1.2.14		X													
+aws-smithy-http@0.63.6		X													
+aws-smithy-http-client@1.1.12		X													
+aws-smithy-json@0.62.5		X													
+aws-smithy-observability@0.2.6		X													
+aws-smithy-query@0.60.15		X													
+aws-smithy-runtime@1.10.3		X													
+aws-smithy-runtime-api@1.11.6		X													
+aws-smithy-types@1.4.7		X													
+aws-smithy-xml@0.60.15		X													
+aws-types@1.3.14		X													
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+base64-simd@0.8.0											X				
+bigdecimal@0.4.10		X									X				
+bimap@0.6.3		X									X				
+bitflags@2.11.0		X									X				
+block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
+bnum@0.12.1		X									X				
+bon@3.9.1		X									X				
+bon-macros@3.9.1		X									X				
+brotli@8.0.2					X						X				
+brotli-decompressor@5.0.0					X						X				
+bumpalo@3.20.2		X									X				
+bytemuck@1.25.0		X									X				X
+bytemuck_derive@1.10.2		X									X				X
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+bytes-utils@0.1.4		X									X				
+cc@1.2.57		X									X				
+cfg-if@1.0.4		X									X				
+chrono@0.4.44		X									X				
+cipher@0.4.4		X									X				
+cmake@0.1.57		X									X				
+combine@4.6.7											X				
+concurrent-queue@2.5.0		X									X				
+const-oid@0.10.2		X									X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-channel@0.5.15		X									X				
+crossbeam-epoch@0.9.18		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.7		X									X				
+ctr@0.9.2		X									X				
+darling@0.20.11											X				
+darling@0.23.0											X				
+darling_core@0.20.11											X				
+darling_core@0.23.0											X				
+darling_macro@0.20.11											X				
+darling_macro@0.23.0											X				
+deranged@0.5.8		X									X				
+derive_builder@0.20.2		X									X				
+derive_builder_core@0.20.2		X									X				
+derive_builder_macro@0.20.2		X									X				
+digest@0.10.7		X									X				
+digest@0.11.3		X									X				
+displaydoc@0.2.5		X									X				
+dissimilar@1.0.11		X													
+dlv-list@0.5.2		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+equivalent@1.0.2		X									X				
+erased-serde@0.4.10		X									X				
+errno@0.3.14		X									X				
+event-listener@5.4.1		X									X				
+event-listener-strategy@0.5.4		X									X				
+expect-test@1.5.1		X									X				
+fastnum@0.7.4		X									X				
+fastrand@2.3.0		X									X				
+find-msvc-tools@0.1.9		X									X				
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X									X				
+fnv@1.0.7		X									X				
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghash@0.5.1		X									X				
+gloo-timers@0.3.0		X									X				
+h2@0.4.13											X				
+half@2.7.1		X									X				
+hashbrown@0.14.5		X									X				
+hashbrown@0.16.1		X									X				
+hashbrown@0.17.1		X									X				
+heck@0.5.0		X									X				
+hex@0.4.3		X									X				
+hmac@0.12.1		X									X				
+http@0.2.12		X									X				
+http@1.4.0		X									X				
+http-body@0.4.6											X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+hybrid-array@0.4.12		X									X				
+hyper@1.8.1											X				
+hyper-rustls@0.27.7		X							X		X				
+hyper-util@0.1.20											X				
+iana-time-zone@0.1.65		X									X				
+iana-time-zone-haiku@0.1.2		X									X				
+iceberg@0.9.0		X													
+iceberg-catalog-glue@0.9.0		X													
+iceberg-storage-opendal@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+indexmap@2.13.0		X									X				
+inout@0.1.4		X									X				
+integer-encoding@3.0.4											X				
+inventory@0.3.22		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.11		X									X				
+itertools@0.13.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.91		X									X				
+lazy_static@1.5.0		X									X				
+lexical-core@1.0.6		X									X				
+lexical-parse-float@1.0.6		X									X				
+lexical-parse-integer@1.0.6		X									X				
+lexical-util@1.0.7		X									X				
+lexical-write-float@1.0.6		X									X				
+lexical-write-integer@1.0.6		X									X				
+libc@0.2.183		X									X				
+libm@0.2.16											X				
+link-section@0.18.1		X									X				
+linktime-proc-macro@0.2.0		X									X				
+linux-raw-sys@0.12.1		X	X								X				
+litemap@0.8.1													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+lz4_flex@0.13.0											X				
+md-5@0.11.0		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+moka@0.12.15		X									X				
+murmur3@0.5.2		X									X				
+nu-ansi-term@0.50.3											X				
+num-bigint@0.4.6		X									X				
+num-complex@0.4.6		X									X				
+num-conv@0.2.0		X									X				
+num-integer@0.1.46		X									X				
+num-traits@0.2.19		X									X				
+once_cell@1.21.4		X									X				
+opaque-debug@0.3.1		X									X				
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+openssl-probe@0.2.1		X									X				
+ordered-float@2.10.1											X				
+ordered-float@4.6.0											X				
+ordered-multimap@0.7.3											X				
+outref@0.5.2											X				
+parking@2.2.1		X									X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+parquet@58.1.0		X													
+paste@1.0.15		X									X				
+percent-encoding@2.3.2		X									X				
+pin-project-lite@0.2.17		X									X				
+pin-utils@0.1.0		X									X				
+pkg-config@0.3.32		X									X				
+polyval@0.6.2		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.4													X		
+powerfmt@0.2.0		X									X				
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro2@1.0.106		X									X				
+quad-rand@0.2.3											X				
+quick-xml@0.39.4											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.9.4		X									X				
+rand_chacha@0.9.0		X									X				
+rand_core@0.6.4		X									X				
+rand_core@0.9.5		X									X				
+redox_syscall@0.5.18											X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-lite@0.1.9		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aws-v4@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqwest@0.12.28		X									X				
+reqwest@0.13.3		X									X				
+ring@0.17.14		X							X						
+roaring@0.11.3		X									X				
+rust-ini@0.21.3											X				
+rustc_version@0.4.1		X									X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.37		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.7.0		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.13									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.27		X									X				
+seq-macro@0.3.6		X									X				
+serde@1.0.228		X									X				
+serde-big-array@0.5.1		X									X				
+serde_bytes@0.11.19		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_repr@0.1.20		X									X				
+serde_urlencoded@0.7.1		X									X				
+serde_with@3.21.0		X									X				
+serde_with_macros@3.21.0		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+sharded-slab@0.1.7											X				
+shlex@1.3.0		X									X				
+signal-hook-registry@1.4.8		X									X				
+simd-adler32@0.3.8											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+snap@1.1.1					X										
+socket2@0.6.3		X									X				
+stable_deref_trait@1.2.1		X									X				
+strsim@0.11.1											X				
+strum@0.27.2											X				
+strum_macros@0.27.2											X				
+subtle@2.6.1					X										
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tagptr@0.2.0		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@2.0.18		X									X				
+thread_local@1.1.9		X									X				
+thrift@0.17.0		X													
+time@0.3.47		X									X				
+time-core@0.1.8		X									X				
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2													X		
+tokio@1.52.1											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-util@0.7.18											X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-attributes@0.1.31											X				
+tracing-core@0.1.36											X				
+tracing-log@0.2.0											X				
+tracing-subscriber@0.3.23											X				
+try-lock@0.2.5											X				
+twox-hash@2.1.2											X				
+typed-builder@0.20.1		X									X				
+typed-builder-macro@0.20.1		X									X				
+typeid@1.0.3		X									X				
+typenum@1.20.1		X									X				
+typetag@0.2.21		X									X				
+typetag-impl@0.2.21		X									X				
+unicode-ident@1.0.24		X									X		X		
+universal-hash@0.5.1		X									X				
+untrusted@0.9.0									X						
+url@2.5.8		X									X				
+urlencoding@2.1.3											X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.0		X									X				
+version_check@0.9.5		X									X				
+vsimd@0.8.0											X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.2+wasi-0.2.9		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.114		X									X				
+wasm-bindgen-futures@0.4.64		X									X				
+wasm-bindgen-macro@0.2.114		X									X				
+wasm-bindgen-macro-support@0.2.114		X									X				
+wasm-bindgen-shared@0.2.114		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.91		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.7								X							
+winapi-util@0.1.11											X			X	
+windows-core@0.62.2		X									X				
+windows-implement@0.60.2		X									X				
+windows-interface@0.59.3		X									X				
+windows-link@0.2.1		X									X				
+windows-result@0.4.1		X									X				
+windows-strings@0.5.1		X									X				
+windows-sys@0.48.0		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.48.5		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.48.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.48.5		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.48.5		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.48.5		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.48.5		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.48.5		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.48.5		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.2													X		
+xattr@1.6.1		X									X				
+xmlparser@0.13.6		X									X				
+yoke@0.8.1													X		
+yoke-derive@0.8.1													X		
+zerocopy@0.8.47		X		X							X				
+zerocopy-derive@0.8.47		X		X							X				
+zerofrom@0.1.6													X		
+zerofrom-derive@0.1.6													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.3													X		
+zerovec@0.11.5													X		
+zerovec-derive@0.11.2													X		
+zlib-rs@0.6.3															X
+zmij@1.0.21											X				
+zstd@0.13.3											X				
+zstd-safe@7.2.4		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/crates/catalog/hms/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/hms/DEPENDENCIES.rust.tsv
@@ -1,370 +1,435 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-broadcast@0.7.2		X									X			
-async-lock@3.4.2		X									X			
-async-recursion@1.1.1		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-cfg_aliases@0.2.1											X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-dashmap@6.1.0											X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-errno@0.3.14		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-faststr@0.2.34		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-fnv@1.0.7		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-half@2.7.1		X									X			
-hashbrown@0.14.5		X									X			
-hashbrown@0.16.1		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hive_metastore@0.2.0		X												
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@1.4.0		X									X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-hyper@1.8.1											X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-catalog-hms@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-indexmap@2.13.0		X									X			
-integer-encoding@3.0.4											X			
-integer-encoding@4.1.0											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-linked-hash-map@0.5.6		X									X			
-linkedbytes@0.1.16		X									X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-memoffset@0.9.1											X			
-metainfo@0.7.14		X									X			
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-motore@0.4.1		X									X			
-motore-macros@0.4.3		X									X			
-mur3@0.1.0											X			
-murmur3@0.5.2		X									X			
-nix@0.29.0											X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-num_enum@0.7.5		X			X						X			
-num_enum_derive@0.7.5		X			X						X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pilota@0.11.10		X									X			
-pin-project@1.1.11		X									X			
-pin-project-internal@1.1.11		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro-crate@3.4.0		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-ref-cast@1.0.25		X									X			
-ref-cast-impl@1.0.25		X									X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc-hash@2.1.1		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.23.37		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-scopeguard@1.2.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-signal-hook-registry@1.4.8		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.5.10		X									X			
-socket2@0.6.2		X									X			
-sonic-number@0.1.1		X												
-sonic-rs@0.3.17		X												
-sonic-simd@0.1.3		X												
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@1.0.69		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@1.0.69		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.26.4		X									X			
-tokio-stream@0.1.18											X			
-tokio-util@0.7.18											X			
-toml_datetime@0.7.5+spec-1.1.0		X									X			
-toml_edit@0.23.10+spec-1.0.0		X									X			
-toml_parser@1.0.9+spec-1.1.0		X									X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-attributes@0.1.31											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-version_check@0.9.5		X									X			
-volo@0.10.7		X									X			
-volo-thrift@0.10.8		X									X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-winnow@0.7.14											X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aead@0.5.2		X									X				
+aes@0.8.4		X									X				
+aes-gcm@0.10.3		X									X				
+ahash@0.8.12		X									X				
+aho-corasick@1.1.4											X			X	
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+android_system_properties@0.1.5		X									X				
+anyhow@1.0.102		X									X				
+apache-avro@0.21.0		X													
+array-init@2.1.0		X									X				
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X									X				
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X									X				
+async-broadcast@0.7.2		X									X				
+async-lock@3.4.2		X									X				
+async-recursion@1.1.1		X									X				
+async-trait@0.1.89		X									X				
+atoi@2.0.0											X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-lc-rs@1.16.2		X							X						
+aws-lc-sys@0.39.0		X			X				X		X	X			
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+bigdecimal@0.4.10		X									X				
+bimap@0.6.3		X									X				
+bitflags@2.11.0		X									X				
+block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
+bnum@0.12.1		X									X				
+bon@3.9.1		X									X				
+bon-macros@3.9.1		X									X				
+brotli@8.0.2					X						X				
+brotli-decompressor@5.0.0					X						X				
+bumpalo@3.20.2		X									X				
+bytemuck@1.25.0		X									X				X
+bytemuck_derive@1.10.2		X									X				X
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+cc@1.2.57		X									X				
+cfg-if@1.0.4		X									X				
+cfg_aliases@0.2.1											X				
+chrono@0.4.44		X									X				
+cipher@0.4.4		X									X				
+cmake@0.1.57		X									X				
+combine@4.6.7											X				
+concurrent-queue@2.5.0		X									X				
+const-oid@0.10.2		X									X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-channel@0.5.15		X									X				
+crossbeam-epoch@0.9.18		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.7		X									X				
+ctr@0.9.2		X									X				
+darling@0.20.11											X				
+darling@0.23.0											X				
+darling_core@0.20.11											X				
+darling_core@0.23.0											X				
+darling_macro@0.20.11											X				
+darling_macro@0.23.0											X				
+dashmap@6.2.1											X				
+derive_builder@0.20.2		X									X				
+derive_builder_core@0.20.2		X									X				
+derive_builder_macro@0.20.2		X									X				
+digest@0.10.7		X									X				
+digest@0.11.3		X									X				
+displaydoc@0.2.5		X									X				
+dissimilar@1.0.11		X													
+dlv-list@0.5.2		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+equivalent@1.0.2		X									X				
+erased-serde@0.4.10		X									X				
+errno@0.3.14		X									X				
+event-listener@5.4.1		X									X				
+event-listener-strategy@0.5.4		X									X				
+expect-test@1.5.1		X									X				
+fastnum@0.7.4		X									X				
+fastrand@2.3.0		X									X				
+faststr@0.2.34		X									X				
+find-msvc-tools@0.1.9		X									X				
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X									X				
+fnv@1.0.7		X									X				
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghash@0.5.1		X									X				
+gloo-timers@0.3.0		X									X				
+half@2.7.1		X									X				
+hashbrown@0.14.5		X									X				
+hashbrown@0.16.1		X									X				
+hashbrown@0.17.1		X									X				
+heck@0.5.0		X									X				
+hex@0.4.3		X									X				
+hive_metastore@0.2.0		X													
+hmac@0.12.1		X									X				
+http@1.4.0		X									X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+hybrid-array@0.4.12		X									X				
+hyper@1.8.1											X				
+hyper-rustls@0.27.7		X							X		X				
+hyper-util@0.1.20											X				
+iana-time-zone@0.1.65		X									X				
+iana-time-zone-haiku@0.1.2		X									X				
+iceberg@0.9.0		X													
+iceberg-catalog-hms@0.9.0		X													
+iceberg-storage-opendal@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+indexmap@2.13.0		X									X				
+inout@0.1.4		X									X				
+integer-encoding@3.0.4											X				
+integer-encoding@4.1.0											X				
+inventory@0.3.22		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.11		X									X				
+itertools@0.13.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.91		X									X				
+lazy_static@1.5.0		X									X				
+lexical-core@1.0.6		X									X				
+lexical-parse-float@1.0.6		X									X				
+lexical-parse-integer@1.0.6		X									X				
+lexical-util@1.0.7		X									X				
+lexical-write-float@1.0.6		X									X				
+lexical-write-integer@1.0.6		X									X				
+libc@0.2.183		X									X				
+libm@0.2.16											X				
+link-section@0.18.1		X									X				
+linked-hash-map@0.5.6		X									X				
+linkedbytes@0.1.16		X									X				
+linktime-proc-macro@0.2.0		X									X				
+linux-raw-sys@0.12.1		X	X								X				
+litemap@0.8.1													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+lz4_flex@0.13.0											X				
+md-5@0.11.0		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+memoffset@0.9.1											X				
+metainfo@0.7.14		X									X				
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+moka@0.12.15		X									X				
+motore@0.4.1		X									X				
+motore-macros@0.4.3		X									X				
+mur3@0.1.0											X				
+murmur3@0.5.2		X									X				
+nix@0.29.0											X				
+nu-ansi-term@0.50.3											X				
+num-bigint@0.4.6		X									X				
+num-complex@0.4.6		X									X				
+num-integer@0.1.46		X									X				
+num-traits@0.2.19		X									X				
+num_enum@0.7.6		X			X						X				
+num_enum_derive@0.7.6		X			X						X				
+once_cell@1.21.4		X									X				
+opaque-debug@0.3.1		X									X				
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+openssl-probe@0.2.1		X									X				
+ordered-float@2.10.1											X				
+ordered-float@4.6.0											X				
+ordered-multimap@0.7.3											X				
+parking@2.2.1		X									X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+parquet@58.1.0		X													
+paste@1.0.15		X									X				
+percent-encoding@2.3.2		X									X				
+pilota@0.11.10		X									X				
+pin-project@1.1.11		X									X				
+pin-project-internal@1.1.11		X									X				
+pin-project-lite@0.2.17		X									X				
+pin-utils@0.1.0		X									X				
+pkg-config@0.3.32		X									X				
+polyval@0.6.2		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.4													X		
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro-crate@3.5.0		X									X				
+proc-macro2@1.0.106		X									X				
+quad-rand@0.2.3											X				
+quick-xml@0.39.4											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.8.5		X									X				
+rand@0.9.4		X									X				
+rand_chacha@0.3.1		X									X				
+rand_chacha@0.9.0		X									X				
+rand_core@0.6.4		X									X				
+rand_core@0.9.5		X									X				
+redox_syscall@0.5.18											X				
+ref-cast@1.0.25		X									X				
+ref-cast-impl@1.0.25		X									X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-lite@0.1.9		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aws-v4@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqwest@0.12.28		X									X				
+reqwest@0.13.3		X									X				
+ring@0.17.14		X							X						
+roaring@0.11.3		X									X				
+rust-ini@0.21.3											X				
+rustc-hash@2.1.1		X									X				
+rustc_version@0.4.1		X									X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.37		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.7.0		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.13									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.27		X									X				
+seq-macro@0.3.6		X									X				
+serde@1.0.228		X									X				
+serde-big-array@0.5.1		X									X				
+serde_bytes@0.11.19		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_repr@0.1.20		X									X				
+serde_urlencoded@0.7.1		X									X				
+serde_with@3.21.0		X									X				
+serde_with_macros@3.21.0		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+sharded-slab@0.1.7											X				
+shlex@1.3.0		X									X				
+signal-hook-registry@1.4.8		X									X				
+simd-adler32@0.3.8											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+snap@1.1.1					X										
+socket2@0.5.10		X									X				
+socket2@0.6.3		X									X				
+sonic-number@0.1.1		X													
+sonic-rs@0.3.17		X													
+sonic-simd@0.1.3		X													
+stable_deref_trait@1.2.1		X									X				
+strsim@0.11.1											X				
+strum@0.27.2											X				
+strum_macros@0.27.2											X				
+subtle@2.6.1					X										
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tagptr@0.2.0		X									X				
+thiserror@1.0.69		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@1.0.69		X									X				
+thiserror-impl@2.0.18		X									X				
+thread_local@1.1.9		X									X				
+thrift@0.17.0		X													
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2													X		
+tokio@1.52.1											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-stream@0.1.18											X				
+tokio-util@0.7.18											X				
+toml_datetime@1.0.1+spec-1.1.0		X									X				
+toml_edit@0.25.5+spec-1.1.0		X									X				
+toml_parser@1.0.10+spec-1.1.0		X									X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-attributes@0.1.31											X				
+tracing-core@0.1.36											X				
+tracing-log@0.2.0											X				
+tracing-subscriber@0.3.23											X				
+try-lock@0.2.5											X				
+twox-hash@2.1.2											X				
+typed-builder@0.20.1		X									X				
+typed-builder-macro@0.20.1		X									X				
+typeid@1.0.3		X									X				
+typenum@1.20.1		X									X				
+typetag@0.2.21		X									X				
+typetag-impl@0.2.21		X									X				
+unicode-ident@1.0.24		X									X		X		
+universal-hash@0.5.1		X									X				
+untrusted@0.9.0									X						
+url@2.5.8		X									X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.0		X									X				
+version_check@0.9.5		X									X				
+volo@0.10.7		X									X				
+volo-thrift@0.10.8		X									X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.2+wasi-0.2.9		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.114		X									X				
+wasm-bindgen-futures@0.4.64		X									X				
+wasm-bindgen-macro@0.2.114		X									X				
+wasm-bindgen-macro-support@0.2.114		X									X				
+wasm-bindgen-shared@0.2.114		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.91		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.7								X							
+winapi-util@0.1.11											X			X	
+windows-core@0.62.2		X									X				
+windows-implement@0.60.2		X									X				
+windows-interface@0.59.3		X									X				
+windows-link@0.2.1		X									X				
+windows-result@0.4.1		X									X				
+windows-strings@0.5.1		X									X				
+windows-sys@0.48.0		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.48.5		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.48.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.48.5		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.48.5		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.48.5		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.48.5		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.48.5		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.48.5		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
+winnow@1.0.0											X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.2													X		
+xattr@1.6.1		X									X				
+yoke@0.8.1													X		
+yoke-derive@0.8.1													X		
+zerocopy@0.8.47		X		X							X				
+zerocopy-derive@0.8.47		X		X							X				
+zerofrom@0.1.6													X		
+zerofrom-derive@0.1.6													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.3													X		
+zerovec@0.11.5													X		
+zerovec-derive@0.11.2													X		
+zlib-rs@0.6.3															X
+zmij@1.0.21											X				
+zstd@0.13.3											X				
+zstd-safe@7.2.4		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/crates/catalog/loader/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/loader/DEPENDENCIES.rust.tsv
@@ -1,439 +1,492 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-allocator-api2@0.2.21		X									X			
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-broadcast@0.7.2		X									X			
-async-lock@3.4.2		X									X			
-async-recursion@1.1.1		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-aws-config@1.8.14		X												
-aws-credential-types@1.2.13		X												
-aws-runtime@1.7.1		X												
-aws-sdk-glue@1.139.0		X												
-aws-sdk-s3tables@1.51.0		X												
-aws-sdk-sso@1.95.0		X												
-aws-sdk-ssooidc@1.97.0		X												
-aws-sdk-sts@1.99.0		X												
-aws-sigv4@1.4.1		X												
-aws-smithy-async@1.2.14		X												
-aws-smithy-http@0.63.6		X												
-aws-smithy-http-client@1.1.12		X												
-aws-smithy-json@0.62.5		X												
-aws-smithy-observability@0.2.6		X												
-aws-smithy-query@0.60.15		X												
-aws-smithy-runtime@1.10.3		X												
-aws-smithy-runtime-api@1.11.6		X												
-aws-smithy-types@1.4.6		X												
-aws-smithy-xml@0.60.15		X												
-aws-types@1.3.13		X												
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-base64-simd@0.8.0											X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-bytes-utils@0.1.4		X									X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-cfg_aliases@0.2.1											X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation@0.10.1		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc@3.4.0		X									X			
-crc-catalog@2.4.0		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-queue@0.3.12		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-dashmap@6.1.0											X			
-deranged@0.5.8		X									X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-errno@0.3.14		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-faststr@0.2.34		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-flume@0.11.1		X									X			
-fnv@1.0.7		X									X			
-foldhash@0.1.5														X
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-intrusive@0.5.0		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-h2@0.3.27											X			
-h2@0.4.13											X			
-half@2.7.1		X									X			
-hashbrown@0.14.5		X									X			
-hashbrown@0.15.5		X									X			
-hashbrown@0.16.1		X									X			
-hashlink@0.10.0		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hive_metastore@0.2.0		X												
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@0.2.12		X									X			
-http@1.4.0		X									X			
-http-body@0.4.6											X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-httpdate@1.0.3		X									X			
-hyper@0.14.32											X			
-hyper@1.8.1											X			
-hyper-rustls@0.24.2		X							X		X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-catalog-glue@0.9.0		X												
-iceberg-catalog-hms@0.9.0		X												
-iceberg-catalog-loader@0.9.0		X												
-iceberg-catalog-rest@0.9.0		X												
-iceberg-catalog-s3tables@0.9.0		X												
-iceberg-catalog-sql@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-indexmap@2.13.0		X									X			
-integer-encoding@3.0.4											X			
-integer-encoding@4.1.0											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-libsqlite3-sys@0.30.1											X			
-linked-hash-map@0.5.6		X									X			
-linkedbytes@0.1.16		X									X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-memoffset@0.9.1											X			
-metainfo@0.7.14		X									X			
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-motore@0.4.1		X									X			
-motore-macros@0.4.3		X									X			
-mur3@0.1.0											X			
-murmur3@0.5.2		X									X			
-nix@0.29.0											X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-conv@0.2.0		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-num_enum@0.7.5		X			X						X			
-num_enum_derive@0.7.5		X			X						X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-openssl-probe@0.2.1		X									X			
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-outref@0.5.2											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pilota@0.11.10		X									X			
-pin-project@1.1.11		X									X			
-pin-project-internal@1.1.11		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-powerfmt@0.2.0		X									X			
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro-crate@3.4.0		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-ref-cast@1.0.25		X									X			
-ref-cast-impl@1.0.25		X									X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc-hash@2.1.1		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.21.12		X							X		X			
-rustls@0.23.37		X							X		X			
-rustls-native-certs@0.8.3		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.101.7									X					
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-schannel@0.1.28											X			
-scopeguard@1.2.0		X									X			
-sct@0.7.1		X							X		X			
-security-framework@3.7.0		X									X			
-security-framework-sys@2.17.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-signal-hook-registry@1.4.8		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.5.10		X									X			
-socket2@0.6.2		X									X			
-sonic-number@0.1.1		X												
-sonic-rs@0.3.17		X												
-sonic-simd@0.1.3		X												
-spin@0.9.8											X			
-sqlx@0.8.6		X									X			
-sqlx-core@0.8.6		X									X			
-sqlx-sqlite@0.8.6		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@1.0.69		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@1.0.69		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-time@0.3.47		X									X			
-time-core@0.1.8		X									X			
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.24.1		X									X			
-tokio-rustls@0.26.4		X									X			
-tokio-stream@0.1.18											X			
-tokio-util@0.7.18											X			
-toml_datetime@0.7.5+spec-1.1.0		X									X			
-toml_edit@0.23.10+spec-1.0.0		X									X			
-toml_parser@1.0.9+spec-1.1.0		X									X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-attributes@0.1.31											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-urlencoding@2.1.3											X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-vcpkg@0.2.15		X									X			
-version_check@0.9.5		X									X			
-volo@0.10.7		X									X			
-volo-thrift@0.10.8		X									X			
-vsimd@0.8.0											X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@0.26.11								X						
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-winnow@0.7.14											X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-xmlparser@0.13.6		X									X			
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aead@0.5.2		X									X				
+aes@0.8.4		X									X				
+aes-gcm@0.10.3		X									X				
+ahash@0.8.12		X									X				
+aho-corasick@1.1.4											X			X	
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+allocator-api2@0.2.21		X									X				
+android_system_properties@0.1.5		X									X				
+anyhow@1.0.102		X									X				
+apache-avro@0.21.0		X													
+array-init@2.1.0		X									X				
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X									X				
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X									X				
+async-broadcast@0.7.2		X									X				
+async-lock@3.4.2		X									X				
+async-recursion@1.1.1		X									X				
+async-trait@0.1.89		X									X				
+atoi@2.0.0											X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-config@1.8.15		X													
+aws-credential-types@1.2.14		X													
+aws-lc-rs@1.16.2		X							X						
+aws-lc-sys@0.39.0		X			X				X		X	X			
+aws-runtime@1.7.2		X													
+aws-sdk-glue@1.142.1		X													
+aws-sdk-s3tables@1.54.0		X													
+aws-sdk-sso@1.97.0		X													
+aws-sdk-ssooidc@1.99.0		X													
+aws-sdk-sts@1.101.0		X													
+aws-sigv4@1.4.2		X													
+aws-smithy-async@1.2.14		X													
+aws-smithy-http@0.63.6		X													
+aws-smithy-http-client@1.1.12		X													
+aws-smithy-json@0.62.5		X													
+aws-smithy-observability@0.2.6		X													
+aws-smithy-query@0.60.15		X													
+aws-smithy-runtime@1.10.3		X													
+aws-smithy-runtime-api@1.11.6		X													
+aws-smithy-types@1.4.7		X													
+aws-smithy-xml@0.60.15		X													
+aws-types@1.3.14		X													
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+base64-simd@0.8.0											X				
+bigdecimal@0.4.10		X									X				
+bimap@0.6.3		X									X				
+bitflags@2.11.0		X									X				
+block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
+bnum@0.12.1		X									X				
+bon@3.9.1		X									X				
+bon-macros@3.9.1		X									X				
+brotli@8.0.2					X						X				
+brotli-decompressor@5.0.0					X						X				
+bumpalo@3.20.2		X									X				
+bytemuck@1.25.0		X									X				X
+bytemuck_derive@1.10.2		X									X				X
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+bytes-utils@0.1.4		X									X				
+cc@1.2.57		X									X				
+cfg-if@1.0.4		X									X				
+cfg_aliases@0.2.1											X				
+chrono@0.4.44		X									X				
+cipher@0.4.4		X									X				
+cmake@0.1.57		X									X				
+combine@4.6.7											X				
+concurrent-queue@2.5.0		X									X				
+const-oid@0.10.2		X									X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc@3.4.0		X									X				
+crc-catalog@2.4.0		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-channel@0.5.15		X									X				
+crossbeam-epoch@0.9.18		X									X				
+crossbeam-queue@0.3.12		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.7		X									X				
+ctr@0.9.2		X									X				
+darling@0.20.11											X				
+darling@0.23.0											X				
+darling_core@0.20.11											X				
+darling_core@0.23.0											X				
+darling_macro@0.20.11											X				
+darling_macro@0.23.0											X				
+dashmap@6.2.1											X				
+deranged@0.5.8		X									X				
+derive_builder@0.20.2		X									X				
+derive_builder_core@0.20.2		X									X				
+derive_builder_macro@0.20.2		X									X				
+digest@0.10.7		X									X				
+digest@0.11.3		X									X				
+displaydoc@0.2.5		X									X				
+dissimilar@1.0.11		X													
+dlv-list@0.5.2		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+equivalent@1.0.2		X									X				
+erased-serde@0.4.10		X									X				
+errno@0.3.14		X									X				
+event-listener@5.4.1		X									X				
+event-listener-strategy@0.5.4		X									X				
+expect-test@1.5.1		X									X				
+fastnum@0.7.4		X									X				
+fastrand@2.3.0		X									X				
+faststr@0.2.34		X									X				
+find-msvc-tools@0.1.9		X									X				
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X									X				
+flume@0.11.1		X									X				
+fnv@1.0.7		X									X				
+foldhash@0.1.5															X
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-intrusive@0.5.0		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghash@0.5.1		X									X				
+gloo-timers@0.3.0		X									X				
+h2@0.4.13											X				
+half@2.7.1		X									X				
+hashbrown@0.14.5		X									X				
+hashbrown@0.15.5		X									X				
+hashbrown@0.16.1		X									X				
+hashbrown@0.17.1		X									X				
+hashlink@0.10.0		X									X				
+heck@0.5.0		X									X				
+hex@0.4.3		X									X				
+hive_metastore@0.2.0		X													
+hmac@0.12.1		X									X				
+http@0.2.12		X									X				
+http@1.4.0		X									X				
+http-body@0.4.6											X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+httpdate@1.0.3		X									X				
+hybrid-array@0.4.12		X									X				
+hyper@1.8.1											X				
+hyper-rustls@0.27.7		X							X		X				
+hyper-util@0.1.20											X				
+iana-time-zone@0.1.65		X									X				
+iana-time-zone-haiku@0.1.2		X									X				
+iceberg@0.9.0		X													
+iceberg-catalog-glue@0.9.0		X													
+iceberg-catalog-hms@0.9.0		X													
+iceberg-catalog-loader@0.9.0		X													
+iceberg-catalog-rest@0.9.0		X													
+iceberg-catalog-s3tables@0.9.0		X													
+iceberg-catalog-sql@0.9.0		X													
+iceberg-storage-opendal@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+indexmap@2.13.0		X									X				
+inout@0.1.4		X									X				
+integer-encoding@3.0.4											X				
+integer-encoding@4.1.0											X				
+inventory@0.3.22		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.11		X									X				
+itertools@0.13.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.91		X									X				
+lazy_static@1.5.0		X									X				
+lexical-core@1.0.6		X									X				
+lexical-parse-float@1.0.6		X									X				
+lexical-parse-integer@1.0.6		X									X				
+lexical-util@1.0.7		X									X				
+lexical-write-float@1.0.6		X									X				
+lexical-write-integer@1.0.6		X									X				
+libc@0.2.183		X									X				
+libm@0.2.16											X				
+libsqlite3-sys@0.30.1											X				
+link-section@0.18.1		X									X				
+linked-hash-map@0.5.6		X									X				
+linkedbytes@0.1.16		X									X				
+linktime-proc-macro@0.2.0		X									X				
+linux-raw-sys@0.12.1		X	X								X				
+litemap@0.8.1													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+lz4_flex@0.13.0											X				
+md-5@0.11.0		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+memoffset@0.9.1											X				
+metainfo@0.7.14		X									X				
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+moka@0.12.15		X									X				
+motore@0.4.1		X									X				
+motore-macros@0.4.3		X									X				
+mur3@0.1.0											X				
+murmur3@0.5.2		X									X				
+nix@0.29.0											X				
+nu-ansi-term@0.50.3											X				
+num-bigint@0.4.6		X									X				
+num-complex@0.4.6		X									X				
+num-conv@0.2.0		X									X				
+num-integer@0.1.46		X									X				
+num-traits@0.2.19		X									X				
+num_enum@0.7.6		X			X						X				
+num_enum_derive@0.7.6		X			X						X				
+once_cell@1.21.4		X									X				
+opaque-debug@0.3.1		X									X				
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+openssl-probe@0.2.1		X									X				
+ordered-float@2.10.1											X				
+ordered-float@4.6.0											X				
+ordered-multimap@0.7.3											X				
+outref@0.5.2											X				
+parking@2.2.1		X									X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+parquet@58.1.0		X													
+paste@1.0.15		X									X				
+percent-encoding@2.3.2		X									X				
+pilota@0.11.10		X									X				
+pin-project@1.1.11		X									X				
+pin-project-internal@1.1.11		X									X				
+pin-project-lite@0.2.17		X									X				
+pin-utils@0.1.0		X									X				
+pkg-config@0.3.32		X									X				
+polyval@0.6.2		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.4													X		
+powerfmt@0.2.0		X									X				
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro-crate@3.5.0		X									X				
+proc-macro2@1.0.106		X									X				
+quad-rand@0.2.3											X				
+quick-xml@0.39.4											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.8.5		X									X				
+rand@0.9.4		X									X				
+rand_chacha@0.3.1		X									X				
+rand_chacha@0.9.0		X									X				
+rand_core@0.6.4		X									X				
+rand_core@0.9.5		X									X				
+redox_syscall@0.5.18											X				
+ref-cast@1.0.25		X									X				
+ref-cast-impl@1.0.25		X									X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-lite@0.1.9		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aws-v4@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqwest@0.12.28		X									X				
+reqwest@0.13.3		X									X				
+ring@0.17.14		X							X						
+roaring@0.11.3		X									X				
+rust-ini@0.21.3											X				
+rustc-hash@2.1.1		X									X				
+rustc_version@0.4.1		X									X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.37		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.7.0		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.13									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.27		X									X				
+seq-macro@0.3.6		X									X				
+serde@1.0.228		X									X				
+serde-big-array@0.5.1		X									X				
+serde_bytes@0.11.19		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_repr@0.1.20		X									X				
+serde_urlencoded@0.7.1		X									X				
+serde_with@3.21.0		X									X				
+serde_with_macros@3.21.0		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+sharded-slab@0.1.7											X				
+shlex@1.3.0		X									X				
+signal-hook-registry@1.4.8		X									X				
+simd-adler32@0.3.8											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+snap@1.1.1					X										
+socket2@0.5.10		X									X				
+socket2@0.6.3		X									X				
+sonic-number@0.1.1		X													
+sonic-rs@0.3.17		X													
+sonic-simd@0.1.3		X													
+spin@0.9.8											X				
+sqlx@0.8.6		X									X				
+sqlx-core@0.8.6		X									X				
+sqlx-sqlite@0.8.6		X									X				
+stable_deref_trait@1.2.1		X									X				
+strsim@0.11.1											X				
+strum@0.27.2											X				
+strum_macros@0.27.2											X				
+subtle@2.6.1					X										
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tagptr@0.2.0		X									X				
+thiserror@1.0.69		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@1.0.69		X									X				
+thiserror-impl@2.0.18		X									X				
+thread_local@1.1.9		X									X				
+thrift@0.17.0		X													
+time@0.3.47		X									X				
+time-core@0.1.8		X									X				
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2													X		
+tokio@1.52.1											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-stream@0.1.18											X				
+tokio-util@0.7.18											X				
+toml_datetime@1.0.1+spec-1.1.0		X									X				
+toml_edit@0.25.5+spec-1.1.0		X									X				
+toml_parser@1.0.10+spec-1.1.0		X									X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-attributes@0.1.31											X				
+tracing-core@0.1.36											X				
+tracing-log@0.2.0											X				
+tracing-subscriber@0.3.23											X				
+try-lock@0.2.5											X				
+twox-hash@2.1.2											X				
+typed-builder@0.20.1		X									X				
+typed-builder-macro@0.20.1		X									X				
+typeid@1.0.3		X									X				
+typenum@1.20.1		X									X				
+typetag@0.2.21		X									X				
+typetag-impl@0.2.21		X									X				
+unicode-ident@1.0.24		X									X		X		
+universal-hash@0.5.1		X									X				
+untrusted@0.9.0									X						
+url@2.5.8		X									X				
+urlencoding@2.1.3											X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.0		X									X				
+vcpkg@0.2.15		X									X				
+version_check@0.9.5		X									X				
+volo@0.10.7		X									X				
+volo-thrift@0.10.8		X									X				
+vsimd@0.8.0											X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.2+wasi-0.2.9		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.114		X									X				
+wasm-bindgen-futures@0.4.64		X									X				
+wasm-bindgen-macro@0.2.114		X									X				
+wasm-bindgen-macro-support@0.2.114		X									X				
+wasm-bindgen-shared@0.2.114		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.91		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.7								X							
+webpki-roots@0.26.11								X							
+webpki-roots@1.0.6								X							
+winapi-util@0.1.11											X			X	
+windows-core@0.62.2		X									X				
+windows-implement@0.60.2		X									X				
+windows-interface@0.59.3		X									X				
+windows-link@0.2.1		X									X				
+windows-result@0.4.1		X									X				
+windows-strings@0.5.1		X									X				
+windows-sys@0.48.0		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.48.5		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.48.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.48.5		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.48.5		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.48.5		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.48.5		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.48.5		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.48.5		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
+winnow@1.0.0											X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.2													X		
+xattr@1.6.1		X									X				
+xmlparser@0.13.6		X									X				
+yoke@0.8.1													X		
+yoke-derive@0.8.1													X		
+zerocopy@0.8.47		X		X							X				
+zerocopy-derive@0.8.47		X		X							X				
+zerofrom@0.1.6													X		
+zerofrom-derive@0.1.6													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.3													X		
+zerovec@0.11.5													X		
+zerovec-derive@0.11.2													X		
+zlib-rs@0.6.3															X
+zmij@1.0.21											X				
+zstd@0.13.3											X				
+zstd-safe@7.2.4		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/crates/catalog/rest/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/rest/DEPENDENCIES.rust.tsv
@@ -1,293 +1,316 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X							X			
-ahash@0.8.12		X							X			
-aho-corasick@1.1.4									X		X	
-alloc-no-stdlib@2.0.4					X							
-alloc-stdlib@0.2.2					X							
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.102		X							X			
-apache-avro@0.21.0		X										
-array-init@2.1.0		X							X			
-arrow-arith@57.3.0		X										
-arrow-array@57.3.0		X										
-arrow-buffer@57.3.0		X										
-arrow-cast@57.3.0		X										
-arrow-data@57.3.0		X										
-arrow-ipc@57.3.0		X										
-arrow-ord@57.3.0		X										
-arrow-schema@57.3.0		X										
-arrow-select@57.3.0		X										
-arrow-string@57.3.0		X										
-as-any@0.3.2		X							X			
-async-lock@3.4.2		X							X			
-async-trait@0.1.89		X							X			
-atoi@2.0.0									X			
-atomic-waker@1.1.2		X							X			
-autocfg@1.5.0		X							X			
-backon@1.6.0		X										
-base64@0.22.1		X							X			
-bigdecimal@0.4.10		X							X			
-bimap@0.6.3		X							X			
-bitflags@2.11.0		X							X			
-block-buffer@0.10.4		X							X			
-bnum@0.12.1		X							X			
-bon@3.9.0		X							X			
-bon-macros@3.9.0		X							X			
-brotli@8.0.2					X				X			
-brotli-decompressor@5.0.0					X				X			
-bumpalo@3.20.2		X							X			
-bytemuck@1.25.0		X							X			X
-byteorder@1.5.0									X		X	
-bytes@1.11.1									X			
-cc@1.2.56		X							X			
-cfg-if@1.0.4		X							X			
-chrono@0.4.44		X							X			
-concurrent-queue@2.5.0		X							X			
-const-random@0.1.18		X							X			
-const-random-macro@0.1.16		X							X			
-core-foundation-sys@0.8.7		X							X			
-crc32fast@1.5.0		X							X			
-crossbeam-channel@0.5.15		X							X			
-crossbeam-epoch@0.9.18		X							X			
-crossbeam-utils@0.8.21		X							X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7		X							X			
-darling@0.20.11									X			
-darling@0.21.3									X			
-darling@0.23.0									X			
-darling_core@0.20.11									X			
-darling_core@0.21.3									X			
-darling_core@0.23.0									X			
-darling_macro@0.20.11									X			
-darling_macro@0.21.3									X			
-darling_macro@0.23.0									X			
-derive_builder@0.20.2		X							X			
-derive_builder_core@0.20.2		X							X			
-derive_builder_macro@0.20.2		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-dissimilar@1.0.10		X										
-either@1.15.0		X							X			
-equivalent@1.0.2		X							X			
-erased-serde@0.4.10		X							X			
-event-listener@5.4.1		X							X			
-event-listener-strategy@0.5.4		X							X			
-expect-test@1.5.1		X							X			
-fastnum@0.7.4		X							X			
-fastrand@2.3.0		X							X			
-find-msvc-tools@0.1.9		X							X			
-flatbuffers@25.12.19		X										
-flate2@1.1.9		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.2		X							X			
-futures@0.3.32		X							X			
-futures-channel@0.3.32		X							X			
-futures-core@0.3.32		X							X			
-futures-executor@0.3.32		X							X			
-futures-io@0.3.32		X							X			
-futures-macro@0.3.32		X							X			
-futures-sink@0.3.32		X							X			
-futures-task@0.3.32		X							X			
-futures-util@0.3.32		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.17		X							X			
-getrandom@0.3.4		X							X			
-getrandom@0.4.1		X							X			
-gloo-timers@0.3.0		X							X			
-h2@0.4.13									X			
-half@2.7.1		X							X			
-hashbrown@0.16.1		X							X			
-heck@0.5.0		X							X			
-http@1.4.0		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-httpdate@1.0.3		X							X			
-hyper@1.8.1									X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-iceberg@0.9.0		X										
-iceberg-catalog-rest@0.9.0		X										
-iceberg_test_utils@0.9.0		X										
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
-ident_case@1.0.1		X							X			
-idna@1.1.0		X							X			
-idna_adapter@1.2.1		X							X			
-indexmap@2.13.0		X							X			
-integer-encoding@3.0.4									X			
-inventory@0.3.22		X							X			
-ipnet@2.12.0		X							X			
-iri-string@0.7.10		X							X			
-itertools@0.13.0		X							X			
-itoa@1.0.17		X							X			
-jobserver@0.1.34		X							X			
-js-sys@0.3.91		X							X			
-lazy_static@1.5.0		X							X			
-lexical-core@1.0.6		X							X			
-lexical-parse-float@1.0.6		X							X			
-lexical-parse-integer@1.0.6		X							X			
-lexical-util@1.0.7		X							X			
-lexical-write-float@1.0.6		X							X			
-lexical-write-integer@1.0.6		X							X			
-libc@0.2.182		X							X			
-libm@0.2.16									X			
-litemap@0.8.1										X		
-lock_api@0.4.14		X							X			
-log@0.4.29		X							X			
-lz4_flex@0.12.0									X			
-memchr@2.8.0									X		X	
-miniz_oxide@0.8.9		X							X			X
-mio@1.1.1									X			
-moka@0.12.14		X							X			
-murmur3@0.5.2		X							X			
-nu-ansi-term@0.50.3									X			
-num-bigint@0.4.6		X							X			
-num-complex@0.4.6		X							X			
-num-integer@0.1.46		X							X			
-num-traits@0.2.19		X							X			
-once_cell@1.21.3		X							X			
-ordered-float@2.10.1									X			
-ordered-float@4.6.0									X			
-parking@2.2.1		X							X			
-parking_lot@0.12.5		X							X			
-parking_lot_core@0.9.12		X							X			
-parquet@57.3.0		X										
-paste@1.0.15		X							X			
-percent-encoding@2.3.2		X							X			
-pin-project-lite@0.2.17		X							X			
-pin-utils@0.1.0		X							X			
-pkg-config@0.3.32		X							X			
-portable-atomic@1.13.1		X							X			
-potential_utf@0.1.4										X		
-ppv-lite86@0.2.21		X							X			
-prettyplease@0.2.37		X							X			
-proc-macro2@1.0.106		X							X			
-quad-rand@0.2.3									X			
-quote@1.0.44		X							X			
-r-efi@5.3.0		X						X	X			
-rand@0.8.5		X							X			
-rand@0.9.2		X							X			
-rand_chacha@0.3.1		X							X			
-rand_chacha@0.9.0		X							X			
-rand_core@0.6.4		X							X			
-rand_core@0.9.5		X							X			
-redox_syscall@0.5.18									X			
-regex@1.12.3		X							X			
-regex-automata@0.4.14		X							X			
-regex-lite@0.1.9		X							X			
-regex-syntax@0.8.10		X							X			
-reqwest@0.12.28		X							X			
-roaring@0.11.3		X							X			
-rustc_version@0.4.1		X							X			
-rustversion@1.0.22		X							X			
-ryu@1.0.23		X				X						
-scopeguard@1.2.0		X							X			
-semver@1.0.27		X							X			
-seq-macro@0.3.6		X							X			
-serde@1.0.228		X							X			
-serde-big-array@0.5.1		X							X			
-serde_bytes@0.11.19		X							X			
-serde_core@1.0.228		X							X			
-serde_derive@1.0.228		X							X			
-serde_json@1.0.149		X							X			
-serde_repr@0.1.20		X							X			
-serde_urlencoded@0.7.1		X							X			
-serde_with@3.17.0		X							X			
-serde_with_macros@3.17.0		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-simd-adler32@0.3.8									X			
-simdutf8@0.1.5		X							X			
-slab@0.4.12									X			
-smallvec@1.15.1		X							X			
-snap@1.1.1					X							
-socket2@0.6.2		X							X			
-stable_deref_trait@1.2.1		X							X			
-strsim@0.11.1									X			
-strum@0.27.2									X			
-strum_macros@0.27.2									X			
-syn@2.0.117		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tagptr@0.2.0		X							X			
-thiserror@2.0.18		X							X			
-thiserror-impl@2.0.18		X							X			
-thread_local@1.1.9		X							X			
-thrift@0.17.0		X										
-tiny-keccak@2.0.2							X					
-tinystr@0.8.2										X		
-tokio@1.50.0									X			
-tokio-macros@2.6.1									X			
-tokio-util@0.7.18									X			
-tower@0.5.3									X			
-tower-http@0.6.8									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-attributes@0.1.31									X			
-tracing-core@0.1.36									X			
-tracing-log@0.2.0									X			
-tracing-subscriber@0.3.22									X			
-try-lock@0.2.5									X			
-twox-hash@2.1.2									X			
-typed-builder@0.20.1		X							X			
-typed-builder-macro@0.20.1		X							X			
-typeid@1.0.3		X							X			
-typenum@1.19.0		X							X			
-typetag@0.2.21		X							X			
-typetag-impl@0.2.21		X							X			
-unicode-ident@1.0.24		X							X	X		
-url@2.5.8		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.22.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasip2@1.0.2+wasi-0.2.9		X	X						X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X			
-wasm-bindgen@0.2.114		X							X			
-wasm-bindgen-futures@0.4.64		X							X			
-wasm-bindgen-macro@0.2.114		X							X			
-wasm-bindgen-macro-support@0.2.114		X							X			
-wasm-bindgen-shared@0.2.114		X							X			
-web-sys@0.3.91		X							X			
-windows-core@0.62.2		X							X			
-windows-implement@0.60.2		X							X			
-windows-interface@0.59.3		X							X			
-windows-link@0.2.1		X							X			
-windows-result@0.4.1		X							X			
-windows-strings@0.5.1		X							X			
-windows-sys@0.60.2		X							X			
-windows-sys@0.61.2		X							X			
-windows-targets@0.53.5		X							X			
-windows_aarch64_gnullvm@0.53.1		X							X			
-windows_aarch64_msvc@0.53.1		X							X			
-windows_i686_gnu@0.53.1		X							X			
-windows_i686_gnullvm@0.53.1		X							X			
-windows_i686_msvc@0.53.1		X							X			
-windows_x86_64_gnu@0.53.1		X							X			
-windows_x86_64_gnullvm@0.53.1		X							X			
-windows_x86_64_msvc@0.53.1		X							X			
-wit-bindgen@0.51.0		X	X						X			
-writeable@0.6.2										X		
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerocopy@0.8.40		X		X					X			
-zerocopy-derive@0.8.40		X		X					X			
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
-zlib-rs@0.6.3												X
-zmij@1.0.21									X			
-zstd@0.13.3									X			
-zstd-safe@7.2.4		X							X			
-zstd-sys@2.0.16+zstd.1.5.7		X							X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X								X			
+aead@0.5.2		X								X			
+aes@0.8.4		X								X			
+aes-gcm@0.10.3		X								X			
+ahash@0.8.12		X								X			
+aho-corasick@1.1.4										X		X	
+alloc-no-stdlib@2.0.4					X								
+alloc-stdlib@0.2.2					X								
+android_system_properties@0.1.5		X								X			
+anyhow@1.0.102		X								X			
+apache-avro@0.21.0		X											
+array-init@2.1.0		X								X			
+arrow-arith@58.3.0		X											
+arrow-array@58.3.0		X								X			
+arrow-buffer@58.3.0		X											
+arrow-cast@58.3.0		X											
+arrow-data@58.3.0		X											
+arrow-ipc@58.1.0		X											
+arrow-ord@58.3.0		X											
+arrow-schema@58.3.0		X											
+arrow-select@58.3.0		X											
+arrow-string@58.3.0		X											
+as-any@0.3.2		X								X			
+async-lock@3.4.2		X								X			
+async-trait@0.1.89		X								X			
+atoi@2.0.0										X			
+atomic-waker@1.1.2		X								X			
+autocfg@1.5.0		X								X			
+backon@1.6.0		X											
+base64@0.22.1		X								X			
+bigdecimal@0.4.10		X								X			
+bimap@0.6.3		X								X			
+bitflags@2.11.0		X								X			
+block-buffer@0.10.4		X								X			
+bnum@0.12.1		X								X			
+bon@3.9.1		X								X			
+bon-macros@3.9.1		X								X			
+brotli@8.0.2					X					X			
+brotli-decompressor@5.0.0					X					X			
+bumpalo@3.20.2		X								X			
+bytemuck@1.25.0		X								X			X
+bytemuck_derive@1.10.2		X								X			X
+byteorder@1.5.0										X		X	
+bytes@1.11.1										X			
+cc@1.2.57		X								X			
+cfg-if@1.0.4		X								X			
+chrono@0.4.44		X								X			
+cipher@0.4.4		X								X			
+concurrent-queue@2.5.0		X								X			
+const-random@0.1.18		X								X			
+const-random-macro@0.1.16		X								X			
+core-foundation-sys@0.8.7		X								X			
+cpufeatures@0.2.17		X								X			
+crc32fast@1.5.0		X								X			
+crossbeam-channel@0.5.15		X								X			
+crossbeam-epoch@0.9.18		X								X			
+crossbeam-utils@0.8.21		X								X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7		X								X			
+ctr@0.9.2		X								X			
+darling@0.20.11										X			
+darling@0.23.0										X			
+darling_core@0.20.11										X			
+darling_core@0.23.0										X			
+darling_macro@0.20.11										X			
+darling_macro@0.23.0										X			
+derive_builder@0.20.2		X								X			
+derive_builder_core@0.20.2		X								X			
+derive_builder_macro@0.20.2		X								X			
+digest@0.10.7		X								X			
+displaydoc@0.2.5		X								X			
+dissimilar@1.0.11		X											
+either@1.15.0		X								X			
+equivalent@1.0.2		X								X			
+erased-serde@0.4.10		X								X			
+event-listener@5.4.1		X								X			
+event-listener-strategy@0.5.4		X								X			
+expect-test@1.5.1		X								X			
+fastnum@0.7.4		X								X			
+fastrand@2.3.0		X								X			
+find-msvc-tools@0.1.9		X								X			
+flatbuffers@25.12.19		X											
+flate2@1.1.9		X								X			
+fnv@1.0.7		X								X			
+form_urlencoded@1.2.2		X								X			
+futures@0.3.32		X								X			
+futures-channel@0.3.32		X								X			
+futures-core@0.3.32		X								X			
+futures-executor@0.3.32		X								X			
+futures-io@0.3.32		X								X			
+futures-macro@0.3.32		X								X			
+futures-sink@0.3.32		X								X			
+futures-task@0.3.32		X								X			
+futures-util@0.3.32		X								X			
+generic-array@0.14.7										X			
+getrandom@0.2.17		X								X			
+getrandom@0.3.4		X								X			
+getrandom@0.4.2		X								X			
+ghash@0.5.1		X								X			
+gloo-timers@0.3.0		X								X			
+h2@0.4.13										X			
+half@2.7.1		X								X			
+hashbrown@0.16.1		X								X			
+hashbrown@0.17.1		X								X			
+heck@0.5.0		X								X			
+http@1.4.0		X								X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1		X								X			
+httpdate@1.0.3		X								X			
+hyper@1.8.1										X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65		X								X			
+iana-time-zone-haiku@0.1.2		X								X			
+iceberg@0.9.0		X											
+iceberg-catalog-rest@0.9.0		X											
+iceberg_test_utils@0.9.0		X											
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+ident_case@1.0.1		X								X			
+idna@1.1.0		X								X			
+idna_adapter@1.2.1		X								X			
+indexmap@2.13.0		X								X			
+inout@0.1.4		X								X			
+integer-encoding@3.0.4										X			
+inventory@0.3.22		X								X			
+ipnet@2.12.0		X								X			
+iri-string@0.7.11		X								X			
+itertools@0.13.0		X								X			
+itoa@1.0.18		X								X			
+jobserver@0.1.34		X								X			
+js-sys@0.3.91		X								X			
+lazy_static@1.5.0		X								X			
+lexical-core@1.0.6		X								X			
+lexical-parse-float@1.0.6		X								X			
+lexical-parse-integer@1.0.6		X								X			
+lexical-util@1.0.7		X								X			
+lexical-write-float@1.0.6		X								X			
+lexical-write-integer@1.0.6		X								X			
+libc@0.2.183		X								X			
+libm@0.2.16										X			
+litemap@0.8.1											X		
+lock_api@0.4.14		X								X			
+log@0.4.29		X								X			
+lz4_flex@0.13.0										X			
+memchr@2.8.0										X		X	
+miniz_oxide@0.8.9		X								X			X
+mio@1.2.0										X			
+moka@0.12.15		X								X			
+murmur3@0.5.2		X								X			
+nu-ansi-term@0.50.3										X			
+num-bigint@0.4.6		X								X			
+num-complex@0.4.6		X								X			
+num-integer@0.1.46		X								X			
+num-traits@0.2.19		X								X			
+once_cell@1.21.4		X								X			
+opaque-debug@0.3.1		X								X			
+ordered-float@2.10.1										X			
+ordered-float@4.6.0										X			
+parking@2.2.1		X								X			
+parking_lot@0.12.5		X								X			
+parking_lot_core@0.9.12		X								X			
+parquet@58.1.0		X											
+paste@1.0.15		X								X			
+percent-encoding@2.3.2		X								X			
+pin-project-lite@0.2.17		X								X			
+pin-utils@0.1.0		X								X			
+pkg-config@0.3.32		X								X			
+polyval@0.6.2		X								X			
+portable-atomic@1.13.1		X								X			
+potential_utf@0.1.4											X		
+ppv-lite86@0.2.21		X								X			
+prettyplease@0.2.37		X								X			
+proc-macro2@1.0.106		X								X			
+quad-rand@0.2.3										X			
+quote@1.0.45		X								X			
+r-efi@5.3.0		X							X	X			
+r-efi@6.0.0		X							X	X			
+rand@0.9.4		X								X			
+rand_chacha@0.9.0		X								X			
+rand_core@0.6.4		X								X			
+rand_core@0.9.5		X								X			
+redox_syscall@0.5.18										X			
+regex@1.12.3		X								X			
+regex-automata@0.4.14		X								X			
+regex-lite@0.1.9		X								X			
+regex-syntax@0.8.10		X								X			
+reqwest@0.12.28		X								X			
+ring@0.17.14		X						X					
+roaring@0.11.3		X								X			
+rustc_version@0.4.1		X								X			
+rustversion@1.0.22		X								X			
+ryu@1.0.23		X				X							
+scopeguard@1.2.0		X								X			
+semver@1.0.27		X								X			
+seq-macro@0.3.6		X								X			
+serde@1.0.228		X								X			
+serde-big-array@0.5.1		X								X			
+serde_bytes@0.11.19		X								X			
+serde_core@1.0.228		X								X			
+serde_derive@1.0.228		X								X			
+serde_json@1.0.149		X								X			
+serde_repr@0.1.20		X								X			
+serde_urlencoded@0.7.1		X								X			
+serde_with@3.21.0		X								X			
+serde_with_macros@3.21.0		X								X			
+sharded-slab@0.1.7										X			
+shlex@1.3.0		X								X			
+simd-adler32@0.3.8										X			
+simdutf8@0.1.5		X								X			
+slab@0.4.12										X			
+smallvec@1.15.1		X								X			
+snap@1.1.1					X								
+socket2@0.6.3		X								X			
+stable_deref_trait@1.2.1		X								X			
+strsim@0.11.1										X			
+strum@0.27.2										X			
+strum_macros@0.27.2										X			
+subtle@2.6.1					X								
+syn@2.0.117		X								X			
+sync_wrapper@1.0.2		X											
+synstructure@0.13.2										X			
+tagptr@0.2.0		X								X			
+thiserror@2.0.18		X								X			
+thiserror-impl@2.0.18		X								X			
+thread_local@1.1.9		X								X			
+thrift@0.17.0		X											
+tiny-keccak@2.0.2							X						
+tinystr@0.8.2											X		
+tokio@1.52.1										X			
+tokio-macros@2.7.0										X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+tracing-log@0.2.0										X			
+tracing-subscriber@0.3.23										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typed-builder@0.20.1		X								X			
+typed-builder-macro@0.20.1		X								X			
+typeid@1.0.3		X								X			
+typenum@1.20.1		X								X			
+typetag@0.2.21		X								X			
+typetag-impl@0.2.21		X								X			
+unicode-ident@1.0.24		X								X	X		
+universal-hash@0.5.1		X								X			
+untrusted@0.9.0								X					
+url@2.5.8		X								X			
+utf8_iter@1.0.4		X								X			
+uuid@1.23.0		X								X			
+version_check@0.9.5		X								X			
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
+wasip2@1.0.2+wasi-0.2.9		X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X			
+wasm-bindgen@0.2.114		X								X			
+wasm-bindgen-futures@0.4.64		X								X			
+wasm-bindgen-macro@0.2.114		X								X			
+wasm-bindgen-macro-support@0.2.114		X								X			
+wasm-bindgen-shared@0.2.114		X								X			
+web-sys@0.3.91		X								X			
+windows-core@0.62.2		X								X			
+windows-implement@0.60.2		X								X			
+windows-interface@0.59.3		X								X			
+windows-link@0.2.1		X								X			
+windows-result@0.4.1		X								X			
+windows-strings@0.5.1		X								X			
+windows-sys@0.52.0		X								X			
+windows-sys@0.60.2		X								X			
+windows-sys@0.61.2		X								X			
+windows-targets@0.52.6		X								X			
+windows-targets@0.53.5		X								X			
+windows_aarch64_gnullvm@0.52.6		X								X			
+windows_aarch64_gnullvm@0.53.1		X								X			
+windows_aarch64_msvc@0.52.6		X								X			
+windows_aarch64_msvc@0.53.1		X								X			
+windows_i686_gnu@0.52.6		X								X			
+windows_i686_gnu@0.53.1		X								X			
+windows_i686_gnullvm@0.52.6		X								X			
+windows_i686_gnullvm@0.53.1		X								X			
+windows_i686_msvc@0.52.6		X								X			
+windows_i686_msvc@0.53.1		X								X			
+windows_x86_64_gnu@0.52.6		X								X			
+windows_x86_64_gnu@0.53.1		X								X			
+windows_x86_64_gnullvm@0.52.6		X								X			
+windows_x86_64_gnullvm@0.53.1		X								X			
+windows_x86_64_msvc@0.52.6		X								X			
+windows_x86_64_msvc@0.53.1		X								X			
+wit-bindgen@0.51.0		X	X							X			
+writeable@0.6.2											X		
+yoke@0.8.1											X		
+yoke-derive@0.8.1											X		
+zerocopy@0.8.47		X		X						X			
+zerocopy-derive@0.8.47		X		X						X			
+zerofrom@0.1.6											X		
+zerofrom-derive@0.1.6											X		
+zeroize@1.8.2		X								X			
+zerotrie@0.2.3											X		
+zerovec@0.11.5											X		
+zerovec-derive@0.11.2											X		
+zlib-rs@0.6.3													X
+zmij@1.0.21										X			
+zstd@0.13.3										X			
+zstd-safe@7.2.4		X								X			
+zstd-sys@2.0.16+zstd.1.5.7		X								X			

--- a/crates/catalog/s3tables/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/s3tables/DEPENDENCIES.rust.tsv
@@ -1,380 +1,429 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-lock@3.4.2		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-aws-config@1.8.14		X												
-aws-credential-types@1.2.13		X												
-aws-runtime@1.7.1		X												
-aws-sdk-s3tables@1.51.0		X												
-aws-sdk-sso@1.95.0		X												
-aws-sdk-ssooidc@1.97.0		X												
-aws-sdk-sts@1.99.0		X												
-aws-sigv4@1.4.1		X												
-aws-smithy-async@1.2.14		X												
-aws-smithy-http@0.63.6		X												
-aws-smithy-http-client@1.1.12		X												
-aws-smithy-json@0.62.5		X												
-aws-smithy-observability@0.2.6		X												
-aws-smithy-query@0.60.15		X												
-aws-smithy-runtime@1.10.3		X												
-aws-smithy-runtime-api@1.11.6		X												
-aws-smithy-types@1.4.6		X												
-aws-smithy-xml@0.60.15		X												
-aws-types@1.3.13		X												
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-base64-simd@0.8.0											X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-bytes-utils@0.1.4		X									X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation@0.10.1		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-deranged@0.5.8		X									X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-errno@0.3.14		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-fnv@1.0.7		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-h2@0.3.27											X			
-h2@0.4.13											X			
-half@2.7.1		X									X			
-hashbrown@0.16.1		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@0.2.12		X									X			
-http@1.4.0		X									X			
-http-body@0.4.6											X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-httpdate@1.0.3		X									X			
-hyper@0.14.32											X			
-hyper@1.8.1											X			
-hyper-rustls@0.24.2		X							X		X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-catalog-s3tables@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-indexmap@2.13.0		X									X			
-integer-encoding@3.0.4											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-murmur3@0.5.2		X									X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-conv@0.2.0		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-openssl-probe@0.2.1		X									X			
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-outref@0.5.2											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-powerfmt@0.2.0		X									X			
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.21.12		X							X		X			
-rustls@0.23.37		X							X		X			
-rustls-native-certs@0.8.3		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.101.7									X					
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-schannel@0.1.28											X			
-scopeguard@1.2.0		X									X			
-sct@0.7.1		X							X		X			
-security-framework@3.7.0		X									X			
-security-framework-sys@2.17.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-signal-hook-registry@1.4.8		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.5.10		X									X			
-socket2@0.6.2		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-time@0.3.47		X									X			
-time-core@0.1.8		X									X			
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.24.1		X									X			
-tokio-rustls@0.26.4		X									X			
-tokio-util@0.7.18											X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-attributes@0.1.31											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-urlencoding@2.1.3											X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-version_check@0.9.5		X									X			
-vsimd@0.8.0											X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-xmlparser@0.13.6		X									X			
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aead@0.5.2		X									X				
+aes@0.8.4		X									X				
+aes-gcm@0.10.3		X									X				
+ahash@0.8.12		X									X				
+aho-corasick@1.1.4											X			X	
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+android_system_properties@0.1.5		X									X				
+anyhow@1.0.102		X									X				
+apache-avro@0.21.0		X													
+array-init@2.1.0		X									X				
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X									X				
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X									X				
+async-lock@3.4.2		X									X				
+async-trait@0.1.89		X									X				
+atoi@2.0.0											X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-config@1.8.15		X													
+aws-credential-types@1.2.14		X													
+aws-lc-rs@1.16.2		X							X						
+aws-lc-sys@0.39.0		X			X				X		X	X			
+aws-runtime@1.7.2		X													
+aws-sdk-s3tables@1.54.0		X													
+aws-sdk-sso@1.97.0		X													
+aws-sdk-ssooidc@1.99.0		X													
+aws-sdk-sts@1.101.0		X													
+aws-sigv4@1.4.2		X													
+aws-smithy-async@1.2.14		X													
+aws-smithy-http@0.63.6		X													
+aws-smithy-http-client@1.1.12		X													
+aws-smithy-json@0.62.5		X													
+aws-smithy-observability@0.2.6		X													
+aws-smithy-query@0.60.15		X													
+aws-smithy-runtime@1.10.3		X													
+aws-smithy-runtime-api@1.11.6		X													
+aws-smithy-types@1.4.7		X													
+aws-smithy-xml@0.60.15		X													
+aws-types@1.3.14		X													
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+base64-simd@0.8.0											X				
+bigdecimal@0.4.10		X									X				
+bimap@0.6.3		X									X				
+bitflags@2.11.0		X									X				
+block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
+bnum@0.12.1		X									X				
+bon@3.9.1		X									X				
+bon-macros@3.9.1		X									X				
+brotli@8.0.2					X						X				
+brotli-decompressor@5.0.0					X						X				
+bumpalo@3.20.2		X									X				
+bytemuck@1.25.0		X									X				X
+bytemuck_derive@1.10.2		X									X				X
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+bytes-utils@0.1.4		X									X				
+cc@1.2.57		X									X				
+cfg-if@1.0.4		X									X				
+chrono@0.4.44		X									X				
+cipher@0.4.4		X									X				
+cmake@0.1.57		X									X				
+combine@4.6.7											X				
+concurrent-queue@2.5.0		X									X				
+const-oid@0.10.2		X									X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-channel@0.5.15		X									X				
+crossbeam-epoch@0.9.18		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.7		X									X				
+ctr@0.9.2		X									X				
+darling@0.20.11											X				
+darling@0.23.0											X				
+darling_core@0.20.11											X				
+darling_core@0.23.0											X				
+darling_macro@0.20.11											X				
+darling_macro@0.23.0											X				
+deranged@0.5.8		X									X				
+derive_builder@0.20.2		X									X				
+derive_builder_core@0.20.2		X									X				
+derive_builder_macro@0.20.2		X									X				
+digest@0.10.7		X									X				
+digest@0.11.3		X									X				
+displaydoc@0.2.5		X									X				
+dissimilar@1.0.11		X													
+dlv-list@0.5.2		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+equivalent@1.0.2		X									X				
+erased-serde@0.4.10		X									X				
+errno@0.3.14		X									X				
+event-listener@5.4.1		X									X				
+event-listener-strategy@0.5.4		X									X				
+expect-test@1.5.1		X									X				
+fastnum@0.7.4		X									X				
+fastrand@2.3.0		X									X				
+find-msvc-tools@0.1.9		X									X				
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X									X				
+fnv@1.0.7		X									X				
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghash@0.5.1		X									X				
+gloo-timers@0.3.0		X									X				
+h2@0.4.13											X				
+half@2.7.1		X									X				
+hashbrown@0.14.5		X									X				
+hashbrown@0.16.1		X									X				
+hashbrown@0.17.1		X									X				
+heck@0.5.0		X									X				
+hex@0.4.3		X									X				
+hmac@0.12.1		X									X				
+http@0.2.12		X									X				
+http@1.4.0		X									X				
+http-body@0.4.6											X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+hybrid-array@0.4.12		X									X				
+hyper@1.8.1											X				
+hyper-rustls@0.27.7		X							X		X				
+hyper-util@0.1.20											X				
+iana-time-zone@0.1.65		X									X				
+iana-time-zone-haiku@0.1.2		X									X				
+iceberg@0.9.0		X													
+iceberg-catalog-s3tables@0.9.0		X													
+iceberg-storage-opendal@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+indexmap@2.13.0		X									X				
+inout@0.1.4		X									X				
+integer-encoding@3.0.4											X				
+inventory@0.3.22		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.11		X									X				
+itertools@0.13.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.91		X									X				
+lazy_static@1.5.0		X									X				
+lexical-core@1.0.6		X									X				
+lexical-parse-float@1.0.6		X									X				
+lexical-parse-integer@1.0.6		X									X				
+lexical-util@1.0.7		X									X				
+lexical-write-float@1.0.6		X									X				
+lexical-write-integer@1.0.6		X									X				
+libc@0.2.183		X									X				
+libm@0.2.16											X				
+link-section@0.18.1		X									X				
+linktime-proc-macro@0.2.0		X									X				
+linux-raw-sys@0.12.1		X	X								X				
+litemap@0.8.1													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+lz4_flex@0.13.0											X				
+md-5@0.11.0		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+moka@0.12.15		X									X				
+murmur3@0.5.2		X									X				
+nu-ansi-term@0.50.3											X				
+num-bigint@0.4.6		X									X				
+num-complex@0.4.6		X									X				
+num-conv@0.2.0		X									X				
+num-integer@0.1.46		X									X				
+num-traits@0.2.19		X									X				
+once_cell@1.21.4		X									X				
+opaque-debug@0.3.1		X									X				
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+openssl-probe@0.2.1		X									X				
+ordered-float@2.10.1											X				
+ordered-float@4.6.0											X				
+ordered-multimap@0.7.3											X				
+outref@0.5.2											X				
+parking@2.2.1		X									X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+parquet@58.1.0		X													
+paste@1.0.15		X									X				
+percent-encoding@2.3.2		X									X				
+pin-project-lite@0.2.17		X									X				
+pin-utils@0.1.0		X									X				
+pkg-config@0.3.32		X									X				
+polyval@0.6.2		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.4													X		
+powerfmt@0.2.0		X									X				
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro2@1.0.106		X									X				
+quad-rand@0.2.3											X				
+quick-xml@0.39.4											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.9.4		X									X				
+rand_chacha@0.9.0		X									X				
+rand_core@0.6.4		X									X				
+rand_core@0.9.5		X									X				
+redox_syscall@0.5.18											X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-lite@0.1.9		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aws-v4@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqwest@0.12.28		X									X				
+reqwest@0.13.3		X									X				
+ring@0.17.14		X							X						
+roaring@0.11.3		X									X				
+rust-ini@0.21.3											X				
+rustc_version@0.4.1		X									X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.37		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.7.0		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.13									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.27		X									X				
+seq-macro@0.3.6		X									X				
+serde@1.0.228		X									X				
+serde-big-array@0.5.1		X									X				
+serde_bytes@0.11.19		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_repr@0.1.20		X									X				
+serde_urlencoded@0.7.1		X									X				
+serde_with@3.21.0		X									X				
+serde_with_macros@3.21.0		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+sharded-slab@0.1.7											X				
+shlex@1.3.0		X									X				
+signal-hook-registry@1.4.8		X									X				
+simd-adler32@0.3.8											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+snap@1.1.1					X										
+socket2@0.6.3		X									X				
+stable_deref_trait@1.2.1		X									X				
+strsim@0.11.1											X				
+strum@0.27.2											X				
+strum_macros@0.27.2											X				
+subtle@2.6.1					X										
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tagptr@0.2.0		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@2.0.18		X									X				
+thread_local@1.1.9		X									X				
+thrift@0.17.0		X													
+time@0.3.47		X									X				
+time-core@0.1.8		X									X				
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2													X		
+tokio@1.52.1											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-util@0.7.18											X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-attributes@0.1.31											X				
+tracing-core@0.1.36											X				
+tracing-log@0.2.0											X				
+tracing-subscriber@0.3.23											X				
+try-lock@0.2.5											X				
+twox-hash@2.1.2											X				
+typed-builder@0.20.1		X									X				
+typed-builder-macro@0.20.1		X									X				
+typeid@1.0.3		X									X				
+typenum@1.20.1		X									X				
+typetag@0.2.21		X									X				
+typetag-impl@0.2.21		X									X				
+unicode-ident@1.0.24		X									X		X		
+universal-hash@0.5.1		X									X				
+untrusted@0.9.0									X						
+url@2.5.8		X									X				
+urlencoding@2.1.3											X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.0		X									X				
+version_check@0.9.5		X									X				
+vsimd@0.8.0											X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.2+wasi-0.2.9		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.114		X									X				
+wasm-bindgen-futures@0.4.64		X									X				
+wasm-bindgen-macro@0.2.114		X									X				
+wasm-bindgen-macro-support@0.2.114		X									X				
+wasm-bindgen-shared@0.2.114		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.91		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.7								X							
+winapi-util@0.1.11											X			X	
+windows-core@0.62.2		X									X				
+windows-implement@0.60.2		X									X				
+windows-interface@0.59.3		X									X				
+windows-link@0.2.1		X									X				
+windows-result@0.4.1		X									X				
+windows-strings@0.5.1		X									X				
+windows-sys@0.48.0		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.48.5		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.48.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.48.5		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.48.5		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.48.5		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.48.5		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.48.5		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.48.5		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.2													X		
+xattr@1.6.1		X									X				
+xmlparser@0.13.6		X									X				
+yoke@0.8.1													X		
+yoke-derive@0.8.1													X		
+zerocopy@0.8.47		X		X							X				
+zerocopy-derive@0.8.47		X		X							X				
+zerofrom@0.1.6													X		
+zerofrom-derive@0.1.6													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.3													X		
+zerovec@0.11.5													X		
+zerovec-derive@0.11.2													X		
+zlib-rs@0.6.3															X
+zmij@1.0.21											X				
+zstd@0.13.3											X				
+zstd-safe@7.2.4		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/crates/catalog/sql/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/sql/DEPENDENCIES.rust.tsv
@@ -1,5 +1,8 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
 adler2@2.0.1	X	X									X			
+aead@0.5.2		X									X			
+aes@0.8.4		X									X			
+aes-gcm@0.10.3		X									X			
 ahash@0.8.12		X									X			
 aho-corasick@1.1.4											X		X	
 alloc-no-stdlib@2.0.4					X									
@@ -9,16 +12,16 @@ android_system_properties@0.1.5		X									X
 anyhow@1.0.102		X									X			
 apache-avro@0.21.0		X												
 array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
+arrow-arith@58.3.0		X												
+arrow-array@58.3.0		X									X			
+arrow-buffer@58.3.0		X												
+arrow-cast@58.3.0		X												
+arrow-data@58.3.0		X												
+arrow-ipc@58.1.0		X												
+arrow-ord@58.3.0		X												
+arrow-schema@58.3.0		X												
+arrow-select@58.3.0		X												
+arrow-string@58.3.0		X												
 as-any@0.3.2		X									X			
 async-lock@3.4.2		X									X			
 async-trait@0.1.89		X									X			
@@ -32,17 +35,19 @@ bimap@0.6.3		X									X
 bitflags@2.11.0		X									X			
 block-buffer@0.10.4		X									X			
 bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
 brotli@8.0.2					X						X			
 brotli-decompressor@5.0.0					X						X			
 bumpalo@3.20.2		X									X			
 bytemuck@1.25.0		X									X			X
+bytemuck_derive@1.10.2		X									X			X
 byteorder@1.5.0											X		X	
 bytes@1.11.1											X			
-cc@1.2.56		X									X			
+cc@1.2.57		X									X			
 cfg-if@1.0.4		X									X			
 chrono@0.4.44		X									X			
+cipher@0.4.4		X									X			
 concurrent-queue@2.5.0		X									X			
 const-random@0.1.18		X									X			
 const-random-macro@0.1.16		X									X			
@@ -57,21 +62,19 @@ crossbeam-queue@0.3.12		X									X
 crossbeam-utils@0.8.21		X									X			
 crunchy@0.2.4											X			
 crypto-common@0.1.7		X									X			
+ctr@0.9.2		X									X			
 darling@0.20.11											X			
-darling@0.21.3											X			
 darling@0.23.0											X			
 darling_core@0.20.11											X			
-darling_core@0.21.3											X			
 darling_core@0.23.0											X			
 darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
 darling_macro@0.23.0											X			
 derive_builder@0.20.2		X									X			
 derive_builder_core@0.20.2		X									X			
 derive_builder_macro@0.20.2		X									X			
 digest@0.10.7		X									X			
 displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
+dissimilar@1.0.11		X												
 either@1.15.0		X									X			
 equivalent@1.0.2		X									X			
 erased-serde@0.4.10		X									X			
@@ -100,11 +103,13 @@ futures-util@0.3.32		X									X
 generic-array@0.14.7											X			
 getrandom@0.2.17		X									X			
 getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
+getrandom@0.4.2		X									X			
+ghash@0.5.1		X									X			
 gloo-timers@0.3.0		X									X			
 half@2.7.1		X									X			
 hashbrown@0.15.5		X									X			
 hashbrown@0.16.1		X									X			
+hashbrown@0.17.1		X									X			
 hashlink@0.10.0		X									X			
 heck@0.5.0		X									X			
 http@1.4.0		X									X			
@@ -129,12 +134,13 @@ ident_case@1.0.1		X									X
 idna@1.1.0		X									X			
 idna_adapter@1.2.1		X									X			
 indexmap@2.13.0		X									X			
+inout@0.1.4		X									X			
 integer-encoding@3.0.4											X			
 inventory@0.3.22		X									X			
 ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
+iri-string@0.7.11		X									X			
 itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
+itoa@1.0.18		X									X			
 jobserver@0.1.34		X									X			
 js-sys@0.3.91		X									X			
 lazy_static@1.5.0		X									X			
@@ -144,46 +150,47 @@ lexical-parse-integer@1.0.6		X									X
 lexical-util@1.0.7		X									X			
 lexical-write-float@1.0.6		X									X			
 lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
+libc@0.2.183		X									X			
 libm@0.2.16											X			
 libsqlite3-sys@0.30.1											X			
 litemap@0.8.1												X		
 lock_api@0.4.14		X									X			
 log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
+lz4_flex@0.13.0											X			
 memchr@2.8.0											X		X	
 miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
+mio@1.2.0											X			
+moka@0.12.15		X									X			
 murmur3@0.5.2		X									X			
 nu-ansi-term@0.50.3											X			
 num-bigint@0.4.6		X									X			
 num-complex@0.4.6		X									X			
 num-integer@0.1.46		X									X			
 num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
+once_cell@1.21.4		X									X			
+opaque-debug@0.3.1		X									X			
 ordered-float@2.10.1											X			
 ordered-float@4.6.0											X			
 parking@2.2.1		X									X			
 parking_lot@0.12.5		X									X			
 parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
+parquet@58.1.0		X												
 paste@1.0.15		X									X			
 percent-encoding@2.3.2		X									X			
 pin-project-lite@0.2.17		X									X			
 pin-utils@0.1.0		X									X			
 pkg-config@0.3.32		X									X			
+polyval@0.6.2		X									X			
 portable-atomic@1.13.1		X									X			
 potential_utf@0.1.4												X		
 ppv-lite86@0.2.21		X									X			
 prettyplease@0.2.37		X									X			
 proc-macro2@1.0.106		X									X			
 quad-rand@0.2.3											X			
-quote@1.0.44		X									X			
+quote@1.0.45		X									X			
 r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
+r-efi@6.0.0		X								X	X			
+rand@0.9.4		X									X			
 rand_chacha@0.9.0		X									X			
 rand_core@0.6.4		X									X			
 rand_core@0.9.5		X									X			
@@ -198,7 +205,7 @@ roaring@0.11.3		X									X
 rustc_version@0.4.1		X									X			
 rustls@0.23.37		X							X		X			
 rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.103.9									X					
+rustls-webpki@0.103.13									X					
 rustversion@1.0.22		X									X			
 ryu@1.0.23		X				X								
 scopeguard@1.2.0		X									X			
@@ -212,8 +219,8 @@ serde_derive@1.0.228		X									X
 serde_json@1.0.149		X									X			
 serde_repr@0.1.20		X									X			
 serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
+serde_with@3.21.0		X									X			
+serde_with_macros@3.21.0		X									X			
 sha2@0.10.9		X									X			
 sharded-slab@0.1.7											X			
 shlex@1.3.0		X									X			
@@ -222,7 +229,7 @@ simdutf8@0.1.5		X									X
 slab@0.4.12											X			
 smallvec@1.15.1		X									X			
 snap@1.1.1					X									
-socket2@0.6.2		X									X			
+socket2@0.6.3		X									X			
 spin@0.9.8											X			
 sqlx@0.8.6		X									X			
 sqlx-core@0.8.6		X									X			
@@ -242,8 +249,8 @@ thread_local@1.1.9		X									X
 thrift@0.17.0		X												
 tiny-keccak@2.0.2							X							
 tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
+tokio@1.52.1											X			
+tokio-macros@2.7.0											X			
 tokio-stream@0.1.18											X			
 tower@0.5.3											X			
 tower-http@0.6.8											X			
@@ -253,20 +260,21 @@ tracing@0.1.44											X
 tracing-attributes@0.1.31											X			
 tracing-core@0.1.36											X			
 tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
+tracing-subscriber@0.3.23											X			
 try-lock@0.2.5											X			
 twox-hash@2.1.2											X			
 typed-builder@0.20.1		X									X			
 typed-builder-macro@0.20.1		X									X			
 typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
+typenum@1.20.1		X									X			
 typetag@0.2.21		X									X			
 typetag-impl@0.2.21		X									X			
 unicode-ident@1.0.24		X									X	X		
+universal-hash@0.5.1		X									X			
 untrusted@0.9.0									X					
 url@2.5.8		X									X			
 utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
+uuid@1.23.0		X									X			
 vcpkg@0.2.15		X									X			
 version_check@0.9.5		X									X			
 want@0.3.1											X			
@@ -312,8 +320,8 @@ wit-bindgen@0.51.0		X	X								X
 writeable@0.6.2												X		
 yoke@0.8.1												X		
 yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
+zerocopy@0.8.47		X		X							X			
+zerocopy-derive@0.8.47		X		X							X			
 zerofrom@0.1.6												X		
 zerofrom-derive@0.1.6												X		
 zeroize@1.8.2		X									X			

--- a/crates/examples/DEPENDENCIES.rust.tsv
+++ b/crates/examples/DEPENDENCIES.rust.tsv
@@ -1,296 +1,319 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X							X			
-ahash@0.8.12		X							X			
-aho-corasick@1.1.4									X		X	
-alloc-no-stdlib@2.0.4					X							
-alloc-stdlib@0.2.2					X							
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.102		X							X			
-apache-avro@0.21.0		X										
-array-init@2.1.0		X							X			
-arrow-arith@57.3.0		X										
-arrow-array@57.3.0		X										
-arrow-buffer@57.3.0		X										
-arrow-cast@57.3.0		X										
-arrow-data@57.3.0		X										
-arrow-ipc@57.3.0		X										
-arrow-ord@57.3.0		X										
-arrow-schema@57.3.0		X										
-arrow-select@57.3.0		X										
-arrow-string@57.3.0		X										
-as-any@0.3.2		X							X			
-async-lock@3.4.2		X							X			
-async-trait@0.1.89		X							X			
-atoi@2.0.0									X			
-atomic-waker@1.1.2		X							X			
-autocfg@1.5.0		X							X			
-backon@1.6.0		X										
-base64@0.22.1		X							X			
-bigdecimal@0.4.10		X							X			
-bimap@0.6.3		X							X			
-bitflags@2.11.0		X							X			
-block-buffer@0.10.4		X							X			
-bnum@0.12.1		X							X			
-bon@3.9.0		X							X			
-bon-macros@3.9.0		X							X			
-brotli@8.0.2					X				X			
-brotli-decompressor@5.0.0					X				X			
-bumpalo@3.20.2		X							X			
-bytemuck@1.25.0		X							X			X
-byteorder@1.5.0									X		X	
-bytes@1.11.1									X			
-cc@1.2.56		X							X			
-cfg-if@1.0.4		X							X			
-chrono@0.4.44		X							X			
-concurrent-queue@2.5.0		X							X			
-const-random@0.1.18		X							X			
-const-random-macro@0.1.16		X							X			
-core-foundation-sys@0.8.7		X							X			
-crc32fast@1.5.0		X							X			
-crossbeam-channel@0.5.15		X							X			
-crossbeam-epoch@0.9.18		X							X			
-crossbeam-utils@0.8.21		X							X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7		X							X			
-darling@0.20.11									X			
-darling@0.21.3									X			
-darling@0.23.0									X			
-darling_core@0.20.11									X			
-darling_core@0.21.3									X			
-darling_core@0.23.0									X			
-darling_macro@0.20.11									X			
-darling_macro@0.21.3									X			
-darling_macro@0.23.0									X			
-derive_builder@0.20.2		X							X			
-derive_builder_core@0.20.2		X							X			
-derive_builder_macro@0.20.2		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-dissimilar@1.0.10		X										
-either@1.15.0		X							X			
-equivalent@1.0.2		X							X			
-erased-serde@0.4.10		X							X			
-errno@0.3.14		X							X			
-event-listener@5.4.1		X							X			
-event-listener-strategy@0.5.4		X							X			
-expect-test@1.5.1		X							X			
-fastnum@0.7.4		X							X			
-fastrand@2.3.0		X							X			
-find-msvc-tools@0.1.9		X							X			
-flatbuffers@25.12.19		X										
-flate2@1.1.9		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.2		X							X			
-futures@0.3.32		X							X			
-futures-channel@0.3.32		X							X			
-futures-core@0.3.32		X							X			
-futures-executor@0.3.32		X							X			
-futures-io@0.3.32		X							X			
-futures-macro@0.3.32		X							X			
-futures-sink@0.3.32		X							X			
-futures-task@0.3.32		X							X			
-futures-util@0.3.32		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.17		X							X			
-getrandom@0.3.4		X							X			
-getrandom@0.4.1		X							X			
-gloo-timers@0.3.0		X							X			
-h2@0.4.13									X			
-half@2.7.1		X							X			
-hashbrown@0.16.1		X							X			
-heck@0.5.0		X							X			
-http@1.4.0		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-httpdate@1.0.3		X							X			
-hyper@1.8.1									X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-iceberg@0.9.0		X										
-iceberg-catalog-rest@0.9.0		X										
-iceberg-examples@0.9.0		X										
-iceberg_test_utils@0.9.0		X										
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
-ident_case@1.0.1		X							X			
-idna@1.1.0		X							X			
-idna_adapter@1.2.1		X							X			
-indexmap@2.13.0		X							X			
-integer-encoding@3.0.4									X			
-inventory@0.3.22		X							X			
-ipnet@2.12.0		X							X			
-iri-string@0.7.10		X							X			
-itertools@0.13.0		X							X			
-itoa@1.0.17		X							X			
-jobserver@0.1.34		X							X			
-js-sys@0.3.91		X							X			
-lazy_static@1.5.0		X							X			
-lexical-core@1.0.6		X							X			
-lexical-parse-float@1.0.6		X							X			
-lexical-parse-integer@1.0.6		X							X			
-lexical-util@1.0.7		X							X			
-lexical-write-float@1.0.6		X							X			
-lexical-write-integer@1.0.6		X							X			
-libc@0.2.182		X							X			
-libm@0.2.16									X			
-litemap@0.8.1										X		
-lock_api@0.4.14		X							X			
-log@0.4.29		X							X			
-lz4_flex@0.12.0									X			
-memchr@2.8.0									X		X	
-miniz_oxide@0.8.9		X							X			X
-mio@1.1.1									X			
-moka@0.12.14		X							X			
-murmur3@0.5.2		X							X			
-nu-ansi-term@0.50.3									X			
-num-bigint@0.4.6		X							X			
-num-complex@0.4.6		X							X			
-num-integer@0.1.46		X							X			
-num-traits@0.2.19		X							X			
-once_cell@1.21.3		X							X			
-ordered-float@2.10.1									X			
-ordered-float@4.6.0									X			
-parking@2.2.1		X							X			
-parking_lot@0.12.5		X							X			
-parking_lot_core@0.9.12		X							X			
-parquet@57.3.0		X										
-paste@1.0.15		X							X			
-percent-encoding@2.3.2		X							X			
-pin-project-lite@0.2.17		X							X			
-pin-utils@0.1.0		X							X			
-pkg-config@0.3.32		X							X			
-portable-atomic@1.13.1		X							X			
-potential_utf@0.1.4										X		
-ppv-lite86@0.2.21		X							X			
-prettyplease@0.2.37		X							X			
-proc-macro2@1.0.106		X							X			
-quad-rand@0.2.3									X			
-quote@1.0.44		X							X			
-r-efi@5.3.0		X						X	X			
-rand@0.8.5		X							X			
-rand@0.9.2		X							X			
-rand_chacha@0.3.1		X							X			
-rand_chacha@0.9.0		X							X			
-rand_core@0.6.4		X							X			
-rand_core@0.9.5		X							X			
-redox_syscall@0.5.18									X			
-regex@1.12.3		X							X			
-regex-automata@0.4.14		X							X			
-regex-lite@0.1.9		X							X			
-regex-syntax@0.8.10		X							X			
-reqwest@0.12.28		X							X			
-roaring@0.11.3		X							X			
-rustc_version@0.4.1		X							X			
-rustversion@1.0.22		X							X			
-ryu@1.0.23		X				X						
-scopeguard@1.2.0		X							X			
-semver@1.0.27		X							X			
-seq-macro@0.3.6		X							X			
-serde@1.0.228		X							X			
-serde-big-array@0.5.1		X							X			
-serde_bytes@0.11.19		X							X			
-serde_core@1.0.228		X							X			
-serde_derive@1.0.228		X							X			
-serde_json@1.0.149		X							X			
-serde_repr@0.1.20		X							X			
-serde_urlencoded@0.7.1		X							X			
-serde_with@3.17.0		X							X			
-serde_with_macros@3.17.0		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-signal-hook-registry@1.4.8		X							X			
-simd-adler32@0.3.8									X			
-simdutf8@0.1.5		X							X			
-slab@0.4.12									X			
-smallvec@1.15.1		X							X			
-snap@1.1.1					X							
-socket2@0.6.2		X							X			
-stable_deref_trait@1.2.1		X							X			
-strsim@0.11.1									X			
-strum@0.27.2									X			
-strum_macros@0.27.2									X			
-syn@2.0.117		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tagptr@0.2.0		X							X			
-thiserror@2.0.18		X							X			
-thiserror-impl@2.0.18		X							X			
-thread_local@1.1.9		X							X			
-thrift@0.17.0		X										
-tiny-keccak@2.0.2							X					
-tinystr@0.8.2										X		
-tokio@1.50.0									X			
-tokio-macros@2.6.1									X			
-tokio-util@0.7.18									X			
-tower@0.5.3									X			
-tower-http@0.6.8									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-attributes@0.1.31									X			
-tracing-core@0.1.36									X			
-tracing-log@0.2.0									X			
-tracing-subscriber@0.3.22									X			
-try-lock@0.2.5									X			
-twox-hash@2.1.2									X			
-typed-builder@0.20.1		X							X			
-typed-builder-macro@0.20.1		X							X			
-typeid@1.0.3		X							X			
-typenum@1.19.0		X							X			
-typetag@0.2.21		X							X			
-typetag-impl@0.2.21		X							X			
-unicode-ident@1.0.24		X							X	X		
-url@2.5.8		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.22.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasip2@1.0.2+wasi-0.2.9		X	X						X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X			
-wasm-bindgen@0.2.114		X							X			
-wasm-bindgen-futures@0.4.64		X							X			
-wasm-bindgen-macro@0.2.114		X							X			
-wasm-bindgen-macro-support@0.2.114		X							X			
-wasm-bindgen-shared@0.2.114		X							X			
-web-sys@0.3.91		X							X			
-windows-core@0.62.2		X							X			
-windows-implement@0.60.2		X							X			
-windows-interface@0.59.3		X							X			
-windows-link@0.2.1		X							X			
-windows-result@0.4.1		X							X			
-windows-strings@0.5.1		X							X			
-windows-sys@0.60.2		X							X			
-windows-sys@0.61.2		X							X			
-windows-targets@0.53.5		X							X			
-windows_aarch64_gnullvm@0.53.1		X							X			
-windows_aarch64_msvc@0.53.1		X							X			
-windows_i686_gnu@0.53.1		X							X			
-windows_i686_gnullvm@0.53.1		X							X			
-windows_i686_msvc@0.53.1		X							X			
-windows_x86_64_gnu@0.53.1		X							X			
-windows_x86_64_gnullvm@0.53.1		X							X			
-windows_x86_64_msvc@0.53.1		X							X			
-wit-bindgen@0.51.0		X	X						X			
-writeable@0.6.2										X		
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerocopy@0.8.40		X		X					X			
-zerocopy-derive@0.8.40		X		X					X			
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
-zlib-rs@0.6.3												X
-zmij@1.0.21									X			
-zstd@0.13.3									X			
-zstd-safe@7.2.4		X							X			
-zstd-sys@2.0.16+zstd.1.5.7		X							X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X								X			
+aead@0.5.2		X								X			
+aes@0.8.4		X								X			
+aes-gcm@0.10.3		X								X			
+ahash@0.8.12		X								X			
+aho-corasick@1.1.4										X		X	
+alloc-no-stdlib@2.0.4					X								
+alloc-stdlib@0.2.2					X								
+android_system_properties@0.1.5		X								X			
+anyhow@1.0.102		X								X			
+apache-avro@0.21.0		X											
+array-init@2.1.0		X								X			
+arrow-arith@58.3.0		X											
+arrow-array@58.3.0		X								X			
+arrow-buffer@58.3.0		X											
+arrow-cast@58.3.0		X											
+arrow-data@58.3.0		X											
+arrow-ipc@58.1.0		X											
+arrow-ord@58.3.0		X											
+arrow-schema@58.3.0		X											
+arrow-select@58.3.0		X											
+arrow-string@58.3.0		X											
+as-any@0.3.2		X								X			
+async-lock@3.4.2		X								X			
+async-trait@0.1.89		X								X			
+atoi@2.0.0										X			
+atomic-waker@1.1.2		X								X			
+autocfg@1.5.0		X								X			
+backon@1.6.0		X											
+base64@0.22.1		X								X			
+bigdecimal@0.4.10		X								X			
+bimap@0.6.3		X								X			
+bitflags@2.11.0		X								X			
+block-buffer@0.10.4		X								X			
+bnum@0.12.1		X								X			
+bon@3.9.1		X								X			
+bon-macros@3.9.1		X								X			
+brotli@8.0.2					X					X			
+brotli-decompressor@5.0.0					X					X			
+bumpalo@3.20.2		X								X			
+bytemuck@1.25.0		X								X			X
+bytemuck_derive@1.10.2		X								X			X
+byteorder@1.5.0										X		X	
+bytes@1.11.1										X			
+cc@1.2.57		X								X			
+cfg-if@1.0.4		X								X			
+chrono@0.4.44		X								X			
+cipher@0.4.4		X								X			
+concurrent-queue@2.5.0		X								X			
+const-random@0.1.18		X								X			
+const-random-macro@0.1.16		X								X			
+core-foundation-sys@0.8.7		X								X			
+cpufeatures@0.2.17		X								X			
+crc32fast@1.5.0		X								X			
+crossbeam-channel@0.5.15		X								X			
+crossbeam-epoch@0.9.18		X								X			
+crossbeam-utils@0.8.21		X								X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7		X								X			
+ctr@0.9.2		X								X			
+darling@0.20.11										X			
+darling@0.23.0										X			
+darling_core@0.20.11										X			
+darling_core@0.23.0										X			
+darling_macro@0.20.11										X			
+darling_macro@0.23.0										X			
+derive_builder@0.20.2		X								X			
+derive_builder_core@0.20.2		X								X			
+derive_builder_macro@0.20.2		X								X			
+digest@0.10.7		X								X			
+displaydoc@0.2.5		X								X			
+dissimilar@1.0.11		X											
+either@1.15.0		X								X			
+equivalent@1.0.2		X								X			
+erased-serde@0.4.10		X								X			
+errno@0.3.14		X								X			
+event-listener@5.4.1		X								X			
+event-listener-strategy@0.5.4		X								X			
+expect-test@1.5.1		X								X			
+fastnum@0.7.4		X								X			
+fastrand@2.3.0		X								X			
+find-msvc-tools@0.1.9		X								X			
+flatbuffers@25.12.19		X											
+flate2@1.1.9		X								X			
+fnv@1.0.7		X								X			
+form_urlencoded@1.2.2		X								X			
+futures@0.3.32		X								X			
+futures-channel@0.3.32		X								X			
+futures-core@0.3.32		X								X			
+futures-executor@0.3.32		X								X			
+futures-io@0.3.32		X								X			
+futures-macro@0.3.32		X								X			
+futures-sink@0.3.32		X								X			
+futures-task@0.3.32		X								X			
+futures-util@0.3.32		X								X			
+generic-array@0.14.7										X			
+getrandom@0.2.17		X								X			
+getrandom@0.3.4		X								X			
+getrandom@0.4.2		X								X			
+ghash@0.5.1		X								X			
+gloo-timers@0.3.0		X								X			
+h2@0.4.13										X			
+half@2.7.1		X								X			
+hashbrown@0.16.1		X								X			
+hashbrown@0.17.1		X								X			
+heck@0.5.0		X								X			
+http@1.4.0		X								X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1		X								X			
+httpdate@1.0.3		X								X			
+hyper@1.8.1										X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65		X								X			
+iana-time-zone-haiku@0.1.2		X								X			
+iceberg@0.9.0		X											
+iceberg-catalog-rest@0.9.0		X											
+iceberg-examples@0.9.0		X											
+iceberg_test_utils@0.9.0		X											
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+ident_case@1.0.1		X								X			
+idna@1.1.0		X								X			
+idna_adapter@1.2.1		X								X			
+indexmap@2.13.0		X								X			
+inout@0.1.4		X								X			
+integer-encoding@3.0.4										X			
+inventory@0.3.22		X								X			
+ipnet@2.12.0		X								X			
+iri-string@0.7.11		X								X			
+itertools@0.13.0		X								X			
+itoa@1.0.18		X								X			
+jobserver@0.1.34		X								X			
+js-sys@0.3.91		X								X			
+lazy_static@1.5.0		X								X			
+lexical-core@1.0.6		X								X			
+lexical-parse-float@1.0.6		X								X			
+lexical-parse-integer@1.0.6		X								X			
+lexical-util@1.0.7		X								X			
+lexical-write-float@1.0.6		X								X			
+lexical-write-integer@1.0.6		X								X			
+libc@0.2.183		X								X			
+libm@0.2.16										X			
+litemap@0.8.1											X		
+lock_api@0.4.14		X								X			
+log@0.4.29		X								X			
+lz4_flex@0.13.0										X			
+memchr@2.8.0										X		X	
+miniz_oxide@0.8.9		X								X			X
+mio@1.2.0										X			
+moka@0.12.15		X								X			
+murmur3@0.5.2		X								X			
+nu-ansi-term@0.50.3										X			
+num-bigint@0.4.6		X								X			
+num-complex@0.4.6		X								X			
+num-integer@0.1.46		X								X			
+num-traits@0.2.19		X								X			
+once_cell@1.21.4		X								X			
+opaque-debug@0.3.1		X								X			
+ordered-float@2.10.1										X			
+ordered-float@4.6.0										X			
+parking@2.2.1		X								X			
+parking_lot@0.12.5		X								X			
+parking_lot_core@0.9.12		X								X			
+parquet@58.1.0		X											
+paste@1.0.15		X								X			
+percent-encoding@2.3.2		X								X			
+pin-project-lite@0.2.17		X								X			
+pin-utils@0.1.0		X								X			
+pkg-config@0.3.32		X								X			
+polyval@0.6.2		X								X			
+portable-atomic@1.13.1		X								X			
+potential_utf@0.1.4											X		
+ppv-lite86@0.2.21		X								X			
+prettyplease@0.2.37		X								X			
+proc-macro2@1.0.106		X								X			
+quad-rand@0.2.3										X			
+quote@1.0.45		X								X			
+r-efi@5.3.0		X							X	X			
+r-efi@6.0.0		X							X	X			
+rand@0.9.4		X								X			
+rand_chacha@0.9.0		X								X			
+rand_core@0.6.4		X								X			
+rand_core@0.9.5		X								X			
+redox_syscall@0.5.18										X			
+regex@1.12.3		X								X			
+regex-automata@0.4.14		X								X			
+regex-lite@0.1.9		X								X			
+regex-syntax@0.8.10		X								X			
+reqwest@0.12.28		X								X			
+ring@0.17.14		X						X					
+roaring@0.11.3		X								X			
+rustc_version@0.4.1		X								X			
+rustversion@1.0.22		X								X			
+ryu@1.0.23		X				X							
+scopeguard@1.2.0		X								X			
+semver@1.0.27		X								X			
+seq-macro@0.3.6		X								X			
+serde@1.0.228		X								X			
+serde-big-array@0.5.1		X								X			
+serde_bytes@0.11.19		X								X			
+serde_core@1.0.228		X								X			
+serde_derive@1.0.228		X								X			
+serde_json@1.0.149		X								X			
+serde_repr@0.1.20		X								X			
+serde_urlencoded@0.7.1		X								X			
+serde_with@3.21.0		X								X			
+serde_with_macros@3.21.0		X								X			
+sharded-slab@0.1.7										X			
+shlex@1.3.0		X								X			
+signal-hook-registry@1.4.8		X								X			
+simd-adler32@0.3.8										X			
+simdutf8@0.1.5		X								X			
+slab@0.4.12										X			
+smallvec@1.15.1		X								X			
+snap@1.1.1					X								
+socket2@0.6.3		X								X			
+stable_deref_trait@1.2.1		X								X			
+strsim@0.11.1										X			
+strum@0.27.2										X			
+strum_macros@0.27.2										X			
+subtle@2.6.1					X								
+syn@2.0.117		X								X			
+sync_wrapper@1.0.2		X											
+synstructure@0.13.2										X			
+tagptr@0.2.0		X								X			
+thiserror@2.0.18		X								X			
+thiserror-impl@2.0.18		X								X			
+thread_local@1.1.9		X								X			
+thrift@0.17.0		X											
+tiny-keccak@2.0.2							X						
+tinystr@0.8.2											X		
+tokio@1.52.1										X			
+tokio-macros@2.7.0										X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+tracing-log@0.2.0										X			
+tracing-subscriber@0.3.23										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typed-builder@0.20.1		X								X			
+typed-builder-macro@0.20.1		X								X			
+typeid@1.0.3		X								X			
+typenum@1.20.1		X								X			
+typetag@0.2.21		X								X			
+typetag-impl@0.2.21		X								X			
+unicode-ident@1.0.24		X								X	X		
+universal-hash@0.5.1		X								X			
+untrusted@0.9.0								X					
+url@2.5.8		X								X			
+utf8_iter@1.0.4		X								X			
+uuid@1.23.0		X								X			
+version_check@0.9.5		X								X			
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
+wasip2@1.0.2+wasi-0.2.9		X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X			
+wasm-bindgen@0.2.114		X								X			
+wasm-bindgen-futures@0.4.64		X								X			
+wasm-bindgen-macro@0.2.114		X								X			
+wasm-bindgen-macro-support@0.2.114		X								X			
+wasm-bindgen-shared@0.2.114		X								X			
+web-sys@0.3.91		X								X			
+windows-core@0.62.2		X								X			
+windows-implement@0.60.2		X								X			
+windows-interface@0.59.3		X								X			
+windows-link@0.2.1		X								X			
+windows-result@0.4.1		X								X			
+windows-strings@0.5.1		X								X			
+windows-sys@0.52.0		X								X			
+windows-sys@0.60.2		X								X			
+windows-sys@0.61.2		X								X			
+windows-targets@0.52.6		X								X			
+windows-targets@0.53.5		X								X			
+windows_aarch64_gnullvm@0.52.6		X								X			
+windows_aarch64_gnullvm@0.53.1		X								X			
+windows_aarch64_msvc@0.52.6		X								X			
+windows_aarch64_msvc@0.53.1		X								X			
+windows_i686_gnu@0.52.6		X								X			
+windows_i686_gnu@0.53.1		X								X			
+windows_i686_gnullvm@0.52.6		X								X			
+windows_i686_gnullvm@0.53.1		X								X			
+windows_i686_msvc@0.52.6		X								X			
+windows_i686_msvc@0.53.1		X								X			
+windows_x86_64_gnu@0.52.6		X								X			
+windows_x86_64_gnu@0.53.1		X								X			
+windows_x86_64_gnullvm@0.52.6		X								X			
+windows_x86_64_gnullvm@0.53.1		X								X			
+windows_x86_64_msvc@0.52.6		X								X			
+windows_x86_64_msvc@0.53.1		X								X			
+wit-bindgen@0.51.0		X	X							X			
+writeable@0.6.2											X		
+yoke@0.8.1											X		
+yoke-derive@0.8.1											X		
+zerocopy@0.8.47		X		X						X			
+zerocopy-derive@0.8.47		X		X						X			
+zerofrom@0.1.6											X		
+zerofrom-derive@0.1.6											X		
+zeroize@1.8.2		X								X			
+zerotrie@0.2.3											X		
+zerovec@0.11.5											X		
+zerovec-derive@0.11.2											X		
+zlib-rs@0.6.3													X
+zmij@1.0.21										X			
+zstd@0.13.3										X			
+zstd-safe@7.2.4		X								X			
+zstd-sys@2.0.16+zstd.1.5.7		X								X			

--- a/crates/iceberg/DEPENDENCIES.rust.tsv
+++ b/crates/iceberg/DEPENDENCIES.rust.tsv
@@ -1,287 +1,311 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X							X			
-ahash@0.8.12		X							X			
-aho-corasick@1.1.4									X		X	
-alloc-no-stdlib@2.0.4					X							
-alloc-stdlib@0.2.2					X							
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.102		X							X			
-apache-avro@0.21.0		X										
-array-init@2.1.0		X							X			
-arrow-arith@57.3.0		X										
-arrow-array@57.3.0		X										
-arrow-buffer@57.3.0		X										
-arrow-cast@57.3.0		X										
-arrow-data@57.3.0		X										
-arrow-ipc@57.3.0		X										
-arrow-ord@57.3.0		X										
-arrow-schema@57.3.0		X										
-arrow-select@57.3.0		X										
-arrow-string@57.3.0		X										
-as-any@0.3.2		X							X			
-async-lock@3.4.2		X							X			
-async-trait@0.1.89		X							X			
-atoi@2.0.0									X			
-atomic-waker@1.1.2		X							X			
-autocfg@1.5.0		X							X			
-backon@1.6.0		X										
-base64@0.22.1		X							X			
-bigdecimal@0.4.10		X							X			
-bimap@0.6.3		X							X			
-bitflags@2.11.0		X							X			
-block-buffer@0.10.4		X							X			
-bnum@0.12.1		X							X			
-bon@3.9.0		X							X			
-bon-macros@3.9.0		X							X			
-brotli@8.0.2					X				X			
-brotli-decompressor@5.0.0					X				X			
-bumpalo@3.20.2		X							X			
-bytemuck@1.25.0		X							X			X
-byteorder@1.5.0									X		X	
-bytes@1.11.1									X			
-cc@1.2.56		X							X			
-cfg-if@1.0.4		X							X			
-chrono@0.4.44		X							X			
-concurrent-queue@2.5.0		X							X			
-const-random@0.1.18		X							X			
-const-random-macro@0.1.16		X							X			
-core-foundation-sys@0.8.7		X							X			
-crc32fast@1.5.0		X							X			
-crossbeam-channel@0.5.15		X							X			
-crossbeam-epoch@0.9.18		X							X			
-crossbeam-utils@0.8.21		X							X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7		X							X			
-darling@0.20.11									X			
-darling@0.21.3									X			
-darling@0.23.0									X			
-darling_core@0.20.11									X			
-darling_core@0.21.3									X			
-darling_core@0.23.0									X			
-darling_macro@0.20.11									X			
-darling_macro@0.21.3									X			
-darling_macro@0.23.0									X			
-derive_builder@0.20.2		X							X			
-derive_builder_core@0.20.2		X							X			
-derive_builder_macro@0.20.2		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-dissimilar@1.0.10		X										
-either@1.15.0		X							X			
-equivalent@1.0.2		X							X			
-erased-serde@0.4.10		X							X			
-event-listener@5.4.1		X							X			
-event-listener-strategy@0.5.4		X							X			
-expect-test@1.5.1		X							X			
-fastnum@0.7.4		X							X			
-fastrand@2.3.0		X							X			
-find-msvc-tools@0.1.9		X							X			
-flatbuffers@25.12.19		X										
-flate2@1.1.9		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.2		X							X			
-futures@0.3.32		X							X			
-futures-channel@0.3.32		X							X			
-futures-core@0.3.32		X							X			
-futures-executor@0.3.32		X							X			
-futures-io@0.3.32		X							X			
-futures-macro@0.3.32		X							X			
-futures-sink@0.3.32		X							X			
-futures-task@0.3.32		X							X			
-futures-util@0.3.32		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.17		X							X			
-getrandom@0.3.4		X							X			
-getrandom@0.4.1		X							X			
-gloo-timers@0.3.0		X							X			
-half@2.7.1		X							X			
-hashbrown@0.16.1		X							X			
-heck@0.5.0		X							X			
-http@1.4.0		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-hyper@1.8.1									X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-iceberg@0.9.0		X										
-iceberg_test_utils@0.9.0		X										
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
-ident_case@1.0.1		X							X			
-idna@1.1.0		X							X			
-idna_adapter@1.2.1		X							X			
-integer-encoding@3.0.4									X			
-inventory@0.3.22		X							X			
-ipnet@2.12.0		X							X			
-iri-string@0.7.10		X							X			
-itertools@0.13.0		X							X			
-itoa@1.0.17		X							X			
-jobserver@0.1.34		X							X			
-js-sys@0.3.91		X							X			
-lazy_static@1.5.0		X							X			
-lexical-core@1.0.6		X							X			
-lexical-parse-float@1.0.6		X							X			
-lexical-parse-integer@1.0.6		X							X			
-lexical-util@1.0.7		X							X			
-lexical-write-float@1.0.6		X							X			
-lexical-write-integer@1.0.6		X							X			
-libc@0.2.182		X							X			
-libm@0.2.16									X			
-litemap@0.8.1										X		
-lock_api@0.4.14		X							X			
-log@0.4.29		X							X			
-lz4_flex@0.12.0									X			
-memchr@2.8.0									X		X	
-miniz_oxide@0.8.9		X							X			X
-mio@1.1.1									X			
-moka@0.12.14		X							X			
-murmur3@0.5.2		X							X			
-nu-ansi-term@0.50.3									X			
-num-bigint@0.4.6		X							X			
-num-complex@0.4.6		X							X			
-num-integer@0.1.46		X							X			
-num-traits@0.2.19		X							X			
-once_cell@1.21.3		X							X			
-ordered-float@2.10.1									X			
-ordered-float@4.6.0									X			
-parking@2.2.1		X							X			
-parking_lot@0.12.5		X							X			
-parking_lot_core@0.9.12		X							X			
-parquet@57.3.0		X										
-paste@1.0.15		X							X			
-percent-encoding@2.3.2		X							X			
-pin-project-lite@0.2.17		X							X			
-pin-utils@0.1.0		X							X			
-pkg-config@0.3.32		X							X			
-portable-atomic@1.13.1		X							X			
-potential_utf@0.1.4										X		
-ppv-lite86@0.2.21		X							X			
-prettyplease@0.2.37		X							X			
-proc-macro2@1.0.106		X							X			
-quad-rand@0.2.3									X			
-quote@1.0.44		X							X			
-r-efi@5.3.0		X						X	X			
-rand@0.8.5		X							X			
-rand@0.9.2		X							X			
-rand_chacha@0.3.1		X							X			
-rand_chacha@0.9.0		X							X			
-rand_core@0.6.4		X							X			
-rand_core@0.9.5		X							X			
-redox_syscall@0.5.18									X			
-regex@1.12.3		X							X			
-regex-automata@0.4.14		X							X			
-regex-lite@0.1.9		X							X			
-regex-syntax@0.8.10		X							X			
-reqwest@0.12.28		X							X			
-roaring@0.11.3		X							X			
-rustc_version@0.4.1		X							X			
-rustversion@1.0.22		X							X			
-ryu@1.0.23		X				X						
-scopeguard@1.2.0		X							X			
-semver@1.0.27		X							X			
-seq-macro@0.3.6		X							X			
-serde@1.0.228		X							X			
-serde-big-array@0.5.1		X							X			
-serde_bytes@0.11.19		X							X			
-serde_core@1.0.228		X							X			
-serde_derive@1.0.228		X							X			
-serde_json@1.0.149		X							X			
-serde_repr@0.1.20		X							X			
-serde_urlencoded@0.7.1		X							X			
-serde_with@3.17.0		X							X			
-serde_with_macros@3.17.0		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-simd-adler32@0.3.8									X			
-simdutf8@0.1.5		X							X			
-slab@0.4.12									X			
-smallvec@1.15.1		X							X			
-snap@1.1.1					X							
-socket2@0.6.2		X							X			
-stable_deref_trait@1.2.1		X							X			
-strsim@0.11.1									X			
-strum@0.27.2									X			
-strum_macros@0.27.2									X			
-syn@2.0.117		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tagptr@0.2.0		X							X			
-thiserror@2.0.18		X							X			
-thiserror-impl@2.0.18		X							X			
-thread_local@1.1.9		X							X			
-thrift@0.17.0		X										
-tiny-keccak@2.0.2							X					
-tinystr@0.8.2										X		
-tokio@1.50.0									X			
-tokio-macros@2.6.1									X			
-tower@0.5.3									X			
-tower-http@0.6.8									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-core@0.1.36									X			
-tracing-log@0.2.0									X			
-tracing-subscriber@0.3.22									X			
-try-lock@0.2.5									X			
-twox-hash@2.1.2									X			
-typed-builder@0.20.1		X							X			
-typed-builder-macro@0.20.1		X							X			
-typeid@1.0.3		X							X			
-typenum@1.19.0		X							X			
-typetag@0.2.21		X							X			
-typetag-impl@0.2.21		X							X			
-unicode-ident@1.0.24		X							X	X		
-url@2.5.8		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.22.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasip2@1.0.2+wasi-0.2.9		X	X						X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X			
-wasm-bindgen@0.2.114		X							X			
-wasm-bindgen-futures@0.4.64		X							X			
-wasm-bindgen-macro@0.2.114		X							X			
-wasm-bindgen-macro-support@0.2.114		X							X			
-wasm-bindgen-shared@0.2.114		X							X			
-web-sys@0.3.91		X							X			
-windows-core@0.62.2		X							X			
-windows-implement@0.60.2		X							X			
-windows-interface@0.59.3		X							X			
-windows-link@0.2.1		X							X			
-windows-result@0.4.1		X							X			
-windows-strings@0.5.1		X							X			
-windows-sys@0.60.2		X							X			
-windows-sys@0.61.2		X							X			
-windows-targets@0.53.5		X							X			
-windows_aarch64_gnullvm@0.53.1		X							X			
-windows_aarch64_msvc@0.53.1		X							X			
-windows_i686_gnu@0.53.1		X							X			
-windows_i686_gnullvm@0.53.1		X							X			
-windows_i686_msvc@0.53.1		X							X			
-windows_x86_64_gnu@0.53.1		X							X			
-windows_x86_64_gnullvm@0.53.1		X							X			
-windows_x86_64_msvc@0.53.1		X							X			
-wit-bindgen@0.51.0		X	X						X			
-writeable@0.6.2										X		
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerocopy@0.8.40		X		X					X			
-zerocopy-derive@0.8.40		X		X					X			
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
-zlib-rs@0.6.3												X
-zmij@1.0.21									X			
-zstd@0.13.3									X			
-zstd-safe@7.2.4		X							X			
-zstd-sys@2.0.16+zstd.1.5.7		X							X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X								X			
+aead@0.5.2		X								X			
+aes@0.8.4		X								X			
+aes-gcm@0.10.3		X								X			
+ahash@0.8.12		X								X			
+aho-corasick@1.1.4										X		X	
+alloc-no-stdlib@2.0.4					X								
+alloc-stdlib@0.2.2					X								
+android_system_properties@0.1.5		X								X			
+anyhow@1.0.102		X								X			
+apache-avro@0.21.0		X											
+array-init@2.1.0		X								X			
+arrow-arith@58.3.0		X											
+arrow-array@58.3.0		X								X			
+arrow-buffer@58.3.0		X											
+arrow-cast@58.3.0		X											
+arrow-data@58.3.0		X											
+arrow-ipc@58.1.0		X											
+arrow-ord@58.3.0		X											
+arrow-schema@58.3.0		X											
+arrow-select@58.3.0		X											
+arrow-string@58.3.0		X											
+as-any@0.3.2		X								X			
+async-lock@3.4.2		X								X			
+async-trait@0.1.89		X								X			
+atoi@2.0.0										X			
+atomic-waker@1.1.2		X								X			
+autocfg@1.5.0		X								X			
+backon@1.6.0		X											
+base64@0.22.1		X								X			
+bigdecimal@0.4.10		X								X			
+bimap@0.6.3		X								X			
+bitflags@2.11.0		X								X			
+block-buffer@0.10.4		X								X			
+bnum@0.12.1		X								X			
+bon@3.9.1		X								X			
+bon-macros@3.9.1		X								X			
+brotli@8.0.2					X					X			
+brotli-decompressor@5.0.0					X					X			
+bumpalo@3.20.2		X								X			
+bytemuck@1.25.0		X								X			X
+bytemuck_derive@1.10.2		X								X			X
+byteorder@1.5.0										X		X	
+bytes@1.11.1										X			
+cc@1.2.57		X								X			
+cfg-if@1.0.4		X								X			
+chrono@0.4.44		X								X			
+cipher@0.4.4		X								X			
+concurrent-queue@2.5.0		X								X			
+const-random@0.1.18		X								X			
+const-random-macro@0.1.16		X								X			
+core-foundation-sys@0.8.7		X								X			
+cpufeatures@0.2.17		X								X			
+crc32fast@1.5.0		X								X			
+crossbeam-channel@0.5.15		X								X			
+crossbeam-epoch@0.9.18		X								X			
+crossbeam-utils@0.8.21		X								X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7		X								X			
+ctr@0.9.2		X								X			
+darling@0.20.11										X			
+darling@0.23.0										X			
+darling_core@0.20.11										X			
+darling_core@0.23.0										X			
+darling_macro@0.20.11										X			
+darling_macro@0.23.0										X			
+derive_builder@0.20.2		X								X			
+derive_builder_core@0.20.2		X								X			
+derive_builder_macro@0.20.2		X								X			
+digest@0.10.7		X								X			
+displaydoc@0.2.5		X								X			
+dissimilar@1.0.11		X											
+either@1.15.0		X								X			
+equivalent@1.0.2		X								X			
+erased-serde@0.4.10		X								X			
+event-listener@5.4.1		X								X			
+event-listener-strategy@0.5.4		X								X			
+expect-test@1.5.1		X								X			
+fastnum@0.7.4		X								X			
+fastrand@2.3.0		X								X			
+find-msvc-tools@0.1.9		X								X			
+flatbuffers@25.12.19		X											
+flate2@1.1.9		X								X			
+fnv@1.0.7		X								X			
+form_urlencoded@1.2.2		X								X			
+futures@0.3.32		X								X			
+futures-channel@0.3.32		X								X			
+futures-core@0.3.32		X								X			
+futures-executor@0.3.32		X								X			
+futures-io@0.3.32		X								X			
+futures-macro@0.3.32		X								X			
+futures-sink@0.3.32		X								X			
+futures-task@0.3.32		X								X			
+futures-util@0.3.32		X								X			
+generic-array@0.14.7										X			
+getrandom@0.2.17		X								X			
+getrandom@0.3.4		X								X			
+getrandom@0.4.2		X								X			
+ghash@0.5.1		X								X			
+gloo-timers@0.3.0		X								X			
+half@2.7.1		X								X			
+hashbrown@0.16.1		X								X			
+hashbrown@0.17.1		X								X			
+heck@0.5.0		X								X			
+http@1.4.0		X								X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1		X								X			
+hyper@1.8.1										X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65		X								X			
+iana-time-zone-haiku@0.1.2		X								X			
+iceberg@0.9.0		X											
+iceberg_test_utils@0.9.0		X											
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+ident_case@1.0.1		X								X			
+idna@1.1.0		X								X			
+idna_adapter@1.2.1		X								X			
+inout@0.1.4		X								X			
+integer-encoding@3.0.4										X			
+inventory@0.3.22		X								X			
+ipnet@2.12.0		X								X			
+iri-string@0.7.11		X								X			
+itertools@0.13.0		X								X			
+itoa@1.0.18		X								X			
+jobserver@0.1.34		X								X			
+js-sys@0.3.91		X								X			
+lazy_static@1.5.0		X								X			
+lexical-core@1.0.6		X								X			
+lexical-parse-float@1.0.6		X								X			
+lexical-parse-integer@1.0.6		X								X			
+lexical-util@1.0.7		X								X			
+lexical-write-float@1.0.6		X								X			
+lexical-write-integer@1.0.6		X								X			
+libc@0.2.183		X								X			
+libm@0.2.16										X			
+litemap@0.8.1											X		
+lock_api@0.4.14		X								X			
+log@0.4.29		X								X			
+lz4_flex@0.13.0										X			
+memchr@2.8.0										X		X	
+miniz_oxide@0.8.9		X								X			X
+mio@1.2.0										X			
+moka@0.12.15		X								X			
+murmur3@0.5.2		X								X			
+nu-ansi-term@0.50.3										X			
+num-bigint@0.4.6		X								X			
+num-complex@0.4.6		X								X			
+num-integer@0.1.46		X								X			
+num-traits@0.2.19		X								X			
+once_cell@1.21.4		X								X			
+opaque-debug@0.3.1		X								X			
+ordered-float@2.10.1										X			
+ordered-float@4.6.0										X			
+parking@2.2.1		X								X			
+parking_lot@0.12.5		X								X			
+parking_lot_core@0.9.12		X								X			
+parquet@58.1.0		X											
+paste@1.0.15		X								X			
+percent-encoding@2.3.2		X								X			
+pin-project-lite@0.2.17		X								X			
+pin-utils@0.1.0		X								X			
+pkg-config@0.3.32		X								X			
+polyval@0.6.2		X								X			
+portable-atomic@1.13.1		X								X			
+potential_utf@0.1.4											X		
+ppv-lite86@0.2.21		X								X			
+prettyplease@0.2.37		X								X			
+proc-macro2@1.0.106		X								X			
+quad-rand@0.2.3										X			
+quote@1.0.45		X								X			
+r-efi@5.3.0		X							X	X			
+r-efi@6.0.0		X							X	X			
+rand@0.9.4		X								X			
+rand_chacha@0.9.0		X								X			
+rand_core@0.6.4		X								X			
+rand_core@0.9.5		X								X			
+redox_syscall@0.5.18										X			
+regex@1.12.3		X								X			
+regex-automata@0.4.14		X								X			
+regex-lite@0.1.9		X								X			
+regex-syntax@0.8.10		X								X			
+reqwest@0.12.28		X								X			
+ring@0.17.14		X						X					
+roaring@0.11.3		X								X			
+rustc_version@0.4.1		X								X			
+rustversion@1.0.22		X								X			
+ryu@1.0.23		X				X							
+scopeguard@1.2.0		X								X			
+semver@1.0.27		X								X			
+seq-macro@0.3.6		X								X			
+serde@1.0.228		X								X			
+serde-big-array@0.5.1		X								X			
+serde_bytes@0.11.19		X								X			
+serde_core@1.0.228		X								X			
+serde_derive@1.0.228		X								X			
+serde_json@1.0.149		X								X			
+serde_repr@0.1.20		X								X			
+serde_urlencoded@0.7.1		X								X			
+serde_with@3.21.0		X								X			
+serde_with_macros@3.21.0		X								X			
+sharded-slab@0.1.7										X			
+shlex@1.3.0		X								X			
+simd-adler32@0.3.8										X			
+simdutf8@0.1.5		X								X			
+slab@0.4.12										X			
+smallvec@1.15.1		X								X			
+snap@1.1.1					X								
+socket2@0.6.3		X								X			
+stable_deref_trait@1.2.1		X								X			
+strsim@0.11.1										X			
+strum@0.27.2										X			
+strum_macros@0.27.2										X			
+subtle@2.6.1					X								
+syn@2.0.117		X								X			
+sync_wrapper@1.0.2		X											
+synstructure@0.13.2										X			
+tagptr@0.2.0		X								X			
+thiserror@2.0.18		X								X			
+thiserror-impl@2.0.18		X								X			
+thread_local@1.1.9		X								X			
+thrift@0.17.0		X											
+tiny-keccak@2.0.2							X						
+tinystr@0.8.2											X		
+tokio@1.52.1										X			
+tokio-macros@2.7.0										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+tracing-log@0.2.0										X			
+tracing-subscriber@0.3.23										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typed-builder@0.20.1		X								X			
+typed-builder-macro@0.20.1		X								X			
+typeid@1.0.3		X								X			
+typenum@1.20.1		X								X			
+typetag@0.2.21		X								X			
+typetag-impl@0.2.21		X								X			
+unicode-ident@1.0.24		X								X	X		
+universal-hash@0.5.1		X								X			
+untrusted@0.9.0								X					
+url@2.5.8		X								X			
+utf8_iter@1.0.4		X								X			
+uuid@1.23.0		X								X			
+version_check@0.9.5		X								X			
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
+wasip2@1.0.2+wasi-0.2.9		X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X			
+wasm-bindgen@0.2.114		X								X			
+wasm-bindgen-futures@0.4.64		X								X			
+wasm-bindgen-macro@0.2.114		X								X			
+wasm-bindgen-macro-support@0.2.114		X								X			
+wasm-bindgen-shared@0.2.114		X								X			
+web-sys@0.3.91		X								X			
+windows-core@0.62.2		X								X			
+windows-implement@0.60.2		X								X			
+windows-interface@0.59.3		X								X			
+windows-link@0.2.1		X								X			
+windows-result@0.4.1		X								X			
+windows-strings@0.5.1		X								X			
+windows-sys@0.52.0		X								X			
+windows-sys@0.60.2		X								X			
+windows-sys@0.61.2		X								X			
+windows-targets@0.52.6		X								X			
+windows-targets@0.53.5		X								X			
+windows_aarch64_gnullvm@0.52.6		X								X			
+windows_aarch64_gnullvm@0.53.1		X								X			
+windows_aarch64_msvc@0.52.6		X								X			
+windows_aarch64_msvc@0.53.1		X								X			
+windows_i686_gnu@0.52.6		X								X			
+windows_i686_gnu@0.53.1		X								X			
+windows_i686_gnullvm@0.52.6		X								X			
+windows_i686_gnullvm@0.53.1		X								X			
+windows_i686_msvc@0.52.6		X								X			
+windows_i686_msvc@0.53.1		X								X			
+windows_x86_64_gnu@0.52.6		X								X			
+windows_x86_64_gnu@0.53.1		X								X			
+windows_x86_64_gnullvm@0.52.6		X								X			
+windows_x86_64_gnullvm@0.53.1		X								X			
+windows_x86_64_msvc@0.52.6		X								X			
+windows_x86_64_msvc@0.53.1		X								X			
+wit-bindgen@0.51.0		X	X							X			
+writeable@0.6.2											X		
+yoke@0.8.1											X		
+yoke-derive@0.8.1											X		
+zerocopy@0.8.47		X		X						X			
+zerocopy-derive@0.8.47		X		X						X			
+zerofrom@0.1.6											X		
+zerofrom-derive@0.1.6											X		
+zeroize@1.8.2		X								X			
+zerotrie@0.2.3											X		
+zerovec@0.11.5											X		
+zerovec-derive@0.11.2											X		
+zlib-rs@0.6.3													X
+zmij@1.0.21										X			
+zstd@0.13.3										X			
+zstd-safe@7.2.4		X								X			
+zstd-sys@2.0.16+zstd.1.5.7		X								X			

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -1,333 +1,398 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-lock@3.4.2		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-fnv@1.0.7		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-h2@0.4.13											X			
-half@2.7.1		X									X			
-hashbrown@0.16.1		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@1.4.0		X									X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-httpdate@1.0.3		X									X			
-hyper@1.8.1											X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-catalog-rest@0.9.0		X												
-iceberg-integration-tests@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-indexmap@2.13.0		X									X			
-integer-encoding@3.0.4											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-murmur3@0.5.2		X									X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.23.37		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-scopeguard@1.2.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.6.2		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.26.4		X									X			
-tokio-util@0.7.18											X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-attributes@0.1.31											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-version_check@0.9.5		X									X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aead@0.5.2		X									X				
+aes@0.8.4		X									X				
+aes-gcm@0.10.3		X									X				
+ahash@0.8.12		X									X				
+aho-corasick@1.1.4											X			X	
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+android_system_properties@0.1.5		X									X				
+anyhow@1.0.102		X									X				
+apache-avro@0.21.0		X													
+array-init@2.1.0		X									X				
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X									X				
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X									X				
+async-lock@3.4.2		X									X				
+async-trait@0.1.89		X									X				
+atoi@2.0.0											X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-lc-rs@1.16.2		X							X						
+aws-lc-sys@0.39.0		X			X				X		X	X			
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+bigdecimal@0.4.10		X									X				
+bimap@0.6.3		X									X				
+bitflags@2.11.0		X									X				
+block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
+bnum@0.12.1		X									X				
+bon@3.9.1		X									X				
+bon-macros@3.9.1		X									X				
+brotli@8.0.2					X						X				
+brotli-decompressor@5.0.0					X						X				
+bumpalo@3.20.2		X									X				
+bytemuck@1.25.0		X									X				X
+bytemuck_derive@1.10.2		X									X				X
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+cc@1.2.57		X									X				
+cfg-if@1.0.4		X									X				
+chrono@0.4.44		X									X				
+cipher@0.4.4		X									X				
+cmake@0.1.57		X									X				
+combine@4.6.7											X				
+concurrent-queue@2.5.0		X									X				
+const-oid@0.10.2		X									X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-channel@0.5.15		X									X				
+crossbeam-epoch@0.9.18		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.7		X									X				
+ctr@0.9.2		X									X				
+darling@0.20.11											X				
+darling@0.23.0											X				
+darling_core@0.20.11											X				
+darling_core@0.23.0											X				
+darling_macro@0.20.11											X				
+darling_macro@0.23.0											X				
+derive_builder@0.20.2		X									X				
+derive_builder_core@0.20.2		X									X				
+derive_builder_macro@0.20.2		X									X				
+digest@0.10.7		X									X				
+digest@0.11.3		X									X				
+displaydoc@0.2.5		X									X				
+dissimilar@1.0.11		X													
+dlv-list@0.5.2		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+equivalent@1.0.2		X									X				
+erased-serde@0.4.10		X									X				
+errno@0.3.14		X									X				
+event-listener@5.4.1		X									X				
+event-listener-strategy@0.5.4		X									X				
+expect-test@1.5.1		X									X				
+fastnum@0.7.4		X									X				
+fastrand@2.3.0		X									X				
+find-msvc-tools@0.1.9		X									X				
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X									X				
+fnv@1.0.7		X									X				
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghash@0.5.1		X									X				
+gloo-timers@0.3.0		X									X				
+h2@0.4.13											X				
+half@2.7.1		X									X				
+hashbrown@0.14.5		X									X				
+hashbrown@0.16.1		X									X				
+hashbrown@0.17.1		X									X				
+heck@0.5.0		X									X				
+hex@0.4.3		X									X				
+hmac@0.12.1		X									X				
+http@1.4.0		X									X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+httpdate@1.0.3		X									X				
+hybrid-array@0.4.12		X									X				
+hyper@1.8.1											X				
+hyper-rustls@0.27.7		X							X		X				
+hyper-util@0.1.20											X				
+iana-time-zone@0.1.65		X									X				
+iana-time-zone-haiku@0.1.2		X									X				
+iceberg@0.9.0		X													
+iceberg-catalog-rest@0.9.0		X													
+iceberg-integration-tests@0.9.0		X													
+iceberg-storage-opendal@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+indexmap@2.13.0		X									X				
+inout@0.1.4		X									X				
+integer-encoding@3.0.4											X				
+inventory@0.3.22		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.11		X									X				
+itertools@0.13.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.91		X									X				
+lazy_static@1.5.0		X									X				
+lexical-core@1.0.6		X									X				
+lexical-parse-float@1.0.6		X									X				
+lexical-parse-integer@1.0.6		X									X				
+lexical-util@1.0.7		X									X				
+lexical-write-float@1.0.6		X									X				
+lexical-write-integer@1.0.6		X									X				
+libc@0.2.183		X									X				
+libm@0.2.16											X				
+link-section@0.18.1		X									X				
+linktime-proc-macro@0.2.0		X									X				
+linux-raw-sys@0.12.1		X	X								X				
+litemap@0.8.1													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+lz4_flex@0.13.0											X				
+md-5@0.11.0		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+moka@0.12.15		X									X				
+murmur3@0.5.2		X									X				
+nu-ansi-term@0.50.3											X				
+num-bigint@0.4.6		X									X				
+num-complex@0.4.6		X									X				
+num-integer@0.1.46		X									X				
+num-traits@0.2.19		X									X				
+once_cell@1.21.4		X									X				
+opaque-debug@0.3.1		X									X				
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+openssl-probe@0.2.1		X									X				
+ordered-float@2.10.1											X				
+ordered-float@4.6.0											X				
+ordered-multimap@0.7.3											X				
+parking@2.2.1		X									X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+parquet@58.1.0		X													
+paste@1.0.15		X									X				
+percent-encoding@2.3.2		X									X				
+pin-project-lite@0.2.17		X									X				
+pin-utils@0.1.0		X									X				
+pkg-config@0.3.32		X									X				
+polyval@0.6.2		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.4													X		
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro2@1.0.106		X									X				
+quad-rand@0.2.3											X				
+quick-xml@0.39.4											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.9.4		X									X				
+rand_chacha@0.9.0		X									X				
+rand_core@0.6.4		X									X				
+rand_core@0.9.5		X									X				
+redox_syscall@0.5.18											X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-lite@0.1.9		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aws-v4@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqwest@0.12.28		X									X				
+reqwest@0.13.3		X									X				
+ring@0.17.14		X							X						
+roaring@0.11.3		X									X				
+rust-ini@0.21.3											X				
+rustc_version@0.4.1		X									X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.37		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.7.0		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.13									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.27		X									X				
+seq-macro@0.3.6		X									X				
+serde@1.0.228		X									X				
+serde-big-array@0.5.1		X									X				
+serde_bytes@0.11.19		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_repr@0.1.20		X									X				
+serde_urlencoded@0.7.1		X									X				
+serde_with@3.21.0		X									X				
+serde_with_macros@3.21.0		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+sharded-slab@0.1.7											X				
+shlex@1.3.0		X									X				
+simd-adler32@0.3.8											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+snap@1.1.1					X										
+socket2@0.6.3		X									X				
+stable_deref_trait@1.2.1		X									X				
+strsim@0.11.1											X				
+strum@0.27.2											X				
+strum_macros@0.27.2											X				
+subtle@2.6.1					X										
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tagptr@0.2.0		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@2.0.18		X									X				
+thread_local@1.1.9		X									X				
+thrift@0.17.0		X													
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2													X		
+tokio@1.52.1											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-util@0.7.18											X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-attributes@0.1.31											X				
+tracing-core@0.1.36											X				
+tracing-log@0.2.0											X				
+tracing-subscriber@0.3.23											X				
+try-lock@0.2.5											X				
+twox-hash@2.1.2											X				
+typed-builder@0.20.1		X									X				
+typed-builder-macro@0.20.1		X									X				
+typeid@1.0.3		X									X				
+typenum@1.20.1		X									X				
+typetag@0.2.21		X									X				
+typetag-impl@0.2.21		X									X				
+unicode-ident@1.0.24		X									X		X		
+universal-hash@0.5.1		X									X				
+untrusted@0.9.0									X						
+url@2.5.8		X									X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.0		X									X				
+version_check@0.9.5		X									X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.2+wasi-0.2.9		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.114		X									X				
+wasm-bindgen-futures@0.4.64		X									X				
+wasm-bindgen-macro@0.2.114		X									X				
+wasm-bindgen-macro-support@0.2.114		X									X				
+wasm-bindgen-shared@0.2.114		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.91		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.7								X							
+winapi-util@0.1.11											X			X	
+windows-core@0.62.2		X									X				
+windows-implement@0.60.2		X									X				
+windows-interface@0.59.3		X									X				
+windows-link@0.2.1		X									X				
+windows-result@0.4.1		X									X				
+windows-strings@0.5.1		X									X				
+windows-sys@0.48.0		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.48.5		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.48.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.48.5		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.48.5		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.48.5		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.48.5		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.48.5		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.48.5		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.2													X		
+xattr@1.6.1		X									X				
+yoke@0.8.1													X		
+yoke-derive@0.8.1													X		
+zerocopy@0.8.47		X		X							X				
+zerocopy-derive@0.8.47		X		X							X				
+zerofrom@0.1.6													X		
+zerofrom-derive@0.1.6													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.3													X		
+zerovec@0.11.5													X		
+zerovec-derive@0.11.2													X		
+zlib-rs@0.6.3															X
+zmij@1.0.21											X				
+zstd@0.13.3											X				
+zstd-safe@7.2.4		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/crates/integrations/cache-moka/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/cache-moka/DEPENDENCIES.rust.tsv
@@ -1,288 +1,312 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X							X			
-ahash@0.8.12		X							X			
-aho-corasick@1.1.4									X		X	
-alloc-no-stdlib@2.0.4					X							
-alloc-stdlib@0.2.2					X							
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.102		X							X			
-apache-avro@0.21.0		X										
-array-init@2.1.0		X							X			
-arrow-arith@57.3.0		X										
-arrow-array@57.3.0		X										
-arrow-buffer@57.3.0		X										
-arrow-cast@57.3.0		X										
-arrow-data@57.3.0		X										
-arrow-ipc@57.3.0		X										
-arrow-ord@57.3.0		X										
-arrow-schema@57.3.0		X										
-arrow-select@57.3.0		X										
-arrow-string@57.3.0		X										
-as-any@0.3.2		X							X			
-async-lock@3.4.2		X							X			
-async-trait@0.1.89		X							X			
-atoi@2.0.0									X			
-atomic-waker@1.1.2		X							X			
-autocfg@1.5.0		X							X			
-backon@1.6.0		X										
-base64@0.22.1		X							X			
-bigdecimal@0.4.10		X							X			
-bimap@0.6.3		X							X			
-bitflags@2.11.0		X							X			
-block-buffer@0.10.4		X							X			
-bnum@0.12.1		X							X			
-bon@3.9.0		X							X			
-bon-macros@3.9.0		X							X			
-brotli@8.0.2					X				X			
-brotli-decompressor@5.0.0					X				X			
-bumpalo@3.20.2		X							X			
-bytemuck@1.25.0		X							X			X
-byteorder@1.5.0									X		X	
-bytes@1.11.1									X			
-cc@1.2.56		X							X			
-cfg-if@1.0.4		X							X			
-chrono@0.4.44		X							X			
-concurrent-queue@2.5.0		X							X			
-const-random@0.1.18		X							X			
-const-random-macro@0.1.16		X							X			
-core-foundation-sys@0.8.7		X							X			
-crc32fast@1.5.0		X							X			
-crossbeam-channel@0.5.15		X							X			
-crossbeam-epoch@0.9.18		X							X			
-crossbeam-utils@0.8.21		X							X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7		X							X			
-darling@0.20.11									X			
-darling@0.21.3									X			
-darling@0.23.0									X			
-darling_core@0.20.11									X			
-darling_core@0.21.3									X			
-darling_core@0.23.0									X			
-darling_macro@0.20.11									X			
-darling_macro@0.21.3									X			
-darling_macro@0.23.0									X			
-derive_builder@0.20.2		X							X			
-derive_builder_core@0.20.2		X							X			
-derive_builder_macro@0.20.2		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-dissimilar@1.0.10		X										
-either@1.15.0		X							X			
-equivalent@1.0.2		X							X			
-erased-serde@0.4.10		X							X			
-event-listener@5.4.1		X							X			
-event-listener-strategy@0.5.4		X							X			
-expect-test@1.5.1		X							X			
-fastnum@0.7.4		X							X			
-fastrand@2.3.0		X							X			
-find-msvc-tools@0.1.9		X							X			
-flatbuffers@25.12.19		X										
-flate2@1.1.9		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.2		X							X			
-futures@0.3.32		X							X			
-futures-channel@0.3.32		X							X			
-futures-core@0.3.32		X							X			
-futures-executor@0.3.32		X							X			
-futures-io@0.3.32		X							X			
-futures-macro@0.3.32		X							X			
-futures-sink@0.3.32		X							X			
-futures-task@0.3.32		X							X			
-futures-util@0.3.32		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.17		X							X			
-getrandom@0.3.4		X							X			
-getrandom@0.4.1		X							X			
-gloo-timers@0.3.0		X							X			
-half@2.7.1		X							X			
-hashbrown@0.16.1		X							X			
-heck@0.5.0		X							X			
-http@1.4.0		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-hyper@1.8.1									X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-iceberg@0.9.0		X										
-iceberg-cache-moka@0.9.0		X										
-iceberg_test_utils@0.9.0		X										
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
-ident_case@1.0.1		X							X			
-idna@1.1.0		X							X			
-idna_adapter@1.2.1		X							X			
-integer-encoding@3.0.4									X			
-inventory@0.3.22		X							X			
-ipnet@2.12.0		X							X			
-iri-string@0.7.10		X							X			
-itertools@0.13.0		X							X			
-itoa@1.0.17		X							X			
-jobserver@0.1.34		X							X			
-js-sys@0.3.91		X							X			
-lazy_static@1.5.0		X							X			
-lexical-core@1.0.6		X							X			
-lexical-parse-float@1.0.6		X							X			
-lexical-parse-integer@1.0.6		X							X			
-lexical-util@1.0.7		X							X			
-lexical-write-float@1.0.6		X							X			
-lexical-write-integer@1.0.6		X							X			
-libc@0.2.182		X							X			
-libm@0.2.16									X			
-litemap@0.8.1										X		
-lock_api@0.4.14		X							X			
-log@0.4.29		X							X			
-lz4_flex@0.12.0									X			
-memchr@2.8.0									X		X	
-miniz_oxide@0.8.9		X							X			X
-mio@1.1.1									X			
-moka@0.12.14		X							X			
-murmur3@0.5.2		X							X			
-nu-ansi-term@0.50.3									X			
-num-bigint@0.4.6		X							X			
-num-complex@0.4.6		X							X			
-num-integer@0.1.46		X							X			
-num-traits@0.2.19		X							X			
-once_cell@1.21.3		X							X			
-ordered-float@2.10.1									X			
-ordered-float@4.6.0									X			
-parking@2.2.1		X							X			
-parking_lot@0.12.5		X							X			
-parking_lot_core@0.9.12		X							X			
-parquet@57.3.0		X										
-paste@1.0.15		X							X			
-percent-encoding@2.3.2		X							X			
-pin-project-lite@0.2.17		X							X			
-pin-utils@0.1.0		X							X			
-pkg-config@0.3.32		X							X			
-portable-atomic@1.13.1		X							X			
-potential_utf@0.1.4										X		
-ppv-lite86@0.2.21		X							X			
-prettyplease@0.2.37		X							X			
-proc-macro2@1.0.106		X							X			
-quad-rand@0.2.3									X			
-quote@1.0.44		X							X			
-r-efi@5.3.0		X						X	X			
-rand@0.8.5		X							X			
-rand@0.9.2		X							X			
-rand_chacha@0.3.1		X							X			
-rand_chacha@0.9.0		X							X			
-rand_core@0.6.4		X							X			
-rand_core@0.9.5		X							X			
-redox_syscall@0.5.18									X			
-regex@1.12.3		X							X			
-regex-automata@0.4.14		X							X			
-regex-lite@0.1.9		X							X			
-regex-syntax@0.8.10		X							X			
-reqwest@0.12.28		X							X			
-roaring@0.11.3		X							X			
-rustc_version@0.4.1		X							X			
-rustversion@1.0.22		X							X			
-ryu@1.0.23		X				X						
-scopeguard@1.2.0		X							X			
-semver@1.0.27		X							X			
-seq-macro@0.3.6		X							X			
-serde@1.0.228		X							X			
-serde-big-array@0.5.1		X							X			
-serde_bytes@0.11.19		X							X			
-serde_core@1.0.228		X							X			
-serde_derive@1.0.228		X							X			
-serde_json@1.0.149		X							X			
-serde_repr@0.1.20		X							X			
-serde_urlencoded@0.7.1		X							X			
-serde_with@3.17.0		X							X			
-serde_with_macros@3.17.0		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-simd-adler32@0.3.8									X			
-simdutf8@0.1.5		X							X			
-slab@0.4.12									X			
-smallvec@1.15.1		X							X			
-snap@1.1.1					X							
-socket2@0.6.2		X							X			
-stable_deref_trait@1.2.1		X							X			
-strsim@0.11.1									X			
-strum@0.27.2									X			
-strum_macros@0.27.2									X			
-syn@2.0.117		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tagptr@0.2.0		X							X			
-thiserror@2.0.18		X							X			
-thiserror-impl@2.0.18		X							X			
-thread_local@1.1.9		X							X			
-thrift@0.17.0		X										
-tiny-keccak@2.0.2							X					
-tinystr@0.8.2										X		
-tokio@1.50.0									X			
-tokio-macros@2.6.1									X			
-tower@0.5.3									X			
-tower-http@0.6.8									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-core@0.1.36									X			
-tracing-log@0.2.0									X			
-tracing-subscriber@0.3.22									X			
-try-lock@0.2.5									X			
-twox-hash@2.1.2									X			
-typed-builder@0.20.1		X							X			
-typed-builder-macro@0.20.1		X							X			
-typeid@1.0.3		X							X			
-typenum@1.19.0		X							X			
-typetag@0.2.21		X							X			
-typetag-impl@0.2.21		X							X			
-unicode-ident@1.0.24		X							X	X		
-url@2.5.8		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.22.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasip2@1.0.2+wasi-0.2.9		X	X						X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X			
-wasm-bindgen@0.2.114		X							X			
-wasm-bindgen-futures@0.4.64		X							X			
-wasm-bindgen-macro@0.2.114		X							X			
-wasm-bindgen-macro-support@0.2.114		X							X			
-wasm-bindgen-shared@0.2.114		X							X			
-web-sys@0.3.91		X							X			
-windows-core@0.62.2		X							X			
-windows-implement@0.60.2		X							X			
-windows-interface@0.59.3		X							X			
-windows-link@0.2.1		X							X			
-windows-result@0.4.1		X							X			
-windows-strings@0.5.1		X							X			
-windows-sys@0.60.2		X							X			
-windows-sys@0.61.2		X							X			
-windows-targets@0.53.5		X							X			
-windows_aarch64_gnullvm@0.53.1		X							X			
-windows_aarch64_msvc@0.53.1		X							X			
-windows_i686_gnu@0.53.1		X							X			
-windows_i686_gnullvm@0.53.1		X							X			
-windows_i686_msvc@0.53.1		X							X			
-windows_x86_64_gnu@0.53.1		X							X			
-windows_x86_64_gnullvm@0.53.1		X							X			
-windows_x86_64_msvc@0.53.1		X							X			
-wit-bindgen@0.51.0		X	X						X			
-writeable@0.6.2										X		
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerocopy@0.8.40		X		X					X			
-zerocopy-derive@0.8.40		X		X					X			
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
-zlib-rs@0.6.3												X
-zmij@1.0.21									X			
-zstd@0.13.3									X			
-zstd-safe@7.2.4		X							X			
-zstd-sys@2.0.16+zstd.1.5.7		X							X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X								X			
+aead@0.5.2		X								X			
+aes@0.8.4		X								X			
+aes-gcm@0.10.3		X								X			
+ahash@0.8.12		X								X			
+aho-corasick@1.1.4										X		X	
+alloc-no-stdlib@2.0.4					X								
+alloc-stdlib@0.2.2					X								
+android_system_properties@0.1.5		X								X			
+anyhow@1.0.102		X								X			
+apache-avro@0.21.0		X											
+array-init@2.1.0		X								X			
+arrow-arith@58.3.0		X											
+arrow-array@58.3.0		X								X			
+arrow-buffer@58.3.0		X											
+arrow-cast@58.3.0		X											
+arrow-data@58.3.0		X											
+arrow-ipc@58.1.0		X											
+arrow-ord@58.3.0		X											
+arrow-schema@58.3.0		X											
+arrow-select@58.3.0		X											
+arrow-string@58.3.0		X											
+as-any@0.3.2		X								X			
+async-lock@3.4.2		X								X			
+async-trait@0.1.89		X								X			
+atoi@2.0.0										X			
+atomic-waker@1.1.2		X								X			
+autocfg@1.5.0		X								X			
+backon@1.6.0		X											
+base64@0.22.1		X								X			
+bigdecimal@0.4.10		X								X			
+bimap@0.6.3		X								X			
+bitflags@2.11.0		X								X			
+block-buffer@0.10.4		X								X			
+bnum@0.12.1		X								X			
+bon@3.9.1		X								X			
+bon-macros@3.9.1		X								X			
+brotli@8.0.2					X					X			
+brotli-decompressor@5.0.0					X					X			
+bumpalo@3.20.2		X								X			
+bytemuck@1.25.0		X								X			X
+bytemuck_derive@1.10.2		X								X			X
+byteorder@1.5.0										X		X	
+bytes@1.11.1										X			
+cc@1.2.57		X								X			
+cfg-if@1.0.4		X								X			
+chrono@0.4.44		X								X			
+cipher@0.4.4		X								X			
+concurrent-queue@2.5.0		X								X			
+const-random@0.1.18		X								X			
+const-random-macro@0.1.16		X								X			
+core-foundation-sys@0.8.7		X								X			
+cpufeatures@0.2.17		X								X			
+crc32fast@1.5.0		X								X			
+crossbeam-channel@0.5.15		X								X			
+crossbeam-epoch@0.9.18		X								X			
+crossbeam-utils@0.8.21		X								X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7		X								X			
+ctr@0.9.2		X								X			
+darling@0.20.11										X			
+darling@0.23.0										X			
+darling_core@0.20.11										X			
+darling_core@0.23.0										X			
+darling_macro@0.20.11										X			
+darling_macro@0.23.0										X			
+derive_builder@0.20.2		X								X			
+derive_builder_core@0.20.2		X								X			
+derive_builder_macro@0.20.2		X								X			
+digest@0.10.7		X								X			
+displaydoc@0.2.5		X								X			
+dissimilar@1.0.11		X											
+either@1.15.0		X								X			
+equivalent@1.0.2		X								X			
+erased-serde@0.4.10		X								X			
+event-listener@5.4.1		X								X			
+event-listener-strategy@0.5.4		X								X			
+expect-test@1.5.1		X								X			
+fastnum@0.7.4		X								X			
+fastrand@2.3.0		X								X			
+find-msvc-tools@0.1.9		X								X			
+flatbuffers@25.12.19		X											
+flate2@1.1.9		X								X			
+fnv@1.0.7		X								X			
+form_urlencoded@1.2.2		X								X			
+futures@0.3.32		X								X			
+futures-channel@0.3.32		X								X			
+futures-core@0.3.32		X								X			
+futures-executor@0.3.32		X								X			
+futures-io@0.3.32		X								X			
+futures-macro@0.3.32		X								X			
+futures-sink@0.3.32		X								X			
+futures-task@0.3.32		X								X			
+futures-util@0.3.32		X								X			
+generic-array@0.14.7										X			
+getrandom@0.2.17		X								X			
+getrandom@0.3.4		X								X			
+getrandom@0.4.2		X								X			
+ghash@0.5.1		X								X			
+gloo-timers@0.3.0		X								X			
+half@2.7.1		X								X			
+hashbrown@0.16.1		X								X			
+hashbrown@0.17.1		X								X			
+heck@0.5.0		X								X			
+http@1.4.0		X								X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1		X								X			
+hyper@1.8.1										X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65		X								X			
+iana-time-zone-haiku@0.1.2		X								X			
+iceberg@0.9.0		X											
+iceberg-cache-moka@0.9.0		X											
+iceberg_test_utils@0.9.0		X											
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+ident_case@1.0.1		X								X			
+idna@1.1.0		X								X			
+idna_adapter@1.2.1		X								X			
+inout@0.1.4		X								X			
+integer-encoding@3.0.4										X			
+inventory@0.3.22		X								X			
+ipnet@2.12.0		X								X			
+iri-string@0.7.11		X								X			
+itertools@0.13.0		X								X			
+itoa@1.0.18		X								X			
+jobserver@0.1.34		X								X			
+js-sys@0.3.91		X								X			
+lazy_static@1.5.0		X								X			
+lexical-core@1.0.6		X								X			
+lexical-parse-float@1.0.6		X								X			
+lexical-parse-integer@1.0.6		X								X			
+lexical-util@1.0.7		X								X			
+lexical-write-float@1.0.6		X								X			
+lexical-write-integer@1.0.6		X								X			
+libc@0.2.183		X								X			
+libm@0.2.16										X			
+litemap@0.8.1											X		
+lock_api@0.4.14		X								X			
+log@0.4.29		X								X			
+lz4_flex@0.13.0										X			
+memchr@2.8.0										X		X	
+miniz_oxide@0.8.9		X								X			X
+mio@1.2.0										X			
+moka@0.12.15		X								X			
+murmur3@0.5.2		X								X			
+nu-ansi-term@0.50.3										X			
+num-bigint@0.4.6		X								X			
+num-complex@0.4.6		X								X			
+num-integer@0.1.46		X								X			
+num-traits@0.2.19		X								X			
+once_cell@1.21.4		X								X			
+opaque-debug@0.3.1		X								X			
+ordered-float@2.10.1										X			
+ordered-float@4.6.0										X			
+parking@2.2.1		X								X			
+parking_lot@0.12.5		X								X			
+parking_lot_core@0.9.12		X								X			
+parquet@58.1.0		X											
+paste@1.0.15		X								X			
+percent-encoding@2.3.2		X								X			
+pin-project-lite@0.2.17		X								X			
+pin-utils@0.1.0		X								X			
+pkg-config@0.3.32		X								X			
+polyval@0.6.2		X								X			
+portable-atomic@1.13.1		X								X			
+potential_utf@0.1.4											X		
+ppv-lite86@0.2.21		X								X			
+prettyplease@0.2.37		X								X			
+proc-macro2@1.0.106		X								X			
+quad-rand@0.2.3										X			
+quote@1.0.45		X								X			
+r-efi@5.3.0		X							X	X			
+r-efi@6.0.0		X							X	X			
+rand@0.9.4		X								X			
+rand_chacha@0.9.0		X								X			
+rand_core@0.6.4		X								X			
+rand_core@0.9.5		X								X			
+redox_syscall@0.5.18										X			
+regex@1.12.3		X								X			
+regex-automata@0.4.14		X								X			
+regex-lite@0.1.9		X								X			
+regex-syntax@0.8.10		X								X			
+reqwest@0.12.28		X								X			
+ring@0.17.14		X						X					
+roaring@0.11.3		X								X			
+rustc_version@0.4.1		X								X			
+rustversion@1.0.22		X								X			
+ryu@1.0.23		X				X							
+scopeguard@1.2.0		X								X			
+semver@1.0.27		X								X			
+seq-macro@0.3.6		X								X			
+serde@1.0.228		X								X			
+serde-big-array@0.5.1		X								X			
+serde_bytes@0.11.19		X								X			
+serde_core@1.0.228		X								X			
+serde_derive@1.0.228		X								X			
+serde_json@1.0.149		X								X			
+serde_repr@0.1.20		X								X			
+serde_urlencoded@0.7.1		X								X			
+serde_with@3.21.0		X								X			
+serde_with_macros@3.21.0		X								X			
+sharded-slab@0.1.7										X			
+shlex@1.3.0		X								X			
+simd-adler32@0.3.8										X			
+simdutf8@0.1.5		X								X			
+slab@0.4.12										X			
+smallvec@1.15.1		X								X			
+snap@1.1.1					X								
+socket2@0.6.3		X								X			
+stable_deref_trait@1.2.1		X								X			
+strsim@0.11.1										X			
+strum@0.27.2										X			
+strum_macros@0.27.2										X			
+subtle@2.6.1					X								
+syn@2.0.117		X								X			
+sync_wrapper@1.0.2		X											
+synstructure@0.13.2										X			
+tagptr@0.2.0		X								X			
+thiserror@2.0.18		X								X			
+thiserror-impl@2.0.18		X								X			
+thread_local@1.1.9		X								X			
+thrift@0.17.0		X											
+tiny-keccak@2.0.2							X						
+tinystr@0.8.2											X		
+tokio@1.52.1										X			
+tokio-macros@2.7.0										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+tracing-log@0.2.0										X			
+tracing-subscriber@0.3.23										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typed-builder@0.20.1		X								X			
+typed-builder-macro@0.20.1		X								X			
+typeid@1.0.3		X								X			
+typenum@1.20.1		X								X			
+typetag@0.2.21		X								X			
+typetag-impl@0.2.21		X								X			
+unicode-ident@1.0.24		X								X	X		
+universal-hash@0.5.1		X								X			
+untrusted@0.9.0								X					
+url@2.5.8		X								X			
+utf8_iter@1.0.4		X								X			
+uuid@1.23.0		X								X			
+version_check@0.9.5		X								X			
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
+wasip2@1.0.2+wasi-0.2.9		X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X			
+wasm-bindgen@0.2.114		X								X			
+wasm-bindgen-futures@0.4.64		X								X			
+wasm-bindgen-macro@0.2.114		X								X			
+wasm-bindgen-macro-support@0.2.114		X								X			
+wasm-bindgen-shared@0.2.114		X								X			
+web-sys@0.3.91		X								X			
+windows-core@0.62.2		X								X			
+windows-implement@0.60.2		X								X			
+windows-interface@0.59.3		X								X			
+windows-link@0.2.1		X								X			
+windows-result@0.4.1		X								X			
+windows-strings@0.5.1		X								X			
+windows-sys@0.52.0		X								X			
+windows-sys@0.60.2		X								X			
+windows-sys@0.61.2		X								X			
+windows-targets@0.52.6		X								X			
+windows-targets@0.53.5		X								X			
+windows_aarch64_gnullvm@0.52.6		X								X			
+windows_aarch64_gnullvm@0.53.1		X								X			
+windows_aarch64_msvc@0.52.6		X								X			
+windows_aarch64_msvc@0.53.1		X								X			
+windows_i686_gnu@0.52.6		X								X			
+windows_i686_gnu@0.53.1		X								X			
+windows_i686_gnullvm@0.52.6		X								X			
+windows_i686_gnullvm@0.53.1		X								X			
+windows_i686_msvc@0.52.6		X								X			
+windows_i686_msvc@0.53.1		X								X			
+windows_x86_64_gnu@0.52.6		X								X			
+windows_x86_64_gnu@0.53.1		X								X			
+windows_x86_64_gnullvm@0.52.6		X								X			
+windows_x86_64_gnullvm@0.53.1		X								X			
+windows_x86_64_msvc@0.52.6		X								X			
+windows_x86_64_msvc@0.53.1		X								X			
+wit-bindgen@0.51.0		X	X							X			
+writeable@0.6.2											X		
+yoke@0.8.1											X		
+yoke-derive@0.8.1											X		
+zerocopy@0.8.47		X		X						X			
+zerocopy-derive@0.8.47		X		X						X			
+zerofrom@0.1.6											X		
+zerofrom-derive@0.1.6											X		
+zeroize@1.8.2		X								X			
+zerotrie@0.2.3											X		
+zerovec@0.11.5											X		
+zerovec-derive@0.11.2											X		
+zlib-rs@0.6.3													X
+zmij@1.0.21										X			
+zstd@0.13.3										X			
+zstd-safe@7.2.4		X								X			
+zstd-sys@2.0.16+zstd.1.5.7		X								X			

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -1,389 +1,412 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-adler2@2.0.1	X	X							X					
-ahash@0.8.12		X							X					
-aho-corasick@1.1.4									X			X		
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-allocator-api2@0.2.21		X							X					
-android_system_properties@0.1.5		X							X					
-anyhow@1.0.102		X							X					
-apache-avro@0.21.0		X												
-ar_archive_writer@0.5.1			X											
-array-init@2.1.0		X							X					
-arrayref@0.3.9				X										
-arrayvec@0.7.6		X							X					
-arrow@57.3.0		X												
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-csv@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-json@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-row@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X							X					
-async-compression@0.4.41		X							X					
-async-lock@3.4.2		X							X					
-async-trait@0.1.89		X							X					
-atoi@2.0.0									X					
-atomic-waker@1.1.2		X							X					
-autocfg@1.5.0		X							X					
-backon@1.6.0		X												
-base64@0.22.1		X							X					
-bigdecimal@0.4.10		X							X					
-bimap@0.6.3		X							X					
-bitflags@2.11.0		X							X					
-blake2@0.10.6		X							X					
-blake3@1.8.3		X	X				X							
-block-buffer@0.10.4		X							X					
-bnum@0.12.1		X							X					
-bon@3.9.0		X							X					
-bon-macros@3.9.0		X							X					
-brotli@8.0.2					X				X					
-brotli-decompressor@5.0.0					X				X					
-bumpalo@3.20.2		X							X					
-bytemuck@1.25.0		X							X				X	
-byteorder@1.5.0									X			X		
-bytes@1.11.1									X					
-bzip2@0.6.1		X							X					
-cc@1.2.56		X							X					
-cfg-if@1.0.4		X							X					
-chrono@0.4.44		X							X					
-chrono-tz@0.10.4		X							X					
-comfy-table@7.2.2									X					
-compression-codecs@0.4.37		X							X					
-compression-core@0.4.31		X							X					
-concurrent-queue@2.5.0		X							X					
-const-random@0.1.18		X							X					
-const-random-macro@0.1.16		X							X					
-constant_time_eq@0.4.2		X					X			X				
-core-foundation-sys@0.8.7		X							X					
-cpufeatures@0.2.17		X							X					
-crc32fast@1.5.0		X							X					
-crossbeam-channel@0.5.15		X							X					
-crossbeam-epoch@0.9.18		X							X					
-crossbeam-utils@0.8.21		X							X					
-crunchy@0.2.4									X					
-crypto-common@0.1.7		X							X					
-csv@1.4.0									X			X		
-csv-core@0.1.13									X			X		
-darling@0.20.11									X					
-darling@0.21.3									X					
-darling@0.23.0									X					
-darling_core@0.20.11									X					
-darling_core@0.21.3									X					
-darling_core@0.23.0									X					
-darling_macro@0.20.11									X					
-darling_macro@0.21.3									X					
-darling_macro@0.23.0									X					
-dashmap@6.1.0									X					
-datafusion@52.2.0		X												
-datafusion-catalog@52.2.0		X												
-datafusion-catalog-listing@52.2.0		X												
-datafusion-common@52.2.0		X												
-datafusion-common-runtime@52.2.0		X												
-datafusion-datasource@52.2.0		X												
-datafusion-datasource-arrow@52.2.0		X												
-datafusion-datasource-csv@52.2.0		X												
-datafusion-datasource-json@52.2.0		X												
-datafusion-datasource-parquet@52.2.0		X												
-datafusion-doc@52.2.0		X												
-datafusion-execution@52.2.0		X												
-datafusion-expr@52.2.0		X												
-datafusion-expr-common@52.2.0		X												
-datafusion-functions@52.2.0		X												
-datafusion-functions-aggregate@52.2.0		X												
-datafusion-functions-aggregate-common@52.2.0		X												
-datafusion-functions-nested@52.2.0		X												
-datafusion-functions-table@52.2.0		X												
-datafusion-functions-window@52.2.0		X												
-datafusion-functions-window-common@52.2.0		X												
-datafusion-macros@52.2.0		X												
-datafusion-optimizer@52.2.0		X												
-datafusion-physical-expr@52.2.0		X												
-datafusion-physical-expr-adapter@52.2.0		X												
-datafusion-physical-expr-common@52.2.0		X												
-datafusion-physical-optimizer@52.2.0		X												
-datafusion-physical-plan@52.2.0		X												
-datafusion-pruning@52.2.0		X												
-datafusion-session@52.2.0		X												
-datafusion-sql@52.2.0		X												
-derive_builder@0.20.2		X							X					
-derive_builder_core@0.20.2		X							X					
-derive_builder_macro@0.20.2		X							X					
-digest@0.10.7		X							X					
-displaydoc@0.2.5		X							X					
-dissimilar@1.0.10		X												
-either@1.15.0		X							X					
-equivalent@1.0.2		X							X					
-erased-serde@0.4.10		X							X					
-errno@0.3.14		X							X					
-event-listener@5.4.1		X							X					
-event-listener-strategy@0.5.4		X							X					
-expect-test@1.5.1		X							X					
-fastnum@0.7.4		X							X					
-fastrand@2.3.0		X							X					
-find-msvc-tools@0.1.9		X							X					
-fixedbitset@0.5.7		X							X					
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X							X					
-fnv@1.0.7		X							X					
-foldhash@0.1.5													X	
-foldhash@0.2.0													X	
-form_urlencoded@1.2.2		X							X					
-futures@0.3.32		X							X					
-futures-channel@0.3.32		X							X					
-futures-core@0.3.32		X							X					
-futures-executor@0.3.32		X							X					
-futures-io@0.3.32		X							X					
-futures-macro@0.3.32		X							X					
-futures-sink@0.3.32		X							X					
-futures-task@0.3.32		X							X					
-futures-util@0.3.32		X							X					
-generic-array@0.14.7									X					
-getrandom@0.2.17		X							X					
-getrandom@0.3.4		X							X					
-getrandom@0.4.1		X							X					
-glob@0.3.3		X							X					
-gloo-timers@0.3.0		X							X					
-half@2.7.1		X							X					
-hashbrown@0.14.5		X							X					
-hashbrown@0.15.5		X							X					
-hashbrown@0.16.1		X							X					
-heck@0.5.0		X							X					
-hex@0.4.3		X							X					
-http@1.4.0		X							X					
-http-body@1.0.1									X					
-http-body-util@0.1.3									X					
-httparse@1.10.1		X							X					
-humantime@2.3.0		X							X					
-hyper@1.8.1									X					
-hyper-util@0.1.20									X					
-iana-time-zone@0.1.65		X							X					
-iana-time-zone-haiku@0.1.2		X							X					
-iceberg@0.9.0		X												
-iceberg-datafusion@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1											X			
-icu_locale_core@2.1.1											X			
-icu_normalizer@2.1.1											X			
-icu_normalizer_data@2.1.1											X			
-icu_properties@2.1.2											X			
-icu_properties_data@2.1.2											X			
-icu_provider@2.1.1											X			
-ident_case@1.0.1		X							X					
-idna@1.1.0		X							X					
-idna_adapter@1.2.1		X							X					
-indexmap@2.13.0		X							X					
-integer-encoding@3.0.4									X					
-inventory@0.3.22		X							X					
-ipnet@2.12.0		X							X					
-iri-string@0.7.10		X							X					
-itertools@0.13.0		X							X					
-itertools@0.14.0		X							X					
-itoa@1.0.17		X							X					
-jobserver@0.1.34		X							X					
-js-sys@0.3.91		X							X					
-lazy_static@1.5.0		X							X					
-lexical-core@1.0.6		X							X					
-lexical-parse-float@1.0.6		X							X					
-lexical-parse-integer@1.0.6		X							X					
-lexical-util@1.0.7		X							X					
-lexical-write-float@1.0.6		X							X					
-lexical-write-integer@1.0.6		X							X					
-libbz2-rs-sys@0.2.2														X
-libc@0.2.182		X							X					
-liblzma@0.4.6		X							X					
-liblzma-sys@0.4.5		X							X					
-libm@0.2.16									X					
-linux-raw-sys@0.12.1		X	X						X					
-litemap@0.8.1											X			
-lock_api@0.4.14		X							X					
-log@0.4.29		X							X					
-lz4_flex@0.12.0									X					
-memchr@2.8.0									X			X		
-miniz_oxide@0.8.9		X							X				X	
-mio@1.1.1									X					
-moka@0.12.14		X							X					
-murmur3@0.5.2		X							X					
-nu-ansi-term@0.50.3									X					
-num-bigint@0.4.6		X							X					
-num-complex@0.4.6		X							X					
-num-integer@0.1.46		X							X					
-num-traits@0.2.19		X							X					
-object@0.37.3		X							X					
-object_store@0.12.5		X							X					
-once_cell@1.21.3		X							X					
-ordered-float@2.10.1									X					
-ordered-float@4.6.0									X					
-parking@2.2.1		X							X					
-parking_lot@0.12.5		X							X					
-parking_lot_core@0.9.12		X							X					
-parquet@57.3.0		X												
-paste@1.0.15		X							X					
-percent-encoding@2.3.2		X							X					
-petgraph@0.8.3		X							X					
-phf@0.12.1									X					
-phf_shared@0.12.1									X					
-pin-project-lite@0.2.17		X							X					
-pin-utils@0.1.0		X							X					
-pkg-config@0.3.32		X							X					
-portable-atomic@1.13.1		X							X					
-potential_utf@0.1.4											X			
-ppv-lite86@0.2.21		X							X					
-prettyplease@0.2.37		X							X					
-proc-macro2@1.0.106		X							X					
-psm@0.1.30		X							X					
-quad-rand@0.2.3									X					
-quote@1.0.44		X							X					
-r-efi@5.3.0		X						X	X					
-rand@0.8.5		X							X					
-rand@0.9.2		X							X					
-rand_chacha@0.3.1		X							X					
-rand_chacha@0.9.0		X							X					
-rand_core@0.6.4		X							X					
-rand_core@0.9.5		X							X					
-recursive@0.1.1									X					
-recursive-proc-macro-impl@0.1.1									X					
-redox_syscall@0.5.18									X					
-regex@1.12.3		X							X					
-regex-automata@0.4.14		X							X					
-regex-lite@0.1.9		X							X					
-regex-syntax@0.8.10		X							X					
-reqwest@0.12.28		X							X					
-roaring@0.11.3		X							X					
-rustc_version@0.4.1		X							X					
-rustix@1.1.4		X	X						X					
-rustversion@1.0.22		X							X					
-ryu@1.0.23		X				X								
-same-file@1.0.6									X			X		
-scopeguard@1.2.0		X							X					
-semver@1.0.27		X							X					
-seq-macro@0.3.6		X							X					
-serde@1.0.228		X							X					
-serde-big-array@0.5.1		X							X					
-serde_bytes@0.11.19		X							X					
-serde_core@1.0.228		X							X					
-serde_derive@1.0.228		X							X					
-serde_json@1.0.149		X							X					
-serde_repr@0.1.20		X							X					
-serde_urlencoded@0.7.1		X							X					
-serde_with@3.17.0		X							X					
-serde_with_macros@3.17.0		X							X					
-sha2@0.10.9		X							X					
-sharded-slab@0.1.7									X					
-shlex@1.3.0		X							X					
-simd-adler32@0.3.8									X					
-simdutf8@0.1.5		X							X					
-siphasher@1.0.2		X							X					
-slab@0.4.12									X					
-smallvec@1.15.1		X							X					
-snap@1.1.1					X									
-socket2@0.6.2		X							X					
-sqlparser@0.59.0		X												
-sqlparser_derive@0.3.0		X												
-stable_deref_trait@1.2.1		X							X					
-stacker@0.1.23		X							X					
-strsim@0.11.1									X					
-strum@0.27.2									X					
-strum_macros@0.27.2									X					
-subtle@2.6.1					X									
-syn@2.0.117		X							X					
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2									X					
-tagptr@0.2.0		X							X					
-tempfile@3.26.0		X							X					
-thiserror@2.0.18		X							X					
-thiserror-impl@2.0.18		X							X					
-thread_local@1.1.9		X							X					
-thrift@0.17.0		X												
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2											X			
-tokio@1.50.0									X					
-tokio-macros@2.6.1									X					
-tokio-util@0.7.18									X					
-tower@0.5.3									X					
-tower-http@0.6.8									X					
-tower-layer@0.3.3									X					
-tower-service@0.3.3									X					
-tracing@0.1.44									X					
-tracing-attributes@0.1.31									X					
-tracing-core@0.1.36									X					
-tracing-log@0.2.0									X					
-tracing-subscriber@0.3.22									X					
-try-lock@0.2.5									X					
-twox-hash@2.1.2									X					
-typed-builder@0.20.1		X							X					
-typed-builder-macro@0.20.1		X							X					
-typeid@1.0.3		X							X					
-typenum@1.19.0		X							X					
-typetag@0.2.21		X							X					
-typetag-impl@0.2.21		X							X					
-unicode-ident@1.0.24		X							X		X			
-unicode-segmentation@1.12.0		X							X					
-unicode-width@0.2.2		X							X					
-url@2.5.8		X							X					
-utf8_iter@1.0.4		X							X					
-uuid@1.22.0		X							X					
-version_check@0.9.5		X							X					
-walkdir@2.5.0									X			X		
-want@0.3.1									X					
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X					
-wasip2@1.0.2+wasi-0.2.9		X	X						X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X					
-wasm-bindgen@0.2.114		X							X					
-wasm-bindgen-futures@0.4.64		X							X					
-wasm-bindgen-macro@0.2.114		X							X					
-wasm-bindgen-macro-support@0.2.114		X							X					
-wasm-bindgen-shared@0.2.114		X							X					
-web-sys@0.3.91		X							X					
-web-time@1.1.0		X							X					
-winapi-util@0.1.11									X			X		
-windows-core@0.62.2		X							X					
-windows-implement@0.60.2		X							X					
-windows-interface@0.59.3		X							X					
-windows-link@0.2.1		X							X					
-windows-result@0.4.1		X							X					
-windows-strings@0.5.1		X							X					
-windows-sys@0.59.0		X							X					
-windows-sys@0.60.2		X							X					
-windows-sys@0.61.2		X							X					
-windows-targets@0.52.6		X							X					
-windows-targets@0.53.5		X							X					
-windows_aarch64_gnullvm@0.52.6		X							X					
-windows_aarch64_gnullvm@0.53.1		X							X					
-windows_aarch64_msvc@0.52.6		X							X					
-windows_aarch64_msvc@0.53.1		X							X					
-windows_i686_gnu@0.52.6		X							X					
-windows_i686_gnu@0.53.1		X							X					
-windows_i686_gnullvm@0.52.6		X							X					
-windows_i686_gnullvm@0.53.1		X							X					
-windows_i686_msvc@0.52.6		X							X					
-windows_i686_msvc@0.53.1		X							X					
-windows_x86_64_gnu@0.52.6		X							X					
-windows_x86_64_gnu@0.53.1		X							X					
-windows_x86_64_gnullvm@0.52.6		X							X					
-windows_x86_64_gnullvm@0.53.1		X							X					
-windows_x86_64_msvc@0.52.6		X							X					
-windows_x86_64_msvc@0.53.1		X							X					
-wit-bindgen@0.51.0		X	X						X					
-writeable@0.6.2											X			
-yoke@0.8.1											X			
-yoke-derive@0.8.1											X			
-zerocopy@0.8.40		X		X					X					
-zerocopy-derive@0.8.40		X		X					X					
-zerofrom@0.1.6											X			
-zerofrom-derive@0.1.6											X			
-zerotrie@0.2.3											X			
-zerovec@0.11.5											X			
-zerovec-derive@0.11.2											X			
-zlib-rs@0.6.3													X	
-zmij@1.0.21									X					
-zstd@0.13.3									X					
-zstd-safe@7.2.4		X							X					
-zstd-sys@2.0.16+zstd.1.5.7		X							X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+adler2@2.0.1	X	X								X					
+aead@0.5.2		X								X					
+aes@0.8.4		X								X					
+aes-gcm@0.10.3		X								X					
+ahash@0.8.12		X								X					
+aho-corasick@1.1.4										X			X		
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+allocator-api2@0.2.21		X								X					
+android_system_properties@0.1.5		X								X					
+anyhow@1.0.102		X								X					
+apache-avro@0.21.0		X													
+ar_archive_writer@0.5.1			X												
+array-init@2.1.0		X								X					
+arrayref@0.3.9				X											
+arrayvec@0.7.6		X								X					
+arrow@58.1.0		X													
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X								X					
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-csv@58.1.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-json@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-row@58.1.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X								X					
+async-compression@0.4.41		X								X					
+async-lock@3.4.2		X								X					
+async-trait@0.1.89		X								X					
+atoi@2.0.0										X					
+atomic-waker@1.1.2		X								X					
+autocfg@1.5.0		X								X					
+backon@1.6.0		X													
+base64@0.22.1		X								X					
+bigdecimal@0.4.10		X								X					
+bimap@0.6.3		X								X					
+bitflags@2.11.0		X								X					
+blake2@0.10.6		X								X					
+blake3@1.8.3		X	X				X								
+block-buffer@0.10.4		X								X					
+bnum@0.12.1		X								X					
+bon@3.9.1		X								X					
+bon-macros@3.9.1		X								X					
+brotli@8.0.2					X					X					
+brotli-decompressor@5.0.0					X					X					
+bumpalo@3.20.2		X								X					
+bytemuck@1.25.0		X								X				X	
+bytemuck_derive@1.10.2		X								X				X	
+byteorder@1.5.0										X			X		
+bytes@1.11.1										X					
+bzip2@0.6.1		X								X					
+cc@1.2.57		X								X					
+cfg-if@1.0.4		X								X					
+chrono@0.4.44		X								X					
+chrono-tz@0.10.4		X								X					
+cipher@0.4.4		X								X					
+comfy-table@7.2.2										X					
+compression-codecs@0.4.37		X								X					
+compression-core@0.4.31		X								X					
+concurrent-queue@2.5.0		X								X					
+const-random@0.1.18		X								X					
+const-random-macro@0.1.16		X								X					
+constant_time_eq@0.4.2		X					X				X				
+core-foundation-sys@0.8.7		X								X					
+cpufeatures@0.2.17		X								X					
+crc32fast@1.5.0		X								X					
+crossbeam-channel@0.5.15		X								X					
+crossbeam-epoch@0.9.18		X								X					
+crossbeam-utils@0.8.21		X								X					
+crunchy@0.2.4										X					
+crypto-common@0.1.7		X								X					
+csv@1.4.0										X			X		
+csv-core@0.1.13										X			X		
+ctr@0.9.2		X								X					
+darling@0.20.11										X					
+darling@0.23.0										X					
+darling_core@0.20.11										X					
+darling_core@0.23.0										X					
+darling_macro@0.20.11										X					
+darling_macro@0.23.0										X					
+dashmap@6.2.1										X					
+datafusion@53.1.0		X													
+datafusion-catalog@53.1.0		X													
+datafusion-catalog-listing@53.1.0		X													
+datafusion-common@53.1.0		X													
+datafusion-common-runtime@53.1.0		X													
+datafusion-datasource@53.1.0		X													
+datafusion-datasource-arrow@53.1.0		X													
+datafusion-datasource-csv@53.1.0		X													
+datafusion-datasource-json@53.1.0		X													
+datafusion-datasource-parquet@53.1.0		X													
+datafusion-doc@53.1.0		X													
+datafusion-execution@53.1.0		X													
+datafusion-expr@53.1.0		X													
+datafusion-expr-common@53.1.0		X													
+datafusion-functions@53.1.0		X													
+datafusion-functions-aggregate@53.1.0		X													
+datafusion-functions-aggregate-common@53.1.0		X													
+datafusion-functions-nested@53.1.0		X													
+datafusion-functions-table@53.1.0		X													
+datafusion-functions-window@53.1.0		X													
+datafusion-functions-window-common@53.1.0		X													
+datafusion-macros@53.1.0		X													
+datafusion-optimizer@53.1.0		X													
+datafusion-physical-expr@53.1.0		X													
+datafusion-physical-expr-adapter@53.1.0		X													
+datafusion-physical-expr-common@53.1.0		X													
+datafusion-physical-optimizer@53.1.0		X													
+datafusion-physical-plan@53.1.0		X													
+datafusion-pruning@53.1.0		X													
+datafusion-session@53.1.0		X													
+datafusion-sql@53.1.0		X													
+derive_builder@0.20.2		X								X					
+derive_builder_core@0.20.2		X								X					
+derive_builder_macro@0.20.2		X								X					
+digest@0.10.7		X								X					
+displaydoc@0.2.5		X								X					
+dissimilar@1.0.11		X													
+either@1.15.0		X								X					
+equivalent@1.0.2		X								X					
+erased-serde@0.4.10		X								X					
+errno@0.3.14		X								X					
+event-listener@5.4.1		X								X					
+event-listener-strategy@0.5.4		X								X					
+expect-test@1.5.1		X								X					
+fastnum@0.7.4		X								X					
+fastrand@2.3.0		X								X					
+find-msvc-tools@0.1.9		X								X					
+fixedbitset@0.5.7		X								X					
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X								X					
+fnv@1.0.7		X								X					
+foldhash@0.1.5														X	
+foldhash@0.2.0														X	
+form_urlencoded@1.2.2		X								X					
+futures@0.3.32		X								X					
+futures-channel@0.3.32		X								X					
+futures-core@0.3.32		X								X					
+futures-executor@0.3.32		X								X					
+futures-io@0.3.32		X								X					
+futures-macro@0.3.32		X								X					
+futures-sink@0.3.32		X								X					
+futures-task@0.3.32		X								X					
+futures-util@0.3.32		X								X					
+generic-array@0.14.7										X					
+getrandom@0.2.17		X								X					
+getrandom@0.3.4		X								X					
+getrandom@0.4.2		X								X					
+ghash@0.5.1		X								X					
+glob@0.3.3		X								X					
+gloo-timers@0.3.0		X								X					
+half@2.7.1		X								X					
+hashbrown@0.14.5		X								X					
+hashbrown@0.15.5		X								X					
+hashbrown@0.16.1		X								X					
+hashbrown@0.17.1		X								X					
+heck@0.5.0		X								X					
+hex@0.4.3		X								X					
+http@1.4.0		X								X					
+http-body@1.0.1										X					
+http-body-util@0.1.3										X					
+httparse@1.10.1		X								X					
+humantime@2.3.0		X								X					
+hyper@1.8.1										X					
+hyper-util@0.1.20										X					
+iana-time-zone@0.1.65		X								X					
+iana-time-zone-haiku@0.1.2		X								X					
+iceberg@0.9.0		X													
+iceberg-datafusion@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1												X			
+icu_locale_core@2.1.1												X			
+icu_normalizer@2.1.1												X			
+icu_normalizer_data@2.1.1												X			
+icu_properties@2.1.2												X			
+icu_properties_data@2.1.2												X			
+icu_provider@2.1.1												X			
+ident_case@1.0.1		X								X					
+idna@1.1.0		X								X					
+idna_adapter@1.2.1		X								X					
+indexmap@2.13.0		X								X					
+inout@0.1.4		X								X					
+integer-encoding@3.0.4										X					
+inventory@0.3.22		X								X					
+ipnet@2.12.0		X								X					
+iri-string@0.7.11		X								X					
+itertools@0.13.0		X								X					
+itertools@0.14.0		X								X					
+itoa@1.0.18		X								X					
+jobserver@0.1.34		X								X					
+js-sys@0.3.91		X								X					
+lazy_static@1.5.0		X								X					
+lexical-core@1.0.6		X								X					
+lexical-parse-float@1.0.6		X								X					
+lexical-parse-integer@1.0.6		X								X					
+lexical-util@1.0.7		X								X					
+lexical-write-float@1.0.6		X								X					
+lexical-write-integer@1.0.6		X								X					
+libbz2-rs-sys@0.2.2															X
+libc@0.2.183		X								X					
+liblzma@0.4.6		X								X					
+liblzma-sys@0.4.5		X								X					
+libm@0.2.16										X					
+linux-raw-sys@0.12.1		X	X							X					
+litemap@0.8.1												X			
+lock_api@0.4.14		X								X					
+log@0.4.29		X								X					
+lz4_flex@0.13.0										X					
+md-5@0.10.6		X								X					
+memchr@2.8.0										X			X		
+miniz_oxide@0.8.9		X								X				X	
+mio@1.2.0										X					
+moka@0.12.15		X								X					
+murmur3@0.5.2		X								X					
+nu-ansi-term@0.50.3										X					
+num-bigint@0.4.6		X								X					
+num-complex@0.4.6		X								X					
+num-integer@0.1.46		X								X					
+num-traits@0.2.19		X								X					
+object@0.37.3		X								X					
+object_store@0.13.2		X								X					
+once_cell@1.21.4		X								X					
+opaque-debug@0.3.1		X								X					
+ordered-float@2.10.1										X					
+ordered-float@4.6.0										X					
+parking@2.2.1		X								X					
+parking_lot@0.12.5		X								X					
+parking_lot_core@0.9.12		X								X					
+parquet@58.1.0		X													
+paste@1.0.15		X								X					
+percent-encoding@2.3.2		X								X					
+petgraph@0.8.3		X								X					
+phf@0.12.1										X					
+phf_shared@0.12.1										X					
+pin-project-lite@0.2.17		X								X					
+pin-utils@0.1.0		X								X					
+pkg-config@0.3.32		X								X					
+polyval@0.6.2		X								X					
+portable-atomic@1.13.1		X								X					
+potential_utf@0.1.4												X			
+ppv-lite86@0.2.21		X								X					
+prettyplease@0.2.37		X								X					
+proc-macro2@1.0.106		X								X					
+psm@0.1.30		X								X					
+quad-rand@0.2.3										X					
+quote@1.0.45		X								X					
+r-efi@5.3.0		X							X	X					
+r-efi@6.0.0		X							X	X					
+rand@0.9.4		X								X					
+rand_chacha@0.9.0		X								X					
+rand_core@0.6.4		X								X					
+rand_core@0.9.5		X								X					
+recursive@0.1.1										X					
+recursive-proc-macro-impl@0.1.1										X					
+redox_syscall@0.5.18										X					
+regex@1.12.3		X								X					
+regex-automata@0.4.14		X								X					
+regex-lite@0.1.9		X								X					
+regex-syntax@0.8.10		X								X					
+reqwest@0.12.28		X								X					
+ring@0.17.14		X						X							
+roaring@0.11.3		X								X					
+rustc_version@0.4.1		X								X					
+rustix@1.1.4		X	X							X					
+rustversion@1.0.22		X								X					
+ryu@1.0.23		X				X									
+same-file@1.0.6										X			X		
+scopeguard@1.2.0		X								X					
+semver@1.0.27		X								X					
+seq-macro@0.3.6		X								X					
+serde@1.0.228		X								X					
+serde-big-array@0.5.1		X								X					
+serde_bytes@0.11.19		X								X					
+serde_core@1.0.228		X								X					
+serde_derive@1.0.228		X								X					
+serde_json@1.0.149		X								X					
+serde_repr@0.1.20		X								X					
+serde_urlencoded@0.7.1		X								X					
+serde_with@3.21.0		X								X					
+serde_with_macros@3.21.0		X								X					
+sha2@0.10.9		X								X					
+sharded-slab@0.1.7										X					
+shlex@1.3.0		X								X					
+simd-adler32@0.3.8										X					
+simdutf8@0.1.5		X								X					
+siphasher@1.0.2		X								X					
+slab@0.4.12										X					
+smallvec@1.15.1		X								X					
+snap@1.1.1					X										
+socket2@0.6.3		X								X					
+sqlparser@0.61.0		X													
+sqlparser_derive@0.5.0		X													
+stable_deref_trait@1.2.1		X								X					
+stacker@0.1.23		X								X					
+strsim@0.11.1										X					
+strum@0.27.2										X					
+strum_macros@0.27.2										X					
+subtle@2.6.1					X										
+syn@2.0.117		X								X					
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2										X					
+tagptr@0.2.0		X								X					
+tempfile@3.27.0		X								X					
+thiserror@2.0.18		X								X					
+thiserror-impl@2.0.18		X								X					
+thread_local@1.1.9		X								X					
+thrift@0.17.0		X													
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2												X			
+tokio@1.52.1										X					
+tokio-macros@2.7.0										X					
+tokio-stream@0.1.18										X					
+tokio-util@0.7.18										X					
+tower@0.5.3										X					
+tower-http@0.6.8										X					
+tower-layer@0.3.3										X					
+tower-service@0.3.3										X					
+tracing@0.1.44										X					
+tracing-attributes@0.1.31										X					
+tracing-core@0.1.36										X					
+tracing-log@0.2.0										X					
+tracing-subscriber@0.3.23										X					
+try-lock@0.2.5										X					
+twox-hash@2.1.2										X					
+typed-builder@0.20.1		X								X					
+typed-builder-macro@0.20.1		X								X					
+typeid@1.0.3		X								X					
+typenum@1.20.1		X								X					
+typetag@0.2.21		X								X					
+typetag-impl@0.2.21		X								X					
+unicode-ident@1.0.24		X								X		X			
+unicode-segmentation@1.12.0		X								X					
+unicode-width@0.2.2		X								X					
+universal-hash@0.5.1		X								X					
+untrusted@0.9.0								X							
+url@2.5.8		X								X					
+utf8_iter@1.0.4		X								X					
+uuid@1.23.0		X								X					
+version_check@0.9.5		X								X					
+walkdir@2.5.0										X			X		
+want@0.3.1										X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X					
+wasip2@1.0.2+wasi-0.2.9		X	X							X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X					
+wasm-bindgen@0.2.114		X								X					
+wasm-bindgen-futures@0.4.64		X								X					
+wasm-bindgen-macro@0.2.114		X								X					
+wasm-bindgen-macro-support@0.2.114		X								X					
+wasm-bindgen-shared@0.2.114		X								X					
+web-sys@0.3.91		X								X					
+web-time@1.1.0		X								X					
+winapi-util@0.1.11										X			X		
+windows-core@0.62.2		X								X					
+windows-implement@0.60.2		X								X					
+windows-interface@0.59.3		X								X					
+windows-link@0.2.1		X								X					
+windows-result@0.4.1		X								X					
+windows-strings@0.5.1		X								X					
+windows-sys@0.48.0		X								X					
+windows-sys@0.52.0		X								X					
+windows-sys@0.59.0		X								X					
+windows-sys@0.60.2		X								X					
+windows-sys@0.61.2		X								X					
+windows-targets@0.48.5		X								X					
+windows-targets@0.52.6		X								X					
+windows-targets@0.53.5		X								X					
+windows_aarch64_gnullvm@0.48.5		X								X					
+windows_aarch64_gnullvm@0.52.6		X								X					
+windows_aarch64_gnullvm@0.53.1		X								X					
+windows_aarch64_msvc@0.48.5		X								X					
+windows_aarch64_msvc@0.52.6		X								X					
+windows_aarch64_msvc@0.53.1		X								X					
+windows_i686_gnu@0.48.5		X								X					
+windows_i686_gnu@0.52.6		X								X					
+windows_i686_gnu@0.53.1		X								X					
+windows_i686_gnullvm@0.52.6		X								X					
+windows_i686_gnullvm@0.53.1		X								X					
+windows_i686_msvc@0.48.5		X								X					
+windows_i686_msvc@0.52.6		X								X					
+windows_i686_msvc@0.53.1		X								X					
+windows_x86_64_gnu@0.48.5		X								X					
+windows_x86_64_gnu@0.52.6		X								X					
+windows_x86_64_gnu@0.53.1		X								X					
+windows_x86_64_gnullvm@0.48.5		X								X					
+windows_x86_64_gnullvm@0.52.6		X								X					
+windows_x86_64_gnullvm@0.53.1		X								X					
+windows_x86_64_msvc@0.48.5		X								X					
+windows_x86_64_msvc@0.52.6		X								X					
+windows_x86_64_msvc@0.53.1		X								X					
+wit-bindgen@0.51.0		X	X							X					
+writeable@0.6.2												X			
+yoke@0.8.1												X			
+yoke-derive@0.8.1												X			
+zerocopy@0.8.47		X		X						X					
+zerocopy-derive@0.8.47		X		X						X					
+zerofrom@0.1.6												X			
+zerofrom-derive@0.1.6												X			
+zeroize@1.8.2		X								X					
+zerotrie@0.2.3												X			
+zerovec@0.11.5												X			
+zerovec-derive@0.11.2												X			
+zlib-rs@0.6.3														X	
+zmij@1.0.21										X					
+zstd@0.13.3										X					
+zstd-safe@7.2.4		X								X					
+zstd-sys@2.0.16+zstd.1.5.7		X								X					

--- a/crates/integrations/playground/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/playground/DEPENDENCIES.rust.tsv
@@ -1,5 +1,8 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
 adler2@2.0.1	X	X								X						
+aead@0.5.2		X								X						
+aes@0.8.4		X								X						
+aes-gcm@0.10.3		X								X						
 ahash@0.8.12		X								X						
 aho-corasick@1.1.4										X				X		
 alloc-no-stdlib@2.0.4					X											
@@ -7,8 +10,10 @@ alloc-stdlib@0.2.2					X
 allocator-api2@0.2.21		X								X						
 android_system_properties@0.1.5		X								X						
 anstream@0.6.21		X								X						
-anstyle@1.0.13		X								X						
+anstream@1.0.0		X								X						
+anstyle@1.0.14		X								X						
 anstyle-parse@0.2.7		X								X						
+anstyle-parse@1.0.0		X								X						
 anstyle-query@1.1.5		X								X						
 anstyle-wincon@3.0.11		X								X						
 anyhow@1.0.102		X								X						
@@ -17,20 +22,20 @@ ar_archive_writer@0.5.1			X
 array-init@2.1.0		X								X						
 arrayref@0.3.9				X												
 arrayvec@0.7.6		X								X						
-arrow@57.3.0		X														
-arrow-arith@57.3.0		X														
-arrow-array@57.3.0		X														
-arrow-buffer@57.3.0		X														
-arrow-cast@57.3.0		X														
-arrow-csv@57.3.0		X														
-arrow-data@57.3.0		X														
-arrow-ipc@57.3.0		X														
-arrow-json@57.3.0		X														
-arrow-ord@57.3.0		X														
-arrow-row@57.3.0		X														
-arrow-schema@57.3.0		X														
-arrow-select@57.3.0		X														
-arrow-string@57.3.0		X														
+arrow@58.1.0		X														
+arrow-arith@58.3.0		X														
+arrow-array@58.3.0		X								X						
+arrow-buffer@58.3.0		X														
+arrow-cast@58.3.0		X														
+arrow-csv@58.1.0		X														
+arrow-data@58.3.0		X														
+arrow-ipc@58.1.0		X														
+arrow-json@58.1.0		X														
+arrow-ord@58.3.0		X														
+arrow-row@58.1.0		X														
+arrow-schema@58.3.0		X														
+arrow-select@58.3.0		X														
+arrow-string@58.3.0		X														
 as-any@0.3.2		X								X						
 async-compression@0.4.41		X								X						
 async-lock@3.4.2		X								X						
@@ -38,13 +43,15 @@ async-trait@0.1.89		X								X
 atoi@2.0.0										X						
 atomic-waker@1.1.2		X								X						
 autocfg@1.5.0		X								X						
-aws-config@1.8.14		X														
-aws-credential-types@1.2.13		X														
-aws-runtime@1.7.1		X														
-aws-sdk-sso@1.95.0		X														
-aws-sdk-ssooidc@1.97.0		X														
-aws-sdk-sts@1.99.0		X														
-aws-sigv4@1.4.1		X														
+aws-config@1.8.15		X														
+aws-credential-types@1.2.14		X														
+aws-lc-rs@1.16.2		X						X								
+aws-lc-sys@0.39.0		X			X			X		X	X					
+aws-runtime@1.7.2		X														
+aws-sdk-sso@1.97.0		X														
+aws-sdk-ssooidc@1.99.0		X														
+aws-sdk-sts@1.101.0		X														
+aws-sigv4@1.4.2		X														
 aws-smithy-async@1.2.14		X														
 aws-smithy-http@0.63.6		X														
 aws-smithy-http-client@1.1.12		X														
@@ -53,9 +60,9 @@ aws-smithy-observability@0.2.6		X
 aws-smithy-query@0.60.15		X														
 aws-smithy-runtime@1.10.3		X														
 aws-smithy-runtime-api@1.11.6		X														
-aws-smithy-types@1.4.6		X														
+aws-smithy-types@1.4.7		X														
 aws-smithy-xml@0.60.15		X														
-aws-types@1.3.13		X														
+aws-types@1.3.14		X														
 backon@1.6.0		X														
 base64@0.22.1		X								X						
 base64-simd@0.8.0										X						
@@ -66,27 +73,31 @@ blake2@0.10.6		X								X
 blake3@1.8.3		X	X				X									
 block-buffer@0.10.4		X								X						
 bnum@0.12.1		X								X						
-bon@3.9.0		X								X						
-bon-macros@3.9.0		X								X						
+bon@3.9.1		X								X						
+bon-macros@3.9.1		X								X						
 brotli@8.0.2					X					X						
 brotli-decompressor@5.0.0					X					X						
 bumpalo@3.20.2		X								X						
 bytemuck@1.25.0		X								X					X	
+bytemuck_derive@1.10.2		X								X					X	
 byteorder@1.5.0										X				X		
 bytes@1.11.1										X						
 bytes-utils@0.1.4		X								X						
 bzip2@0.6.1		X								X						
-cc@1.2.56		X								X						
+cc@1.2.57		X								X						
 cfg-if@1.0.4		X								X						
 cfg_aliases@0.2.1										X						
+chacha20@0.10.0		X								X						
 chrono@0.4.44		X								X						
 chrono-tz@0.10.4		X								X						
-clap@4.5.60		X								X						
-clap_builder@4.5.60		X								X						
-clap_derive@4.5.55		X								X						
-clap_lex@1.0.0		X								X						
+cipher@0.4.4		X								X						
+clap@4.6.0		X								X						
+clap_builder@4.6.0		X								X						
+clap_derive@4.6.0		X								X						
+clap_lex@1.1.0		X								X						
 clipboard-win@5.4.1						X										
-colorchoice@1.0.4		X								X						
+cmake@0.1.57		X								X						
+colorchoice@1.0.5		X								X						
 comfy-table@7.2.2										X						
 compression-codecs@0.4.37		X								X						
 compression-core@0.4.31		X								X						
@@ -97,6 +108,7 @@ constant_time_eq@0.4.2		X					X				X
 core-foundation@0.10.1		X								X						
 core-foundation-sys@0.8.7		X								X						
 cpufeatures@0.2.17		X								X						
+cpufeatures@0.3.0		X								X						
 crc32fast@1.5.0		X								X						
 crossbeam-channel@0.5.15		X								X						
 crossbeam-epoch@0.9.18		X								X						
@@ -105,49 +117,47 @@ crunchy@0.2.4										X
 crypto-common@0.1.7		X								X						
 csv@1.4.0										X				X		
 csv-core@0.1.13										X				X		
+ctr@0.9.2		X								X						
 darling@0.20.11										X						
-darling@0.21.3										X						
 darling@0.23.0										X						
 darling_core@0.20.11										X						
-darling_core@0.21.3										X						
 darling_core@0.23.0										X						
 darling_macro@0.20.11										X						
-darling_macro@0.21.3										X						
 darling_macro@0.23.0										X						
-dashmap@6.1.0										X						
-datafusion@52.2.0		X														
-datafusion-catalog@52.2.0		X														
-datafusion-catalog-listing@52.2.0		X														
-datafusion-cli@52.2.0		X														
-datafusion-common@52.2.0		X														
-datafusion-common-runtime@52.2.0		X														
-datafusion-datasource@52.2.0		X														
-datafusion-datasource-arrow@52.2.0		X														
-datafusion-datasource-avro@52.2.0		X														
-datafusion-datasource-csv@52.2.0		X														
-datafusion-datasource-json@52.2.0		X														
-datafusion-datasource-parquet@52.2.0		X														
-datafusion-doc@52.2.0		X														
-datafusion-execution@52.2.0		X														
-datafusion-expr@52.2.0		X														
-datafusion-expr-common@52.2.0		X														
-datafusion-functions@52.2.0		X														
-datafusion-functions-aggregate@52.2.0		X														
-datafusion-functions-aggregate-common@52.2.0		X														
-datafusion-functions-nested@52.2.0		X														
-datafusion-functions-table@52.2.0		X														
-datafusion-functions-window@52.2.0		X														
-datafusion-functions-window-common@52.2.0		X														
-datafusion-macros@52.2.0		X														
-datafusion-optimizer@52.2.0		X														
-datafusion-physical-expr@52.2.0		X														
-datafusion-physical-expr-adapter@52.2.0		X														
-datafusion-physical-expr-common@52.2.0		X														
-datafusion-physical-optimizer@52.2.0		X														
-datafusion-physical-plan@52.2.0		X														
-datafusion-pruning@52.2.0		X														
-datafusion-session@52.2.0		X														
-datafusion-sql@52.2.0		X														
+dashmap@6.2.1										X						
+datafusion@53.1.0		X														
+datafusion-catalog@53.1.0		X														
+datafusion-catalog-listing@53.1.0		X														
+datafusion-cli@53.1.0		X														
+datafusion-common@53.1.0		X														
+datafusion-common-runtime@53.1.0		X														
+datafusion-datasource@53.1.0		X														
+datafusion-datasource-arrow@53.1.0		X														
+datafusion-datasource-avro@53.1.0		X														
+datafusion-datasource-csv@53.1.0		X														
+datafusion-datasource-json@53.1.0		X														
+datafusion-datasource-parquet@53.1.0		X														
+datafusion-doc@53.1.0		X														
+datafusion-execution@53.1.0		X														
+datafusion-expr@53.1.0		X														
+datafusion-expr-common@53.1.0		X														
+datafusion-functions@53.1.0		X														
+datafusion-functions-aggregate@53.1.0		X														
+datafusion-functions-aggregate-common@53.1.0		X														
+datafusion-functions-nested@53.1.0		X														
+datafusion-functions-table@53.1.0		X														
+datafusion-functions-window@53.1.0		X														
+datafusion-functions-window-common@53.1.0		X														
+datafusion-macros@53.1.0		X														
+datafusion-optimizer@53.1.0		X														
+datafusion-physical-expr@53.1.0		X														
+datafusion-physical-expr-adapter@53.1.0		X														
+datafusion-physical-expr-common@53.1.0		X														
+datafusion-physical-optimizer@53.1.0		X														
+datafusion-physical-plan@53.1.0		X														
+datafusion-pruning@53.1.0		X														
+datafusion-session@53.1.0		X														
+datafusion-sql@53.1.0		X														
 deranged@0.5.8		X								X						
 derive_builder@0.20.2		X								X						
 derive_builder_core@0.20.2		X								X						
@@ -156,7 +166,8 @@ digest@0.10.7		X								X
 dirs@6.0.0		X								X						
 dirs-sys@0.5.0		X								X						
 displaydoc@0.2.5		X								X						
-dissimilar@1.0.10		X														
+dissimilar@1.0.11		X														
+dunce@1.0.5		X					X				X					
 either@1.15.0		X								X						
 endian-type@0.1.2										X						
 env_filter@1.0.0		X								X						
@@ -180,6 +191,7 @@ foldhash@0.1.5															X
 foldhash@0.2.0															X	
 form_urlencoded@1.2.2		X								X						
 fs-err@3.3.0		X								X						
+fs_extra@1.3.0										X						
 futures@0.3.32		X								X						
 futures-channel@0.3.32		X								X						
 futures-core@0.3.32		X								X						
@@ -192,7 +204,8 @@ futures-util@0.3.32		X								X
 generic-array@0.14.7										X						
 getrandom@0.2.17		X								X						
 getrandom@0.3.4		X								X						
-getrandom@0.4.1		X								X						
+getrandom@0.4.2		X								X						
+ghash@0.5.1		X								X						
 glob@0.3.3		X								X						
 gloo-timers@0.3.0		X								X						
 h2@0.4.13										X						
@@ -200,6 +213,7 @@ half@2.7.1		X								X
 hashbrown@0.14.5		X								X						
 hashbrown@0.15.5		X								X						
 hashbrown@0.16.1		X								X						
+hashbrown@0.17.1		X								X						
 heck@0.5.0		X								X						
 hex@0.4.3		X								X						
 hmac@0.12.1		X								X						
@@ -233,15 +247,16 @@ ident_case@1.0.1		X								X
 idna@1.1.0		X								X						
 idna_adapter@1.2.1		X								X						
 indexmap@2.13.0		X								X						
+inout@0.1.4		X								X						
 integer-encoding@3.0.4										X						
 inventory@0.3.22		X								X						
 ipnet@2.12.0		X								X						
-iri-string@0.7.10		X								X						
+iri-string@0.7.11		X								X						
 is_terminal_polyfill@1.70.2		X								X						
 itertools@0.13.0		X								X						
 itertools@0.14.0		X								X						
-itoa@1.0.17		X								X						
-jiff@0.2.22										X				X		
+itoa@1.0.18		X								X						
+jiff@0.2.23										X				X		
 jobserver@0.1.34		X								X						
 js-sys@0.3.91		X								X						
 lazy_static@1.5.0		X								X						
@@ -252,7 +267,7 @@ lexical-util@1.0.7		X								X
 lexical-write-float@1.0.6		X								X						
 lexical-write-integer@1.0.6		X								X						
 libbz2-rs-sys@0.2.2																X
-libc@0.2.182		X								X						
+libc@0.2.183		X								X						
 liblzma@0.4.6		X								X						
 liblzma-sys@0.4.5		X								X						
 libm@0.2.16										X						
@@ -262,12 +277,13 @@ linux-raw-sys@0.12.1		X	X							X
 litemap@0.8.1													X			
 lock_api@0.4.14		X								X						
 log@0.4.29		X								X						
-lz4_flex@0.12.0										X						
+lz4_flex@0.13.0										X						
+md-5@0.10.6		X								X						
 memchr@2.8.0										X				X		
 mimalloc@0.1.48										X						
 miniz_oxide@0.8.9		X								X					X	
-mio@1.1.1										X						
-moka@0.12.14		X								X						
+mio@1.2.0										X						
+moka@0.12.15		X								X						
 murmur3@0.5.2		X								X						
 nibble_vec@0.1.0										X						
 nix@0.30.1										X						
@@ -278,9 +294,10 @@ num-conv@0.2.0		X								X
 num-integer@0.1.46		X								X						
 num-traits@0.2.19		X								X						
 object@0.37.3		X								X						
-object_store@0.12.5		X								X						
-once_cell@1.21.3		X								X						
+object_store@0.13.2		X								X						
+once_cell@1.21.4		X								X						
 once_cell_polyfill@1.70.2		X								X						
+opaque-debug@0.3.1		X								X						
 openssl-probe@0.2.1		X								X						
 option-ext@0.2.0												X				
 ordered-float@2.10.1										X						
@@ -289,7 +306,7 @@ outref@0.5.2										X
 parking@2.2.1		X								X						
 parking_lot@0.12.5		X								X						
 parking_lot_core@0.9.12		X								X						
-parquet@57.3.0		X														
+parquet@58.1.0		X														
 paste@1.0.15		X								X						
 percent-encoding@2.3.2		X								X						
 petgraph@0.8.3		X								X						
@@ -298,8 +315,9 @@ phf_shared@0.12.1										X
 pin-project-lite@0.2.17		X								X						
 pin-utils@0.1.0		X								X						
 pkg-config@0.3.32		X								X						
+polyval@0.6.2		X								X						
 portable-atomic@1.13.1		X								X						
-portable-atomic-util@0.2.5		X								X						
+portable-atomic-util@0.2.6		X								X						
 potential_utf@0.1.4													X			
 powerfmt@0.2.0		X								X						
 ppv-lite86@0.2.21		X								X						
@@ -307,14 +325,15 @@ prettyplease@0.2.37		X								X
 proc-macro2@1.0.106		X								X						
 psm@0.1.30		X								X						
 quad-rand@0.2.3										X						
-quick-xml@0.38.4										X						
-quote@1.0.44		X								X						
+quick-xml@0.39.4										X						
+quote@1.0.45		X								X						
 r-efi@5.3.0		X							X	X						
+r-efi@6.0.0		X							X	X						
 radix_trie@0.2.1										X						
-rand@0.8.5		X								X						
-rand@0.9.2		X								X						
-rand_chacha@0.3.1		X								X						
+rand@0.10.1		X								X						
+rand@0.9.4		X								X						
 rand_chacha@0.9.0		X								X						
+rand_core@0.10.0		X								X						
 rand_core@0.6.4		X								X						
 rand_core@0.9.5		X								X						
 recursive@0.1.1										X						
@@ -332,14 +351,13 @@ rustc_version@0.4.1		X								X
 rustix@1.1.4		X	X							X						
 rustls@0.23.37		X						X		X						
 rustls-native-certs@0.8.3		X						X		X						
-rustls-pemfile@2.2.0		X						X		X						
 rustls-pki-types@1.14.0		X								X						
-rustls-webpki@0.103.9								X								
+rustls-webpki@0.103.13								X								
 rustversion@1.0.22		X								X						
 rustyline@17.0.2										X						
 ryu@1.0.23		X				X										
 same-file@1.0.6										X				X		
-schannel@0.1.28										X						
+schannel@0.1.29										X						
 scopeguard@1.2.0		X								X						
 security-framework@3.7.0		X								X						
 security-framework-sys@2.17.0		X								X						
@@ -354,8 +372,9 @@ serde_json@1.0.149		X								X
 serde_repr@0.1.20		X								X						
 serde_spanned@0.6.9		X								X						
 serde_urlencoded@0.7.1		X								X						
-serde_with@3.17.0		X								X						
-serde_with_macros@3.17.0		X								X						
+serde_with@3.21.0		X								X						
+serde_with_macros@3.21.0		X								X						
+sha1@0.10.6		X								X						
 sha2@0.10.9		X								X						
 sharded-slab@0.1.7										X						
 shlex@1.3.0		X								X						
@@ -366,9 +385,9 @@ siphasher@1.0.2		X								X
 slab@0.4.12										X						
 smallvec@1.15.1		X								X						
 snap@1.1.1					X											
-socket2@0.6.2		X								X						
-sqlparser@0.59.0		X														
-sqlparser_derive@0.3.0		X														
+socket2@0.6.3		X								X						
+sqlparser@0.61.0		X														
+sqlparser_derive@0.5.0		X														
 stable_deref_trait@1.2.1		X								X						
 stacker@0.1.23		X								X						
 strsim@0.11.1										X						
@@ -379,7 +398,7 @@ syn@2.0.117		X								X
 sync_wrapper@1.0.2		X														
 synstructure@0.13.2										X						
 tagptr@0.2.0		X								X						
-tempfile@3.26.0		X								X						
+tempfile@3.27.0		X								X						
 thiserror@2.0.18		X								X						
 thiserror-impl@2.0.18		X								X						
 thread_local@1.1.9		X								X						
@@ -388,9 +407,10 @@ time@0.3.47		X								X
 time-core@0.1.8		X								X						
 tiny-keccak@2.0.2							X									
 tinystr@0.8.2													X			
-tokio@1.50.0										X						
-tokio-macros@2.6.1										X						
+tokio@1.52.1										X						
+tokio-macros@2.7.0										X						
 tokio-rustls@0.26.4		X								X						
+tokio-stream@0.1.18										X						
 tokio-util@0.7.18										X						
 toml@0.8.23		X								X						
 toml_datetime@0.6.11		X								X						
@@ -404,24 +424,25 @@ tracing@0.1.44										X
 tracing-attributes@0.1.31										X						
 tracing-core@0.1.36										X						
 tracing-log@0.2.0										X						
-tracing-subscriber@0.3.22										X						
+tracing-subscriber@0.3.23										X						
 try-lock@0.2.5										X						
 twox-hash@2.1.2										X						
 typed-builder@0.20.1		X								X						
 typed-builder-macro@0.20.1		X								X						
 typeid@1.0.3		X								X						
-typenum@1.19.0		X								X						
+typenum@1.20.1		X								X						
 typetag@0.2.21		X								X						
 typetag-impl@0.2.21		X								X						
 unicode-ident@1.0.24		X								X			X			
 unicode-segmentation@1.12.0		X								X						
 unicode-width@0.2.2		X								X						
+universal-hash@0.5.1		X								X						
 untrusted@0.9.0								X								
 url@2.5.8		X								X						
 urlencoding@2.1.3										X						
 utf8_iter@1.0.4		X								X						
 utf8parse@0.2.2		X								X						
-uuid@1.22.0		X								X						
+uuid@1.23.0		X								X						
 version_check@0.9.5		X								X						
 vsimd@0.8.0										X						
 walkdir@2.5.0										X				X		
@@ -444,36 +465,45 @@ windows-interface@0.59.3		X								X
 windows-link@0.2.1		X								X						
 windows-result@0.4.1		X								X						
 windows-strings@0.5.1		X								X						
+windows-sys@0.48.0		X								X						
 windows-sys@0.52.0		X								X						
 windows-sys@0.59.0		X								X						
 windows-sys@0.60.2		X								X						
 windows-sys@0.61.2		X								X						
+windows-targets@0.48.5		X								X						
 windows-targets@0.52.6		X								X						
 windows-targets@0.53.5		X								X						
+windows_aarch64_gnullvm@0.48.5		X								X						
 windows_aarch64_gnullvm@0.52.6		X								X						
 windows_aarch64_gnullvm@0.53.1		X								X						
+windows_aarch64_msvc@0.48.5		X								X						
 windows_aarch64_msvc@0.52.6		X								X						
 windows_aarch64_msvc@0.53.1		X								X						
+windows_i686_gnu@0.48.5		X								X						
 windows_i686_gnu@0.52.6		X								X						
 windows_i686_gnu@0.53.1		X								X						
 windows_i686_gnullvm@0.52.6		X								X						
 windows_i686_gnullvm@0.53.1		X								X						
+windows_i686_msvc@0.48.5		X								X						
 windows_i686_msvc@0.52.6		X								X						
 windows_i686_msvc@0.53.1		X								X						
+windows_x86_64_gnu@0.48.5		X								X						
 windows_x86_64_gnu@0.52.6		X								X						
 windows_x86_64_gnu@0.53.1		X								X						
+windows_x86_64_gnullvm@0.48.5		X								X						
 windows_x86_64_gnullvm@0.52.6		X								X						
 windows_x86_64_gnullvm@0.53.1		X								X						
+windows_x86_64_msvc@0.48.5		X								X						
 windows_x86_64_msvc@0.52.6		X								X						
 windows_x86_64_msvc@0.53.1		X								X						
-winnow@0.7.14										X						
+winnow@0.7.15										X						
 wit-bindgen@0.51.0		X	X							X						
 writeable@0.6.2													X			
 xmlparser@0.13.6		X								X						
 yoke@0.8.1													X			
 yoke-derive@0.8.1													X			
-zerocopy@0.8.40		X		X						X						
-zerocopy-derive@0.8.40		X		X						X						
+zerocopy@0.8.47		X		X						X						
+zerocopy-derive@0.8.47		X		X						X						
 zerofrom@0.1.6													X			
 zerofrom-derive@0.1.6													X			
 zeroize@1.8.2		X								X						

--- a/crates/sqllogictest/DEPENDENCIES.rust.tsv
+++ b/crates/sqllogictest/DEPENDENCIES.rust.tsv
@@ -1,455 +1,481 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-adler2@2.0.1	X	X							X					
-ahash@0.8.12		X							X					
-aho-corasick@1.1.4									X			X		
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-allocator-api2@0.2.21		X							X					
-android_system_properties@0.1.5		X							X					
-anstream@0.6.21		X							X					
-anstyle@1.0.13		X							X					
-anstyle-parse@0.2.7		X							X					
-anstyle-query@1.1.5		X							X					
-anstyle-wincon@3.0.11		X							X					
-anyhow@1.0.102		X							X					
-apache-avro@0.21.0		X												
-ar_archive_writer@0.5.1			X											
-array-init@2.1.0		X							X					
-arrayref@0.3.9				X										
-arrayvec@0.7.6		X							X					
-arrow@57.3.0		X												
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-csv@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-json@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-row@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X							X					
-async-compression@0.4.41		X							X					
-async-lock@3.4.2		X							X					
-async-recursion@1.1.1		X							X					
-async-trait@0.1.89		X							X					
-atoi@2.0.0									X					
-atomic-waker@1.1.2		X							X					
-autocfg@1.5.0		X							X					
-backon@1.6.0		X												
-base64@0.22.1		X							X					
-bigdecimal@0.4.10		X							X					
-bimap@0.6.3		X							X					
-bitflags@2.11.0		X							X					
-blake2@0.10.6		X							X					
-blake3@1.8.3		X	X				X							
-block-buffer@0.10.4		X							X					
-bnum@0.12.1		X							X					
-bon@3.9.0		X							X					
-bon-macros@3.9.0		X							X					
-brotli@8.0.2					X				X					
-brotli-decompressor@5.0.0					X				X					
-bumpalo@3.20.2		X							X					
-bytemuck@1.25.0		X							X				X	
-byteorder@1.5.0									X			X		
-bytes@1.11.1									X					
-bzip2@0.6.1		X							X					
-cc@1.2.56		X							X					
-cfg-if@1.0.4		X							X					
-chrono@0.4.44		X							X					
-chrono-tz@0.10.4		X							X					
-clap@4.5.60		X							X					
-clap_builder@4.5.60		X							X					
-clap_derive@4.5.55		X							X					
-clap_lex@1.0.0		X							X					
-colorchoice@1.0.4		X							X					
-comfy-table@7.2.2									X					
-compression-codecs@0.4.37		X							X					
-compression-core@0.4.31		X							X					
-concurrent-queue@2.5.0		X							X					
-console@0.16.2									X					
-const-random@0.1.18		X							X					
-const-random-macro@0.1.16		X							X					
-constant_time_eq@0.4.2		X					X			X				
-core-foundation-sys@0.8.7		X							X					
-cpufeatures@0.2.17		X							X					
-crc32fast@1.5.0		X							X					
-crossbeam-channel@0.5.15		X							X					
-crossbeam-epoch@0.9.18		X							X					
-crossbeam-utils@0.8.21		X							X					
-crunchy@0.2.4									X					
-crypto-common@0.1.7		X							X					
-csv@1.4.0									X			X		
-csv-core@0.1.13									X			X		
-darling@0.20.11									X					
-darling@0.21.3									X					
-darling@0.23.0									X					
-darling_core@0.20.11									X					
-darling_core@0.21.3									X					
-darling_core@0.23.0									X					
-darling_macro@0.20.11									X					
-darling_macro@0.21.3									X					
-darling_macro@0.23.0									X					
-dashmap@6.1.0									X					
-datafusion@52.2.0		X												
-datafusion-catalog@52.2.0		X												
-datafusion-catalog-listing@52.2.0		X												
-datafusion-common@52.2.0		X												
-datafusion-common-runtime@52.2.0		X												
-datafusion-datasource@52.2.0		X												
-datafusion-datasource-arrow@52.2.0		X												
-datafusion-datasource-avro@52.2.0		X												
-datafusion-datasource-csv@52.2.0		X												
-datafusion-datasource-json@52.2.0		X												
-datafusion-datasource-parquet@52.2.0		X												
-datafusion-doc@52.2.0		X												
-datafusion-execution@52.2.0		X												
-datafusion-expr@52.2.0		X												
-datafusion-expr-common@52.2.0		X												
-datafusion-functions@52.2.0		X												
-datafusion-functions-aggregate@52.2.0		X												
-datafusion-functions-aggregate-common@52.2.0		X												
-datafusion-functions-nested@52.2.0		X												
-datafusion-functions-table@52.2.0		X												
-datafusion-functions-window@52.2.0		X												
-datafusion-functions-window-common@52.2.0		X												
-datafusion-macros@52.2.0		X												
-datafusion-optimizer@52.2.0		X												
-datafusion-physical-expr@52.2.0		X												
-datafusion-physical-expr-adapter@52.2.0		X												
-datafusion-physical-expr-common@52.2.0		X												
-datafusion-physical-optimizer@52.2.0		X												
-datafusion-physical-plan@52.2.0		X												
-datafusion-pruning@52.2.0		X												
-datafusion-session@52.2.0		X												
-datafusion-spark@52.2.0		X												
-datafusion-sql@52.2.0		X												
-datafusion-sqllogictest@52.2.0		X												
-datafusion-substrait@52.2.0		X												
-derive_builder@0.20.2		X							X					
-derive_builder_core@0.20.2		X							X					
-derive_builder_macro@0.20.2		X							X					
-digest@0.10.7		X							X					
-displaydoc@0.2.5		X							X					
-dissimilar@1.0.10		X												
-dyn-clone@1.0.20		X							X					
-educe@0.6.0									X					
-either@1.15.0		X							X					
-encode_unicode@1.0.0		X							X					
-enum-ordinalize@4.3.2									X					
-enum-ordinalize-derive@4.3.2									X					
-env_filter@1.0.0		X							X					
-env_logger@0.11.9		X							X					
-equivalent@1.0.2		X							X					
-erased-serde@0.4.10		X							X					
-errno@0.3.14		X							X					
-escape8259@0.5.3									X					
-event-listener@5.4.1		X							X					
-event-listener-strategy@0.5.4		X							X					
-expect-test@1.5.1		X							X					
-fastnum@0.7.4		X							X					
-fastrand@2.3.0		X							X					
-find-msvc-tools@0.1.9		X							X					
-fixedbitset@0.5.7		X							X					
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X							X					
-fnv@1.0.7		X							X					
-foldhash@0.1.5													X	
-foldhash@0.2.0													X	
-form_urlencoded@1.2.2		X							X					
-fs-err@3.3.0		X							X					
-futures@0.3.32		X							X					
-futures-channel@0.3.32		X							X					
-futures-core@0.3.32		X							X					
-futures-executor@0.3.32		X							X					
-futures-io@0.3.32		X							X					
-futures-macro@0.3.32		X							X					
-futures-sink@0.3.32		X							X					
-futures-task@0.3.32		X							X					
-futures-util@0.3.32		X							X					
-generic-array@0.14.7									X					
-getrandom@0.2.17		X							X					
-getrandom@0.3.4		X							X					
-getrandom@0.4.1		X							X					
-glob@0.3.3		X							X					
-gloo-timers@0.3.0		X							X					
-half@2.7.1		X							X					
-hashbrown@0.14.5		X							X					
-hashbrown@0.15.5		X							X					
-hashbrown@0.16.1		X							X					
-heck@0.5.0		X							X					
-hex@0.4.3		X							X					
-http@1.4.0		X							X					
-http-body@1.0.1									X					
-http-body-util@0.1.3									X					
-httparse@1.10.1		X							X					
-humantime@2.3.0		X							X					
-hyper@1.8.1									X					
-hyper-util@0.1.20									X					
-iana-time-zone@0.1.65		X							X					
-iana-time-zone-haiku@0.1.2		X							X					
-iceberg@0.9.0		X												
-iceberg-datafusion@0.9.0		X												
-iceberg-sqllogictest@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1											X			
-icu_locale_core@2.1.1											X			
-icu_normalizer@2.1.1											X			
-icu_normalizer_data@2.1.1											X			
-icu_properties@2.1.2											X			
-icu_properties_data@2.1.2											X			
-icu_provider@2.1.1											X			
-ident_case@1.0.1		X							X					
-idna@1.1.0		X							X					
-idna_adapter@1.2.1		X							X					
-indexmap@2.13.0		X							X					
-indicatif@0.18.4									X					
-integer-encoding@3.0.4									X					
-inventory@0.3.22		X							X					
-ipnet@2.12.0		X							X					
-iri-string@0.7.10		X							X					
-is_terminal_polyfill@1.70.2		X							X					
-itertools@0.13.0		X							X					
-itertools@0.14.0		X							X					
-itoa@1.0.17		X							X					
-jiff@0.2.22									X			X		
-jobserver@0.1.34		X							X					
-js-sys@0.3.91		X							X					
-lazy_static@1.5.0		X							X					
-lexical-core@1.0.6		X							X					
-lexical-parse-float@1.0.6		X							X					
-lexical-parse-integer@1.0.6		X							X					
-lexical-util@1.0.7		X							X					
-lexical-write-float@1.0.6		X							X					
-lexical-write-integer@1.0.6		X							X					
-libbz2-rs-sys@0.2.2														X
-libc@0.2.182		X							X					
-liblzma@0.4.6		X							X					
-liblzma-sys@0.4.5		X							X					
-libm@0.2.16									X					
-libtest-mimic@0.8.1		X							X					
-linux-raw-sys@0.12.1		X	X						X					
-litemap@0.8.1											X			
-lock_api@0.4.14		X							X					
-log@0.4.29		X							X					
-lz4_flex@0.12.0									X					
-md-5@0.10.6		X							X					
-memchr@2.8.0									X			X		
-miniz_oxide@0.8.9		X							X				X	
-mio@1.1.1									X					
-moka@0.12.14		X							X					
-multimap@0.10.1		X							X					
-murmur3@0.5.2		X							X					
-nu-ansi-term@0.50.3									X					
-num-bigint@0.4.6		X							X					
-num-complex@0.4.6		X							X					
-num-integer@0.1.46		X							X					
-num-traits@0.2.19		X							X					
-object@0.37.3		X							X					
-object_store@0.12.5		X							X					
-once_cell@1.21.3		X							X					
-once_cell_polyfill@1.70.2		X							X					
-ordered-float@2.10.1									X					
-ordered-float@4.6.0									X					
-owo-colors@4.3.0									X					
-parking@2.2.1		X							X					
-parking_lot@0.12.5		X							X					
-parking_lot_core@0.9.12		X							X					
-parquet@57.3.0		X												
-paste@1.0.15		X							X					
-pbjson@0.8.0									X					
-pbjson-build@0.8.0									X					
-pbjson-types@0.8.0									X					
-percent-encoding@2.3.2		X							X					
-petgraph@0.8.3		X							X					
-phf@0.12.1									X					
-phf_shared@0.12.1									X					
-pin-project-lite@0.2.17		X							X					
-pin-utils@0.1.0		X							X					
-pkg-config@0.3.32		X							X					
-portable-atomic@1.13.1		X							X					
-portable-atomic-util@0.2.5		X							X					
-potential_utf@0.1.4											X			
-ppv-lite86@0.2.21		X							X					
-prettyplease@0.2.37		X							X					
-proc-macro2@1.0.106		X							X					
-prost@0.14.3		X												
-prost-build@0.14.3		X												
-prost-derive@0.14.3		X												
-prost-types@0.14.3		X												
-psm@0.1.30		X							X					
-quad-rand@0.2.3									X					
-quote@1.0.44		X							X					
-r-efi@5.3.0		X						X	X					
-rand@0.8.5		X							X					
-rand@0.9.2		X							X					
-rand_chacha@0.3.1		X							X					
-rand_chacha@0.9.0		X							X					
-rand_core@0.6.4		X							X					
-rand_core@0.9.5		X							X					
-recursive@0.1.1									X					
-recursive-proc-macro-impl@0.1.1									X					
-redox_syscall@0.5.18									X					
-regex@1.12.3		X							X					
-regex-automata@0.4.14		X							X					
-regex-lite@0.1.9		X							X					
-regex-syntax@0.8.10		X							X					
-regress@0.10.5		X							X					
-reqwest@0.12.28		X							X					
-roaring@0.11.3		X							X					
-rustc_version@0.4.1		X							X					
-rustix@1.1.4		X	X						X					
-rustversion@1.0.22		X							X					
-ryu@1.0.23		X				X								
-same-file@1.0.6									X			X		
-schemars@0.8.22									X					
-schemars_derive@0.8.22									X					
-scopeguard@1.2.0		X							X					
-semver@1.0.27		X							X					
-seq-macro@0.3.6		X							X					
-serde@1.0.228		X							X					
-serde-big-array@0.5.1		X							X					
-serde_bytes@0.11.19		X							X					
-serde_core@1.0.228		X							X					
-serde_derive@1.0.228		X							X					
-serde_derive_internals@0.29.1		X							X					
-serde_json@1.0.149		X							X					
-serde_repr@0.1.20		X							X					
-serde_spanned@0.6.9		X							X					
-serde_tokenstream@0.2.3		X												
-serde_urlencoded@0.7.1		X							X					
-serde_with@3.17.0		X							X					
-serde_with_macros@3.17.0		X							X					
-serde_yaml@0.9.34+deprecated		X							X					
-sha1@0.10.6		X							X					
-sha2@0.10.9		X							X					
-sharded-slab@0.1.7									X					
-shlex@1.3.0		X							X					
-simd-adler32@0.3.8									X					
-simdutf8@0.1.5		X							X					
-similar@2.7.0		X												
-siphasher@1.0.2		X							X					
-slab@0.4.12									X					
-smallvec@1.15.1		X							X					
-snap@1.1.1					X									
-socket2@0.6.2		X							X					
-sqllogictest@0.28.4		X							X					
-sqlparser@0.59.0		X												
-sqlparser_derive@0.3.0		X												
-stable_deref_trait@1.2.1		X							X					
-stacker@0.1.23		X							X					
-strsim@0.11.1									X					
-strum@0.27.2									X					
-strum_macros@0.27.2									X					
-subst@0.3.8		X		X										
-substrait@0.62.2		X												
-subtle@2.6.1					X									
-syn@2.0.117		X							X					
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2									X					
-tagptr@0.2.0		X							X					
-tempfile@3.26.0		X							X					
-thiserror@2.0.18		X							X					
-thiserror-impl@2.0.18		X							X					
-thread_local@1.1.9		X							X					
-thrift@0.17.0		X												
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2											X			
-tokio@1.50.0									X					
-tokio-macros@2.6.1									X					
-tokio-util@0.7.18									X					
-toml@0.8.23		X							X					
-toml_datetime@0.6.11		X							X					
-toml_edit@0.22.27		X							X					
-toml_write@0.1.2		X							X					
-tower@0.5.3									X					
-tower-http@0.6.8									X					
-tower-layer@0.3.3									X					
-tower-service@0.3.3									X					
-tracing@0.1.44									X					
-tracing-attributes@0.1.31									X					
-tracing-core@0.1.36									X					
-tracing-log@0.2.0									X					
-tracing-subscriber@0.3.22									X					
-try-lock@0.2.5									X					
-twox-hash@2.1.2									X					
-typed-builder@0.20.1		X							X					
-typed-builder-macro@0.20.1		X							X					
-typeid@1.0.3		X							X					
-typenum@1.19.0		X							X					
-typetag@0.2.21		X							X					
-typetag-impl@0.2.21		X							X					
-typify@0.5.0		X												
-typify-impl@0.5.0		X												
-typify-macro@0.5.0		X												
-unicode-ident@1.0.24		X							X		X			
-unicode-segmentation@1.12.0		X							X					
-unicode-width@0.1.14		X							X					
-unicode-width@0.2.2		X							X					
-unit-prefix@0.5.2									X					
-unsafe-libyaml@0.2.11									X					
-url@2.5.8		X							X					
-utf8_iter@1.0.4		X							X					
-utf8parse@0.2.2		X							X					
-uuid@1.22.0		X							X					
-version_check@0.9.5		X							X					
-walkdir@2.5.0									X			X		
-want@0.3.1									X					
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X					
-wasip2@1.0.2+wasi-0.2.9		X	X						X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X					
-wasm-bindgen@0.2.114		X							X					
-wasm-bindgen-futures@0.4.64		X							X					
-wasm-bindgen-macro@0.2.114		X							X					
-wasm-bindgen-macro-support@0.2.114		X							X					
-wasm-bindgen-shared@0.2.114		X							X					
-web-sys@0.3.91		X							X					
-web-time@1.1.0		X							X					
-winapi-util@0.1.11									X			X		
-windows-core@0.62.2		X							X					
-windows-implement@0.60.2		X							X					
-windows-interface@0.59.3		X							X					
-windows-link@0.2.1		X							X					
-windows-result@0.4.1		X							X					
-windows-strings@0.5.1		X							X					
-windows-sys@0.59.0		X							X					
-windows-sys@0.60.2		X							X					
-windows-sys@0.61.2		X							X					
-windows-targets@0.52.6		X							X					
-windows-targets@0.53.5		X							X					
-windows_aarch64_gnullvm@0.52.6		X							X					
-windows_aarch64_gnullvm@0.53.1		X							X					
-windows_aarch64_msvc@0.52.6		X							X					
-windows_aarch64_msvc@0.53.1		X							X					
-windows_i686_gnu@0.52.6		X							X					
-windows_i686_gnu@0.53.1		X							X					
-windows_i686_gnullvm@0.52.6		X							X					
-windows_i686_gnullvm@0.53.1		X							X					
-windows_i686_msvc@0.52.6		X							X					
-windows_i686_msvc@0.53.1		X							X					
-windows_x86_64_gnu@0.52.6		X							X					
-windows_x86_64_gnu@0.53.1		X							X					
-windows_x86_64_gnullvm@0.52.6		X							X					
-windows_x86_64_gnullvm@0.53.1		X							X					
-windows_x86_64_msvc@0.52.6		X							X					
-windows_x86_64_msvc@0.53.1		X							X					
-winnow@0.7.14									X					
-wit-bindgen@0.51.0		X	X						X					
-writeable@0.6.2											X			
-yoke@0.8.1											X			
-yoke-derive@0.8.1											X			
-zerocopy@0.8.40		X		X					X					
-zerocopy-derive@0.8.40		X		X					X					
-zerofrom@0.1.6											X			
-zerofrom-derive@0.1.6											X			
-zerotrie@0.2.3											X			
-zerovec@0.11.5											X			
-zerovec-derive@0.11.2											X			
-zlib-rs@0.6.3													X	
-zmij@1.0.21									X					
-zstd@0.13.3									X					
-zstd-safe@7.2.4		X							X					
-zstd-sys@2.0.16+zstd.1.5.7		X							X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+adler2@2.0.1	X	X								X					
+aead@0.5.2		X								X					
+aes@0.8.4		X								X					
+aes-gcm@0.10.3		X								X					
+ahash@0.8.12		X								X					
+aho-corasick@1.1.4										X			X		
+alloc-no-stdlib@2.0.4					X										
+alloc-stdlib@0.2.2					X										
+allocator-api2@0.2.21		X								X					
+android_system_properties@0.1.5		X								X					
+anstream@0.6.21		X								X					
+anstream@1.0.0		X								X					
+anstyle@1.0.14		X								X					
+anstyle-parse@0.2.7		X								X					
+anstyle-parse@1.0.0		X								X					
+anstyle-query@1.1.5		X								X					
+anstyle-wincon@3.0.11		X								X					
+anyhow@1.0.102		X								X					
+apache-avro@0.21.0		X													
+ar_archive_writer@0.5.1			X												
+array-init@2.1.0		X								X					
+arrayref@0.3.9				X											
+arrayvec@0.7.6		X								X					
+arrow@58.1.0		X													
+arrow-arith@58.3.0		X													
+arrow-array@58.3.0		X								X					
+arrow-buffer@58.3.0		X													
+arrow-cast@58.3.0		X													
+arrow-csv@58.1.0		X													
+arrow-data@58.3.0		X													
+arrow-ipc@58.1.0		X													
+arrow-json@58.1.0		X													
+arrow-ord@58.3.0		X													
+arrow-row@58.1.0		X													
+arrow-schema@58.3.0		X													
+arrow-select@58.3.0		X													
+arrow-string@58.3.0		X													
+as-any@0.3.2		X								X					
+async-compression@0.4.41		X								X					
+async-lock@3.4.2		X								X					
+async-recursion@1.1.1		X								X					
+async-trait@0.1.89		X								X					
+atoi@2.0.0										X					
+atomic-waker@1.1.2		X								X					
+autocfg@1.5.0		X								X					
+backon@1.6.0		X													
+base64@0.22.1		X								X					
+bigdecimal@0.4.10		X								X					
+bimap@0.6.3		X								X					
+bitflags@2.11.0		X								X					
+blake2@0.10.6		X								X					
+blake3@1.8.3		X	X				X								
+block-buffer@0.10.4		X								X					
+bnum@0.12.1		X								X					
+bon@3.9.1		X								X					
+bon-macros@3.9.1		X								X					
+brotli@8.0.2					X					X					
+brotli-decompressor@5.0.0					X					X					
+bumpalo@3.20.2		X								X					
+bytemuck@1.25.0		X								X				X	
+bytemuck_derive@1.10.2		X								X				X	
+byteorder@1.5.0										X			X		
+bytes@1.11.1										X					
+bzip2@0.6.1		X								X					
+cc@1.2.57		X								X					
+cfg-if@1.0.4		X								X					
+chrono@0.4.44		X								X					
+chrono-tz@0.10.4		X								X					
+cipher@0.4.4		X								X					
+clap@4.6.0		X								X					
+clap_builder@4.6.0		X								X					
+clap_derive@4.6.0		X								X					
+clap_lex@1.1.0		X								X					
+colorchoice@1.0.5		X								X					
+comfy-table@7.2.2										X					
+compression-codecs@0.4.37		X								X					
+compression-core@0.4.31		X								X					
+concurrent-queue@2.5.0		X								X					
+console@0.16.3										X					
+const-random@0.1.18		X								X					
+const-random-macro@0.1.16		X								X					
+constant_time_eq@0.4.2		X					X				X				
+core-foundation-sys@0.8.7		X								X					
+cpufeatures@0.2.17		X								X					
+crc32fast@1.5.0		X								X					
+crossbeam-channel@0.5.15		X								X					
+crossbeam-epoch@0.9.18		X								X					
+crossbeam-utils@0.8.21		X								X					
+crunchy@0.2.4										X					
+crypto-common@0.1.7		X								X					
+csv@1.4.0										X			X		
+csv-core@0.1.13										X			X		
+ctr@0.9.2		X								X					
+darling@0.20.11										X					
+darling@0.23.0										X					
+darling_core@0.20.11										X					
+darling_core@0.23.0										X					
+darling_macro@0.20.11										X					
+darling_macro@0.23.0										X					
+dashmap@6.2.1										X					
+datafusion@53.1.0		X													
+datafusion-catalog@53.1.0		X													
+datafusion-catalog-listing@53.1.0		X													
+datafusion-common@53.1.0		X													
+datafusion-common-runtime@53.1.0		X													
+datafusion-datasource@53.1.0		X													
+datafusion-datasource-arrow@53.1.0		X													
+datafusion-datasource-avro@53.1.0		X													
+datafusion-datasource-csv@53.1.0		X													
+datafusion-datasource-json@53.1.0		X													
+datafusion-datasource-parquet@53.1.0		X													
+datafusion-doc@53.1.0		X													
+datafusion-execution@53.1.0		X													
+datafusion-expr@53.1.0		X													
+datafusion-expr-common@53.1.0		X													
+datafusion-functions@53.1.0		X													
+datafusion-functions-aggregate@53.1.0		X													
+datafusion-functions-aggregate-common@53.1.0		X													
+datafusion-functions-nested@53.1.0		X													
+datafusion-functions-table@53.1.0		X													
+datafusion-functions-window@53.1.0		X													
+datafusion-functions-window-common@53.1.0		X													
+datafusion-macros@53.1.0		X													
+datafusion-optimizer@53.1.0		X													
+datafusion-physical-expr@53.1.0		X													
+datafusion-physical-expr-adapter@53.1.0		X													
+datafusion-physical-expr-common@53.1.0		X													
+datafusion-physical-optimizer@53.1.0		X													
+datafusion-physical-plan@53.1.0		X													
+datafusion-pruning@53.1.0		X													
+datafusion-session@53.1.0		X													
+datafusion-spark@53.1.0		X													
+datafusion-sql@53.1.0		X													
+datafusion-sqllogictest@53.1.0		X													
+datafusion-substrait@53.1.0		X													
+derive_builder@0.20.2		X								X					
+derive_builder_core@0.20.2		X								X					
+derive_builder_macro@0.20.2		X								X					
+digest@0.10.7		X								X					
+displaydoc@0.2.5		X								X					
+dissimilar@1.0.11		X													
+dyn-clone@1.0.20		X								X					
+educe@0.6.0										X					
+either@1.15.0		X								X					
+encode_unicode@1.0.0		X								X					
+enum-ordinalize@4.3.2										X					
+enum-ordinalize-derive@4.3.2										X					
+env_filter@1.0.0		X								X					
+env_logger@0.11.9		X								X					
+equivalent@1.0.2		X								X					
+erased-serde@0.4.10		X								X					
+errno@0.3.14		X								X					
+escape8259@0.5.3										X					
+event-listener@5.4.1		X								X					
+event-listener-strategy@0.5.4		X								X					
+expect-test@1.5.1		X								X					
+fastnum@0.7.4		X								X					
+fastrand@2.3.0		X								X					
+find-msvc-tools@0.1.9		X								X					
+fixedbitset@0.5.7		X								X					
+flatbuffers@25.12.19		X													
+flate2@1.1.9		X								X					
+fnv@1.0.7		X								X					
+foldhash@0.1.5														X	
+foldhash@0.2.0														X	
+form_urlencoded@1.2.2		X								X					
+fs-err@3.3.0		X								X					
+futures@0.3.32		X								X					
+futures-channel@0.3.32		X								X					
+futures-core@0.3.32		X								X					
+futures-executor@0.3.32		X								X					
+futures-io@0.3.32		X								X					
+futures-macro@0.3.32		X								X					
+futures-sink@0.3.32		X								X					
+futures-task@0.3.32		X								X					
+futures-util@0.3.32		X								X					
+generic-array@0.14.7										X					
+getrandom@0.2.17		X								X					
+getrandom@0.3.4		X								X					
+getrandom@0.4.2		X								X					
+ghash@0.5.1		X								X					
+glob@0.3.3		X								X					
+gloo-timers@0.3.0		X								X					
+half@2.7.1		X								X					
+hashbrown@0.14.5		X								X					
+hashbrown@0.15.5		X								X					
+hashbrown@0.16.1		X								X					
+hashbrown@0.17.1		X								X					
+heck@0.5.0		X								X					
+hex@0.4.3		X								X					
+http@1.4.0		X								X					
+http-body@1.0.1										X					
+http-body-util@0.1.3										X					
+httparse@1.10.1		X								X					
+humantime@2.3.0		X								X					
+hyper@1.8.1										X					
+hyper-util@0.1.20										X					
+iana-time-zone@0.1.65		X								X					
+iana-time-zone-haiku@0.1.2		X								X					
+iceberg@0.9.0		X													
+iceberg-datafusion@0.9.0		X													
+iceberg-sqllogictest@0.9.0		X													
+iceberg_test_utils@0.9.0		X													
+icu_collections@2.1.1												X			
+icu_locale_core@2.1.1												X			
+icu_normalizer@2.1.1												X			
+icu_normalizer_data@2.1.1												X			
+icu_properties@2.1.2												X			
+icu_properties_data@2.1.2												X			
+icu_provider@2.1.1												X			
+ident_case@1.0.1		X								X					
+idna@1.1.0		X								X					
+idna_adapter@1.2.1		X								X					
+indexmap@2.13.0		X								X					
+indicatif@0.18.4										X					
+inout@0.1.4		X								X					
+integer-encoding@3.0.4										X					
+inventory@0.3.22		X								X					
+ipnet@2.12.0		X								X					
+iri-string@0.7.11		X								X					
+is_terminal_polyfill@1.70.2		X								X					
+itertools@0.13.0		X								X					
+itertools@0.14.0		X								X					
+itoa@1.0.18		X								X					
+jiff@0.2.23										X			X		
+jobserver@0.1.34		X								X					
+js-sys@0.3.91		X								X					
+lazy_static@1.5.0		X								X					
+lexical-core@1.0.6		X								X					
+lexical-parse-float@1.0.6		X								X					
+lexical-parse-integer@1.0.6		X								X					
+lexical-util@1.0.7		X								X					
+lexical-write-float@1.0.6		X								X					
+lexical-write-integer@1.0.6		X								X					
+libbz2-rs-sys@0.2.2															X
+libc@0.2.183		X								X					
+liblzma@0.4.6		X								X					
+liblzma-sys@0.4.5		X								X					
+libm@0.2.16										X					
+libtest-mimic@0.8.2		X								X					
+linux-raw-sys@0.12.1		X	X							X					
+litemap@0.8.1												X			
+lock_api@0.4.14		X								X					
+log@0.4.29		X								X					
+lz4_flex@0.13.0										X					
+md-5@0.10.6		X								X					
+memchr@2.8.0										X			X		
+miniz_oxide@0.8.9		X								X				X	
+mio@1.2.0										X					
+moka@0.12.15		X								X					
+multimap@0.10.1		X								X					
+murmur3@0.5.2		X								X					
+nu-ansi-term@0.50.3										X					
+num-bigint@0.4.6		X								X					
+num-complex@0.4.6		X								X					
+num-integer@0.1.46		X								X					
+num-traits@0.2.19		X								X					
+object@0.37.3		X								X					
+object_store@0.13.2		X								X					
+once_cell@1.21.4		X								X					
+once_cell_polyfill@1.70.2		X								X					
+opaque-debug@0.3.1		X								X					
+ordered-float@2.10.1										X					
+ordered-float@4.6.0										X					
+owo-colors@4.3.0										X					
+parking@2.2.1		X								X					
+parking_lot@0.12.5		X								X					
+parking_lot_core@0.9.12		X								X					
+parquet@58.1.0		X													
+paste@1.0.15		X								X					
+pbjson@0.8.0										X					
+pbjson-build@0.8.0										X					
+pbjson-types@0.8.0										X					
+percent-encoding@2.3.2		X								X					
+petgraph@0.8.3		X								X					
+phf@0.12.1										X					
+phf_shared@0.12.1										X					
+pin-project-lite@0.2.17		X								X					
+pin-utils@0.1.0		X								X					
+pkg-config@0.3.32		X								X					
+polyval@0.6.2		X								X					
+portable-atomic@1.13.1		X								X					
+portable-atomic-util@0.2.6		X								X					
+potential_utf@0.1.4												X			
+ppv-lite86@0.2.21		X								X					
+prettyplease@0.2.37		X								X					
+proc-macro2@1.0.106		X								X					
+prost@0.14.3		X													
+prost-build@0.14.3		X													
+prost-derive@0.14.3		X													
+prost-types@0.14.3		X													
+psm@0.1.30		X								X					
+quad-rand@0.2.3										X					
+quote@1.0.45		X								X					
+r-efi@5.3.0		X							X	X					
+r-efi@6.0.0		X							X	X					
+rand@0.8.5		X								X					
+rand@0.9.4		X								X					
+rand_chacha@0.3.1		X								X					
+rand_chacha@0.9.0		X								X					
+rand_core@0.6.4		X								X					
+rand_core@0.9.5		X								X					
+recursive@0.1.1										X					
+recursive-proc-macro-impl@0.1.1										X					
+redox_syscall@0.5.18										X					
+regex@1.12.3		X								X					
+regex-automata@0.4.14		X								X					
+regex-lite@0.1.9		X								X					
+regex-syntax@0.8.10		X								X					
+regress@0.10.5		X								X					
+reqwest@0.12.28		X								X					
+ring@0.17.14		X						X							
+roaring@0.11.3		X								X					
+rustc_version@0.4.1		X								X					
+rustix@1.1.4		X	X							X					
+rustversion@1.0.22		X								X					
+ryu@1.0.23		X				X									
+same-file@1.0.6										X			X		
+schemars@0.8.22										X					
+schemars_derive@0.8.22										X					
+scopeguard@1.2.0		X								X					
+semver@1.0.27		X								X					
+seq-macro@0.3.6		X								X					
+serde@1.0.228		X								X					
+serde-big-array@0.5.1		X								X					
+serde_bytes@0.11.19		X								X					
+serde_core@1.0.228		X								X					
+serde_derive@1.0.228		X								X					
+serde_derive_internals@0.29.1		X								X					
+serde_json@1.0.149		X								X					
+serde_repr@0.1.20		X								X					
+serde_spanned@0.6.9		X								X					
+serde_tokenstream@0.2.3		X													
+serde_urlencoded@0.7.1		X								X					
+serde_with@3.21.0		X								X					
+serde_with_macros@3.21.0		X								X					
+serde_yaml@0.9.34+deprecated		X								X					
+sha1@0.10.6		X								X					
+sha2@0.10.9		X								X					
+sharded-slab@0.1.7										X					
+shlex@1.3.0		X								X					
+simd-adler32@0.3.8										X					
+simdutf8@0.1.5		X								X					
+similar@2.7.0		X													
+siphasher@1.0.2		X								X					
+slab@0.4.12										X					
+smallvec@1.15.1		X								X					
+snap@1.1.1					X										
+socket2@0.6.3		X								X					
+sqllogictest@0.29.1		X								X					
+sqlparser@0.61.0		X													
+sqlparser_derive@0.5.0		X													
+stable_deref_trait@1.2.1		X								X					
+stacker@0.1.23		X								X					
+strsim@0.11.1										X					
+strum@0.27.2										X					
+strum_macros@0.27.2										X					
+subst@0.3.8		X		X											
+substrait@0.62.2		X													
+subtle@2.6.1					X										
+syn@2.0.117		X								X					
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2										X					
+tagptr@0.2.0		X								X					
+tempfile@3.27.0		X								X					
+thiserror@2.0.18		X								X					
+thiserror-impl@2.0.18		X								X					
+thread_local@1.1.9		X								X					
+thrift@0.17.0		X													
+tiny-keccak@2.0.2							X								
+tinystr@0.8.2												X			
+tokio@1.52.1										X					
+tokio-macros@2.7.0										X					
+tokio-stream@0.1.18										X					
+tokio-util@0.7.18										X					
+toml@0.8.23		X								X					
+toml_datetime@0.6.11		X								X					
+toml_edit@0.22.27		X								X					
+toml_write@0.1.2		X								X					
+tower@0.5.3										X					
+tower-http@0.6.8										X					
+tower-layer@0.3.3										X					
+tower-service@0.3.3										X					
+tracing@0.1.44										X					
+tracing-attributes@0.1.31										X					
+tracing-core@0.1.36										X					
+tracing-log@0.2.0										X					
+tracing-subscriber@0.3.23										X					
+try-lock@0.2.5										X					
+twox-hash@2.1.2										X					
+typed-builder@0.20.1		X								X					
+typed-builder-macro@0.20.1		X								X					
+typeid@1.0.3		X								X					
+typenum@1.20.1		X								X					
+typetag@0.2.21		X								X					
+typetag-impl@0.2.21		X								X					
+typify@0.5.0		X													
+typify-impl@0.5.0		X													
+typify-macro@0.5.0		X													
+unicode-ident@1.0.24		X								X		X			
+unicode-segmentation@1.12.0		X								X					
+unicode-width@0.1.14		X								X					
+unicode-width@0.2.2		X								X					
+unit-prefix@0.5.2										X					
+universal-hash@0.5.1		X								X					
+unsafe-libyaml@0.2.11										X					
+untrusted@0.9.0								X							
+url@2.5.8		X								X					
+utf8_iter@1.0.4		X								X					
+utf8parse@0.2.2		X								X					
+uuid@1.23.0		X								X					
+version_check@0.9.5		X								X					
+walkdir@2.5.0										X			X		
+want@0.3.1										X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X					
+wasip2@1.0.2+wasi-0.2.9		X	X							X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X					
+wasm-bindgen@0.2.114		X								X					
+wasm-bindgen-futures@0.4.64		X								X					
+wasm-bindgen-macro@0.2.114		X								X					
+wasm-bindgen-macro-support@0.2.114		X								X					
+wasm-bindgen-shared@0.2.114		X								X					
+web-sys@0.3.91		X								X					
+web-time@1.1.0		X								X					
+winapi-util@0.1.11										X			X		
+windows-core@0.62.2		X								X					
+windows-implement@0.60.2		X								X					
+windows-interface@0.59.3		X								X					
+windows-link@0.2.1		X								X					
+windows-result@0.4.1		X								X					
+windows-strings@0.5.1		X								X					
+windows-sys@0.48.0		X								X					
+windows-sys@0.52.0		X								X					
+windows-sys@0.59.0		X								X					
+windows-sys@0.60.2		X								X					
+windows-sys@0.61.2		X								X					
+windows-targets@0.48.5		X								X					
+windows-targets@0.52.6		X								X					
+windows-targets@0.53.5		X								X					
+windows_aarch64_gnullvm@0.48.5		X								X					
+windows_aarch64_gnullvm@0.52.6		X								X					
+windows_aarch64_gnullvm@0.53.1		X								X					
+windows_aarch64_msvc@0.48.5		X								X					
+windows_aarch64_msvc@0.52.6		X								X					
+windows_aarch64_msvc@0.53.1		X								X					
+windows_i686_gnu@0.48.5		X								X					
+windows_i686_gnu@0.52.6		X								X					
+windows_i686_gnu@0.53.1		X								X					
+windows_i686_gnullvm@0.52.6		X								X					
+windows_i686_gnullvm@0.53.1		X								X					
+windows_i686_msvc@0.48.5		X								X					
+windows_i686_msvc@0.52.6		X								X					
+windows_i686_msvc@0.53.1		X								X					
+windows_x86_64_gnu@0.48.5		X								X					
+windows_x86_64_gnu@0.52.6		X								X					
+windows_x86_64_gnu@0.53.1		X								X					
+windows_x86_64_gnullvm@0.48.5		X								X					
+windows_x86_64_gnullvm@0.52.6		X								X					
+windows_x86_64_gnullvm@0.53.1		X								X					
+windows_x86_64_msvc@0.48.5		X								X					
+windows_x86_64_msvc@0.52.6		X								X					
+windows_x86_64_msvc@0.53.1		X								X					
+winnow@0.7.15										X					
+wit-bindgen@0.51.0		X	X							X					
+writeable@0.6.2												X			
+yoke@0.8.1												X			
+yoke-derive@0.8.1												X			
+zerocopy@0.8.47		X		X						X					
+zerocopy-derive@0.8.47		X		X						X					
+zerofrom@0.1.6												X			
+zerofrom-derive@0.1.6												X			
+zeroize@1.8.2		X								X					
+zerotrie@0.2.3												X			
+zerovec@0.11.5												X			
+zerovec-derive@0.11.2												X			
+zlib-rs@0.6.3														X	
+zmij@1.0.21										X					
+zstd@0.13.3										X					
+zstd-safe@7.2.4		X								X					
+zstd-sys@2.0.16+zstd.1.5.7		X								X					

--- a/crates/storage/opendal/DEPENDENCIES.rust.tsv
+++ b/crates/storage/opendal/DEPENDENCIES.rust.tsv
@@ -1,327 +1,522 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-ahash@0.8.12		X									X			
-aho-corasick@1.1.4											X		X	
-alloc-no-stdlib@2.0.4					X									
-alloc-stdlib@0.2.2					X									
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.102		X									X			
-apache-avro@0.21.0		X												
-array-init@2.1.0		X									X			
-arrow-arith@57.3.0		X												
-arrow-array@57.3.0		X												
-arrow-buffer@57.3.0		X												
-arrow-cast@57.3.0		X												
-arrow-data@57.3.0		X												
-arrow-ipc@57.3.0		X												
-arrow-ord@57.3.0		X												
-arrow-schema@57.3.0		X												
-arrow-select@57.3.0		X												
-arrow-string@57.3.0		X												
-as-any@0.3.2		X									X			
-async-lock@3.4.2		X									X			
-async-trait@0.1.89		X									X			
-atoi@2.0.0											X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-bigdecimal@0.4.10		X									X			
-bimap@0.6.3		X									X			
-bitflags@2.11.0		X									X			
-block-buffer@0.10.4		X									X			
-bnum@0.12.1		X									X			
-bon@3.9.0		X									X			
-bon-macros@3.9.0		X									X			
-brotli@8.0.2					X						X			
-brotli-decompressor@5.0.0					X						X			
-bumpalo@3.20.2		X									X			
-bytemuck@1.25.0		X									X			X
-byteorder@1.5.0											X		X	
-bytes@1.11.1											X			
-cc@1.2.56		X									X			
-cfg-if@1.0.4		X									X			
-chrono@0.4.44		X									X			
-concurrent-queue@2.5.0		X									X			
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.20.11											X			
-darling@0.21.3											X			
-darling@0.23.0											X			
-darling_core@0.20.11											X			
-darling_core@0.21.3											X			
-darling_core@0.23.0											X			
-darling_macro@0.20.11											X			
-darling_macro@0.21.3											X			
-darling_macro@0.23.0											X			
-derive_builder@0.20.2		X									X			
-derive_builder_core@0.20.2		X									X			
-derive_builder_macro@0.20.2		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dissimilar@1.0.10		X												
-either@1.15.0		X									X			
-equivalent@1.0.2		X									X			
-erased-serde@0.4.10		X									X			
-event-listener@5.4.1		X									X			
-event-listener-strategy@0.5.4		X									X			
-expect-test@1.5.1		X									X			
-fastnum@0.7.4		X									X			
-fastrand@2.3.0		X									X			
-find-msvc-tools@0.1.9		X									X			
-flatbuffers@25.12.19		X												
-flate2@1.1.9		X									X			
-fnv@1.0.7		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.32		X									X			
-futures-channel@0.3.32		X									X			
-futures-core@0.3.32		X									X			
-futures-executor@0.3.32		X									X			
-futures-io@0.3.32		X									X			
-futures-macro@0.3.32		X									X			
-futures-sink@0.3.32		X									X			
-futures-task@0.3.32		X									X			
-futures-util@0.3.32		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.17		X									X			
-getrandom@0.3.4		X									X			
-getrandom@0.4.1		X									X			
-gloo-timers@0.3.0		X									X			
-half@2.7.1		X									X			
-hashbrown@0.16.1		X									X			
-heck@0.5.0		X									X			
-hex@0.4.3		X									X			
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@1.4.0		X									X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-hyper@1.8.1											X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.20											X			
-iana-time-zone@0.1.65		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.9.0		X												
-iceberg-storage-opendal@0.9.0		X												
-iceberg_test_utils@0.9.0		X												
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-integer-encoding@3.0.4											X			
-inventory@0.3.22		X									X			
-ipnet@2.12.0		X									X			
-iri-string@0.7.10		X									X			
-itertools@0.13.0		X									X			
-itoa@1.0.17		X									X			
-jiff@0.2.22											X		X	
-jiff-tzdb@0.1.5											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.91		X									X			
-lazy_static@1.5.0		X									X			
-lexical-core@1.0.6		X									X			
-lexical-parse-float@1.0.6		X									X			
-lexical-parse-integer@1.0.6		X									X			
-lexical-util@1.0.7		X									X			
-lexical-write-float@1.0.6		X									X			
-lexical-write-integer@1.0.6		X									X			
-libc@0.2.182		X									X			
-libm@0.2.16											X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.29		X									X			
-lz4_flex@0.12.0											X			
-md-5@0.10.6		X									X			
-memchr@2.8.0											X		X	
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.1											X			
-moka@0.12.14		X									X			
-murmur3@0.5.2		X									X			
-nu-ansi-term@0.50.3											X			
-num-bigint@0.4.6		X									X			
-num-complex@0.4.6		X									X			
-num-integer@0.1.46		X									X			
-num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-ordered-float@2.10.1											X			
-ordered-float@4.6.0											X			
-parking@2.2.1		X									X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-parquet@57.3.0		X												
-paste@1.0.15		X									X			
-percent-encoding@2.3.2		X									X			
-pin-project-lite@0.2.17		X									X			
-pin-utils@0.1.0		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.13.1		X									X			
-portable-atomic-util@0.2.5		X									X			
-potential_utf@0.1.4												X		
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro2@1.0.106		X									X			
-quad-rand@0.2.3											X			
-quick-xml@0.38.4											X			
-quote@1.0.44		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand@0.9.2		X									X			
-rand_chacha@0.3.1		X									X			
-rand_chacha@0.9.0		X									X			
-rand_core@0.6.4		X									X			
-rand_core@0.9.5		X									X			
-redox_syscall@0.5.18											X			
-regex@1.12.3		X									X			
-regex-automata@0.4.14		X									X			
-regex-lite@0.1.9		X									X			
-regex-syntax@0.8.10		X									X			
-reqsign@0.16.5		X												
-reqwest@0.12.28		X									X			
-ring@0.17.14		X							X					
-roaring@0.11.3		X									X			
-rustc_version@0.4.1		X									X			
-rustls@0.23.37		X							X		X			
-rustls-pki-types@1.14.0		X									X			
-rustls-webpki@0.103.9									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.23		X				X								
-scopeguard@1.2.0		X									X			
-semver@1.0.27		X									X			
-seq-macro@0.3.6		X									X			
-serde@1.0.228		X									X			
-serde-big-array@0.5.1		X									X			
-serde_bytes@0.11.19		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.149		X									X			
-serde_repr@0.1.20		X									X			
-serde_urlencoded@0.7.1		X									X			
-serde_with@3.17.0		X									X			
-serde_with_macros@3.17.0		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-sharded-slab@0.1.7											X			
-shlex@1.3.0		X									X			
-simd-adler32@0.3.8											X			
-simdutf8@0.1.5		X									X			
-slab@0.4.12											X			
-smallvec@1.15.1		X									X			
-snap@1.1.1					X									
-socket2@0.6.2		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.11.1											X			
-strum@0.27.2											X			
-strum_macros@0.27.2											X			
-subtle@2.6.1					X									
-syn@2.0.117		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tagptr@0.2.0		X									X			
-thiserror@2.0.18		X									X			
-thiserror-impl@2.0.18		X									X			
-thread_local@1.1.9		X									X			
-thrift@0.17.0		X												
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.50.0											X			
-tokio-macros@2.6.1											X			
-tokio-rustls@0.26.4		X									X			
-tokio-util@0.7.18											X			
-tower@0.5.3											X			
-tower-http@0.6.8											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.44											X			
-tracing-core@0.1.36											X			
-tracing-log@0.2.0											X			
-tracing-subscriber@0.3.22											X			
-try-lock@0.2.5											X			
-twox-hash@2.1.2											X			
-typed-builder@0.20.1		X									X			
-typed-builder-macro@0.20.1		X									X			
-typeid@1.0.3		X									X			
-typenum@1.19.0		X									X			
-typetag@0.2.21		X									X			
-typetag-impl@0.2.21		X									X			
-unicode-ident@1.0.24		X									X	X		
-untrusted@0.9.0									X					
-url@2.5.8		X									X			
-utf8_iter@1.0.4		X									X			
-uuid@1.22.0		X									X			
-version_check@0.9.5		X									X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.2+wasi-0.2.9		X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
-wasm-bindgen@0.2.114		X									X			
-wasm-bindgen-futures@0.4.64		X									X			
-wasm-bindgen-macro@0.2.114		X									X			
-wasm-bindgen-macro-support@0.2.114		X									X			
-wasm-bindgen-shared@0.2.114		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.91		X									X			
-webpki-roots@1.0.6								X						
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-wit-bindgen@0.51.0		X	X								X			
-writeable@0.6.2												X		
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.40		X		X							X			
-zerocopy-derive@0.8.40		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zlib-rs@0.6.3														X
-zmij@1.0.21											X			
-zstd@0.13.3											X			
-zstd-safe@7.2.4		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X					
+aead@0.5.2		X									X					
+aes@0.8.4		X									X					
+aes-gcm@0.10.3		X									X					
+ahash@0.8.12		X									X					
+aho-corasick@1.1.4											X				X	
+alloc-no-stdlib@2.0.4					X											
+alloc-stdlib@0.2.2					X											
+android_system_properties@0.1.5		X									X					
+anstream@1.0.0		X									X					
+anstyle@1.0.14		X									X					
+anstyle-parse@1.0.0		X									X					
+anstyle-query@1.1.5		X									X					
+anstyle-wincon@3.0.11		X									X					
+anyhow@1.0.102		X									X					
+apache-avro@0.21.0		X														
+approx@0.5.1		X														
+array-init@2.1.0		X									X					
+arrayref@0.3.9				X												
+arrayvec@0.7.6		X									X					
+arrow-arith@58.3.0		X														
+arrow-array@58.3.0		X									X					
+arrow-buffer@58.3.0		X														
+arrow-cast@58.3.0		X														
+arrow-data@58.3.0		X														
+arrow-ipc@58.1.0		X														
+arrow-ord@58.3.0		X														
+arrow-schema@58.3.0		X														
+arrow-select@58.3.0		X														
+arrow-string@58.3.0		X														
+as-any@0.3.2		X									X					
+async-lock@3.4.2		X									X					
+async-trait@0.1.89		X									X					
+atoi@2.0.0											X					
+atomic-waker@1.1.2		X									X					
+autocfg@1.5.0		X									X					
+aws-lc-rs@1.16.2		X							X							
+aws-lc-sys@0.39.0		X			X				X		X	X				
+backon@1.6.0		X														
+base64@0.22.1		X									X					
+base64ct@1.8.3		X									X					
+bigdecimal@0.4.10		X									X					
+bimap@0.6.3		X									X					
+bitflags@2.11.0		X									X					
+blake3@1.8.3		X	X				X									
+block-buffer@0.10.4		X									X					
+block-buffer@0.12.0		X									X					
+block-padding@0.3.3		X									X					
+bnum@0.12.1		X									X					
+bon@3.9.1		X									X					
+bon-macros@3.9.1		X									X					
+brotli@8.0.2					X						X					
+brotli-decompressor@5.0.0					X						X					
+bstr@1.12.1		X									X					
+bumpalo@3.20.2		X									X					
+bytemuck@1.25.0		X									X					X
+bytemuck_derive@1.10.2		X									X					X
+byteorder@1.5.0											X				X	
+bytes@1.11.1											X					
+cbc@0.1.2		X									X					
+cc@1.2.57		X									X					
+cfg-if@0.1.10		X									X					
+cfg-if@1.0.4		X									X					
+chacha20@0.10.0		X									X					
+chrono@0.4.44		X									X					
+cipher@0.4.4		X									X					
+clap@4.6.0		X									X					
+clap_builder@4.6.0		X									X					
+clap_derive@4.6.0		X									X					
+clap_lex@1.1.0		X									X					
+cmake@0.1.57		X									X					
+colorchoice@1.0.5		X									X					
+colored@3.1.1													X			
+combine@4.6.7											X					
+concurrent-queue@2.5.0		X									X					
+const-oid@0.10.2		X									X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+const-str@1.1.0											X					
+const_panic@0.2.15																X
+constant_time_eq@0.4.2		X					X					X				
+core-foundation@0.10.1		X									X					
+core-foundation@0.9.4		X									X					
+core-foundation-sys@0.8.7		X									X					
+countio@0.3.0											X					
+cpufeatures@0.2.17		X									X					
+cpufeatures@0.3.0		X									X					
+crc32c@0.6.8		X									X					
+crc32fast@1.5.0		X									X					
+crossbeam-channel@0.5.15		X									X					
+crossbeam-epoch@0.9.18		X									X					
+crossbeam-utils@0.8.21		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.7		X									X					
+crypto-common@0.2.2		X									X					
+csv@1.4.0											X				X	
+csv-core@0.1.13											X				X	
+ctor@0.6.3		X									X					
+ctor@1.0.7		X									X					
+ctor-proc-macro@0.0.7		X									X					
+ctr@0.9.2		X									X					
+darling@0.20.11											X					
+darling@0.23.0											X					
+darling_core@0.20.11											X					
+darling_core@0.23.0											X					
+darling_macro@0.20.11											X					
+darling_macro@0.23.0											X					
+der@0.7.10		X									X					
+deranged@0.5.8		X									X					
+derive_builder@0.20.2		X									X					
+derive_builder_core@0.20.2		X									X					
+derive_builder_macro@0.20.2		X									X					
+digest@0.10.7		X									X					
+digest@0.11.3		X									X					
+dirs@6.0.0		X									X					
+dirs-sys@0.5.0		X									X					
+displaydoc@0.2.5		X									X					
+dissimilar@1.0.11		X														
+dlv-list@0.5.2		X									X					
+dtor@0.1.1		X									X					
+dtor-proc-macro@0.0.6		X									X					
+dunce@1.0.5		X					X					X				
+either@1.15.0		X									X					
+equivalent@1.0.2		X									X					
+erased-serde@0.4.10		X									X					
+errno@0.3.14		X									X					
+event-listener@5.4.1		X									X					
+event-listener-strategy@0.5.4		X									X					
+expect-test@1.5.1		X									X					
+fastnum@0.7.4		X									X					
+fastrand@2.3.0		X									X					
+find-msvc-tools@0.1.9		X									X					
+flatbuffers@25.12.19		X														
+flate2@1.1.9		X									X					
+fnv@1.0.7		X									X					
+form_urlencoded@1.2.2		X									X					
+fs_extra@1.3.0											X					
+futures@0.3.32		X									X					
+futures-channel@0.3.32		X									X					
+futures-core@0.3.32		X									X					
+futures-executor@0.3.32		X									X					
+futures-io@0.3.32		X									X					
+futures-macro@0.3.32		X									X					
+futures-sink@0.3.32		X									X					
+futures-task@0.3.32		X									X					
+futures-util@0.3.32		X									X					
+gearhash@0.1.3		X									X					
+generic-array@0.14.7											X					
+getrandom@0.2.17		X									X					
+getrandom@0.3.4		X									X					
+getrandom@0.4.2		X									X					
+ghash@0.5.1		X									X					
+git-version@0.3.9				X												
+git-version-macro@0.3.9				X												
+gloo-timers@0.3.0		X									X					
+half@2.7.1		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.16.1		X									X					
+hashbrown@0.17.1		X									X					
+heapify@0.2.0		X									X					
+heck@0.5.0		X									X					
+hex@0.4.3		X									X					
+hf-xet@1.5.2		X														
+hmac@0.12.1		X									X					
+http@1.4.0		X									X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+humantime@2.3.0		X									X					
+hybrid-array@0.4.12		X									X					
+hyper@1.8.1											X					
+hyper-rustls@0.27.7		X							X		X					
+hyper-util@0.1.20											X					
+iana-time-zone@0.1.65		X									X					
+iana-time-zone-haiku@0.1.2		X									X					
+iceberg@0.9.0		X														
+iceberg-storage-opendal@0.9.0		X														
+iceberg_test_utils@0.9.0		X														
+icu_collections@2.1.1														X		
+icu_locale_core@2.1.1														X		
+icu_normalizer@2.1.1														X		
+icu_normalizer_data@2.1.1														X		
+icu_properties@2.1.2														X		
+icu_properties_data@2.1.2														X		
+icu_provider@2.1.1														X		
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.1		X									X					
+inout@0.1.4		X									X					
+integer-encoding@3.0.4											X					
+inventory@0.3.22		X									X					
+ipnet@2.12.0		X									X					
+iri-string@0.7.11		X									X					
+is_terminal_polyfill@1.70.2		X									X					
+itertools@0.13.0		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.18		X									X					
+jiff@0.2.23											X				X	
+jiff-tzdb@0.1.6											X				X	
+jiff-tzdb-platform@0.1.3											X				X	
+jni@0.22.4		X									X					
+jni-macros@0.22.4		X									X					
+jni-sys@0.4.1		X									X					
+jni-sys-macros@0.4.1		X									X					
+jobserver@0.1.34		X									X					
+js-sys@0.3.91		X									X					
+jsonwebtoken@10.3.0											X					
+konst@0.4.3																X
+konst_proc_macros@0.4.1																X
+lazy_static@1.5.0		X									X					
+lexical-core@1.0.6		X									X					
+lexical-parse-float@1.0.6		X									X					
+lexical-parse-integer@1.0.6		X									X					
+lexical-util@1.0.7		X									X					
+lexical-write-float@1.0.6		X									X					
+lexical-write-integer@1.0.6		X									X					
+libc@0.2.183		X									X					
+libm@0.2.16											X					
+libredox@0.1.14											X					
+link-section@0.18.1		X									X					
+linktime-proc-macro@0.2.0		X									X					
+linux-raw-sys@0.12.1		X	X								X					
+litemap@0.8.1														X		
+lock_api@0.4.14		X									X					
+log@0.4.29		X									X					
+lz4_flex@0.13.0											X					
+matchers@0.2.0											X					
+md-5@0.11.0		X									X					
+mea@0.6.3		X														
+memchr@2.8.0											X				X	
+miniz_oxide@0.8.9		X									X					X
+mio@1.2.0											X					
+moka@0.12.15		X									X					
+more-asserts@0.3.1		X					X				X				X	
+murmur3@0.5.2		X									X					
+ntapi@0.4.3		X									X					
+nu-ansi-term@0.50.3											X					
+num-bigint@0.4.6		X									X					
+num-bigint-dig@0.8.6		X									X					
+num-complex@0.4.6		X									X					
+num-conv@0.2.0		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-traits@0.2.19		X									X					
+objc2-core-foundation@0.3.2		X									X					X
+objc2-io-kit@0.3.2		X									X					X
+objc2-system-configuration@0.3.2		X									X					X
+once_cell@1.21.4		X									X					
+once_cell_polyfill@1.70.2		X									X					
+oneshot@0.1.13		X									X					
+opaque-debug@0.3.1		X									X					
+opendal@0.57.0		X														
+opendal-core@0.57.0		X														
+opendal-layer-concurrent-limit@0.57.0		X														
+opendal-layer-logging@0.57.0		X														
+opendal-layer-retry@0.57.0		X														
+opendal-layer-timeout@0.57.0		X														
+opendal-service-azdls@0.57.0		X														
+opendal-service-azure-common@0.57.0		X														
+opendal-service-fs@0.57.0		X														
+opendal-service-gcs@0.57.0		X														
+opendal-service-hf@0.57.0		X														
+opendal-service-oss@0.57.0		X														
+opendal-service-s3@0.57.0		X														
+openssl-probe@0.2.1		X									X					
+option-ext@0.2.0													X			
+ordered-float@2.10.1											X					
+ordered-float@4.6.0											X					
+ordered-multimap@0.7.3											X					
+os_str_bytes@6.6.1		X									X					
+parking@2.2.1		X									X					
+parking_lot@0.12.5		X									X					
+parking_lot_core@0.9.12		X									X					
+parquet@58.1.0		X														
+paste@1.0.15		X									X					
+pbkdf2@0.12.2		X									X					
+pem@3.0.6											X					
+pem-rfc7468@0.7.0		X									X					
+percent-encoding@2.3.2		X									X					
+pin-project@1.1.11		X									X					
+pin-project-internal@1.1.11		X									X					
+pin-project-lite@0.2.17		X									X					
+pin-utils@0.1.0		X									X					
+pkcs1@0.7.5		X									X					
+pkcs5@0.7.1		X									X					
+pkcs8@0.10.2		X									X					
+pkg-config@0.3.32		X									X					
+polyval@0.6.2		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.6		X									X					
+potential_utf@0.1.4														X		
+powerfmt@0.2.0		X									X					
+ppv-lite86@0.2.21		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.106		X									X					
+quad-rand@0.2.3											X					
+quick-xml@0.39.4											X					
+quote@1.0.45		X									X					
+r-efi@5.3.0		X								X	X					
+r-efi@6.0.0		X								X	X					
+rand@0.10.1		X									X					
+rand@0.8.5		X									X					
+rand@0.9.4		X									X					
+rand_chacha@0.3.1		X									X					
+rand_chacha@0.9.0		X									X					
+rand_core@0.10.0		X									X					
+rand_core@0.6.4		X									X					
+rand_core@0.9.5		X									X					
+redb@3.1.3		X									X					
+redox_syscall@0.5.18											X					
+redox_users@0.5.2											X					
+regex@1.12.3		X									X					
+regex-automata@0.4.14		X									X					
+regex-lite@0.1.9		X									X					
+regex-syntax@0.8.10		X									X					
+reqsign-aliyun-oss@3.0.0		X														
+reqsign-aws-v4@3.0.0		X														
+reqsign-azure-storage@3.0.0		X														
+reqsign-core@3.0.0		X														
+reqsign-file-read-tokio@3.0.0		X														
+reqsign-google@3.0.0		X														
+reqwest@0.12.28		X									X					
+reqwest@0.13.3		X									X					
+reqwest-middleware@0.5.2		X									X					
+ring@0.17.14		X							X							
+roaring@0.11.3		X									X					
+rsa@0.9.10		X									X					
+rust-ini@0.21.3											X					
+rustc_version@0.4.1		X									X					
+rustix@1.1.4		X	X								X					
+rustls@0.23.37		X							X		X					
+rustls-native-certs@0.8.3		X							X		X					
+rustls-pki-types@1.14.0		X									X					
+rustls-platform-verifier@0.7.0		X									X					
+rustls-platform-verifier-android@0.1.1		X									X					
+rustls-webpki@0.103.13									X							
+rustversion@1.0.22		X									X					
+ryu@1.0.23		X				X										
+safe-transmute@0.11.3											X					
+salsa20@0.10.2		X									X					
+same-file@1.0.6											X				X	
+schannel@0.1.29											X					
+scopeguard@1.2.0		X									X					
+scrypt@0.11.0		X									X					
+security-framework@3.7.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.27		X									X					
+seq-macro@0.3.6		X									X					
+serde@1.0.228		X									X					
+serde-big-array@0.5.1		X									X					
+serde_bytes@0.11.19		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.149		X									X					
+serde_repr@0.1.20		X									X					
+serde_urlencoded@0.7.1		X									X					
+serde_with@3.21.0		X									X					
+serde_with_macros@3.21.0		X									X					
+sha1@0.10.6		X									X					
+sha2@0.10.9		X									X					
+sha2-asm@0.6.4											X					
+sharded-slab@0.1.7											X					
+shellexpand@3.1.2		X									X					
+shlex@1.3.0		X									X					
+signature@2.2.0		X									X					
+simd-adler32@0.3.8											X					
+simd_cesu8@1.1.1		X									X					
+simdutf8@0.1.5		X									X					
+simple_asn1@0.6.4									X							
+slab@0.4.12											X					
+smallvec@1.15.1		X									X					
+snap@1.1.1					X											
+socket2@0.6.3		X									X					
+spin@0.9.8											X					
+spki@0.7.3		X									X					
+stable_deref_trait@1.2.1		X									X					
+static_assertions@1.1.0		X									X					
+statrs@0.18.0											X					
+strsim@0.11.1											X					
+strum@0.27.2											X					
+strum_macros@0.27.2											X					
+subtle@2.6.1					X											
+symlink@0.1.0		X									X					
+syn@2.0.117		X									X					
+sync_wrapper@1.0.2		X														
+synstructure@0.13.2											X					
+sysinfo@0.38.4											X					
+system-configuration@0.7.0		X									X					
+system-configuration-sys@0.6.0		X									X					
+tagptr@0.2.0		X									X					
+tempfile@3.27.0		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@2.0.18		X									X					
+thread_local@1.1.9		X									X					
+thrift@0.17.0		X														
+time@0.3.47		X									X					
+time-core@0.1.8		X									X					
+time-macros@0.2.27		X									X					
+tiny-keccak@2.0.2							X									
+tinystr@0.8.2														X		
+tokio@1.52.1											X					
+tokio-macros@2.7.0											X					
+tokio-retry@0.3.1											X					
+tokio-rustls@0.26.4		X									X					
+tokio-util@0.7.18											X					
+tower@0.5.3											X					
+tower-http@0.6.8											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.44											X					
+tracing-appender@0.2.5											X					
+tracing-attributes@0.1.31											X					
+tracing-core@0.1.36											X					
+tracing-log@0.2.0											X					
+tracing-serde@0.2.0											X					
+tracing-subscriber@0.3.23											X					
+try-lock@0.2.5											X					
+twox-hash@2.1.2											X					
+typed-builder@0.20.1		X									X					
+typed-builder-macro@0.20.1		X									X					
+typeid@1.0.3		X									X					
+typenum@1.20.1		X									X					
+typetag@0.2.21		X									X					
+typetag-impl@0.2.21		X									X					
+typewit@1.15.2																X
+unicode-ident@1.0.24		X									X			X		
+universal-hash@0.5.1		X									X					
+untrusted@0.7.1									X							
+untrusted@0.9.0									X							
+url@2.5.8		X									X					
+urlencoding@2.1.3											X					
+utf8_iter@1.0.4		X									X					
+utf8parse@0.2.2		X									X					
+uuid@1.23.0		X									X					
+version_check@0.9.5		X									X					
+walkdir@2.5.0											X				X	
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasi@0.14.7+wasi-0.2.4		X	X								X					
+wasip2@1.0.2+wasi-0.2.9		X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasite@1.0.2		X				X					X					
+wasm-bindgen@0.2.114		X									X					
+wasm-bindgen-futures@0.4.64		X									X					
+wasm-bindgen-macro@0.2.114		X									X					
+wasm-bindgen-macro-support@0.2.114		X									X					
+wasm-bindgen-shared@0.2.114		X									X					
+wasm-streams@0.5.0		X									X					
+web-sys@0.3.91		X									X					
+web-time@1.1.0		X									X					
+webpki-root-certs@1.0.7								X								
+whoami@2.1.1		X				X					X					
+winapi@0.3.9		X									X					
+winapi-i686-pc-windows-gnu@0.4.0		X									X					
+winapi-util@0.1.11											X				X	
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X					
+windows@0.62.2		X									X					
+windows-collections@0.3.2		X									X					
+windows-core@0.62.2		X									X					
+windows-future@0.3.2		X									X					
+windows-implement@0.60.2		X									X					
+windows-interface@0.59.3		X									X					
+windows-link@0.2.1		X									X					
+windows-numerics@0.3.1		X									X					
+windows-registry@0.6.1		X									X					
+windows-result@0.4.1		X									X					
+windows-strings@0.5.1		X									X					
+windows-sys@0.48.0		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.60.2		X									X					
+windows-sys@0.61.2		X									X					
+windows-targets@0.48.5		X									X					
+windows-targets@0.52.6		X									X					
+windows-targets@0.53.5		X									X					
+windows-threading@0.2.1		X									X					
+windows_aarch64_gnullvm@0.48.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_gnullvm@0.53.1		X									X					
+windows_aarch64_msvc@0.48.5		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_aarch64_msvc@0.53.1		X									X					
+windows_i686_gnu@0.48.5		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnu@0.53.1		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_gnullvm@0.53.1		X									X					
+windows_i686_msvc@0.48.5		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_i686_msvc@0.53.1		X									X					
+windows_x86_64_gnu@0.48.5		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnu@0.53.1		X									X					
+windows_x86_64_gnullvm@0.48.5		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_gnullvm@0.53.1		X									X					
+windows_x86_64_msvc@0.48.5		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+windows_x86_64_msvc@0.53.1		X									X					
+wit-bindgen@0.51.0		X	X								X					
+writeable@0.6.2														X		
+xattr@1.6.1		X									X					
+xet-client@1.5.2		X														
+xet-core-structures@1.5.2		X														
+xet-data@1.5.2		X														
+xet-runtime@1.5.2		X														
+yoke@0.8.1														X		
+yoke-derive@0.8.1														X		
+zerocopy@0.8.47		X		X							X					
+zerocopy-derive@0.8.47		X		X							X					
+zerofrom@0.1.6														X		
+zerofrom-derive@0.1.6														X		
+zeroize@1.8.2		X									X					
+zerotrie@0.2.3														X		
+zerovec@0.11.5														X		
+zerovec-derive@0.11.2														X		
+zlib-rs@0.6.3																X
+zmij@1.0.21											X					
+zstd@0.13.3											X					
+zstd-safe@7.2.4		X									X					
+zstd-sys@2.0.16+zstd.1.5.7		X									X					

--- a/crates/test_utils/DEPENDENCIES.rust.tsv
+++ b/crates/test_utils/DEPENDENCIES.rust.tsv
@@ -1,287 +1,311 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X							X			
-ahash@0.8.12		X							X			
-aho-corasick@1.1.4									X		X	
-alloc-no-stdlib@2.0.4					X							
-alloc-stdlib@0.2.2					X							
-android_system_properties@0.1.5		X							X			
-anyhow@1.0.102		X							X			
-apache-avro@0.21.0		X										
-array-init@2.1.0		X							X			
-arrow-arith@57.3.0		X										
-arrow-array@57.3.0		X										
-arrow-buffer@57.3.0		X										
-arrow-cast@57.3.0		X										
-arrow-data@57.3.0		X										
-arrow-ipc@57.3.0		X										
-arrow-ord@57.3.0		X										
-arrow-schema@57.3.0		X										
-arrow-select@57.3.0		X										
-arrow-string@57.3.0		X										
-as-any@0.3.2		X							X			
-async-lock@3.4.2		X							X			
-async-trait@0.1.89		X							X			
-atoi@2.0.0									X			
-atomic-waker@1.1.2		X							X			
-autocfg@1.5.0		X							X			
-backon@1.6.0		X										
-base64@0.22.1		X							X			
-bigdecimal@0.4.10		X							X			
-bimap@0.6.3		X							X			
-bitflags@2.11.0		X							X			
-block-buffer@0.10.4		X							X			
-bnum@0.12.1		X							X			
-bon@3.9.0		X							X			
-bon-macros@3.9.0		X							X			
-brotli@8.0.2					X				X			
-brotli-decompressor@5.0.0					X				X			
-bumpalo@3.20.2		X							X			
-bytemuck@1.25.0		X							X			X
-byteorder@1.5.0									X		X	
-bytes@1.11.1									X			
-cc@1.2.56		X							X			
-cfg-if@1.0.4		X							X			
-chrono@0.4.44		X							X			
-concurrent-queue@2.5.0		X							X			
-const-random@0.1.18		X							X			
-const-random-macro@0.1.16		X							X			
-core-foundation-sys@0.8.7		X							X			
-crc32fast@1.5.0		X							X			
-crossbeam-channel@0.5.15		X							X			
-crossbeam-epoch@0.9.18		X							X			
-crossbeam-utils@0.8.21		X							X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7		X							X			
-darling@0.20.11									X			
-darling@0.21.3									X			
-darling@0.23.0									X			
-darling_core@0.20.11									X			
-darling_core@0.21.3									X			
-darling_core@0.23.0									X			
-darling_macro@0.20.11									X			
-darling_macro@0.21.3									X			
-darling_macro@0.23.0									X			
-derive_builder@0.20.2		X							X			
-derive_builder_core@0.20.2		X							X			
-derive_builder_macro@0.20.2		X							X			
-digest@0.10.7		X							X			
-displaydoc@0.2.5		X							X			
-dissimilar@1.0.10		X										
-either@1.15.0		X							X			
-equivalent@1.0.2		X							X			
-erased-serde@0.4.10		X							X			
-event-listener@5.4.1		X							X			
-event-listener-strategy@0.5.4		X							X			
-expect-test@1.5.1		X							X			
-fastnum@0.7.4		X							X			
-fastrand@2.3.0		X							X			
-find-msvc-tools@0.1.9		X							X			
-flatbuffers@25.12.19		X										
-flate2@1.1.9		X							X			
-fnv@1.0.7		X							X			
-form_urlencoded@1.2.2		X							X			
-futures@0.3.32		X							X			
-futures-channel@0.3.32		X							X			
-futures-core@0.3.32		X							X			
-futures-executor@0.3.32		X							X			
-futures-io@0.3.32		X							X			
-futures-macro@0.3.32		X							X			
-futures-sink@0.3.32		X							X			
-futures-task@0.3.32		X							X			
-futures-util@0.3.32		X							X			
-generic-array@0.14.7									X			
-getrandom@0.2.17		X							X			
-getrandom@0.3.4		X							X			
-getrandom@0.4.1		X							X			
-gloo-timers@0.3.0		X							X			
-half@2.7.1		X							X			
-hashbrown@0.16.1		X							X			
-heck@0.5.0		X							X			
-http@1.4.0		X							X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1		X							X			
-hyper@1.8.1									X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65		X							X			
-iana-time-zone-haiku@0.1.2		X							X			
-iceberg@0.9.0		X										
-iceberg_test_utils@0.9.0		X										
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
-ident_case@1.0.1		X							X			
-idna@1.1.0		X							X			
-idna_adapter@1.2.1		X							X			
-integer-encoding@3.0.4									X			
-inventory@0.3.22		X							X			
-ipnet@2.12.0		X							X			
-iri-string@0.7.10		X							X			
-itertools@0.13.0		X							X			
-itoa@1.0.17		X							X			
-jobserver@0.1.34		X							X			
-js-sys@0.3.91		X							X			
-lazy_static@1.5.0		X							X			
-lexical-core@1.0.6		X							X			
-lexical-parse-float@1.0.6		X							X			
-lexical-parse-integer@1.0.6		X							X			
-lexical-util@1.0.7		X							X			
-lexical-write-float@1.0.6		X							X			
-lexical-write-integer@1.0.6		X							X			
-libc@0.2.182		X							X			
-libm@0.2.16									X			
-litemap@0.8.1										X		
-lock_api@0.4.14		X							X			
-log@0.4.29		X							X			
-lz4_flex@0.12.0									X			
-memchr@2.8.0									X		X	
-miniz_oxide@0.8.9		X							X			X
-mio@1.1.1									X			
-moka@0.12.14		X							X			
-murmur3@0.5.2		X							X			
-nu-ansi-term@0.50.3									X			
-num-bigint@0.4.6		X							X			
-num-complex@0.4.6		X							X			
-num-integer@0.1.46		X							X			
-num-traits@0.2.19		X							X			
-once_cell@1.21.3		X							X			
-ordered-float@2.10.1									X			
-ordered-float@4.6.0									X			
-parking@2.2.1		X							X			
-parking_lot@0.12.5		X							X			
-parking_lot_core@0.9.12		X							X			
-parquet@57.3.0		X										
-paste@1.0.15		X							X			
-percent-encoding@2.3.2		X							X			
-pin-project-lite@0.2.17		X							X			
-pin-utils@0.1.0		X							X			
-pkg-config@0.3.32		X							X			
-portable-atomic@1.13.1		X							X			
-potential_utf@0.1.4										X		
-ppv-lite86@0.2.21		X							X			
-prettyplease@0.2.37		X							X			
-proc-macro2@1.0.106		X							X			
-quad-rand@0.2.3									X			
-quote@1.0.44		X							X			
-r-efi@5.3.0		X						X	X			
-rand@0.8.5		X							X			
-rand@0.9.2		X							X			
-rand_chacha@0.3.1		X							X			
-rand_chacha@0.9.0		X							X			
-rand_core@0.6.4		X							X			
-rand_core@0.9.5		X							X			
-redox_syscall@0.5.18									X			
-regex@1.12.3		X							X			
-regex-automata@0.4.14		X							X			
-regex-lite@0.1.9		X							X			
-regex-syntax@0.8.10		X							X			
-reqwest@0.12.28		X							X			
-roaring@0.11.3		X							X			
-rustc_version@0.4.1		X							X			
-rustversion@1.0.22		X							X			
-ryu@1.0.23		X				X						
-scopeguard@1.2.0		X							X			
-semver@1.0.27		X							X			
-seq-macro@0.3.6		X							X			
-serde@1.0.228		X							X			
-serde-big-array@0.5.1		X							X			
-serde_bytes@0.11.19		X							X			
-serde_core@1.0.228		X							X			
-serde_derive@1.0.228		X							X			
-serde_json@1.0.149		X							X			
-serde_repr@0.1.20		X							X			
-serde_urlencoded@0.7.1		X							X			
-serde_with@3.17.0		X							X			
-serde_with_macros@3.17.0		X							X			
-sharded-slab@0.1.7									X			
-shlex@1.3.0		X							X			
-simd-adler32@0.3.8									X			
-simdutf8@0.1.5		X							X			
-slab@0.4.12									X			
-smallvec@1.15.1		X							X			
-snap@1.1.1					X							
-socket2@0.6.2		X							X			
-stable_deref_trait@1.2.1		X							X			
-strsim@0.11.1									X			
-strum@0.27.2									X			
-strum_macros@0.27.2									X			
-syn@2.0.117		X							X			
-sync_wrapper@1.0.2		X										
-synstructure@0.13.2									X			
-tagptr@0.2.0		X							X			
-thiserror@2.0.18		X							X			
-thiserror-impl@2.0.18		X							X			
-thread_local@1.1.9		X							X			
-thrift@0.17.0		X										
-tiny-keccak@2.0.2							X					
-tinystr@0.8.2										X		
-tokio@1.50.0									X			
-tokio-macros@2.6.1									X			
-tower@0.5.3									X			
-tower-http@0.6.8									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-core@0.1.36									X			
-tracing-log@0.2.0									X			
-tracing-subscriber@0.3.22									X			
-try-lock@0.2.5									X			
-twox-hash@2.1.2									X			
-typed-builder@0.20.1		X							X			
-typed-builder-macro@0.20.1		X							X			
-typeid@1.0.3		X							X			
-typenum@1.19.0		X							X			
-typetag@0.2.21		X							X			
-typetag-impl@0.2.21		X							X			
-unicode-ident@1.0.24		X							X	X		
-url@2.5.8		X							X			
-utf8_iter@1.0.4		X							X			
-uuid@1.22.0		X							X			
-version_check@0.9.5		X							X			
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X						X			
-wasip2@1.0.2+wasi-0.2.9		X	X						X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X						X			
-wasm-bindgen@0.2.114		X							X			
-wasm-bindgen-futures@0.4.64		X							X			
-wasm-bindgen-macro@0.2.114		X							X			
-wasm-bindgen-macro-support@0.2.114		X							X			
-wasm-bindgen-shared@0.2.114		X							X			
-web-sys@0.3.91		X							X			
-windows-core@0.62.2		X							X			
-windows-implement@0.60.2		X							X			
-windows-interface@0.59.3		X							X			
-windows-link@0.2.1		X							X			
-windows-result@0.4.1		X							X			
-windows-strings@0.5.1		X							X			
-windows-sys@0.60.2		X							X			
-windows-sys@0.61.2		X							X			
-windows-targets@0.53.5		X							X			
-windows_aarch64_gnullvm@0.53.1		X							X			
-windows_aarch64_msvc@0.53.1		X							X			
-windows_i686_gnu@0.53.1		X							X			
-windows_i686_gnullvm@0.53.1		X							X			
-windows_i686_msvc@0.53.1		X							X			
-windows_x86_64_gnu@0.53.1		X							X			
-windows_x86_64_gnullvm@0.53.1		X							X			
-windows_x86_64_msvc@0.53.1		X							X			
-wit-bindgen@0.51.0		X	X						X			
-writeable@0.6.2										X		
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerocopy@0.8.40		X		X					X			
-zerocopy-derive@0.8.40		X		X					X			
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
-zlib-rs@0.6.3												X
-zmij@1.0.21									X			
-zstd@0.13.3									X			
-zstd-safe@7.2.4		X							X			
-zstd-sys@2.0.16+zstd.1.5.7		X							X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X								X			
+aead@0.5.2		X								X			
+aes@0.8.4		X								X			
+aes-gcm@0.10.3		X								X			
+ahash@0.8.12		X								X			
+aho-corasick@1.1.4										X		X	
+alloc-no-stdlib@2.0.4					X								
+alloc-stdlib@0.2.2					X								
+android_system_properties@0.1.5		X								X			
+anyhow@1.0.102		X								X			
+apache-avro@0.21.0		X											
+array-init@2.1.0		X								X			
+arrow-arith@58.3.0		X											
+arrow-array@58.3.0		X								X			
+arrow-buffer@58.3.0		X											
+arrow-cast@58.3.0		X											
+arrow-data@58.3.0		X											
+arrow-ipc@58.1.0		X											
+arrow-ord@58.3.0		X											
+arrow-schema@58.3.0		X											
+arrow-select@58.3.0		X											
+arrow-string@58.3.0		X											
+as-any@0.3.2		X								X			
+async-lock@3.4.2		X								X			
+async-trait@0.1.89		X								X			
+atoi@2.0.0										X			
+atomic-waker@1.1.2		X								X			
+autocfg@1.5.0		X								X			
+backon@1.6.0		X											
+base64@0.22.1		X								X			
+bigdecimal@0.4.10		X								X			
+bimap@0.6.3		X								X			
+bitflags@2.11.0		X								X			
+block-buffer@0.10.4		X								X			
+bnum@0.12.1		X								X			
+bon@3.9.1		X								X			
+bon-macros@3.9.1		X								X			
+brotli@8.0.2					X					X			
+brotli-decompressor@5.0.0					X					X			
+bumpalo@3.20.2		X								X			
+bytemuck@1.25.0		X								X			X
+bytemuck_derive@1.10.2		X								X			X
+byteorder@1.5.0										X		X	
+bytes@1.11.1										X			
+cc@1.2.57		X								X			
+cfg-if@1.0.4		X								X			
+chrono@0.4.44		X								X			
+cipher@0.4.4		X								X			
+concurrent-queue@2.5.0		X								X			
+const-random@0.1.18		X								X			
+const-random-macro@0.1.16		X								X			
+core-foundation-sys@0.8.7		X								X			
+cpufeatures@0.2.17		X								X			
+crc32fast@1.5.0		X								X			
+crossbeam-channel@0.5.15		X								X			
+crossbeam-epoch@0.9.18		X								X			
+crossbeam-utils@0.8.21		X								X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7		X								X			
+ctr@0.9.2		X								X			
+darling@0.20.11										X			
+darling@0.23.0										X			
+darling_core@0.20.11										X			
+darling_core@0.23.0										X			
+darling_macro@0.20.11										X			
+darling_macro@0.23.0										X			
+derive_builder@0.20.2		X								X			
+derive_builder_core@0.20.2		X								X			
+derive_builder_macro@0.20.2		X								X			
+digest@0.10.7		X								X			
+displaydoc@0.2.5		X								X			
+dissimilar@1.0.11		X											
+either@1.15.0		X								X			
+equivalent@1.0.2		X								X			
+erased-serde@0.4.10		X								X			
+event-listener@5.4.1		X								X			
+event-listener-strategy@0.5.4		X								X			
+expect-test@1.5.1		X								X			
+fastnum@0.7.4		X								X			
+fastrand@2.3.0		X								X			
+find-msvc-tools@0.1.9		X								X			
+flatbuffers@25.12.19		X											
+flate2@1.1.9		X								X			
+fnv@1.0.7		X								X			
+form_urlencoded@1.2.2		X								X			
+futures@0.3.32		X								X			
+futures-channel@0.3.32		X								X			
+futures-core@0.3.32		X								X			
+futures-executor@0.3.32		X								X			
+futures-io@0.3.32		X								X			
+futures-macro@0.3.32		X								X			
+futures-sink@0.3.32		X								X			
+futures-task@0.3.32		X								X			
+futures-util@0.3.32		X								X			
+generic-array@0.14.7										X			
+getrandom@0.2.17		X								X			
+getrandom@0.3.4		X								X			
+getrandom@0.4.2		X								X			
+ghash@0.5.1		X								X			
+gloo-timers@0.3.0		X								X			
+half@2.7.1		X								X			
+hashbrown@0.16.1		X								X			
+hashbrown@0.17.1		X								X			
+heck@0.5.0		X								X			
+http@1.4.0		X								X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1		X								X			
+hyper@1.8.1										X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65		X								X			
+iana-time-zone-haiku@0.1.2		X								X			
+iceberg@0.9.0		X											
+iceberg_test_utils@0.9.0		X											
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+ident_case@1.0.1		X								X			
+idna@1.1.0		X								X			
+idna_adapter@1.2.1		X								X			
+inout@0.1.4		X								X			
+integer-encoding@3.0.4										X			
+inventory@0.3.22		X								X			
+ipnet@2.12.0		X								X			
+iri-string@0.7.11		X								X			
+itertools@0.13.0		X								X			
+itoa@1.0.18		X								X			
+jobserver@0.1.34		X								X			
+js-sys@0.3.91		X								X			
+lazy_static@1.5.0		X								X			
+lexical-core@1.0.6		X								X			
+lexical-parse-float@1.0.6		X								X			
+lexical-parse-integer@1.0.6		X								X			
+lexical-util@1.0.7		X								X			
+lexical-write-float@1.0.6		X								X			
+lexical-write-integer@1.0.6		X								X			
+libc@0.2.183		X								X			
+libm@0.2.16										X			
+litemap@0.8.1											X		
+lock_api@0.4.14		X								X			
+log@0.4.29		X								X			
+lz4_flex@0.13.0										X			
+memchr@2.8.0										X		X	
+miniz_oxide@0.8.9		X								X			X
+mio@1.2.0										X			
+moka@0.12.15		X								X			
+murmur3@0.5.2		X								X			
+nu-ansi-term@0.50.3										X			
+num-bigint@0.4.6		X								X			
+num-complex@0.4.6		X								X			
+num-integer@0.1.46		X								X			
+num-traits@0.2.19		X								X			
+once_cell@1.21.4		X								X			
+opaque-debug@0.3.1		X								X			
+ordered-float@2.10.1										X			
+ordered-float@4.6.0										X			
+parking@2.2.1		X								X			
+parking_lot@0.12.5		X								X			
+parking_lot_core@0.9.12		X								X			
+parquet@58.1.0		X											
+paste@1.0.15		X								X			
+percent-encoding@2.3.2		X								X			
+pin-project-lite@0.2.17		X								X			
+pin-utils@0.1.0		X								X			
+pkg-config@0.3.32		X								X			
+polyval@0.6.2		X								X			
+portable-atomic@1.13.1		X								X			
+potential_utf@0.1.4											X		
+ppv-lite86@0.2.21		X								X			
+prettyplease@0.2.37		X								X			
+proc-macro2@1.0.106		X								X			
+quad-rand@0.2.3										X			
+quote@1.0.45		X								X			
+r-efi@5.3.0		X							X	X			
+r-efi@6.0.0		X							X	X			
+rand@0.9.4		X								X			
+rand_chacha@0.9.0		X								X			
+rand_core@0.6.4		X								X			
+rand_core@0.9.5		X								X			
+redox_syscall@0.5.18										X			
+regex@1.12.3		X								X			
+regex-automata@0.4.14		X								X			
+regex-lite@0.1.9		X								X			
+regex-syntax@0.8.10		X								X			
+reqwest@0.12.28		X								X			
+ring@0.17.14		X						X					
+roaring@0.11.3		X								X			
+rustc_version@0.4.1		X								X			
+rustversion@1.0.22		X								X			
+ryu@1.0.23		X				X							
+scopeguard@1.2.0		X								X			
+semver@1.0.27		X								X			
+seq-macro@0.3.6		X								X			
+serde@1.0.228		X								X			
+serde-big-array@0.5.1		X								X			
+serde_bytes@0.11.19		X								X			
+serde_core@1.0.228		X								X			
+serde_derive@1.0.228		X								X			
+serde_json@1.0.149		X								X			
+serde_repr@0.1.20		X								X			
+serde_urlencoded@0.7.1		X								X			
+serde_with@3.21.0		X								X			
+serde_with_macros@3.21.0		X								X			
+sharded-slab@0.1.7										X			
+shlex@1.3.0		X								X			
+simd-adler32@0.3.8										X			
+simdutf8@0.1.5		X								X			
+slab@0.4.12										X			
+smallvec@1.15.1		X								X			
+snap@1.1.1					X								
+socket2@0.6.3		X								X			
+stable_deref_trait@1.2.1		X								X			
+strsim@0.11.1										X			
+strum@0.27.2										X			
+strum_macros@0.27.2										X			
+subtle@2.6.1					X								
+syn@2.0.117		X								X			
+sync_wrapper@1.0.2		X											
+synstructure@0.13.2										X			
+tagptr@0.2.0		X								X			
+thiserror@2.0.18		X								X			
+thiserror-impl@2.0.18		X								X			
+thread_local@1.1.9		X								X			
+thrift@0.17.0		X											
+tiny-keccak@2.0.2							X						
+tinystr@0.8.2											X		
+tokio@1.52.1										X			
+tokio-macros@2.7.0										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+tracing-log@0.2.0										X			
+tracing-subscriber@0.3.23										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typed-builder@0.20.1		X								X			
+typed-builder-macro@0.20.1		X								X			
+typeid@1.0.3		X								X			
+typenum@1.20.1		X								X			
+typetag@0.2.21		X								X			
+typetag-impl@0.2.21		X								X			
+unicode-ident@1.0.24		X								X	X		
+universal-hash@0.5.1		X								X			
+untrusted@0.9.0								X					
+url@2.5.8		X								X			
+utf8_iter@1.0.4		X								X			
+uuid@1.23.0		X								X			
+version_check@0.9.5		X								X			
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
+wasip2@1.0.2+wasi-0.2.9		X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X							X			
+wasm-bindgen@0.2.114		X								X			
+wasm-bindgen-futures@0.4.64		X								X			
+wasm-bindgen-macro@0.2.114		X								X			
+wasm-bindgen-macro-support@0.2.114		X								X			
+wasm-bindgen-shared@0.2.114		X								X			
+web-sys@0.3.91		X								X			
+windows-core@0.62.2		X								X			
+windows-implement@0.60.2		X								X			
+windows-interface@0.59.3		X								X			
+windows-link@0.2.1		X								X			
+windows-result@0.4.1		X								X			
+windows-strings@0.5.1		X								X			
+windows-sys@0.52.0		X								X			
+windows-sys@0.60.2		X								X			
+windows-sys@0.61.2		X								X			
+windows-targets@0.52.6		X								X			
+windows-targets@0.53.5		X								X			
+windows_aarch64_gnullvm@0.52.6		X								X			
+windows_aarch64_gnullvm@0.53.1		X								X			
+windows_aarch64_msvc@0.52.6		X								X			
+windows_aarch64_msvc@0.53.1		X								X			
+windows_i686_gnu@0.52.6		X								X			
+windows_i686_gnu@0.53.1		X								X			
+windows_i686_gnullvm@0.52.6		X								X			
+windows_i686_gnullvm@0.53.1		X								X			
+windows_i686_msvc@0.52.6		X								X			
+windows_i686_msvc@0.53.1		X								X			
+windows_x86_64_gnu@0.52.6		X								X			
+windows_x86_64_gnu@0.53.1		X								X			
+windows_x86_64_gnullvm@0.52.6		X								X			
+windows_x86_64_gnullvm@0.53.1		X								X			
+windows_x86_64_msvc@0.52.6		X								X			
+windows_x86_64_msvc@0.53.1		X								X			
+wit-bindgen@0.51.0		X	X							X			
+writeable@0.6.2											X		
+yoke@0.8.1											X		
+yoke-derive@0.8.1											X		
+zerocopy@0.8.47		X		X						X			
+zerocopy-derive@0.8.47		X		X						X			
+zerofrom@0.1.6											X		
+zerofrom-derive@0.1.6											X		
+zeroize@1.8.2		X								X			
+zerotrie@0.2.3											X		
+zerovec@0.11.5											X		
+zerovec-derive@0.11.2											X		
+zlib-rs@0.6.3													X
+zmij@1.0.21										X			
+zstd@0.13.3										X			
+zstd-safe@7.2.4		X								X			
+zstd-sys@2.0.16+zstd.1.5.7		X								X			

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -90,7 +90,6 @@ This issue is used to track tasks of the iceberg rust ${iceberg_version} release
 
 - [ ] Bump version in project
 - [ ] Update docs
-- [ ] Generate dependencies list
 - [ ] Create and push release candidate tag
 
 #### ASF Side
@@ -124,27 +123,6 @@ This version is the final version, not the release candidate version.
 ### Update docs
 
 Update `CHANGELOG.md` by drafting a new release [note on GitHub Releases](https://github.com/apache/iceberg-rust/releases/new).
-
-### Generate dependencies list
-
-Download and set up `cargo-deny`. You can refer to [cargo-deny](https://embarkstudios.github.io/cargo-deny/cli/index.html).
-For example:
-
-```shell
-cargo install cargo-deny
-```
-
-Run the following command to update the dependencies list of every package:
-
-```shell
-dev/release/dependencies.sh generate
-```
-
-Run the following command to verify the updated dependencies' license:
-
-```shell
-dev/release/dependencies.sh check
-```
 
 ### Create release candidate tag and artifacts
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2675.

## What changes are included in this PR?

This change moves the responsibility for dependency TSV file updates from the release manager to the PR author.

CI is updated to enforce this and prompt the PR author on what to change.

Note, the check for licenses is already checked by CI and so I am removing this from the release runbook also.

## Are these changes tested?

No. I have updated the dependency TSV files based on the instruction, however I have not exercised the new CI workflow.