### PR TITLE
chore(release): support explicit Python in RC verifier

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -84,6 +84,7 @@ Common options:
 dev/release/verify_rc.sh 0.9.1 2 --verify_signature 0
 dev/release/verify_rc.sh 0.9.1 2 --import_gpg_keys 1
 dev/release/verify_rc.sh 0.9.1 2 --build 0 --python 0 --check_headers 0
+dev/release/verify_rc.sh 0.9.1 2 --python_bin /opt/homebrew/bin/python3.11
 ```
 
 Defaults:
@@ -95,6 +96,7 @@ Defaults:
 - `--check_headers 1`: check Apache license headers against the extracted source archive.
 - `--build 1`: build and test the Rust source distribution.
 - `--python 1`: build and test pyiceberg-core.
+- `--python_bin <unset>`: set `PYO3_PYTHON` and `UV_PYTHON` for Python-linked Rust and pyiceberg-core checks.
 - `--tmp_dir <auto>`: verification sandbox; auto-created and deleted on success when omitted.
 
 ## Promote an RC to a Release

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -95,6 +95,11 @@ Options:
       Whether to build and test pyiceberg-core.
       Default: 1
 
+  --python_bin <path>
+      Python interpreter for Python-linked Rust and pyiceberg-core checks.
+      Sets PYO3_PYTHON and UV_PYTHON for build and test steps.
+      Default: unset
+
   --tmp_dir <dir>
       Verification sandbox. If omitted, a temporary directory is created and deleted on success.
       Default: auto-created temporary directory
@@ -106,6 +111,7 @@ Examples:
   $0 0.9.1 2
   $0 0.9.1 2 --download 0
   $0 0.9.1 2 --import_gpg_keys 1
+  $0 0.9.1 2 --python_bin /opt/homebrew/bin/python3.11
   $0 0.9.1 2 --download 0 --build 0 --python 0 --check_headers 0 --verify_signature 0
 USAGE
 }
@@ -238,6 +244,11 @@ parse_args() {
         PYTHON="$2"
         shift 2
         ;;
+      --python_bin | --python-bin)
+        require_option_value "$1" "${2:-}"
+        PYTHON_BIN="$2"
+        shift 2
+        ;;
       --tmp_dir | --tmp-dir)
         require_option_value "$1" "${2:-}"
         VERIFY_TMPDIR="$2"
@@ -272,6 +283,11 @@ validate_args() {
 
   if [[ ! "${RC}" =~ ^[0-9]+$ ]]; then
     echo "RC '${RC}' must be a number, for example: 0, 1, or 2." >&2
+    return 1
+  fi
+
+  if [ -n "${PYTHON_BIN}" ] && ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+    echo "Python interpreter '${PYTHON_BIN}' was not found." >&2
     return 1
   fi
 }
@@ -369,13 +385,21 @@ check_license_headers() {
   docker run --rm -v "${VERIFY_TMPDIR}/${ARCHIVE_BASE_NAME}:/github/workspace" apache/skywalking-eyes header check
 }
 
+run_with_python_bin() {
+  if [ -n "${PYTHON_BIN}" ]; then
+    PYO3_PYTHON="${PYTHON_BIN}" UV_PYTHON="${PYTHON_BIN}" "$@"
+  else
+    "$@"
+  fi
+}
+
 test_source_distribution() {
   require_command make
   (
     trap - ERR
     cd "${ARCHIVE_BASE_NAME}"
-    make build
-    make test
+    run_with_python_bin make build
+    run_with_python_bin make test
   )
 }
 
@@ -385,8 +409,8 @@ test_python_distribution() {
   (
     trap - ERR
     cd "${ARCHIVE_BASE_NAME}/bindings/python"
-    make install
-    make test
+    run_with_python_bin make install
+    run_with_python_bin make test
   )
 }
 
@@ -407,6 +431,7 @@ IMPORT_GPG_KEYS="0"
 CHECK_HEADERS="1"
 BUILD="1"
 PYTHON="1"
+PYTHON_BIN="${PYTHON_BIN:-}"
 
 show_help_if_requested "$@"
 run_step "Parse command arguments" parse_args "$@"


### PR DESCRIPTION
## Summary

- Add `--python_bin` / `--python-bin` to `dev/release/verify_rc.sh`.
- Use that interpreter as both `PYO3_PYTHON` and `UV_PYTHON` for Rust workspace and pyiceberg-core verification steps.

## Why

During 0.10.0 RC verification, Python-linked Rust test discovery could fail on macOS when the active Conda Python did not provide a shared `libpython` dylib. The release artifacts were valid, but the verifier needed a supported way to point PyO3 and uv/maturin at a Python.org or Homebrew interpreter with a shared library.

---

Co-authored-by: @codex