### PR TITLE
feat(encryption) [12/N] write encrypted manifest list

### DIFF
--- a/crates/iceberg/src/spec/manifest_list/writer.rs
+++ b/crates/iceberg/src/spec/manifest_list/writer.rs
@@ -315,10 +315,13 @@ fn require_row_counts_in_manifest(manifest: &ManifestFile) -> Result<(u64, u64)>
 mod test {
     use std::fs;
     use std::path::Path;
+    use std::sync::Arc;
 
     use tempfile::TempDir;
 
     use super::ManifestListWriter;
+    use crate::encryption::kms::{KeyManagementClient, MemoryKeyManagementClient};
+    use crate::encryption::{EncryptedInputFile, EncryptionManager};
     use crate::io::{FileIO, FileWrite};
     use crate::spec::{
         Datum, FieldSummary, ManifestContentType, ManifestFile, ManifestList,
@@ -605,6 +608,77 @@ mod test {
         assert_eq!(manifest_list, expected_manifest_list);
 
         temp_dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_manifest_list_writer_v3_encrypted_round_trip() {
+        let (mgr, file_io) = fresh_encryption_manager_and_io();
+        let path = "memory:///manifest_list_v3_encrypted.avro";
+
+        let encrypted_output = mgr.encrypt(file_io.new_output(path).unwrap());
+        let key_metadata = encrypted_output.key_metadata().clone();
+
+        let snapshot_id = 9_000_000_000_000_001i64;
+        let seq_num = 7i64;
+        let mut expected = ManifestList {
+            entries: vec![ManifestFile {
+                manifest_path: "memory:///encrypted/v3_m0.avro".to_string(),
+                manifest_length: 1234,
+                partition_spec_id: 0,
+                content: ManifestContentType::Data,
+                sequence_number: UNASSIGNED_SEQUENCE_NUMBER,
+                min_sequence_number: UNASSIGNED_SEQUENCE_NUMBER,
+                added_snapshot_id: snapshot_id,
+                added_files_count: Some(2),
+                existing_files_count: Some(0),
+                deleted_files_count: Some(0),
+                added_rows_count: Some(10),
+                existing_rows_count: Some(0),
+                deleted_rows_count: Some(0),
+                partitions: Some(vec![FieldSummary {
+                    contains_null: false,
+                    contains_nan: Some(false),
+                    lower_bound: Some(Datum::long(1).to_bytes().unwrap()),
+                    upper_bound: Some(Datum::long(1).to_bytes().unwrap()),
+                }]),
+                key_metadata: None,
+                first_row_id: None,
+            }],
+        };
+
+        let file_writer = encrypted_output.writer().await.unwrap();
+        let mut writer = ManifestListWriter::v3(file_writer, snapshot_id, Some(0), seq_num, None);
+        writer
+            .add_manifests(expected.entries.clone().into_iter())
+            .unwrap();
+        writer.close().await.unwrap();
+
+        let raw_bytes = file_io.new_input(path).unwrap().read().await.unwrap();
+        assert!(
+            ManifestList::parse_with_version(&raw_bytes, crate::spec::FormatVersion::V3).is_err(),
+            "raw bytes should be ciphertext, not parseable as Avro"
+        );
+
+        let plaintext = EncryptedInputFile::new(file_io.new_input(path).unwrap(), key_metadata)
+            .read()
+            .await
+            .unwrap();
+        let manifest_list =
+            ManifestList::parse_with_version(&plaintext, crate::spec::FormatVersion::V3).unwrap();
+
+        expected.entries[0].sequence_number = seq_num;
+        expected.entries[0].min_sequence_number = seq_num;
+        assert_eq!(manifest_list, expected);
+    }
+
+    fn fresh_encryption_manager_and_io() -> (EncryptionManager, FileIO) {
+        let kms = MemoryKeyManagementClient::new();
+        kms.add_master_key("master-1").unwrap();
+        let mgr = EncryptionManager::builder()
+            .kms_client(Arc::new(kms) as Arc<dyn KeyManagementClient>)
+            .table_key_id("master-1")
+            .build();
+        (mgr, FileIO::new_with_memory())
     }
 
     async fn file_writer(path: &Path, io: FileIO) -> Box<dyn FileWrite> {

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -149,11 +149,12 @@ mod tests {
     use tempfile::TempDir;
     use uuid::Uuid;
 
+    use crate::encryption::kms::MemoryKeyManagementClient;
     use crate::io::FileIO;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestEntry,
         ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef, Struct,
-        TableMetadata,
+        TableMetadata, TableProperties,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;
@@ -399,6 +400,91 @@ mod tests {
                 .get("key")
                 .unwrap(),
             "val"
+        );
+    }
+
+    fn make_v3_encrypted_table() -> Table {
+        let json = fs::read_to_string(format!(
+            "{}/testdata/table_metadata/TableMetadataV3ValidMinimal.json",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let metadata = serde_json::from_str::<TableMetadata>(&json).unwrap();
+
+        // Turn on encryption via the master key id understood by the KMS below.
+        let mut props = HashMap::new();
+        props.insert(
+            TableProperties::PROPERTY_ENCRYPTION_KEY_ID.to_string(),
+            "master-1".to_string(),
+        );
+        let metadata = metadata
+            .into_builder(None)
+            .set_properties(props)
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+
+        let kms = MemoryKeyManagementClient::new();
+        kms.add_master_key("master-1").unwrap();
+
+        Table::builder()
+            .metadata(metadata)
+            .metadata_location("memory:///table/metadata/v1.json")
+            .identifier(TableIdent::from_strs(["ns1", "enc"]).unwrap())
+            .file_io(FileIO::new_with_memory())
+            .kms_client(Arc::new(kms))
+            .runtime(test_runtime())
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_commit_with_encryption_adds_keys_and_records_snapshot_key_id() {
+        let table = make_v3_encrypted_table();
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(1))]))
+            .build()
+            .unwrap();
+
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(vec![data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        let added_key_ids: Vec<String> = updates
+            .iter()
+            .filter_map(|u| match u {
+                TableUpdate::AddEncryptionKey { encryption_key } => {
+                    Some(encryption_key.key_id().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(added_key_ids.len(), 2, "got {updates:?}");
+
+        // Encryption keys are added before the snapshot, so it isn't updates[0] here.
+        let new_snapshot = updates
+            .iter()
+            .find_map(|u| match u {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .expect("commit should add a snapshot");
+
+        let snapshot_key_id = new_snapshot
+            .encryption_key_id()
+            .expect("encrypted snapshot should record its manifest-list key id");
+        assert!(
+            added_key_ids.iter().any(|id| id == snapshot_key_id),
+            "snapshot key id {snapshot_key_id} not in added keys {added_key_ids:?}"
         );
     }
 

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -149,12 +149,13 @@ mod tests {
     use tempfile::TempDir;
     use uuid::Uuid;
 
+    use crate::encryption::SensitiveBytes;
     use crate::encryption::kms::MemoryKeyManagementClient;
     use crate::io::FileIO;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH, ManifestEntry,
         ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef, Struct,
-        TableMetadata, TableProperties,
+        TableMetadata,
     };
     use crate::table::Table;
     use crate::test_utils::test_runtime;
@@ -287,7 +288,7 @@ mod tests {
         assert!(!delete_manifest.has_added_files());
         assert!(!delete_manifest.has_existing_files());
 
-        let mut manifest_list_write = ManifestListWriter::v2(
+        let mut manifest_list_writer = ManifestListWriter::v2(
             table
                 .file_io()
                 .new_output(current_snapshot.manifest_list())
@@ -299,10 +300,10 @@ mod tests {
             current_snapshot.parent_snapshot_id(),
             current_snapshot.sequence_number(),
         );
-        manifest_list_write
+        manifest_list_writer
             .add_manifests(vec![data_manifest, delete_manifest].into_iter())
             .unwrap();
-        manifest_list_write.close().await.unwrap();
+        manifest_list_writer.close().await.unwrap();
 
         (table, tmp_dir, delete_manifest_path)
     }
@@ -403,36 +404,48 @@ mod tests {
         );
     }
 
-    fn make_v3_encrypted_table() -> Table {
+    /// See `testdata/manifests_lists/README.md`.
+    const FIXTURE_MASTER_KEY_ID: &str = "master-1";
+    const FIXTURE_MASTER_KEY_BYTES: [u8; 16] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f,
+    ];
+
+    async fn make_v3_encrypted_table() -> Table {
         let json = fs::read_to_string(format!(
-            "{}/testdata/table_metadata/TableMetadataV3ValidMinimal.json",
+            "{}/testdata/table_metadata/TableMetadataV3ValidEncryption.json",
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
         let metadata = serde_json::from_str::<TableMetadata>(&json).unwrap();
 
-        // Turn on encryption via the master key id understood by the KMS below.
-        let mut props = HashMap::new();
-        props.insert(
-            TableProperties::PROPERTY_ENCRYPTION_KEY_ID.to_string(),
-            "master-1".to_string(),
-        );
-        let metadata = metadata
-            .into_builder(None)
-            .set_properties(props)
-            .unwrap()
-            .build()
-            .unwrap()
-            .metadata;
-
         let kms = MemoryKeyManagementClient::new();
-        kms.add_master_key("master-1").unwrap();
+        kms.add_master_key_bytes(
+            FIXTURE_MASTER_KEY_ID,
+            SensitiveBytes::new(FIXTURE_MASTER_KEY_BYTES),
+        )
+        .unwrap();
+
+        let file_io = FileIO::new_with_memory();
+
+        let manifest_list_bytes = fs::read(format!(
+            "{}/testdata/manifests_lists/manifest-list-v3-encrypted.avro",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let parent_manifest_list = metadata.current_snapshot().unwrap().manifest_list();
+        file_io
+            .new_output(parent_manifest_list)
+            .unwrap()
+            .write(manifest_list_bytes.into())
+            .await
+            .unwrap();
 
         Table::builder()
             .metadata(metadata)
             .metadata_location("memory:///table/metadata/v1.json")
             .identifier(TableIdent::from_strs(["ns1", "enc"]).unwrap())
-            .file_io(FileIO::new_with_memory())
+            .file_io(file_io)
             .kms_client(Arc::new(kms))
             .runtime(test_runtime())
             .build()
@@ -441,7 +454,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_with_encryption_adds_keys_and_records_snapshot_key_id() {
-        let table = make_v3_encrypted_table();
+        let table = make_v3_encrypted_table().await;
 
         let data_file = DataFileBuilder::default()
             .content(DataContentType::Data)
@@ -450,7 +463,7 @@ mod tests {
             .file_size_in_bytes(100)
             .record_count(1)
             .partition_spec_id(table.metadata().default_partition_spec_id())
-            .partition(Struct::from_iter([Some(Literal::long(1))]))
+            .partition(Struct::empty())
             .build()
             .unwrap();
 
@@ -468,7 +481,7 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert_eq!(added_key_ids.len(), 2, "got {updates:?}");
+        assert!(!added_key_ids.is_empty(), "got {updates:?}");
 
         // Encryption keys are added before the snapshot, so it isn't updates[0] here.
         let new_snapshot = updates
@@ -485,6 +498,18 @@ mod tests {
         assert!(
             added_key_ids.iter().any(|id| id == snapshot_key_id),
             "snapshot key id {snapshot_key_id} not in added keys {added_key_ids:?}"
+        );
+
+        let new_snapshot_ref: SnapshotRef = Arc::new(new_snapshot.clone());
+        let manifest_list = table
+            .manifest_list_reader(&new_snapshot_ref)
+            .load()
+            .await
+            .expect("newly written encrypted manifest list should decrypt and parse");
+        assert_eq!(
+            manifest_list.entries().len(),
+            1,
+            "append should record exactly the one new data manifest"
         );
     }
 

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -443,28 +443,35 @@ impl<'a> SnapshotProducer<'a> {
         let manifest_list_path = self.generate_manifest_list_file_path(0);
         let next_seq_num = self.table.metadata().next_sequence_number();
         let first_row_id = self.table.metadata().next_row_id();
-        let writer = self
+
+        let raw_output = self
             .table
             .file_io()
-            .new_output(manifest_list_path.clone())?
-            .writer()
-            .await?;
+            .new_output(manifest_list_path.clone())?;
+
+        let (writer, encryption_key_id) = match self.table.encryption_manager() {
+            Some(em) => {
+                let encrypted_output = em.encrypt(raw_output);
+                let key_id = em
+                    .encrypt_manifest_list_key_metadata(encrypted_output.key_metadata())
+                    .await?;
+                (encrypted_output.writer().await?, Some(key_id))
+            }
+            None => (raw_output.writer().await?, None),
+        };
+
+        let parent_snapshot_id = self.table.metadata().current_snapshot_id();
         let mut manifest_list_writer = match self.table.metadata().format_version() {
-            FormatVersion::V1 => ManifestListWriter::v1(
-                writer,
-                self.snapshot_id,
-                self.table.metadata().current_snapshot_id(),
-            ),
-            FormatVersion::V2 => ManifestListWriter::v2(
-                writer,
-                self.snapshot_id,
-                self.table.metadata().current_snapshot_id(),
-                next_seq_num,
-            ),
+            FormatVersion::V1 => {
+                ManifestListWriter::v1(writer, self.snapshot_id, parent_snapshot_id)
+            }
+            FormatVersion::V2 => {
+                ManifestListWriter::v2(writer, self.snapshot_id, parent_snapshot_id, next_seq_num)
+            }
             FormatVersion::V3 => ManifestListWriter::v3(
                 writer,
                 self.snapshot_id,
-                self.table.metadata().current_snapshot_id(),
+                parent_snapshot_id,
                 next_seq_num,
                 Some(first_row_id),
             ),
@@ -493,6 +500,7 @@ impl<'a> SnapshotProducer<'a> {
             .with_sequence_number(next_seq_num)
             .with_summary(summary)
             .with_schema_id(self.table.metadata().current_schema_id())
+            .with_encryption_key_id(encryption_key_id)
             .with_timestamp_ms(commit_ts);
 
         let new_snapshot = if let Some(writer_next_row_id) = writer_next_row_id {
@@ -504,7 +512,22 @@ impl<'a> SnapshotProducer<'a> {
             new_snapshot.build()
         };
 
-        let updates = vec![
+        let encryption_key_updates: Vec<TableUpdate> = self
+            .table
+            .encryption_manager()
+            .map(|em| {
+                em.with_encryption_keys(|keys| {
+                    keys.values()
+                        .filter(|k| self.table.metadata().encryption_key(k.key_id()).is_none())
+                        .map(|k| TableUpdate::AddEncryptionKey {
+                            encryption_key: k.clone(),
+                        })
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+
+        let updates = [encryption_key_updates, vec![
             TableUpdate::AddSnapshot {
                 snapshot: new_snapshot,
             },
@@ -515,7 +538,8 @@ impl<'a> SnapshotProducer<'a> {
                     SnapshotRetention::branch(None, None, None),
                 ),
             },
-        ];
+        ]]
+        .concat();
 
         let requirements = vec![
             TableRequirement::UuidMatch {


### PR DESCRIPTION
## Which issue does this PR close?
- Working towards: #2034

## What changes are included in this PR?
Adds encrypted manifest-list writing and wires it into SnapshotProducer::commit. When the table has an EncryptionManager, the manifest list is encrypted, its key is  KEK-wrapped, the wrapped key id is stored on the snapshot.

## Are these changes tested?
Encrypted round-trip unit test on the manifest-list writer