### PR TITLE
fix(spec): use canonical fixed[N] type string in PrimitiveType Display

### DIFF
--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -380,7 +380,7 @@ impl fmt::Display for PrimitiveType {
             PrimitiveType::TimestamptzNs => write!(f, "timestamptz_ns"),
             PrimitiveType::String => write!(f, "string"),
             PrimitiveType::Uuid => write!(f, "uuid"),
-            PrimitiveType::Fixed(size) => write!(f, "fixed({size})"),
+            PrimitiveType::Fixed(size) => write!(f, "fixed[{size}]"),
             PrimitiveType::Binary => write!(f, "binary"),
         }
     }
@@ -1241,6 +1241,65 @@ mod tests {
 
         assert_eq!(5, Type::decimal_required_bytes(10).unwrap());
         assert_eq!(16, Type::decimal_required_bytes(38).unwrap());
+    }
+
+    #[test]
+    fn test_primitive_type_display() {
+        // `Display`, `Serialize`, and `Deserialize` must all agree on the
+        // canonical Iceberg type string (matching iceberg-go / iceberg-java).
+        // `fixed` uses square brackets — `fixed[N]`, not `fixed(N)` — and both
+        // `Display` and the custom `Serialize` impl embed that format string
+        // independently, so this test pins all three directions to catch drift.
+        let cases = [
+            (PrimitiveType::Boolean, "boolean"),
+            (PrimitiveType::Int, "int"),
+            (PrimitiveType::Long, "long"),
+            (PrimitiveType::Float, "float"),
+            (PrimitiveType::Double, "double"),
+            (
+                PrimitiveType::Decimal {
+                    precision: 9,
+                    scale: 2,
+                },
+                "decimal(9, 2)",
+            ),
+            (
+                PrimitiveType::Decimal {
+                    precision: 38,
+                    scale: 0,
+                },
+                "decimal(38, 0)",
+            ),
+            (PrimitiveType::Date, "date"),
+            (PrimitiveType::Time, "time"),
+            (PrimitiveType::Timestamp, "timestamp"),
+            (PrimitiveType::Timestamptz, "timestamptz"),
+            (PrimitiveType::TimestampNs, "timestamp_ns"),
+            (PrimitiveType::TimestamptzNs, "timestamptz_ns"),
+            (PrimitiveType::String, "string"),
+            (PrimitiveType::Uuid, "uuid"),
+            (PrimitiveType::Fixed(4), "fixed[4]"),
+            (PrimitiveType::Fixed(0), "fixed[0]"),
+            (PrimitiveType::Binary, "binary"),
+        ];
+        for (ty, expected) in cases {
+            let quoted = serde_json::to_string(expected).unwrap();
+
+            // `Display` emits the canonical string.
+            assert_eq!(ty.to_string(), expected, "Display mismatch for {ty:?}");
+            // `Serialize` emits the same canonical string.
+            assert_eq!(
+                serde_json::to_string(&ty).unwrap(),
+                quoted,
+                "serialize mismatch for {ty:?}"
+            );
+            // `Deserialize` accepts it and yields the original type.
+            assert_eq!(
+                serde_json::from_str::<PrimitiveType>(&quoted).unwrap(),
+                ty,
+                "deserialize mismatch for {expected}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- N/A — trivial spec-conformance fix. Happy to file a tracking issue if preferred.

## What changes are included in this PR?

`PrimitiveType`'s `Display` impl emitted `fixed(N)` (parentheses), diverging from the
canonical Iceberg type string `fixed[N]` (square brackets) used everywhere else:

- the serde path — `serialize_fixed` already emits `fixed[{value}]` and
  `deserialize_fixed` parses `fixed[`;
- the reference implementations — iceberg-java (`Types.FixedType.toString()`) and
  iceberg-go (`FixedType.String()`) both use `fixed[N]`, as does PyIceberg.

`Fixed` was the only `Display` arm inconsistent with its own serialized form
(`Decimal`, for comparison, matches: `decimal(p, s)` in both). The likely origin was
a copy of the `decimal(...)` paren style.

This PR:
- changes the `Display` arm to `fixed[{size}]`;
- adds `test_primitive_type_display`, a table-driven test over every `PrimitiveType`
  variant that pins **all three** directions — `Display`, `Serialize`, and
  `Deserialize` — to the same canonical string, so this class of drift is caught in
  future.

No behavioral impact on any wire/interop path: the serde (de)serialization was already
correct, and `Display` has no `FromStr` counterpart — its output is consumed only in
diagnostic/error strings. This is purely a bug fix, not a format change to persisted data.

## Are these changes tested?

Yes. New unit test `test_primitive_type_display` in
`crates/iceberg/src/spec/datatypes.rs` asserts, for every primitive variant (including
`Fixed(4)`, the `Fixed(0)` edge case, and `Decimal` boundary values):

1. `Display` emits the canonical string (`fixed[4]`, not `fixed(4)`);
2. `Serialize` produces the same string;
3. `Deserialize` round-trips it back to the original type.

The pre-existing `fixed(N)` bug was invisible precisely because the serde path was
already correct — no round-trip test exercised `Display` directly. This test closes
that gap. Verified locally: `cargo test -p iceberg spec::datatypes` (12 pass),
`cargo fmt --check`, and `cargo clippy` all clean.