### PR TITLE
fix: table metadata updates location on with_new_metadata

### DIFF
--- a/crates/iceberg/src/catalog/metadata_location.rs
+++ b/crates/iceberg/src/catalog/metadata_location.rs
@@ -83,7 +83,7 @@ impl MetadataLocation {
     /// Updates the metadata location with compression settings from the new metadata.
     pub fn with_new_metadata(&self, new_metadata: &TableMetadata) -> Self {
         Self {
-            table_location: self.table_location.clone(),
+            table_location: new_metadata.location.clone(),
             version: self.version,
             id: self.id,
             compression_codec: Self::compression_from_properties(new_metadata.properties()),

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -2470,7 +2470,7 @@ mod tests {
             updated_table
                 .metadata_location()
                 .unwrap()
-                .starts_with("s3://bucket/test/location/metadata/00001-")
+                .starts_with("s3://bucket/test/new_location/data/metadata/00001-")
         );
 
         assert_eq!(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Discovered as part of https://github.com/apache/iceberg-rust/issues/2775.

## What changes are included in this PR?

- Updating table metadata with a new location previously preserved the metadata location. This PR will now update the metadata paths to behave the same way data paths do when updating a location.

## Are these changes tested?

- Behavior is exercised by an existing catalog test (`test_table_commit`), which had the previous (bad) behavior encoded.