### PR TITLE
feat: Honor write.metadata.path for metadata file locations

### DIFF
--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -615,7 +615,8 @@ impl Catalog for GlueCatalog {
         let metadata = TableMetadataBuilder::from_table_creation(creation)?
             .build()?
             .metadata;
-        let metadata_location = MetadataLocation::new_with_metadata(location.clone(), &metadata);
+        let metadata_location =
+            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/catalog/glue/src/catalog.rs
+++ b/crates/catalog/glue/src/catalog.rs
@@ -602,21 +602,16 @@ impl Catalog for GlueCatalog {
         let db_name = validate_namespace(namespace)?;
         let table_name = creation.name.clone();
 
-        let location = match &creation.location {
-            Some(location) => location.clone(),
-            None => {
-                let ns = self.get_namespace(namespace).await?;
-                let location =
-                    get_default_table_location(&ns, &db_name, &table_name, &self.config.warehouse);
-                creation.location = Some(location.clone());
-                location
-            }
-        };
+        if creation.location.is_none() {
+            let ns = self.get_namespace(namespace).await?;
+            let location =
+                get_default_table_location(&ns, &db_name, &table_name, &self.config.warehouse);
+            creation.location = Some(location);
+        }
         let metadata = TableMetadataBuilder::from_table_creation(creation)?
             .build()?
             .metadata;
-        let metadata_location =
-            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?;
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -346,7 +346,6 @@ mod tests {
     #[test]
     fn test_convert_to_glue_table() -> Result<()> {
         let table_name = "my_table".to_string();
-        let location = "s3a://warehouse/hive".to_string();
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
@@ -355,8 +354,7 @@ mod tests {
             .build()?;
 
         let metadata = create_metadata(schema)?;
-        let metadata_location =
-            MetadataLocation::try_new_with_metadata(location, &metadata)?.to_string();
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?.to_string();
 
         let parameters = HashMap::from([
             (ICEBERG_FIELD_ID.to_string(), "1".to_string()),

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -356,7 +356,7 @@ mod tests {
 
         let metadata = create_metadata(schema)?;
         let metadata_location =
-            MetadataLocation::new_with_metadata(location, &metadata).to_string();
+            MetadataLocation::try_new_with_metadata(location, &metadata)?.to_string();
 
         let parameters = HashMap::from([
             (ICEBERG_FIELD_ID.to_string(), "1".to_string()),

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -519,7 +519,8 @@ impl Catalog for HmsCatalog {
             .build()?
             .metadata;
 
-        let metadata_location = MetadataLocation::new_with_metadata(location.clone(), &metadata);
+        let metadata_location =
+            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -519,8 +519,7 @@ impl Catalog for HmsCatalog {
             .build()?
             .metadata;
 
-        let metadata_location =
-            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?;
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/catalog/hms/src/utils.rs
+++ b/crates/catalog/hms/src/utils.rs
@@ -361,8 +361,7 @@ mod tests {
         let metadata = TableMetadataBuilder::from_table_creation(table_creation)?
             .build()?
             .metadata;
-        let metadata_location =
-            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?.to_string();
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?.to_string();
 
         let result = convert_to_hive_table(
             db_name.clone(),

--- a/crates/catalog/hms/src/utils.rs
+++ b/crates/catalog/hms/src/utils.rs
@@ -362,7 +362,7 @@ mod tests {
             .build()?
             .metadata;
         let metadata_location =
-            MetadataLocation::new_with_metadata(location.clone(), &metadata).to_string();
+            MetadataLocation::try_new_with_metadata(location.clone(), &metadata)?.to_string();
 
         let result = convert_to_hive_table(
             db_name.clone(),

--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -553,7 +553,7 @@ impl Catalog for S3TablesCatalog {
         let metadata = TableMetadataBuilder::from_table_creation(creation)?
             .build()?
             .metadata;
-        let metadata_location = MetadataLocation::new_with_metadata(table_location, &metadata);
+        let metadata_location = MetadataLocation::try_new_with_metadata(table_location, &metadata)?;
         metadata.write_to(&self.file_io, &metadata_location).await?;
 
         // update metadata location

--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -553,7 +553,7 @@ impl Catalog for S3TablesCatalog {
         let metadata = TableMetadataBuilder::from_table_creation(creation)?
             .build()?
             .metadata;
-        let metadata_location = MetadataLocation::try_new_with_metadata(table_location, &metadata)?;
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?;
         metadata.write_to(&self.file_io, &metadata_location).await?;
 
         // update metadata location

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -876,7 +876,7 @@ impl Catalog for SqlCatalog {
             .build()?
             .metadata;
         let tbl_metadata_location =
-            MetadataLocation::new_with_metadata(location.clone(), &tbl_metadata);
+            MetadataLocation::try_new_with_metadata(location.clone(), &tbl_metadata)?;
 
         tbl_metadata
             .write_to(&self.fileio, &tbl_metadata_location)

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -843,40 +843,35 @@ impl Catalog for SqlCatalog {
             return table_already_exists_err(&tbl_ident);
         }
 
-        let (tbl_creation, location) = match creation.location.clone() {
-            Some(location) => (creation, location),
-            None => {
-                // fall back to namespace-specific location
-                // and then to warehouse location
-                let nsp_properties = self.get_namespace(namespace).await?.properties().clone();
-                let nsp_location = match nsp_properties.get(NAMESPACE_LOCATION_PROPERTY_KEY) {
-                    Some(location) => location.clone(),
-                    None => {
-                        format!(
-                            "{}/{}",
-                            self.warehouse_location.clone(),
-                            namespace.join("/")
-                        )
-                    }
-                };
+        let tbl_creation = if creation.location.is_some() {
+            creation
+        } else {
+            // fall back to namespace-specific location
+            // and then to warehouse location
+            let nsp_properties = self.get_namespace(namespace).await?.properties().clone();
+            let nsp_location = match nsp_properties.get(NAMESPACE_LOCATION_PROPERTY_KEY) {
+                Some(location) => location.clone(),
+                None => {
+                    format!(
+                        "{}/{}",
+                        self.warehouse_location.clone(),
+                        namespace.join("/")
+                    )
+                }
+            };
 
-                let tbl_location = format!("{}/{}", nsp_location, tbl_ident.name());
+            let tbl_location = format!("{}/{}", nsp_location, tbl_ident.name());
 
-                (
-                    TableCreation {
-                        location: Some(tbl_location.clone()),
-                        ..creation
-                    },
-                    tbl_location,
-                )
+            TableCreation {
+                location: Some(tbl_location),
+                ..creation
             }
         };
 
         let tbl_metadata = TableMetadataBuilder::from_table_creation(tbl_creation)?
             .build()?
             .metadata;
-        let tbl_metadata_location =
-            MetadataLocation::try_new_with_metadata(location.clone(), &tbl_metadata)?;
+        let tbl_metadata_location = MetadataLocation::try_new_with_metadata(&tbl_metadata)?;
 
         tbl_metadata
             .write_to(&self.fileio, &tbl_metadata_location)

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2609,7 +2609,7 @@ pub fn iceberg::spec::TableMetadata::last_updated_ms(&self) -> i64
 pub fn iceberg::spec::TableMetadata::last_updated_timestamp(&self) -> iceberg::Result<chrono::datetime::DateTime<chrono::offset::utc::Utc>>
 pub fn iceberg::spec::TableMetadata::location(&self) -> &str
 pub fn iceberg::spec::TableMetadata::metadata_compression_codec(&self) -> iceberg::Result<iceberg::compression::CompressionCodec>
-pub fn iceberg::spec::TableMetadata::metadata_location_root(&self) -> alloc::string::String
+pub fn iceberg::spec::TableMetadata::metadata_location_root(&self) -> iceberg::Result<alloc::string::String>
 pub fn iceberg::spec::TableMetadata::metadata_log(&self) -> &[iceberg::spec::MetadataLog]
 pub fn iceberg::spec::TableMetadata::next_row_id(&self) -> u64
 pub fn iceberg::spec::TableMetadata::next_sequence_number(&self) -> i64
@@ -2713,6 +2713,7 @@ pub iceberg::spec::TableProperties::metadata_compression_codec: iceberg::compres
 pub iceberg::spec::TableProperties::min_snapshots_to_keep: usize
 pub iceberg::spec::TableProperties::write_datafusion_fanout_enabled: bool
 pub iceberg::spec::TableProperties::write_format_default: alloc::string::String
+pub iceberg::spec::TableProperties::write_metadata_path: core::option::Option<alloc::string::String>
 pub iceberg::spec::TableProperties::write_target_file_size_bytes: usize
 impl iceberg::spec::TableProperties
 pub const iceberg::spec::TableProperties::PROPERTY_COMMIT_MAX_RETRY_WAIT_MS: &str

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2608,6 +2608,7 @@ pub fn iceberg::spec::TableMetadata::last_updated_ms(&self) -> i64
 pub fn iceberg::spec::TableMetadata::last_updated_timestamp(&self) -> iceberg::Result<chrono::datetime::DateTime<chrono::offset::utc::Utc>>
 pub fn iceberg::spec::TableMetadata::location(&self) -> &str
 pub fn iceberg::spec::TableMetadata::metadata_compression_codec(&self) -> iceberg::Result<iceberg::compression::CompressionCodec>
+pub fn iceberg::spec::TableMetadata::metadata_location_root(&self) -> alloc::string::String
 pub fn iceberg::spec::TableMetadata::metadata_log(&self) -> &[iceberg::spec::MetadataLog]
 pub fn iceberg::spec::TableMetadata::next_row_id(&self) -> u64
 pub fn iceberg::spec::TableMetadata::next_sequence_number(&self) -> i64

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3507,7 +3507,7 @@ pub fn iceberg::memory::MemoryCatalog::update_table<'life0, 'async_trait>(&'life
 pub struct iceberg::MetadataLocation
 impl iceberg::MetadataLocation
 pub fn iceberg::MetadataLocation::compression_codec(&self) -> iceberg::compression::CompressionCodec
-pub fn iceberg::MetadataLocation::try_new_with_metadata(table_location: impl alloc::string::ToString, metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
+pub fn iceberg::MetadataLocation::try_new_with_metadata(metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
 pub fn iceberg::MetadataLocation::try_with_new_metadata(&self, new_metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
 pub fn iceberg::MetadataLocation::with_next_version(&self) -> Self
 impl core::clone::Clone for iceberg::MetadataLocation

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2591,7 +2591,6 @@ pub fn iceberg::spec::TableMetadata::current_schema(&self) -> &iceberg::spec::Sc
 pub fn iceberg::spec::TableMetadata::current_schema_id(&self) -> iceberg::spec::SchemaId
 pub fn iceberg::spec::TableMetadata::current_snapshot(&self) -> core::option::Option<&iceberg::spec::SnapshotRef>
 pub fn iceberg::spec::TableMetadata::current_snapshot_id(&self) -> core::option::Option<i64>
-pub fn iceberg::spec::TableMetadata::default_metadata_dir(table_location: &str) -> alloc::string::String
 pub fn iceberg::spec::TableMetadata::default_partition_spec(&self) -> &iceberg::spec::PartitionSpecRef
 pub fn iceberg::spec::TableMetadata::default_partition_spec_id(&self) -> i32
 pub fn iceberg::spec::TableMetadata::default_partition_type(&self) -> &iceberg::spec::StructType
@@ -2609,7 +2608,7 @@ pub fn iceberg::spec::TableMetadata::last_updated_ms(&self) -> i64
 pub fn iceberg::spec::TableMetadata::last_updated_timestamp(&self) -> iceberg::Result<chrono::datetime::DateTime<chrono::offset::utc::Utc>>
 pub fn iceberg::spec::TableMetadata::location(&self) -> &str
 pub fn iceberg::spec::TableMetadata::metadata_compression_codec(&self) -> iceberg::Result<iceberg::compression::CompressionCodec>
-pub fn iceberg::spec::TableMetadata::metadata_location_root(&self) -> iceberg::Result<alloc::string::String>
+pub fn iceberg::spec::TableMetadata::metadata_location(&self) -> iceberg::Result<alloc::string::String>
 pub fn iceberg::spec::TableMetadata::metadata_log(&self) -> &[iceberg::spec::MetadataLog]
 pub fn iceberg::spec::TableMetadata::next_row_id(&self) -> u64
 pub fn iceberg::spec::TableMetadata::next_sequence_number(&self) -> i64
@@ -2762,7 +2761,6 @@ pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_NORM_LEVEL_DEFAUL
 pub const iceberg::spec::TableProperties::PROPERTY_SNAPSHOT_COUNT: &str
 pub const iceberg::spec::TableProperties::PROPERTY_UUID: &str
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_METADATA_PATH: &str
-pub const iceberg::spec::TableProperties::PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR: &str
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT: &str
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT: u64
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES: &str
@@ -3510,7 +3508,6 @@ pub struct iceberg::MetadataLocation
 impl iceberg::MetadataLocation
 pub fn iceberg::MetadataLocation::compression_codec(&self) -> iceberg::compression::CompressionCodec
 pub fn iceberg::MetadataLocation::new_with_metadata(table_location: impl alloc::string::ToString, metadata: &iceberg::spec::TableMetadata) -> Self
-pub fn iceberg::MetadataLocation::new_with_table_location(table_location: impl alloc::string::ToString) -> Self
 pub fn iceberg::MetadataLocation::with_new_metadata(&self, new_metadata: &iceberg::spec::TableMetadata) -> Self
 pub fn iceberg::MetadataLocation::with_next_version(&self) -> Self
 impl core::clone::Clone for iceberg::MetadataLocation

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2591,6 +2591,7 @@ pub fn iceberg::spec::TableMetadata::current_schema(&self) -> &iceberg::spec::Sc
 pub fn iceberg::spec::TableMetadata::current_schema_id(&self) -> iceberg::spec::SchemaId
 pub fn iceberg::spec::TableMetadata::current_snapshot(&self) -> core::option::Option<&iceberg::spec::SnapshotRef>
 pub fn iceberg::spec::TableMetadata::current_snapshot_id(&self) -> core::option::Option<i64>
+pub fn iceberg::spec::TableMetadata::default_metadata_dir(table_location: &str) -> alloc::string::String
 pub fn iceberg::spec::TableMetadata::default_partition_spec(&self) -> &iceberg::spec::PartitionSpecRef
 pub fn iceberg::spec::TableMetadata::default_partition_spec_id(&self) -> i32
 pub fn iceberg::spec::TableMetadata::default_partition_type(&self) -> &iceberg::spec::StructType
@@ -2759,6 +2760,8 @@ pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_NORM_LEVEL: &str
 pub const iceberg::spec::TableProperties::PROPERTY_PARQUET_CDC_NORM_LEVEL_DEFAULT: i32
 pub const iceberg::spec::TableProperties::PROPERTY_SNAPSHOT_COUNT: &str
 pub const iceberg::spec::TableProperties::PROPERTY_UUID: &str
+pub const iceberg::spec::TableProperties::PROPERTY_WRITE_METADATA_PATH: &str
+pub const iceberg::spec::TableProperties::PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR: &str
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT: &str
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT: u64
 pub const iceberg::spec::TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES: &str

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3507,8 +3507,8 @@ pub fn iceberg::memory::MemoryCatalog::update_table<'life0, 'async_trait>(&'life
 pub struct iceberg::MetadataLocation
 impl iceberg::MetadataLocation
 pub fn iceberg::MetadataLocation::compression_codec(&self) -> iceberg::compression::CompressionCodec
-pub fn iceberg::MetadataLocation::new_with_metadata(table_location: impl alloc::string::ToString, metadata: &iceberg::spec::TableMetadata) -> Self
-pub fn iceberg::MetadataLocation::with_new_metadata(&self, new_metadata: &iceberg::spec::TableMetadata) -> Self
+pub fn iceberg::MetadataLocation::try_new_with_metadata(table_location: impl alloc::string::ToString, metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
+pub fn iceberg::MetadataLocation::try_with_new_metadata(&self, new_metadata: &iceberg::spec::TableMetadata) -> iceberg::Result<Self>
 pub fn iceberg::MetadataLocation::with_next_version(&self) -> Self
 impl core::clone::Clone for iceberg::MetadataLocation
 pub fn iceberg::MetadataLocation::clone(&self) -> iceberg::MetadataLocation

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -286,30 +286,27 @@ impl Catalog for MemoryCatalog {
         let table_name = table_creation.name.clone();
         let table_ident = TableIdent::new(namespace_ident.clone(), table_name);
 
-        let (table_creation, location) = match table_creation.location.clone() {
-            Some(location) => (table_creation, location),
-            None => {
-                let namespace_properties = root_namespace_state.get_properties(namespace_ident)?;
-                let location_prefix = match namespace_properties.get(LOCATION) {
-                    Some(namespace_location) => namespace_location.clone(),
-                    None => format!("{}/{}", self.warehouse_location, namespace_ident.join("/")),
-                };
+        let table_creation = if table_creation.location.is_some() {
+            table_creation
+        } else {
+            let namespace_properties = root_namespace_state.get_properties(namespace_ident)?;
+            let location_prefix = match namespace_properties.get(LOCATION) {
+                Some(namespace_location) => namespace_location.clone(),
+                None => format!("{}/{}", self.warehouse_location, namespace_ident.join("/")),
+            };
 
-                let location = format!("{}/{}", location_prefix, table_ident.name());
+            let location = format!("{}/{}", location_prefix, table_ident.name());
 
-                let new_table_creation = TableCreation {
-                    location: Some(location.clone()),
-                    ..table_creation
-                };
-
-                (new_table_creation, location)
+            TableCreation {
+                location: Some(location),
+                ..table_creation
             }
         };
 
         let metadata = TableMetadataBuilder::from_table_creation(table_creation)?
             .build()?
             .metadata;
-        let metadata_location = MetadataLocation::try_new_with_metadata(location, &metadata)?;
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -309,7 +309,7 @@ impl Catalog for MemoryCatalog {
         let metadata = TableMetadataBuilder::from_table_creation(table_creation)?
             .build()?
             .metadata;
-        let metadata_location = MetadataLocation::new_with_metadata(location, &metadata);
+        let metadata_location = MetadataLocation::try_new_with_metadata(location, &metadata)?;
 
         metadata.write_to(&self.file_io, &metadata_location).await?;
 

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -55,19 +55,21 @@ impl MetadataLocation {
     ///
     /// The metadata directory honors the `write.metadata.path` table property when set,
     /// otherwise defaults to the `metadata` subdirectory of `table_location`.
-    pub fn new_with_metadata(table_location: impl ToString, metadata: &TableMetadata) -> Self {
+    pub fn try_new_with_metadata(
+        table_location: impl ToString,
+        metadata: &TableMetadata,
+    ) -> Result<Self> {
         let table_location = table_location.to_string();
         let location = metadata
-            .table_properties()
-            .ok()
-            .and_then(|props| props.write_metadata_path)
+            .table_properties()?
+            .write_metadata_path
             .unwrap_or_else(|| format!("{table_location}/{METADATA_FOLDER_NAME}"));
-        Self {
+        Ok(Self {
             location,
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: Self::compression_from_properties(metadata.properties()),
-        }
+        })
     }
 
     /// Creates a new metadata location for an updated metadata file.
@@ -81,14 +83,15 @@ impl MetadataLocation {
         }
     }
 
-    /// Updates the metadata location with compression settings from the new metadata.
-    pub fn with_new_metadata(&self, new_metadata: &TableMetadata) -> Self {
-        Self {
-            location: self.location.clone(),
+    /// Updates the metadata location with the metadata directory
+    /// and compression settings from the new metadata.
+    pub fn try_with_new_metadata(&self, new_metadata: &TableMetadata) -> Result<Self> {
+        Ok(Self {
+            location: new_metadata.metadata_location()?,
             version: self.version,
             id: self.id,
             compression_codec: Self::compression_from_properties(new_metadata.properties()),
-        }
+        })
     }
 
     /// Returns the compression codec used for this metadata location.
@@ -165,7 +168,7 @@ mod test {
     use uuid::Uuid;
 
     use crate::compression::CompressionCodec;
-    use crate::spec::{Schema, TableMetadata, TableMetadataBuilder};
+    use crate::spec::{Schema, TableMetadata, TableMetadataBuilder, TableProperties};
     use crate::{MetadataLocation, TableCreation};
 
     fn create_test_metadata(properties: HashMap<String, String>) -> TableMetadata {
@@ -306,7 +309,7 @@ mod test {
     fn test_metadata_location_with_next_version() {
         let metadata = create_test_metadata(HashMap::new());
         let test_cases = vec![
-            MetadataLocation::new_with_metadata("/abc", &metadata),
+            MetadataLocation::try_new_with_metadata("/abc", &metadata).unwrap(),
             MetadataLocation::from_str(
                 "/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
             )
@@ -370,7 +373,7 @@ mod test {
             "gzip".to_string(),
         );
         let metadata_gzip = create_test_metadata(props_gzip);
-        let updated_gzip = location.with_new_metadata(&metadata_gzip);
+        let updated_gzip = location.try_with_new_metadata(&metadata_gzip).unwrap();
         assert_eq!(
             updated_gzip.compression_codec,
             CompressionCodec::gzip_default()
@@ -384,7 +387,7 @@ mod test {
         // Update back to no compression
         let props_none = HashMap::new();
         let metadata_none = create_test_metadata(props_none);
-        let updated_none = updated_gzip.with_new_metadata(&metadata_none);
+        let updated_none = updated_gzip.try_with_new_metadata(&metadata_none).unwrap();
         assert_eq!(updated_none.compression_codec, CompressionCodec::None);
         assert_eq!(updated_none.version, 0);
         assert_eq!(
@@ -399,7 +402,9 @@ mod test {
             "none".to_string(),
         );
         let metadata_explicit_none = create_test_metadata(props_explicit_none);
-        let updated_explicit = updated_gzip.with_new_metadata(&metadata_explicit_none);
+        let updated_explicit = updated_gzip
+            .try_with_new_metadata(&metadata_explicit_none)
+            .unwrap();
         assert_eq!(updated_explicit.compression_codec, CompressionCodec::None);
         assert_eq!(
             updated_explicit.to_string(),
@@ -408,10 +413,43 @@ mod test {
     }
 
     #[test]
+    fn test_with_new_metadata_re_derives_location() {
+        // Start from a parsed location under some existing metadata directory
+        let location = MetadataLocation::from_str(
+            "/old/table/metadata/00003-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
+        )
+        .unwrap();
+
+        // A new metadata (no `write.metadata.path`) re-derives to `<location>/metadata`,
+        // preserving the version and id of the existing location
+        let relocated = create_test_metadata(HashMap::new());
+        let updated = location.try_with_new_metadata(&relocated).unwrap();
+        assert!(
+            updated.to_string().starts_with("/test/table/metadata/"),
+            "unexpected location: {updated}"
+        );
+        assert_eq!(updated.version, location.version);
+        assert_eq!(updated.id, location.id);
+
+        // A configured `write.metadata.path` is honored on updates too
+        let props = HashMap::from([(
+            TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
+            "s3://bucket/custom-meta".to_string(),
+        )]);
+        let with_meta_path = create_test_metadata(props);
+        let updated = location.try_with_new_metadata(&with_meta_path).unwrap();
+        assert!(
+            updated.to_string().starts_with("s3://bucket/custom-meta/"),
+            "unexpected location: {updated}"
+        );
+    }
+
+    #[test]
     fn test_new_with_metadata_honors_write_metadata_path() {
         // Test metadata lives under `<location>/metadata` by default
         let default_meta = create_test_metadata(HashMap::new());
-        let default_loc = MetadataLocation::new_with_metadata("/test/table", &default_meta);
+        let default_loc =
+            MetadataLocation::try_new_with_metadata("/test/table", &default_meta).unwrap();
         assert!(
             default_loc
                 .to_string()
@@ -421,11 +459,12 @@ mod test {
 
         // Test a configured `write.metadata.path` is honored
         let props = HashMap::from([(
-            "write.metadata.path".to_string(),
+            TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
             "s3://bucket/custom-meta".to_string(),
         )]);
         let custom_meta = create_test_metadata(props);
-        let custom_loc = MetadataLocation::new_with_metadata("/test/table", &custom_meta);
+        let custom_loc =
+            MetadataLocation::try_new_with_metadata("/test/table", &custom_meta).unwrap();
         assert!(
             custom_loc
                 .to_string()

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -86,11 +86,10 @@ impl MetadataLocation {
         }
     }
 
-    /// Updates the metadata location with the metadata directory
-    /// and compression settings derived from the new metadata.
+    /// Updates the metadata location with compression settings from the new metadata.
     pub fn with_new_metadata(&self, new_metadata: &TableMetadata) -> Self {
         Self {
-            metadata_dir: new_metadata.metadata_location_root(),
+            metadata_dir: self.metadata_dir.clone(),
             version: self.version,
             id: self.id,
             compression_codec: Self::compression_from_properties(new_metadata.properties()),
@@ -439,33 +438,5 @@ mod test {
             "unexpected location: {custom_loc}"
         );
         assert!(custom_loc.to_string().ends_with(".metadata.json"));
-    }
-
-    #[test]
-    fn test_with_new_metadata_honors_write_metadata_path() {
-        // Parse the current (default-location) metadata file, bump the
-        // version, then apply new metadata that sets `write.metadata.path`. Test the metadata
-        // directory is derived from the metadata object, not the previous path)
-        let current = MetadataLocation::from_str(
-            "/test/table/metadata/00000-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
-        )
-        .unwrap();
-
-        let props = HashMap::from([(
-            "write.metadata.path".to_string(),
-            "s3://bucket/custom-meta".to_string(),
-        )]);
-        let new_meta = create_test_metadata(props);
-
-        let next = current.with_next_version().with_new_metadata(&new_meta);
-        assert_eq!(next.version, 1);
-        assert!(
-            next.to_string()
-                .starts_with("s3://bucket/custom-meta/00001-"),
-            "unexpected location: {next}"
-        );
-
-        let reparsed = MetadataLocation::from_str(&next.to_string()).unwrap();
-        assert_eq!(reparsed, next);
     }
 }

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -67,8 +67,12 @@ impl MetadataLocation {
     /// The metadata directory honors the `write.metadata.path` table property when set,
     /// otherwise defaults to the `metadata` subdirectory of `table_location`.
     pub fn new_with_metadata(table_location: impl ToString, metadata: &TableMetadata) -> Self {
+        let table_location = table_location.to_string();
+        let metadata_dir = metadata
+            .metadata_location_root_with_base(&table_location)
+            .unwrap_or_else(|_| TableMetadata::default_metadata_dir(&table_location));
         Self {
-            metadata_dir: metadata.metadata_location_root_with_base(&table_location.to_string()),
+            metadata_dir,
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: Self::compression_from_properties(metadata.properties()),

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -25,11 +25,14 @@ use crate::compression::CompressionCodec;
 use crate::spec::{TableMetadata, parse_metadata_file_compression};
 use crate::{Error, ErrorKind, Result};
 
-/// Helper for parsing a location of the format: `<location>/metadata/<version>-<uuid>.metadata.json`
-/// or with compression: `<location>/metadata/<version>-<uuid>.gz.metadata.json`
+/// Helper for parsing a location of the format: `<metadata-dir>/<version>-<uuid>.metadata.json`
+/// or with compression: `<metadata-dir>/<version>-<uuid>.gz.metadata.json`
+///
+/// `<metadata-dir>` is set to the `write.metadata.path` table property and
+/// it defaults to the `<location>/metadata` when the property is not set.
 #[derive(Clone, Debug, PartialEq)]
 pub struct MetadataLocation {
-    table_location: String,
+    metadata_dir: String,
     version: i32,
     id: Uuid,
     compression_codec: CompressionCodec,
@@ -50,7 +53,7 @@ impl MetadataLocation {
     )]
     pub fn new_with_table_location(table_location: impl ToString) -> Self {
         Self {
-            table_location: table_location.to_string(),
+            metadata_dir: format!("{}/metadata", table_location.to_string()),
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: CompressionCodec::None,
@@ -60,9 +63,12 @@ impl MetadataLocation {
     /// Creates a completely new metadata location starting at version 0,
     /// with compression settings from the table metadata.
     /// Only used for creating a new table. For updates, see `next_version`.
+    ///
+    /// The metadata directory honors the `write.metadata.path` table property when set,
+    /// otherwise defaults to the `metadata` subdirectory of `table_location`.
     pub fn new_with_metadata(table_location: impl ToString, metadata: &TableMetadata) -> Self {
         Self {
-            table_location: table_location.to_string(),
+            metadata_dir: metadata.metadata_location_root_with_base(&table_location.to_string()),
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: Self::compression_from_properties(metadata.properties()),
@@ -73,17 +79,18 @@ impl MetadataLocation {
     /// Increments the version number and generates a new UUID.
     pub fn with_next_version(&self) -> Self {
         Self {
-            table_location: self.table_location.clone(),
+            metadata_dir: self.metadata_dir.clone(),
             version: self.version + 1,
             id: Uuid::new_v4(),
             compression_codec: self.compression_codec,
         }
     }
 
-    /// Updates the metadata location with compression settings from the new metadata.
+    /// Updates the metadata location with the metadata directory
+    /// and compression settings derived from the new metadata.
     pub fn with_new_metadata(&self, new_metadata: &TableMetadata) -> Self {
         Self {
-            table_location: self.table_location.clone(),
+            metadata_dir: new_metadata.metadata_location_root(),
             version: self.version,
             id: self.id,
             compression_codec: Self::compression_from_properties(new_metadata.properties()),
@@ -93,15 +100,6 @@ impl MetadataLocation {
     /// Returns the compression codec used for this metadata location.
     pub fn compression_codec(&self) -> CompressionCodec {
         self.compression_codec
-    }
-
-    fn parse_metadata_path_prefix(path: &str) -> Result<String> {
-        let prefix = path.strip_suffix("/metadata").ok_or(Error::new(
-            ErrorKind::Unexpected,
-            format!("Metadata location not under \"/metadata\" subdirectory: {path}"),
-        ))?;
-
-        Ok(prefix.to_string())
     }
 
     /// Parses a file name of the format `<version>-<uuid>.metadata.json`
@@ -139,8 +137,8 @@ impl Display for MetadataLocation {
         let suffix = self.compression_codec.suffix().unwrap_or("");
         write!(
             f,
-            "{}/metadata/{:0>5}-{}{}.metadata.json",
-            self.table_location, self.version, self.id, suffix
+            "{}/{:0>5}-{}{}.metadata.json",
+            self.metadata_dir, self.version, self.id, suffix
         )
     }
 }
@@ -149,16 +147,15 @@ impl FromStr for MetadataLocation {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let (path, file_name) = s.rsplit_once('/').ok_or(Error::new(
+        let (metadata_dir, file_name) = s.rsplit_once('/').ok_or(Error::new(
             ErrorKind::Unexpected,
             format!("Invalid metadata location: {s}"),
         ))?;
 
-        let prefix = Self::parse_metadata_path_prefix(path)?;
         let (version, id, compression_codec) = Self::parse_file_name(file_name)?;
 
         Ok(MetadataLocation {
-            table_location: prefix,
+            metadata_dir: metadata_dir.to_string(),
             version,
             id,
             compression_codec,
@@ -198,7 +195,7 @@ mod test {
             (
                 "/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "".to_string(),
+                    metadata_dir: "/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -208,7 +205,7 @@ mod test {
             (
                 "/abc/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "/abc".to_string(),
+                    metadata_dir: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -218,7 +215,7 @@ mod test {
             (
                 "/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "/abc/def".to_string(),
+                    metadata_dir: "/abc/def/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -228,7 +225,7 @@ mod test {
             (
                 "https://127.0.0.1/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "https://127.0.0.1".to_string(),
+                    metadata_dir: "https://127.0.0.1/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -238,7 +235,7 @@ mod test {
             (
                 "/abc/metadata/1234567-81056704-ce5b-41c4-bb83-eb6408081af6.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "/abc".to_string(),
+                    metadata_dir: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("81056704-ce5b-41c4-bb83-eb6408081af6").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -248,7 +245,7 @@ mod test {
             (
                 "/abc/metadata/00000-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "/abc".to_string(),
+                    metadata_dir: "/abc/metadata".to_string(),
                     version: 0,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -258,7 +255,7 @@ mod test {
             (
                 "/abc/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.gz.metadata.json",
                 Ok(MetadataLocation {
-                    table_location: "/abc".to_string(),
+                    metadata_dir: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::gzip_default(),
@@ -279,10 +276,15 @@ mod test {
                 "/metadata/noversion-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Err("".to_string()),
             ),
-            // No /metadata subdirectory
+            // Metadata dir does not need to be named "metadata" (e.g. a `write.metadata.path`` location)
             (
                 "/wrongsubdir/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
-                Err("".to_string()),
+                Ok(MetadataLocation {
+                    metadata_dir: "/wrongsubdir".to_string(),
+                    version: 1234567,
+                    id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
+                    compression_codec: CompressionCodec::None,
+                }),
             ),
             // No .metadata.json suffix
             (
@@ -321,7 +323,7 @@ mod test {
             let next = MetadataLocation::from_str(&input.to_string())
                 .unwrap()
                 .with_next_version();
-            assert_eq!(next.table_location, input.table_location);
+            assert_eq!(next.metadata_dir, input.metadata_dir);
             assert_eq!(next.version, input.version + 1);
             assert_ne!(next.id, input.id);
         }
@@ -409,5 +411,61 @@ mod test {
             updated_explicit.to_string(),
             "/test/table/metadata/00000-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json"
         );
+    }
+
+    #[test]
+    fn test_new_with_metadata_honors_write_metadata_path() {
+        // Test metadata lives under `<location>/metadata` by default
+        let default_meta = create_test_metadata(HashMap::new());
+        let default_loc = MetadataLocation::new_with_metadata("/test/table", &default_meta);
+        assert!(
+            default_loc
+                .to_string()
+                .starts_with("/test/table/metadata/00000-"),
+            "unexpected location: {default_loc}"
+        );
+
+        // Test a configured `write.metadata.path` is honored
+        let props = HashMap::from([(
+            "write.metadata.path".to_string(),
+            "s3://bucket/custom-meta".to_string(),
+        )]);
+        let custom_meta = create_test_metadata(props);
+        let custom_loc = MetadataLocation::new_with_metadata("/test/table", &custom_meta);
+        assert!(
+            custom_loc
+                .to_string()
+                .starts_with("s3://bucket/custom-meta/00000-"),
+            "unexpected location: {custom_loc}"
+        );
+        assert!(custom_loc.to_string().ends_with(".metadata.json"));
+    }
+
+    #[test]
+    fn test_with_new_metadata_honors_write_metadata_path() {
+        // Parse the current (default-location) metadata file, bump the
+        // version, then apply new metadata that sets `write.metadata.path`. Test the metadata
+        // directory is derived from the metadata object, not the previous path)
+        let current = MetadataLocation::from_str(
+            "/test/table/metadata/00000-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
+        )
+        .unwrap();
+
+        let props = HashMap::from([(
+            "write.metadata.path".to_string(),
+            "s3://bucket/custom-meta".to_string(),
+        )]);
+        let new_meta = create_test_metadata(props);
+
+        let next = current.with_next_version().with_new_metadata(&new_meta);
+        assert_eq!(next.version, 1);
+        assert!(
+            next.to_string()
+                .starts_with("s3://bucket/custom-meta/00001-"),
+            "unexpected location: {next}"
+        );
+
+        let reparsed = MetadataLocation::from_str(&next.to_string()).unwrap();
+        assert_eq!(reparsed, next);
     }
 }

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -53,7 +53,7 @@ impl MetadataLocation {
     )]
     pub fn new_with_table_location(table_location: impl ToString) -> Self {
         Self {
-            metadata_dir: format!("{}/metadata", table_location.to_string()),
+            metadata_dir: TableMetadata::default_metadata_dir(&table_location.to_string()),
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: CompressionCodec::None,

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -49,23 +49,13 @@ impl MetadataLocation {
         parse_metadata_file_compression(properties).unwrap_or(CompressionCodec::None)
     }
 
-    /// Creates a completely new metadata location starting at version 0,
-    /// with compression settings from the table metadata.
-    /// Only used for creating a new table. For updates, see `next_version`.
-    ///
-    /// The metadata directory honors the `write.metadata.path` table property when set,
-    /// otherwise defaults to the `metadata` subdirectory of `table_location`.
-    pub fn try_new_with_metadata(
-        table_location: impl ToString,
-        metadata: &TableMetadata,
-    ) -> Result<Self> {
-        let table_location = table_location.to_string();
-        let location = metadata
-            .table_properties()?
-            .write_metadata_path
-            .unwrap_or_else(|| format!("{table_location}/{METADATA_FOLDER_NAME}"));
+    /// Creates a completely new metadata location starting at version 0, deriving the
+    /// metadata directory and compression settings from the table metadata.
+    /// Only used for creating a new table. For updates, see `with_next_version` and
+    /// `try_with_new_metadata`.
+    pub fn try_new_with_metadata(metadata: &TableMetadata) -> Result<Self> {
         Ok(Self {
-            location,
+            location: metadata.metadata_location()?,
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: Self::compression_from_properties(metadata.properties()),
@@ -273,7 +263,7 @@ mod test {
                 "/metadata/noversion-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Err("".to_string()),
             ),
-            // Metadata dir does not need to be named "metadata" (e.g. a `write.metadata.path`` location)
+            // Metadata dir does not need to be named "metadata" (e.g. a `write.metadata.path` location)
             (
                 "/wrongsubdir/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
@@ -309,7 +299,7 @@ mod test {
     fn test_metadata_location_with_next_version() {
         let metadata = create_test_metadata(HashMap::new());
         let test_cases = vec![
-            MetadataLocation::try_new_with_metadata("/abc", &metadata).unwrap(),
+            MetadataLocation::try_new_with_metadata(&metadata).unwrap(),
             MetadataLocation::from_str(
                 "/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
             )
@@ -448,8 +438,7 @@ mod test {
     fn test_new_with_metadata_honors_write_metadata_path() {
         // Test metadata lives under `<location>/metadata` by default
         let default_meta = create_test_metadata(HashMap::new());
-        let default_loc =
-            MetadataLocation::try_new_with_metadata("/test/table", &default_meta).unwrap();
+        let default_loc = MetadataLocation::try_new_with_metadata(&default_meta).unwrap();
         assert!(
             default_loc
                 .to_string()
@@ -463,8 +452,7 @@ mod test {
             "s3://bucket/custom-meta".to_string(),
         )]);
         let custom_meta = create_test_metadata(props);
-        let custom_loc =
-            MetadataLocation::try_new_with_metadata("/test/table", &custom_meta).unwrap();
+        let custom_loc = MetadataLocation::try_new_with_metadata(&custom_meta).unwrap();
         assert!(
             custom_loc
                 .to_string()

--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -25,6 +25,10 @@ use crate::compression::CompressionCodec;
 use crate::spec::{TableMetadata, parse_metadata_file_compression};
 use crate::{Error, ErrorKind, Result};
 
+/// Default folder name for metadata files under the table location, used when the
+/// `write.metadata.path` table property is not set.
+pub(crate) const METADATA_FOLDER_NAME: &str = "metadata";
+
 /// Helper for parsing a location of the format: `<metadata-dir>/<version>-<uuid>.metadata.json`
 /// or with compression: `<metadata-dir>/<version>-<uuid>.gz.metadata.json`
 ///
@@ -32,7 +36,7 @@ use crate::{Error, ErrorKind, Result};
 /// it defaults to the `<location>/metadata` when the property is not set.
 #[derive(Clone, Debug, PartialEq)]
 pub struct MetadataLocation {
-    metadata_dir: String,
+    location: String,
     version: i32,
     id: Uuid,
     compression_codec: CompressionCodec,
@@ -45,21 +49,6 @@ impl MetadataLocation {
         parse_metadata_file_compression(properties).unwrap_or(CompressionCodec::None)
     }
 
-    /// Creates a completely new metadata location starting at version 0.
-    /// Only used for creating a new table. For updates, see `next_version`.
-    #[deprecated(
-        since = "0.8.0",
-        note = "Use new_with_metadata instead to properly handle compression settings"
-    )]
-    pub fn new_with_table_location(table_location: impl ToString) -> Self {
-        Self {
-            metadata_dir: TableMetadata::default_metadata_dir(&table_location.to_string()),
-            version: 0,
-            id: Uuid::new_v4(),
-            compression_codec: CompressionCodec::None,
-        }
-    }
-
     /// Creates a completely new metadata location starting at version 0,
     /// with compression settings from the table metadata.
     /// Only used for creating a new table. For updates, see `next_version`.
@@ -68,11 +57,13 @@ impl MetadataLocation {
     /// otherwise defaults to the `metadata` subdirectory of `table_location`.
     pub fn new_with_metadata(table_location: impl ToString, metadata: &TableMetadata) -> Self {
         let table_location = table_location.to_string();
-        let metadata_dir = metadata
-            .metadata_location_root_with_base(&table_location)
-            .unwrap_or_else(|_| TableMetadata::default_metadata_dir(&table_location));
+        let location = metadata
+            .table_properties()
+            .ok()
+            .and_then(|props| props.write_metadata_path)
+            .unwrap_or_else(|| format!("{table_location}/{METADATA_FOLDER_NAME}"));
         Self {
-            metadata_dir,
+            location,
             version: 0,
             id: Uuid::new_v4(),
             compression_codec: Self::compression_from_properties(metadata.properties()),
@@ -83,7 +74,7 @@ impl MetadataLocation {
     /// Increments the version number and generates a new UUID.
     pub fn with_next_version(&self) -> Self {
         Self {
-            metadata_dir: self.metadata_dir.clone(),
+            location: self.location.clone(),
             version: self.version + 1,
             id: Uuid::new_v4(),
             compression_codec: self.compression_codec,
@@ -93,7 +84,7 @@ impl MetadataLocation {
     /// Updates the metadata location with compression settings from the new metadata.
     pub fn with_new_metadata(&self, new_metadata: &TableMetadata) -> Self {
         Self {
-            metadata_dir: self.metadata_dir.clone(),
+            location: self.location.clone(),
             version: self.version,
             id: self.id,
             compression_codec: Self::compression_from_properties(new_metadata.properties()),
@@ -141,7 +132,7 @@ impl Display for MetadataLocation {
         write!(
             f,
             "{}/{:0>5}-{}{}.metadata.json",
-            self.metadata_dir, self.version, self.id, suffix
+            self.location, self.version, self.id, suffix
         )
     }
 }
@@ -150,7 +141,7 @@ impl FromStr for MetadataLocation {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let (metadata_dir, file_name) = s.rsplit_once('/').ok_or(Error::new(
+        let (location, file_name) = s.rsplit_once('/').ok_or(Error::new(
             ErrorKind::Unexpected,
             format!("Invalid metadata location: {s}"),
         ))?;
@@ -158,7 +149,7 @@ impl FromStr for MetadataLocation {
         let (version, id, compression_codec) = Self::parse_file_name(file_name)?;
 
         Ok(MetadataLocation {
-            metadata_dir: metadata_dir.to_string(),
+            location: location.to_string(),
             version,
             id,
             compression_codec,
@@ -198,7 +189,7 @@ mod test {
             (
                 "/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/metadata".to_string(),
+                    location: "/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -208,7 +199,7 @@ mod test {
             (
                 "/abc/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/abc/metadata".to_string(),
+                    location: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -218,7 +209,7 @@ mod test {
             (
                 "/abc/def/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/abc/def/metadata".to_string(),
+                    location: "/abc/def/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -228,7 +219,7 @@ mod test {
             (
                 "https://127.0.0.1/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "https://127.0.0.1/metadata".to_string(),
+                    location: "https://127.0.0.1/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -238,7 +229,7 @@ mod test {
             (
                 "/abc/metadata/1234567-81056704-ce5b-41c4-bb83-eb6408081af6.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/abc/metadata".to_string(),
+                    location: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("81056704-ce5b-41c4-bb83-eb6408081af6").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -248,7 +239,7 @@ mod test {
             (
                 "/abc/metadata/00000-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/abc/metadata".to_string(),
+                    location: "/abc/metadata".to_string(),
                     version: 0,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -258,7 +249,7 @@ mod test {
             (
                 "/abc/metadata/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.gz.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/abc/metadata".to_string(),
+                    location: "/abc/metadata".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::gzip_default(),
@@ -283,7 +274,7 @@ mod test {
             (
                 "/wrongsubdir/1234567-2cd22b57-5127-4198-92ba-e4e67c79821b.metadata.json",
                 Ok(MetadataLocation {
-                    metadata_dir: "/wrongsubdir".to_string(),
+                    location: "/wrongsubdir".to_string(),
                     version: 1234567,
                     id: Uuid::from_str("2cd22b57-5127-4198-92ba-e4e67c79821b").unwrap(),
                     compression_codec: CompressionCodec::None,
@@ -326,7 +317,7 @@ mod test {
             let next = MetadataLocation::from_str(&input.to_string())
                 .unwrap()
                 .with_next_version();
-            assert_eq!(next.metadata_dir, input.metadata_dir);
+            assert_eq!(next.location, input.location);
             assert_eq!(next.version, input.version + 1);
             assert_ne!(next.id, input.id);
         }

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -403,7 +403,7 @@ impl TableCommit {
 
         let new_metadata_location = MetadataLocation::from_str(current_metadata_location)?
             .with_next_version()
-            .with_new_metadata(&new_metadata)
+            .try_with_new_metadata(&new_metadata)?
             .to_string();
 
         Ok(table
@@ -2442,12 +2442,13 @@ mod tests {
             "v2"
         );
 
-        // metadata version should be bumped
+        // metadata version should be bumped, and the metadata directory should be
+        // re-derived from the updated table location
         assert!(
             updated_table
                 .metadata_location()
                 .unwrap()
-                .starts_with("s3://bucket/test/location/metadata/00001-")
+                .starts_with("s3://bucket/test/new_location/data/metadata/00001-")
         );
 
         assert_eq!(

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -2442,13 +2442,12 @@ mod tests {
             "v2"
         );
 
-        // metadata version should be bumped and the new metadata file is written under the updated
-        // table location's metadata directory
+        // metadata version should be bumped
         assert!(
             updated_table
                 .metadata_location()
                 .unwrap()
-                .starts_with("s3://bucket/test/new_location/data/metadata/00001-")
+                .starts_with("s3://bucket/test/location/metadata/00001-")
         );
 
         assert_eq!(

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -2442,12 +2442,13 @@ mod tests {
             "v2"
         );
 
-        // metadata version should be bumped
+        // metadata version should be bumped and the new metadata file is written under the updated
+        // table location's metadata directory
         assert!(
             updated_table
                 .metadata_location()
                 .unwrap()
-                .starts_with("s3://bucket/test/location/metadata/00001-")
+                .starts_with("s3://bucket/test/new_location/data/metadata/00001-")
         );
 
         assert_eq!(

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -377,18 +377,18 @@ impl TableMetadata {
     ///
     /// Honors the `write.metadata.path` table property when set, otherwise defaults
     /// to the `metadata` directory under the table location.
-    pub fn metadata_location_root(&self) -> String {
+    pub fn metadata_location_root(&self) -> Result<String> {
         self.metadata_location_root_with_base(self.location())
     }
 
     /// Like [`Self::metadata_location_root`], but uses an explicit table location as
     /// the base for the default `<location>/metadata` when `write.metadata.path` is not
     /// configured.
-    pub(crate) fn metadata_location_root_with_base(&self, base: &str) -> String {
-        self.properties
-            .get(TableProperties::PROPERTY_WRITE_METADATA_PATH)
-            .map(|location| location.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| Self::default_metadata_dir(base))
+    pub(crate) fn metadata_location_root_with_base(&self, base: &str) -> Result<String> {
+        Ok(self
+            .table_properties()?
+            .write_metadata_path
+            .unwrap_or_else(|| Self::default_metadata_dir(base)))
     }
 
     /// Returns the metadata compression codec from table properties.
@@ -4317,7 +4317,7 @@ mod tests {
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json");
         assert_eq!(metadata.location(), "s3://bucket/test/location");
         assert_eq!(
-            metadata.metadata_location_root(),
+            metadata.metadata_location_root().unwrap(),
             "s3://bucket/test/location/metadata"
         );
     }
@@ -4335,7 +4335,7 @@ mod tests {
             .unwrap()
             .metadata;
         assert_eq!(
-            metadata.metadata_location_root(),
+            metadata.metadata_location_root().unwrap(),
             "s3://other-bucket/custom-meta"
         );
     }
@@ -4354,7 +4354,7 @@ mod tests {
             .unwrap()
             .metadata;
         assert_eq!(
-            metadata.metadata_location_root(),
+            metadata.metadata_location_root().unwrap(),
             "s3://other-bucket/custom-meta"
         );
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -47,11 +47,6 @@ use crate::{Error, ErrorKind};
 static MAIN_BRANCH: &str = "main";
 pub(crate) static ONE_MINUTE_MS: i64 = 60_000;
 
-/// Table property for the base location of metadata files.
-const WRITE_METADATA_LOCATION: &str = "write.metadata.path";
-/// Default subdirectory when `write.metadata.path` is not configured.
-const DEFAULT_METADATA_DIR: &str = "metadata";
-
 /// Sentinel value used by the Java implementation and older metadata files
 /// to represent a missing/empty current snapshot ID. During deserialization,
 /// this value is normalized to `None`.
@@ -369,6 +364,15 @@ impl TableMetadata {
         &self.properties
     }
 
+    /// Returns the default metadata directory for a table location: the `metadata`
+    /// subdirectory under `table_location`. Used when `write.metadata.path` is not set.
+    pub fn default_metadata_dir(table_location: &str) -> String {
+        format!(
+            "{table_location}/{}",
+            TableProperties::PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR
+        )
+    }
+
     /// Returns the base location for metadata files.
     ///
     /// Honors the `write.metadata.path` table property when set, otherwise defaults
@@ -382,9 +386,9 @@ impl TableMetadata {
     /// configured.
     pub(crate) fn metadata_location_root_with_base(&self, base: &str) -> String {
         self.properties
-            .get(WRITE_METADATA_LOCATION)
+            .get(TableProperties::PROPERTY_WRITE_METADATA_PATH)
             .map(|location| location.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| format!("{base}/{DEFAULT_METADATA_DIR}"))
+            .unwrap_or_else(|| Self::default_metadata_dir(base))
     }
 
     /// Returns the metadata compression codec from table properties.
@@ -4323,7 +4327,7 @@ mod tests {
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
             .into_builder(None)
             .set_properties(HashMap::from([(
-                super::WRITE_METADATA_LOCATION.to_string(),
+                TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
                 "s3://other-bucket/custom-meta".to_string(),
             )]))
             .unwrap()
@@ -4342,7 +4346,7 @@ mod tests {
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
             .into_builder(None)
             .set_properties(HashMap::from([(
-                super::WRITE_METADATA_LOCATION.to_string(),
+                TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
                 "s3://other-bucket/custom-meta/".to_string(),
             )]))
             .unwrap()

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -3615,7 +3615,8 @@ mod tests {
         let original_metadata: TableMetadata = get_test_table_metadata("TableMetadataV2Valid.json");
 
         // Define the metadata location
-        let metadata_location = MetadataLocation::new_with_metadata(temp_path, &original_metadata);
+        let metadata_location =
+            MetadataLocation::try_new_with_metadata(temp_path, &original_metadata).unwrap();
         let metadata_location_str = metadata_location.to_string();
 
         // Write the metadata
@@ -3699,7 +3700,7 @@ mod tests {
 
         // Create MetadataLocation with compression codec from metadata
         let metadata_location =
-            MetadataLocation::new_with_metadata(temp_path, &compressed_metadata);
+            MetadataLocation::try_new_with_metadata(temp_path, &compressed_metadata).unwrap();
         let metadata_location_str = metadata_location.to_string();
 
         // Verify the location has the .gz extension

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -47,6 +47,11 @@ use crate::{Error, ErrorKind};
 static MAIN_BRANCH: &str = "main";
 pub(crate) static ONE_MINUTE_MS: i64 = 60_000;
 
+/// Table property for the base location of metadata files.
+const WRITE_METADATA_LOCATION: &str = "write.metadata.path";
+/// Default subdirectory when `write.metadata.path` is not configured.
+const DEFAULT_METADATA_DIR: &str = "metadata";
+
 /// Sentinel value used by the Java implementation and older metadata files
 /// to represent a missing/empty current snapshot ID. During deserialization,
 /// this value is normalized to `None`.
@@ -362,6 +367,24 @@ impl TableMetadata {
     #[inline]
     pub fn properties(&self) -> &HashMap<String, String> {
         &self.properties
+    }
+
+    /// Returns the base location for metadata files.
+    ///
+    /// Honors the `write.metadata.path` table property when set, otherwise defaults
+    /// to the `metadata` directory under the table location.
+    pub fn metadata_location_root(&self) -> String {
+        self.metadata_location_root_with_base(self.location())
+    }
+
+    /// Like [`Self::metadata_location_root`], but uses an explicit table location as
+    /// the base for the default `<location>/metadata` when `write.metadata.path` is not
+    /// configured.
+    pub(crate) fn metadata_location_root_with_base(&self, base: &str) -> String {
+        self.properties
+            .get(WRITE_METADATA_LOCATION)
+            .map(|location| location.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| format!("{base}/{DEFAULT_METADATA_DIR}"))
     }
 
     /// Returns the metadata compression codec from table properties.
@@ -4282,5 +4305,53 @@ mod tests {
             deserialized_snapshot.row_range().unwrap();
         assert_eq!(deserialized_first_row_id, 100);
         assert_eq!(deserialized_added_rows, 50);
+    }
+
+    #[test]
+    fn test_metadata_location_root_default() {
+        // Verify metadata files go to `<location>/metadata` when `write.metadata.path` is not set
+        let metadata = get_test_table_metadata("TableMetadataV2Valid.json");
+        assert_eq!(metadata.location(), "s3://bucket/test/location");
+        assert_eq!(
+            metadata.metadata_location_root(),
+            "s3://bucket/test/location/metadata"
+        );
+    }
+
+    #[test]
+    fn test_metadata_location_root_honors_write_metadata_path() {
+        let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
+            .into_builder(None)
+            .set_properties(HashMap::from([(
+                super::WRITE_METADATA_LOCATION.to_string(),
+                "s3://other-bucket/custom-meta".to_string(),
+            )]))
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        assert_eq!(
+            metadata.metadata_location_root(),
+            "s3://other-bucket/custom-meta"
+        );
+    }
+
+    #[test]
+    fn test_metadata_location_root_trims_trailing_slash() {
+        // A configured path with a trailing slash must not yield a doubled separator
+        let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
+            .into_builder(None)
+            .set_properties(HashMap::from([(
+                super::WRITE_METADATA_LOCATION.to_string(),
+                "s3://other-bucket/custom-meta/".to_string(),
+            )]))
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        assert_eq!(
+            metadata.metadata_location_root(),
+            "s3://other-bucket/custom-meta"
+        );
     }
 }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -37,7 +37,7 @@ use super::{
     SnapshotRef, SnapshotRetention, SortOrder, SortOrderRef, StatisticsFile, StructType,
     TableProperties, parse_metadata_file_compression,
 };
-use crate::catalog::MetadataLocation;
+use crate::catalog::{METADATA_FOLDER_NAME, MetadataLocation};
 use crate::compression::CompressionCodec;
 use crate::error::{Result, timestamp_ms_to_utc};
 use crate::io::FileIO;
@@ -364,31 +364,15 @@ impl TableMetadata {
         &self.properties
     }
 
-    /// Returns the default metadata directory for a table location: the `metadata`
-    /// subdirectory under `table_location`. Used when `write.metadata.path` is not set.
-    pub fn default_metadata_dir(table_location: &str) -> String {
-        format!(
-            "{table_location}/{}",
-            TableProperties::PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR
-        )
-    }
-
-    /// Returns the base location for metadata files.
+    /// Returns the base location for metadata files (manifests, manifest lists).
     ///
     /// Honors the `write.metadata.path` table property when set, otherwise defaults
-    /// to the `metadata` directory under the table location.
-    pub fn metadata_location_root(&self) -> Result<String> {
-        self.metadata_location_root_with_base(self.location())
-    }
-
-    /// Like [`Self::metadata_location_root`], but uses an explicit table location as
-    /// the base for the default `<location>/metadata` when `write.metadata.path` is not
-    /// configured.
-    pub(crate) fn metadata_location_root_with_base(&self, base: &str) -> Result<String> {
+    /// to the `metadata` subdirectory under the table location.
+    pub fn metadata_location(&self) -> Result<String> {
         Ok(self
             .table_properties()?
             .write_metadata_path
-            .unwrap_or_else(|| Self::default_metadata_dir(base)))
+            .unwrap_or_else(|| format!("{}/{}", self.location(), METADATA_FOLDER_NAME)))
     }
 
     /// Returns the metadata compression codec from table properties.
@@ -4312,18 +4296,18 @@ mod tests {
     }
 
     #[test]
-    fn test_metadata_location_root_default() {
+    fn test_metadata_location_default() {
         // Verify metadata files go to `<location>/metadata` when `write.metadata.path` is not set
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json");
         assert_eq!(metadata.location(), "s3://bucket/test/location");
         assert_eq!(
-            metadata.metadata_location_root().unwrap(),
+            metadata.metadata_location().unwrap(),
             "s3://bucket/test/location/metadata"
         );
     }
 
     #[test]
-    fn test_metadata_location_root_honors_write_metadata_path() {
+    fn test_metadata_location_honors_write_metadata_path() {
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
             .into_builder(None)
             .set_properties(HashMap::from([(
@@ -4335,13 +4319,13 @@ mod tests {
             .unwrap()
             .metadata;
         assert_eq!(
-            metadata.metadata_location_root().unwrap(),
+            metadata.metadata_location().unwrap(),
             "s3://other-bucket/custom-meta"
         );
     }
 
     #[test]
-    fn test_metadata_location_root_trims_trailing_slash() {
+    fn test_metadata_location_trims_trailing_slash() {
         // A configured path with a trailing slash must not yield a doubled separator
         let metadata = get_test_table_metadata("TableMetadataV2Valid.json")
             .into_builder(None)
@@ -4354,7 +4338,7 @@ mod tests {
             .unwrap()
             .metadata;
         assert_eq!(
-            metadata.metadata_location_root().unwrap(),
+            metadata.metadata_location().unwrap(),
             "s3://other-bucket/custom-meta"
         );
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1651,6 +1651,16 @@ mod tests {
         serde_json::from_str(&metadata).unwrap()
     }
 
+    /// Loads a test table metadata and relocates it to `location`, so that derived
+    /// metadata paths point at a writable (e.g. temp) directory.
+    fn get_test_table_metadata_at(file_name: &str, location: &str) -> TableMetadata {
+        TableMetadataBuilder::new_from_metadata(get_test_table_metadata(file_name), None)
+            .set_location(location.to_string())
+            .build()
+            .unwrap()
+            .metadata
+    }
+
     #[test]
     fn test_table_data_v2() {
         let data = r#"
@@ -3612,11 +3622,12 @@ mod tests {
         let file_io = FileIO::new_with_fs();
 
         // Use an existing test metadata from the test files
-        let original_metadata: TableMetadata = get_test_table_metadata("TableMetadataV2Valid.json");
+        let original_metadata: TableMetadata =
+            get_test_table_metadata_at("TableMetadataV2Valid.json", temp_path);
 
         // Define the metadata location
         let metadata_location =
-            MetadataLocation::try_new_with_metadata(temp_path, &original_metadata).unwrap();
+            MetadataLocation::try_new_with_metadata(&original_metadata).unwrap();
         let metadata_location_str = metadata_location.to_string();
 
         // Write the metadata
@@ -3680,7 +3691,8 @@ mod tests {
         let file_io = FileIO::new_with_fs();
 
         // Get a test metadata and add gzip compression property
-        let original_metadata: TableMetadata = get_test_table_metadata("TableMetadataV2Valid.json");
+        let original_metadata: TableMetadata =
+            get_test_table_metadata_at("TableMetadataV2Valid.json", temp_path);
 
         // Modify properties to enable gzip compression (using mixed case to test case-insensitive matching)
         let mut props = original_metadata.properties.clone();
@@ -3700,7 +3712,7 @@ mod tests {
 
         // Create MetadataLocation with compression codec from metadata
         let metadata_location =
-            MetadataLocation::try_new_with_metadata(temp_path, &compressed_metadata).unwrap();
+            MetadataLocation::try_new_with_metadata(&compressed_metadata).unwrap();
         let metadata_location_str = metadata_location.to_string();
 
         // Verify the location has the .gz extension

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -112,6 +112,9 @@ pub struct TableProperties {
     pub write_format_default: String,
     /// The target file size for files.
     pub write_target_file_size_bytes: usize,
+    /// Base directory for metadata files (manifests, manifest lists), with any
+    /// trailing slash trimmed. `None` if `write.metadata.path` is not set.
+    pub write_metadata_path: Option<String>,
     /// Compression codec for metadata files (JSON)
     pub metadata_compression_codec: CompressionCodec,
     /// Whether to use `FanoutWriter` for partitioned tables.
@@ -332,6 +335,9 @@ impl TryFrom<&HashMap<String, String>> for TableProperties {
                 TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES,
                 TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
             )?,
+            write_metadata_path: props
+                .get(TableProperties::PROPERTY_WRITE_METADATA_PATH)
+                .map(|path| path.trim_end_matches('/').to_string()),
             metadata_compression_codec: parse_metadata_file_compression(props)?,
             write_datafusion_fanout_enabled: parse_property(
                 props,
@@ -462,6 +468,24 @@ mod tests {
         assert_eq!(table_properties.max_snapshot_age_ms, 1234);
         assert_eq!(table_properties.min_snapshots_to_keep, 7);
         assert_eq!(table_properties.max_ref_age_ms, 5678);
+    }
+
+    #[test]
+    fn test_table_properties_write_metadata_path() {
+        // Test unset
+        let table_properties = TableProperties::try_from(&HashMap::new()).unwrap();
+        assert_eq!(table_properties.write_metadata_path, None);
+
+        // Test trimmed of any trailing slash
+        let props = HashMap::from([(
+            TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
+            "s3://other-bucket/custom-meta/".to_string(),
+        )]);
+        let table_properties = TableProperties::try_from(&props).unwrap();
+        assert_eq!(
+            table_properties.write_metadata_path.as_deref(),
+            Some("s3://other-bucket/custom-meta")
+        );
     }
 
     #[test]

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -235,9 +235,6 @@ impl TableProperties {
     /// When unset, metadata files default to the `metadata` directory under the table
     /// location.
     pub const PROPERTY_WRITE_METADATA_PATH: &str = "write.metadata.path";
-    /// Default subdirectory (under the table location) for metadata files when
-    /// [`Self::PROPERTY_WRITE_METADATA_PATH`] is not configured.
-    pub const PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR: &str = "metadata";
 
     /// Compression codec for metadata files (JSON)
     pub const PROPERTY_METADATA_COMPRESSION_CODEC: &str = "write.metadata.compression-codec";

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -40,6 +40,37 @@ where
     })
 }
 
+/// Strips trailing slashes from a location, preserving a bare URI scheme root
+fn strip_trailing_slash(path: &str) -> &str {
+    let mut path = path;
+    while !path.ends_with("://") {
+        let Some(stripped) = path.strip_suffix('/') else {
+            break;
+        };
+        path = stripped;
+    }
+    path
+}
+
+fn parse_location_property(
+    properties: &HashMap<String, String>,
+    key: &str,
+) -> Result<Option<String>> {
+    properties
+        .get(key)
+        .map(|path| {
+            if path.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!("Invalid value for {key}: path must not be empty"),
+                ));
+            }
+
+            Ok(strip_trailing_slash(path).to_string())
+        })
+        .transpose()
+}
+
 /// Parse compression codec for metadata files from table properties.
 /// Retrieves the compression codec property, applies defaults, and parses the value.
 /// Only "none" (or empty string) and "gzip" are supported for metadata compression.
@@ -332,9 +363,10 @@ impl TryFrom<&HashMap<String, String>> for TableProperties {
                 TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES,
                 TableProperties::PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
             )?,
-            write_metadata_path: props
-                .get(TableProperties::PROPERTY_WRITE_METADATA_PATH)
-                .map(|path| path.trim_end_matches('/').to_string()),
+            write_metadata_path: parse_location_property(
+                props,
+                TableProperties::PROPERTY_WRITE_METADATA_PATH,
+            )?,
             metadata_compression_codec: parse_metadata_file_compression(props)?,
             write_datafusion_fanout_enabled: parse_property(
                 props,
@@ -473,7 +505,19 @@ mod tests {
         let table_properties = TableProperties::try_from(&HashMap::new()).unwrap();
         assert_eq!(table_properties.write_metadata_path, None);
 
-        // Test trimmed of any trailing slash
+        // Test empty path is invalid
+        let props = HashMap::from([(
+            TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
+            String::new(),
+        )]);
+        let error = TableProperties::try_from(&props).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert!(
+            error
+                .message()
+                .contains(TableProperties::PROPERTY_WRITE_METADATA_PATH)
+        );
+
         let props = HashMap::from([(
             TableProperties::PROPERTY_WRITE_METADATA_PATH.to_string(),
             "s3://other-bucket/custom-meta/".to_string(),
@@ -483,6 +527,22 @@ mod tests {
             table_properties.write_metadata_path.as_deref(),
             Some("s3://other-bucket/custom-meta")
         );
+    }
+
+    #[test]
+    fn test_strip_trailing_slash() {
+        for (path, expected) in [
+            ("s3://bucket/db/tbl", "s3://bucket/db/tbl"),
+            ("s3://bucket/db/tbl/", "s3://bucket/db/tbl"),
+            ("s3://bucket/db/tbl////", "s3://bucket/db/tbl"),
+            ("blobstore://", "blobstore://"),
+            ("blobstore:///", "blobstore://"),
+            ("file:///", "file://"),
+            ("////", ""),
+            ("", ""),
+        ] {
+            assert_eq!(strip_trailing_slash(path), expected);
+        }
     }
 
     #[test]

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -228,6 +228,14 @@ impl TableProperties {
     /// Default target file size
     pub const PROPERTY_WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT: usize = 512 * 1024 * 1024; // 512 MB
 
+    /// Base location for metadata files (manifests, manifest lists, table metadata).
+    /// When unset, metadata files default to the `metadata` directory under the table
+    /// location.
+    pub const PROPERTY_WRITE_METADATA_PATH: &str = "write.metadata.path";
+    /// Default subdirectory (under the table location) for metadata files when
+    /// [`Self::PROPERTY_WRITE_METADATA_PATH`] is not configured.
+    pub const PROPERTY_WRITE_METADATA_PATH_DEFAULT_DIR: &str = "metadata";
+
     /// Compression codec for metadata files (JSON)
     pub const PROPERTY_METADATA_COMPRESSION_CODEC: &str = "write.metadata.compression-codec";
     /// Default metadata compression codec - uncompressed

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -360,6 +360,77 @@ mod tests {
         assert!(Arc::new(action).commit(&table).await.is_err());
     }
 
+    /// A `fast_append` must write the manifest list and the manifest
+    /// files under the `write.metadata.path` prefix when configured,
+    /// rather than the default `<location>/metadata` directory.
+    #[tokio::test]
+    async fn test_fast_append_honors_write_metadata_path() {
+        let base = make_v2_minimal_table();
+        let metadata_root = format!("{}/custom-meta", base.metadata().location());
+        let metadata = base
+            .metadata()
+            .clone()
+            .into_builder(None)
+            .set_properties(HashMap::from([(
+                "write.metadata.path".to_string(),
+                metadata_root.clone(),
+            )]))
+            .unwrap()
+            .build()
+            .unwrap()
+            .metadata;
+        let table = base.with_metadata(Arc::new(metadata));
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(format!("{}/data/1.parquet", table.metadata().location()))
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+
+        let tx = Transaction::new(&table);
+        let action = tx.fast_append().add_data_files(vec![data_file]);
+        let mut action_commit = Arc::new(action).commit(&table).await.unwrap();
+        let updates = action_commit.take_updates();
+
+        let new_snapshot: SnapshotRef = if let TableUpdate::AddSnapshot { snapshot } = &updates[0] {
+            SnapshotRef::new(snapshot.clone())
+        } else {
+            unreachable!("first update of a fast append should be AddSnapshot")
+        };
+
+        let prefix = format!("{metadata_root}/");
+
+        // Manifest list
+        assert!(
+            new_snapshot.manifest_list().starts_with(prefix.as_str()),
+            "manifest list {} not under configured write.metadata.path {metadata_root}",
+            new_snapshot.manifest_list()
+        );
+
+        // Manifest files
+        let manifest_list = table
+            .manifest_list_reader(&new_snapshot)
+            .load()
+            .await
+            .unwrap();
+        assert!(
+            !manifest_list.entries().is_empty(),
+            "expected at least one manifest entry"
+        );
+        for entry in manifest_list.entries() {
+            assert!(
+                entry.manifest_path.starts_with(prefix.as_str()),
+                "manifest {} not under configured write.metadata.path {metadata_root}",
+                entry.manifest_path
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_set_snapshot_properties() {
         let table = make_v2_minimal_table();

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -240,7 +240,7 @@ impl<'a> SnapshotProducer<'a> {
     fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {
         let new_manifest_path = format!(
             "{}/{}-m{}.{}",
-            self.table.metadata().metadata_location_root(),
+            self.table.metadata().metadata_location_root()?,
             self.commit_uuid,
             self.manifest_counter.next().unwrap(),
             DataFileFormat::Avro
@@ -417,15 +417,15 @@ impl<'a> SnapshotProducer<'a> {
         )
     }
 
-    fn generate_manifest_list_file_path(&self, attempt: i64) -> String {
-        format!(
+    fn generate_manifest_list_file_path(&self, attempt: i64) -> Result<String> {
+        Ok(format!(
             "{}/snap-{}-{}-{}.{}",
-            self.table.metadata().metadata_location_root(),
+            self.table.metadata().metadata_location_root()?,
             self.snapshot_id,
             attempt,
             self.commit_uuid,
             DataFileFormat::Avro
-        )
+        ))
     }
 
     /// Finished building the action and return the [`ActionCommit`] to the transaction.
@@ -434,7 +434,7 @@ impl<'a> SnapshotProducer<'a> {
         snapshot_produce_operation: OP,
         process: MP,
     ) -> Result<ActionCommit> {
-        let manifest_list_path = self.generate_manifest_list_file_path(0);
+        let manifest_list_path = self.generate_manifest_list_file_path(0)?;
         let next_seq_num = self.table.metadata().next_sequence_number();
         let first_row_id = self.table.metadata().next_row_id();
         let writer = self

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -34,8 +34,6 @@ use crate::table::Table;
 use crate::transaction::ActionCommit;
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
 
-const META_ROOT_PATH: &str = "metadata";
-
 /// A trait that defines how different table operations produce new snapshots.
 ///
 /// `SnapshotProduceOperation` is used by [`SnapshotProducer`] to customize snapshot creation
@@ -241,9 +239,8 @@ impl<'a> SnapshotProducer<'a> {
 
     fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {
         let new_manifest_path = format!(
-            "{}/{}/{}-m{}.{}",
-            self.table.metadata().location(),
-            META_ROOT_PATH,
+            "{}/{}-m{}.{}",
+            self.table.metadata().metadata_location_root(),
             self.commit_uuid,
             self.manifest_counter.next().unwrap(),
             DataFileFormat::Avro
@@ -422,9 +419,8 @@ impl<'a> SnapshotProducer<'a> {
 
     fn generate_manifest_list_file_path(&self, attempt: i64) -> String {
         format!(
-            "{}/{}/snap-{}-{}-{}.{}",
-            self.table.metadata().location(),
-            META_ROOT_PATH,
+            "{}/snap-{}-{}-{}.{}",
+            self.table.metadata().metadata_location_root(),
             self.snapshot_id,
             attempt,
             self.commit_uuid,

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -240,7 +240,7 @@ impl<'a> SnapshotProducer<'a> {
     fn new_manifest_writer(&mut self, content: ManifestContentType) -> Result<ManifestWriter> {
         let new_manifest_path = format!(
             "{}/{}-m{}.{}",
-            self.table.metadata().metadata_location_root()?,
+            self.table.metadata().metadata_location()?,
             self.commit_uuid,
             self.manifest_counter.next().unwrap(),
             DataFileFormat::Avro
@@ -420,7 +420,7 @@ impl<'a> SnapshotProducer<'a> {
     fn generate_manifest_list_file_path(&self, attempt: i64) -> Result<String> {
         Ok(format!(
             "{}/snap-{}-{}-{}.{}",
-            self.table.metadata().metadata_location_root()?,
+            self.table.metadata().metadata_location()?,
             self.snapshot_id,
             attempt,
             self.commit_uuid,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2775.

## What changes are included in this PR?

Metadata files were always written under `<table-location>/metadata`, ignoring the `write.metadata.path` table property. Iceberg Java honors it (via `BaseMetastoreTableOperations.metadataFileLocation`); this brings iceberg-rust in line and mirrors the existing `write.data.path` handling for data files.

- Add `TableMetadata::metadata_location_root()`, returning `write.metadata.path` (trailing slash trimmed) when set, otherwise `<location>/metadata`.
- Use it in `SnapshotProducer` for the manifest and manifest-list paths, and in `MetadataLocation` for the table metadata JSON.
- `MetadataLocation` now stores the resolved metadata directory rather than the table location. On commit, the directory is re-derived from the metadata being committed (the version is still parsed from the previous file name), matching Iceberg Java. As a result `MetadataLocation::from_str` no longer requires the file to live under a `/metadata` directory (a custom `write.metadata.path` does not have to); file-name validation is unchanged.

## Are these changes tested?

Unit tests:

- `TableMetadata::metadata_location_root()`: default, configured `write.metadata.path`, and trailing-slash trimming.
- `MetadataLocation`: create (`new_with_metadata`) and commit (`with_new_metadata`) honor `write.metadata.path`; `from_str` round-trip cases updated for arbitrary metadata dirs.
- A `fast_append` transaction test asserting the manifest list and manifests are written under a configured `write.metadata.path`.
- Updated `catalog::tests::test_table_commit` to reflect the new metadata file following the updated table location.