### PR TITLE
fix(arrow): map Iceberg Binary to Arrow Binary instead of LargeBinary

### DIFF
--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -688,7 +688,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
                     .unwrap_or(DataType::LargeBinary),
             )),
             crate::spec::PrimitiveType::Binary => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::LargeBinary))
+                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Binary))
             }
         }
     }
@@ -1666,8 +1666,8 @@ mod tests {
                 false,
                 "12",
             ),
-            simple_field("l", DataType::LargeBinary, false, "13"),
-            simple_field("o", DataType::LargeBinary, false, "22"),
+            simple_field("l", DataType::Binary, false, "13"),
+            simple_field("o", DataType::Binary, false, "22"),
             simple_field("m", DataType::FixedSizeBinary(10), false, "11"),
             simple_field(
                 "list",
@@ -1695,7 +1695,7 @@ mod tests {
                 "fixed_list",
                 DataType::List(Arc::new(simple_field(
                     "element",
-                    DataType::LargeBinary,
+                    DataType::Binary,
                     false,
                     "26",
                 ))),

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -678,10 +678,10 @@ mod test {
             )
             .unwrap(),
         ) as ArrayRef;
-        let col13 = Arc::new(arrow_array::LargeBinaryArray::from_opt_vec(vec![
-            Some(b"one"),
-            Some(b""),
-            Some(b"zzzz"),
+        let col13 = Arc::new(arrow_array::BinaryArray::from_opt_vec(vec![
+            Some(b"one".as_slice()),
+            Some(b"".as_slice()),
+            Some(b"zzzz".as_slice()),
         ])) as ArrayRef;
         let to_write = RecordBatch::try_new(delete_arrow_schema.clone(), vec![
             col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13,

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -1124,11 +1124,11 @@ mod tests {
             None,
             Some("d"),
         ])) as ArrayRef;
-        let col6 = Arc::new(arrow_array::LargeBinaryArray::from_opt_vec(vec![
-            Some(b"one"),
+        let col6 = Arc::new(arrow_array::BinaryArray::from_opt_vec(vec![
+            Some(b"one".as_slice()),
             None,
-            Some(b""),
-            Some(b"zzzz"),
+            Some(b"".as_slice()),
+            Some(b"zzzz".as_slice()),
         ])) as ArrayRef;
         let col7 = Arc::new(arrow_array::Date32Array::from(vec![
             Some(0),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2698.

## What changes are included in this PR?

`type_to_arrow_type` mapped `PrimitiveType::Binary` to `DataType::LargeBinary`. This is inconsistent with:

1. **Java** — `ArrowSchemaUtil` maps Iceberg `BinaryType` to Arrow `Binary` (`ArrowType.Binary.INSTANCE`), and `FixedType` to `FixedSizeBinary`.
2. **parquet-rs** — an unannotated Parquet `BYTE_ARRAY` column (no UTF8/String logical type) is read as `DataType::Binary` by default; `LargeBinary` only appears when the file's embedded Arrow schema metadata or a user-supplied schema forces it.

The mismatch forces an unnecessary cast when reading Binary columns and diverges from the rest of the ecosystem.

This PR maps `PrimitiveType::Binary` to `DataType::Binary` (`crates/iceberg/src/arrow/schema.rs`). The conversions that go the other way already accept both representations, so externally produced `LargeBinary` columns keep working:

- `arrow_schema_to_schema` accepts `Binary | LargeBinary | BinaryView` → Iceberg `Binary`.
- the arrow-to-literal path (`arrow/value.rs`) downcasts to `LargeBinaryArray` *or* `BinaryArray`.
- the bucket transform handles both `DataType::Binary` and `DataType::LargeBinary`.

`Fixed` is unaffected (still `FixedSizeBinary`, with the rarely-hit `LargeBinary` fallback for lengths exceeding `i32::MAX` left in place).

Test fixtures that asserted the old output were updated: the `schema_to_arrow_schema` round-trip fixture (the two `binary` fields and the `list<binary>` element) and the writer tests that fed `LargeBinaryArray` for an Iceberg `Binary` column (`parquet_writer`, `equality_delete_writer`) now use `BinaryArray`.

## Are these changes tested?

Existing coverage. `test_schema_to_arrow_schema` / `test_arrow_schema_to_schema` exercise both directions of the mapping and now assert `Binary`; the two writer tests round-trip an Iceberg `Binary` column end-to-end through Parquet. Full `iceberg` lib suite (1312 tests) passes, including all `arrow::` and `writer::` tests; clippy and rustfmt clean.

Note on overlap with #2668: that PR added a `LargeBinary` arm to `create_primitive_array_repeated` for `_partition` columns under the old mapping. With this change that arm is no longer exercised for Iceberg Binary, but it's harmless to keep as a fallback — whichever lands second can drop it.
