### PR TITLE
chore: Update changelog for 0.10.0 RC4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * Fix zizmor pin by @blackmwk in https://github.com/apache/iceberg-rust/pull/2762
 * feat(encryption) [8/N] Read encrypted manifest file by @xanderbailey in https://github.com/apache/iceberg-rust/pull/2586
 * Reject negative positional delete positions by @fallintoplace in https://github.com/apache/iceberg-rust/pull/2631
+* chore: Update changelog for 0.10.0 by @dannycjones in https://github.com/apache/iceberg-rust/pull/2782
+* Include license and notice files in iceberg-storage-opendal crate by @ankane in https://github.com/apache/iceberg-rust/pull/2823
+* fix(license): Add missing LICENSE and NOTICE symlinks for iceberg-cache-moka and iceberg-catalog-loader by @dannycjones in https://github.com/apache/iceberg-rust/pull/2828
 
 ## [v0.9.0] - 2026-03-10
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow up for 0.10.0 RC4.

## What changes are included in this PR?

Change log entries for missing changes in 0.10.0 RC4. The changelog is worded for the original commits to `main`, and not as the squashed cherry pick in #2830.

## Are these changes tested?

N/A