### PR TITLE
ci-testing: check crates.io trusted publishing authenticates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,6 @@ name: Publish
 
 on:
   push:
-    tags:
-      # Trigger this workflow when tag follows the versioning format: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc.<release_candidate>
-      # Example valid tags: v0.4.0, v0.4.0-rc.1
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   workflow_dispatch:
 
 permissions:
@@ -53,22 +48,5 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
         id: auth
 
-      - name: Publish crates
-        # Only publish if it's a tag and the tag is not a pre-release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
-        run: cargo publish --workspace --all-features
-        shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-  # Trigger Python release after crate publishing completes.
-  # Only runs for tag pushes; for manual Python releases, use workflow_dispatch on release_python.yml directly.
-  release-python:
-    needs: [publish]
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    permissions:
-      contents: read
-      id-token: write # Required for PyPI trusted publishing in the called workflow
-    uses: ./.github/workflows/release_python.yml
-    with:
-      release_tag: ${{ github.ref_name }}
+      - name: Success
+        run: echo "Workflow succeeded showing crates.io trusted publishing authenticated"


### PR DESCRIPTION
This PR is for testing. Do not merge.

Instead, we should push it to a temporary branch and verify that the workflow succeeds.

cc @CTTY 