### PR TITLE
fix(glue): Exclude historical schemas from Glue columns

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -52,8 +52,8 @@ impl GlueSchemaBuilder {
 
         visit_schema(current_schema, &mut builder)?;
 
+        // Keeping the returned builder state unchanged for compatibility with callers that may inspect it before calling `build`.
         builder.is_current = false;
-
 
         Ok(builder)
     }
@@ -324,6 +324,78 @@ mod tests {
             create_column("c11", "string", "11", false)?,
             create_column("c12", "binary", "12", false)?,
             create_column("c13", "binary", "13", false)?,
+        ];
+
+        assert_eq!(result, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_schema_evolution_only_converts_current_schema_fields() -> Result<()> {
+        let initial_schema = serde_json::from_str::<Schema>(
+            r#"{
+                "type": "struct",
+                "schema-id": 1,
+                "fields": [
+                    {
+                        "id": 1,
+                        "name": "id",
+                        "required": true,
+                        "type": "long"
+                    },
+                    {
+                        "id": 2,
+                        "name": "name",
+                        "required": false,
+                        "type": "string"
+                    }
+                ]
+            }"#,
+        )?;
+        let metadata = create_metadata(initial_schema)?;
+
+        let evolved_schema = serde_json::from_str::<Schema>(
+            r#"{
+                "type": "struct",
+                "schema-id": 2,
+                "fields": [
+                    {
+                        "id": 1,
+                        "name": "id",
+                        "required": true,
+                        "type": "long"
+                    },
+                    {
+                        "id": 2,
+                        "name": "name",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "id": 3,
+                        "name": "age",
+                        "required": false,
+                        "type": "int"
+                    }
+                ]
+            }"#,
+        )?;
+
+        let metadata = TableMetadataBuilder::new_from_metadata(metadata, None)
+            .add_schema(evolved_schema)?
+            .set_current_schema(TableMetadataBuilder::LAST_ADDED)?
+            .build()?
+            .metadata;
+
+        assert_eq!(metadata.schemas_iter().len(), 2);
+
+        let result = GlueSchemaBuilder::from_iceberg(&metadata)?.build();
+
+        let expected = vec![
+            create_column("id", "bigint", "1", false)?,
+            create_column("name", "string", "2", true)?,
+            create_column("age", "int", "3", true)?,
         ];
 
         assert_eq!(result, expected);

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -52,15 +52,6 @@ impl GlueSchemaBuilder {
 
         visit_schema(current_schema, &mut builder)?;
 
-        builder.is_current = false;
-
-        for schema in metadata.schemas_iter() {
-            if schema.schema_id() == current_schema.schema_id() {
-                continue;
-            }
-
-            visit_schema(schema, &mut builder)?;
-        }
 
         Ok(builder)
     }

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -52,6 +52,8 @@ impl GlueSchemaBuilder {
 
         visit_schema(current_schema, &mut builder)?;
 
+        builder.is_current = false;
+
 
         Ok(builder)
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2749

## What changes are included in this PR?

This PR updates Glue schema conversion so AWS Glue `StorageDescriptor.columns` is populated only from the current Iceberg schema.

Previously, `GlueSchemaBuilder::from_iceberg` converted the current schema and then also converted historical schemas from table metadata. Those historical fields were written to Glue with `iceberg.field.current=false`, but Glue does not use that parameter to filter visible columns, which could cause duplicate columns to appear in the Glue Console after schema evolution.

Historical schemas are still preserved in Iceberg table metadata. This change only prevents them from being projected into Glue's visible column list.

## Are these changes tested?

Yes.

Added a regression test covering schema evolution with historical schemas, and verified the Glue schema output contains only current schema fields.

Ran locally:

```shell
cargo test -p iceberg-catalog-glue