### PR TITLE
Infra: Group github/codeql-action bumps into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,13 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 7
+    groups:
+      # The codeql-action init/autobuild/analyze steps must all run the
+      # same version - split PRs cause a version mismatch that fails the
+      # Analyze jobs. Group them so a single PR bumps all of them together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # Maintain dependencies for iceberg
   - package-ecosystem: "cargo"


### PR DESCRIPTION
Thus, dependabot can update these two jobs in a single PR:

https://github.com/apache/iceberg-rust/blob/6077a42ea061f73a561c26880993f84fafb1ba0f/.github/workflows/codeql.yml#L48-L54

- https://github.com/apache/infrastructure-actions/pull/1028
