### PR TITLE
chore: Update all cargo install references to use --locked

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Install toml-cli
-      run: cargo install toml-cli
+      run: cargo install --locked toml-cli
       shell: bash
 
     - name: Set pyproject version

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-clippy:
 	cargo clippy --all-targets --all-features --workspace -- -D warnings
 
 install-cargo-machete:
-	cargo install cargo-machete@0.7.0
+	cargo install --locked cargo-machete@0.7.0
 
 cargo-machete: install-cargo-machete
 	cargo machete
@@ -98,7 +98,7 @@ clean:
 	cargo clean
 
 install-mdbook:
-	cargo install mdbook@0.4.36
+	cargo install --locked mdbook@0.4.36
 
 site: install-mdbook
 	cd website && mdbook serve

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -61,7 +61,7 @@ Defaults:
 `--check_deps 1` requires `cargo-deny`. Install it with:
 
 ```shell
-cargo install cargo-deny
+cargo install --locked cargo-deny
 ```
 
 ## Verify an RC

--- a/dev/release/create_rc.sh
+++ b/dev/release/create_rc.sh
@@ -152,7 +152,7 @@ require_cargo_deny() {
   require_command cargo
   if ! cargo deny --version >/dev/null 2>&1; then
     echo "This step requires 'cargo-deny' for dependency license checks." >&2
-    echo "Install it with: cargo install cargo-deny" >&2
+    echo "Install it with: cargo install --locked cargo-deny" >&2
     echo "To skip this step locally, pass: --check_deps 0" >&2
     return 1
   fi


### PR DESCRIPTION
## Which issue does this PR close?

Addresses follow-up item: https://github.com/apache/iceberg-rust/pull/2627#pullrequestreview-4484455091

## What changes are included in this PR?

This change ensures that all CLI installs via Cargo will install using the same dependency graph as the crate was published with, avoiding dependencies silently changing. Sometimes patch version updates are fine, although occasionally breaking changes can slip in. This change standardizes all installs in the codebase to recommend using --locked.

## Are these changes tested?

Tested by running the tools locally.