### PR TITLE
chore(ci): Remove '--locked' flag on toml-cli install

### DIFF
--- a/.github/actions/overwrite-package-version/action.yml
+++ b/.github/actions/overwrite-package-version/action.yml
@@ -25,7 +25,9 @@ runs:
   using: "composite"
   steps:
     - name: Install toml-cli
-      run: cargo install --locked toml-cli
+      # Avoid `--locked` as its lock file is not recently updated,
+      # and its dependencies at the time rely on unstable nightly features since removed.
+      run: cargo install toml-cli
       shell: bash
 
     - name: Set pyproject version


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## What changes are included in this PR?

We moved all CLI installs to `--locked` in #2739. Unfortunately, this doesn't work for `toml-cli` as it is not regularly updated and its lock file refers to outdated dependencies. In particular, it points to crates which use nightly unstable features which no longer exist.

This change removes `--locked` and adds a comment to explain why.

Alternatively, we could use the stable toolchain here although I think it's OK to use newer dependencies instead.

## Are these changes tested?

Manually tested, the following command succeeds:

```
cargo +nightly-2026-03-05 install toml-cli --force
```