### PR TITLE
ci: drop unnecessary protoc installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Cargo clippy
         run: make check-clippy
 
@@ -126,11 +121,6 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build
         run: make build
 
@@ -151,11 +141,6 @@ jobs:
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check each crate standalone
         run: |
@@ -216,11 +201,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -264,10 +244,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get MSRV
         id: get-msrv
         uses: ./.github/actions/get-msrv

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -48,10 +48,5 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check public API
         run: make check-public-api

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,11 +48,6 @@ jobs:
         with:
           mdbook-version: "0.4.36"
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build
         working-directory: website
         run: mdbook build


### PR DESCRIPTION
## Which issue does this PR close?

- None. CI maintenance.

## What changes are included in this PR?

Deletes every `Install protoc` step: five in ci.yml, one in public-api.yml, one in website.yml.

The installs were added with the datafusion 48 bump (#1501). That bump pulled in the `substrait` crate, whose build script runs prost-build, and prost-build shells out to protoc. The DataFusion 54 bump (#2648) dropped `substrait` and `prost-build` from the tree, and prost-build was the only thing that ever ran protoc. The remaining `prost`/`prost-derive` dependencies come from datafusion-proto, which ships pregenerated code and has no build script. So nothing in `make build`, the test suite, or the `cargo doc` run in website.yml needs protoc anymore.

A side benefit of this simplification is that we remove a dependency on arduino/setup-protoc, which hasn't seen a commit since September 2024 and was printing a Node runtime deprecation warning on every run.

## Are these changes tested?

- Verified on a fork based past #2648: all ci.yml and public-api.yml jobs run green without protoc, including the full docker-backed test suite.
- `cargo metadata` confirms datafusion-proto and datafusion-proto-common have no build script. `prost-build` is absent from Cargo.lock and nothing in the workspace source references protoc.