### PR TITLE
ci: install taplo and cargo-machete from prebuilt binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,16 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
 
+      - name: Install lint tools
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
+        with:
+          tool: taplo@0.9.3,cargo-machete@0.7.0
+
       - name: Check License Header
         uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
 
       - name: Check toml format
-        run: make check-toml
+        run: taplo fmt --check
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -84,7 +89,7 @@ jobs:
         run: make check-clippy
 
       - name: Cargo Machete
-        run: make cargo-machete
+        run: cargo machete
 
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a CI maintenance change for the `check` job's tooling.

## What changes are included in this PR?

The `check` job installs `taplo` and `cargo-machete` from source on every run: `make check-toml` runs `cargo install --locked taplo-cli@0.9.3` and `make cargo-machete` runs `cargo install cargo-machete@0.7.0`. Compiling these tools from source costs roughly 2 minutes per run, on each OS in the `check` matrix.

This switches both to prebuilt binaries via `taiki-e/install-action` — the same mechanism the repo already uses for `cargo-nextest` (in the `tests` job) and `cargo-public-api` (in `public-api.yml`). The action downloads the published release binary instead of compiling it.

Concretely, in the `check` job this adds one install step and points the two checks at the installed binaries:

- `taiki-e/install-action` with `tool: taplo@0.9.3,cargo-machete@0.7.0`
- `taplo fmt --check`
- `cargo machete`

The pinned tool versions match what the `Makefile` installs today (`taplo` 0.9.3, `cargo-machete` 0.7.0), so the checks themselves are unchanged — only the install path differs. The `Makefile` targets are left as-is for local development.

## Are these changes tested?

- Not run locally; this is a GitHub Actions workflow-only change.
