### PR TITLE
ci: cache Python bindings Rust artifacts

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -82,6 +82,16 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
+      # Linux maturin builds may run inside manylinux Docker, so host Rust caches only help Windows/macOS.
+      - name: Setup Rust toolchain
+        if: runner.os != 'Linux'
+        uses: ./.github/actions/setup-builder
+      - name: Cache Rust artifacts
+        if: runner.os != 'Linux'
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: bindings-python
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: "bindings/python"


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a CI maintenance change for the Python bindings test job.

## What changes are included in this PR?

This adds a real Rust artifact cache to the Python bindings CI test job for host maturin builds on Windows and macOS.

Concretely, this PR adds two steps before `PyO3/maturin-action`:

- `Setup Rust toolchain`
- `Cache Rust artifacts`

Linux maturin builds may run inside the manylinux Docker container, where the host `target/` cache is not expected to help. Windows and macOS build on the host, so `swatinem/rust-cache` can restore Cargo artifacts for the expensive maturin compile.

The cache uses a dedicated bindings key, and its `save-if` behavior matches the existing CI cache discipline: PRs may restore cache entries, but only `main` pushes create new ones.

## Are these changes tested?

  - Not run locally; this is a GitHub Actions workflow-only change.
