### PR TITLE
fix(arrow): error on required field absent from data file with no default

### DIFF
--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -893,52 +893,10 @@ mod test {
 
         let err = transformer.process_record_batch(file_batch).unwrap_err();
         assert!(
-            err.to_string().contains("Missing required field: missing_str"),
+            err.to_string()
+                .contains("Missing required field: missing_str"),
             "unexpected error: {err}"
         );
-    }
-
-    #[test]
-    fn schema_evolution_optional_field_absent_without_default_is_null() {
-        // The companion to the required-field case: an optional field absent from the data file
-        // with no initial-default falls back to null (spec Column Projection rule #4).
-        let snapshot_schema = Arc::new(
-            Schema::builder()
-                .with_schema_id(1)
-                .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "maybe_str", Type::Primitive(PrimitiveType::String))
-                        .into(),
-                ])
-                .build()
-                .unwrap(),
-        );
-        let projected_iceberg_field_ids = [1, 2];
-
-        let mut transformer =
-            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
-                .build();
-
-        let file_schema = Arc::new(ArrowSchema::new(vec![simple_field(
-            "id",
-            DataType::Int32,
-            false,
-            "1",
-        )]));
-        let file_batch =
-            RecordBatch::try_new(file_schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
-                .unwrap();
-
-        let result = transformer.process_record_batch(file_batch).unwrap();
-        assert_eq!(result.num_columns(), 2);
-        let maybe_str = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        assert!(maybe_str.is_null(0));
-        assert!(maybe_str.is_null(1));
-        assert!(maybe_str.is_null(2));
     }
 
     #[test]

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -549,6 +549,20 @@ impl RecordBatchTransformer {
                     // Rule #2 (name mapping) was already applied in reader.rs if needed.
                     // If field_id is still not found, the column doesn't exist in the Parquet file.
                     // Fall through to rule #3 (initial_default) or rule #4 (null).
+                    //
+                    // Per the spec's "Default values", null is only a valid default for an
+                    // optional field. A required field that is absent with no initial-default
+                    // therefore has no valid value and must error, rather than producing a null
+                    // column that violates the field's required constraint. This matches
+                    // Iceberg-Java's Parquet readers (BaseParquetReaders / SparkParquetReaders),
+                    // which raise "Missing required field: <name>".
+                    if iceberg_field.initial_default.is_none() && iceberg_field.required {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!("Missing required field: {}", iceberg_field.name),
+                        ));
+                    }
+
                     let default_value = iceberg_field.initial_default.as_ref().and_then(|lit| {
                         if let Literal::Primitive(prim) = lit {
                             Some(prim.clone())
@@ -842,6 +856,89 @@ mod test {
         assert!(date_column.is_null(0));
         assert!(date_column.is_null(1));
         assert!(date_column.is_null(2));
+    }
+
+    #[test]
+    fn schema_evolution_required_field_absent_without_default_errors() {
+        // Per the spec's "Default values", null is only a valid default for an optional field, so
+        // a required field that is absent from the data file with no initial-default has no valid
+        // value and must error. Matches Iceberg-Java's Parquet readers, which raise
+        // "Missing required field: <name>".
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "missing_str", Type::Primitive(PrimitiveType::String))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![simple_field(
+            "id",
+            DataType::Int32,
+            false,
+            "1",
+        )]));
+        let file_batch =
+            RecordBatch::try_new(file_schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+                .unwrap();
+
+        let err = transformer.process_record_batch(file_batch).unwrap_err();
+        assert!(
+            err.to_string().contains("Missing required field: missing_str"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn schema_evolution_optional_field_absent_without_default_is_null() {
+        // The companion to the required-field case: an optional field absent from the data file
+        // with no initial-default falls back to null (spec Column Projection rule #4).
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "maybe_str", Type::Primitive(PrimitiveType::String))
+                        .into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let projected_iceberg_field_ids = [1, 2];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_iceberg_field_ids)
+                .build();
+
+        let file_schema = Arc::new(ArrowSchema::new(vec![simple_field(
+            "id",
+            DataType::Int32,
+            false,
+            "1",
+        )]));
+        let file_batch =
+            RecordBatch::try_new(file_schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+                .unwrap();
+
+        let result = transformer.process_record_batch(file_batch).unwrap();
+        assert_eq!(result.num_columns(), 2);
+        let maybe_str = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(maybe_str.is_null(0));
+        assert!(maybe_str.is_null(1));
+        assert!(maybe_str.is_null(2));
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2795.

## What changes are included in this PR?

When a projected field is not present in a data file, `RecordBatchTransformer` resolves it using the spec's Column Projection fallback rules. For a field with no `initial-default` it produced a null column (rule #4) unconditionally. That is correct only for optional fields.

Per the spec's Default values section, null is a valid default only for an optional field:

> If either default is not set for an optional field, then the default value is null for compatibility with older spec versions.

So a required field that is absent from a data file with no `initial-default` has no valid value, and producing a null column for it violates the field's required (non-nullable) constraint. Previously this surfaced later as a confusing Arrow error (`Column '<name>' is declared as non-nullable but contains null values`) instead of a clear one.

This PR adds the required-field case to the "not present" fallback in `record_batch_transformer.rs`: if a field is absent from the data file, has no `initial-default`, and is required, return `Missing required field: <name>`. The resolution order now mirrors Iceberg-Java's Parquet readers (`BaseParquetReaders` / `SparkParquetReaders.defaultReader`): file value, then `initial-default`, then null if optional, otherwise error.

## Are these changes tested?

Yes, a unit test in `record_batch_transformer.rs`. Together with the existing `test_all_four_spec_rules` and `schema_evolution_adds_date_column_with_nulls`, all combinations of a field absent from the data file are covered:

- absent + has `initial-default` returns the default value (rule #3) - existing `test_all_four_spec_rules`.
- absent + optional + no default returns null (rule #4) - existing `test_all_four_spec_rules` and `schema_evolution_adds_date_column_with_nulls`.
- absent + required + no default now errors with `Missing required field: <name>` - new `schema_evolution_required_field_absent_without_default_errors`.
