### PR TITLE
fix: Update Python binding test fixtures to close catalogs

### DIFF
--- a/bindings/python/tests/test_datafusion_table_provider.py
+++ b/bindings/python/tests/test_datafusion_table_provider.py
@@ -40,7 +40,7 @@ def warehouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="session")
-def catalog(warehouse: Path) -> Catalog:
+def catalog(warehouse: Path):
     catalog = load_catalog(
         "default",
         **{
@@ -48,7 +48,8 @@ def catalog(warehouse: Path) -> Catalog:
             "warehouse": f"file://{warehouse}",
         },
     )
-    return catalog
+    yield catalog
+    catalog.close()
 
 
 @pytest.fixture(scope="session")

--- a/bindings/python/tests/test_huggingface_and_cdc.py
+++ b/bindings/python/tests/test_huggingface_and_cdc.py
@@ -47,13 +47,15 @@ requires_datafusion_53 = pytest.mark.skipif(
 @pytest.fixture(scope="module")
 def local_catalog(tmp_path_factory: pytest.TempPathFactory):
     warehouse = tmp_path_factory.mktemp("cdc_warehouse")
-    return load_catalog(
+    catalog = load_catalog(
         "default",
         **{
             "uri": f"sqlite:///{warehouse}/pyiceberg_catalog.db",
             "warehouse": f"file://{warehouse}",
         },
     )
+    yield catalog
+    catalog.close()
 
 
 @pytest.fixture(scope="module")
@@ -168,7 +170,8 @@ def hf_cdc_table(sample_table):
     # HfFileSystem.dircache may reflect the pre-write state; invalidate it so
     # subsequent reads (info/open) see the files just uploaded via xet.
     tbl.io.get_fs("hf").invalidate_cache()
-    return tbl, token
+    yield tbl, token
+    catalog.close()
 
 
 @requires_hf


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2720.

## What changes are included in this PR?

On Python 3.13, the tests error with ResourceWarning: unclosed database at session teardown. This is because the SqlCatalog (and its underlying sqlite3 connections) are never explicitly closed. Python 3.13 began reporting this error: https://docs.python.org/3.13/whatsnew/3.13.html#sqlite3

This change adopts the PyTest fixture generator pattern, where the fixture yields some value and then after the test, the fixture function is resumed to perform cleanup.

## Are these changes tested?

Yes, tests pass after the changes on Python 3.13 and Python 3.14.