### PR TITLE
ci: fix the cargo-public-api double install

### DIFF
--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -53,10 +53,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install cargo-public-api
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
-        with:
-          tool: cargo-public-api
-
       - name: Check public API
         run: make check-public-api

--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,16 @@ MSRV_VERSION    := $(shell awk -F'"' '/^rust-version/ {print $$2}' Cargo.toml)
 check-msrv:
 	cargo +$(MSRV_VERSION) check --workspace
 
-PUBLIC_API_CRATES := $(shell cargo metadata --no-deps --format-version 1 | \
-	jq -r '.packages[] | select(.publish == null) | "\(.name):\(.manifest_path)"')
+# Evaluated inside the recipes that need it rather than with $(shell) at parse
+# time, so plain `make <target>` invocations don't pay a cargo metadata call.
+PUBLIC_API_CRATES_CMD = cargo metadata --no-deps --format-version 1 | \
+	jq -r '.packages[] | select(.publish == null) | "\(.name):\(.manifest_path)"'
 
 install-cargo-public-api:
 	cargo install --locked cargo-public-api@0.51.0
 
 generate-public-api: install-cargo-public-api
-	@for entry in $(PUBLIC_API_CRATES); do \
+	@for entry in $$($(PUBLIC_API_CRATES_CMD)); do \
 		crate=$${entry%%:*}; \
 		manifest=$${entry##*:}; \
 		crate_dir=$$(dirname "$$manifest"); \
@@ -72,7 +74,7 @@ generate-public-api: install-cargo-public-api
 
 check-public-api: install-cargo-public-api
 	@fail=0; \
-	for entry in $(PUBLIC_API_CRATES); do \
+	for entry in $$($(PUBLIC_API_CRATES_CMD)); do \
 		crate=$${entry%%:*}; \
 		manifest=$${entry##*:}; \
 		crate_dir=$$(dirname "$$manifest"); \


### PR DESCRIPTION
## Which issue does this PR close?

- None. CI maintenance for the Public API job.

## What changes are included in this PR?

The job installs cargo-public-api twice per run. `taiki-e/install-action` has no prebuilt binary for it, so that step falls back to cargo-binstall and compiles the latest release from source (currently v0.52.0, ~76s). `make check-public-api` then compiles the pinned v0.51.0 from source again (~72s) because the installed version doesn't match the pin. And since the binary on disk never matches the pin at cache-save time, rust-cache never shortcuts either install.

This deletes the install-action step. The Makefile's `cargo install --locked cargo-public-api@0.51.0` becomes the only install; on warm runs rust-cache restores the pinned binary and the install is a no-op. 0.51.0 is the version the checked-in `public-api.txt` files were generated with, so the check itself is unchanged.

The Makefile also stops computing `PUBLIC_API_CRATES` with `$(shell cargo metadata ...)` at parse time, which made every `make` invocation pay a cargo metadata call. The list is now evaluated inside the two recipes that use it, with identical command and output.

Warm Public API job time on a fork: 4:03 to 1:36.

## Are these changes tested?

- Verified on a fork: warm runs skip the install and run the same checks.
- `make check-public-api` and `make generate-public-api` expand to the same commands as before.