### PR TITLE
refactor(encryption) standard encryption metadata should store `SecureKey`

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -313,9 +313,17 @@ pub fn iceberg::encryption::SecureKey::as_bytes(&self) -> &[u8]
 pub fn iceberg::encryption::SecureKey::generate(key_size: iceberg::encryption::AesKeySize) -> Self
 pub fn iceberg::encryption::SecureKey::key_size(&self) -> iceberg::encryption::AesKeySize
 pub fn iceberg::encryption::SecureKey::new(key: &[u8]) -> iceberg::Result<Self>
+impl core::clone::Clone for iceberg::encryption::SecureKey
+pub fn iceberg::encryption::SecureKey::clone(&self) -> iceberg::encryption::SecureKey
+impl core::cmp::Eq for iceberg::encryption::SecureKey
+impl core::cmp::PartialEq for iceberg::encryption::SecureKey
+pub fn iceberg::encryption::SecureKey::eq(&self, other: &iceberg::encryption::SecureKey) -> bool
 impl core::convert::TryFrom<iceberg::encryption::SensitiveBytes> for iceberg::encryption::SecureKey
 pub type iceberg::encryption::SecureKey::Error = iceberg::Error
 pub fn iceberg::encryption::SecureKey::try_from(key: iceberg::encryption::SensitiveBytes) -> iceberg::Result<Self>
+impl core::fmt::Debug for iceberg::encryption::SecureKey
+pub fn iceberg::encryption::SecureKey::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for iceberg::encryption::SecureKey
 pub struct iceberg::encryption::SensitiveBytes(_)
 impl iceberg::encryption::SensitiveBytes
 pub fn iceberg::encryption::SensitiveBytes::as_bytes(&self) -> &[u8]
@@ -340,9 +348,10 @@ impl iceberg::encryption::StandardKeyMetadata
 pub fn iceberg::encryption::StandardKeyMetadata::aad_prefix(&self) -> core::option::Option<&[u8]>
 pub fn iceberg::encryption::StandardKeyMetadata::decode(bytes: &[u8]) -> iceberg::Result<Self>
 pub fn iceberg::encryption::StandardKeyMetadata::encode(&self) -> iceberg::Result<alloc::boxed::Box<[u8]>>
-pub fn iceberg::encryption::StandardKeyMetadata::encryption_key(&self) -> &iceberg::encryption::SensitiveBytes
+pub fn iceberg::encryption::StandardKeyMetadata::encryption_key(&self) -> &iceberg::encryption::SecureKey
 pub fn iceberg::encryption::StandardKeyMetadata::file_length(&self) -> core::option::Option<u64>
-pub fn iceberg::encryption::StandardKeyMetadata::new(encryption_key: &[u8]) -> Self
+pub fn iceberg::encryption::StandardKeyMetadata::from_secure_key(encryption_key: iceberg::encryption::SecureKey) -> Self
+pub fn iceberg::encryption::StandardKeyMetadata::new(encryption_key: &[u8]) -> iceberg::Result<Self>
 pub fn iceberg::encryption::StandardKeyMetadata::with_aad_prefix(self, aad_prefix: &[u8]) -> Self
 pub fn iceberg::encryption::StandardKeyMetadata::with_file_length(self, length: u64) -> Self
 impl core::clone::Clone for iceberg::encryption::StandardKeyMetadata

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -318,6 +318,8 @@ pub fn iceberg::encryption::SecureKey::clone(&self) -> iceberg::encryption::Secu
 impl core::cmp::Eq for iceberg::encryption::SecureKey
 impl core::cmp::PartialEq for iceberg::encryption::SecureKey
 pub fn iceberg::encryption::SecureKey::eq(&self, other: &iceberg::encryption::SecureKey) -> bool
+impl core::convert::From<iceberg::encryption::SecureKey> for iceberg::encryption::StandardKeyMetadata
+pub fn iceberg::encryption::StandardKeyMetadata::from(encryption_key: iceberg::encryption::SecureKey) -> Self
 impl core::convert::TryFrom<iceberg::encryption::SensitiveBytes> for iceberg::encryption::SecureKey
 pub type iceberg::encryption::SecureKey::Error = iceberg::Error
 pub fn iceberg::encryption::SecureKey::try_from(key: iceberg::encryption::SensitiveBytes) -> iceberg::Result<Self>
@@ -350,8 +352,7 @@ pub fn iceberg::encryption::StandardKeyMetadata::decode(bytes: &[u8]) -> iceberg
 pub fn iceberg::encryption::StandardKeyMetadata::encode(&self) -> iceberg::Result<alloc::boxed::Box<[u8]>>
 pub fn iceberg::encryption::StandardKeyMetadata::encryption_key(&self) -> &iceberg::encryption::SecureKey
 pub fn iceberg::encryption::StandardKeyMetadata::file_length(&self) -> core::option::Option<u64>
-pub fn iceberg::encryption::StandardKeyMetadata::from_secure_key(encryption_key: iceberg::encryption::SecureKey) -> Self
-pub fn iceberg::encryption::StandardKeyMetadata::new(encryption_key: &[u8]) -> iceberg::Result<Self>
+pub fn iceberg::encryption::StandardKeyMetadata::try_new(encryption_key: &[u8]) -> iceberg::Result<Self>
 pub fn iceberg::encryption::StandardKeyMetadata::with_aad_prefix(self, aad_prefix: &[u8]) -> Self
 pub fn iceberg::encryption::StandardKeyMetadata::with_file_length(self, length: u64) -> Self
 impl core::clone::Clone for iceberg::encryption::StandardKeyMetadata
@@ -359,6 +360,8 @@ pub fn iceberg::encryption::StandardKeyMetadata::clone(&self) -> iceberg::encryp
 impl core::cmp::Eq for iceberg::encryption::StandardKeyMetadata
 impl core::cmp::PartialEq for iceberg::encryption::StandardKeyMetadata
 pub fn iceberg::encryption::StandardKeyMetadata::eq(&self, other: &iceberg::encryption::StandardKeyMetadata) -> bool
+impl core::convert::From<iceberg::encryption::SecureKey> for iceberg::encryption::StandardKeyMetadata
+pub fn iceberg::encryption::StandardKeyMetadata::from(encryption_key: iceberg::encryption::SecureKey) -> Self
 impl core::fmt::Debug for iceberg::encryption::StandardKeyMetadata
 pub fn iceberg::encryption::StandardKeyMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::encryption::StandardKeyMetadata

--- a/crates/iceberg/src/arrow/delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/delete_file_loader.rs
@@ -203,7 +203,7 @@ mod tests {
         let del_path = format!("{table_location}/encrypted-pos-del.parquet");
         write_encrypted_parquet(&del_path, &batch, encryption_key, Some(aad_prefix));
 
-        let key_metadata = StandardKeyMetadata::new(encryption_key)
+        let key_metadata = StandardKeyMetadata::try_new(encryption_key)
             .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()
@@ -283,7 +283,7 @@ mod tests {
         let del_path = format!("{table_location}/encrypted-eq-del.parquet");
         write_encrypted_parquet(&del_path, &batch, encryption_key, Some(aad_prefix));
 
-        let key_metadata = StandardKeyMetadata::new(encryption_key)
+        let key_metadata = StandardKeyMetadata::try_new(encryption_key)
             .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()

--- a/crates/iceberg/src/arrow/delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/delete_file_loader.rs
@@ -204,6 +204,7 @@ mod tests {
         write_encrypted_parquet(&del_path, &batch, encryption_key, Some(aad_prefix));
 
         let key_metadata = StandardKeyMetadata::new(encryption_key)
+            .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()
             .unwrap();
@@ -283,6 +284,7 @@ mod tests {
         write_encrypted_parquet(&del_path, &batch, encryption_key, Some(aad_prefix));
 
         let key_metadata = StandardKeyMetadata::new(encryption_key)
+            .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()
             .unwrap();

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -732,7 +732,7 @@ mod tests {
         let file_path = format!("{table_location}/encrypted.parquet");
         write_encrypted_parquet(&file_path, &batch, encryption_key, Some(aad_prefix));
 
-        let key_metadata = crate::encryption::StandardKeyMetadata::new(encryption_key)
+        let key_metadata = crate::encryption::StandardKeyMetadata::try_new(encryption_key)
             .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()
@@ -863,7 +863,7 @@ mod tests {
         let file_path = format!("{table_location}/encrypted_wrong_key.parquet");
         write_encrypted_parquet(&file_path, &batch, encryption_key, None);
 
-        let wrong_key_metadata = crate::encryption::StandardKeyMetadata::new(wrong_key)
+        let wrong_key_metadata = crate::encryption::StandardKeyMetadata::try_new(wrong_key)
             .unwrap()
             .encode()
             .unwrap();

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -733,6 +733,7 @@ mod tests {
         write_encrypted_parquet(&file_path, &batch, encryption_key, Some(aad_prefix));
 
         let key_metadata = crate::encryption::StandardKeyMetadata::new(encryption_key)
+            .unwrap()
             .with_aad_prefix(aad_prefix)
             .encode()
             .unwrap();
@@ -863,6 +864,7 @@ mod tests {
         write_encrypted_parquet(&file_path, &batch, encryption_key, None);
 
         let wrong_key_metadata = crate::encryption::StandardKeyMetadata::new(wrong_key)
+            .unwrap()
             .encode()
             .unwrap();
 

--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -138,6 +138,10 @@ impl FromStr for AesKeySize {
 }
 
 /// A secure encryption key that zeroes its memory on drop.
+///
+/// The `Debug` impl is safe to expose: the inner [`SensitiveBytes`] redacts
+/// the key material, printing only its length.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SecureKey {
     key: SensitiveBytes,
     key_size: AesKeySize,

--- a/crates/iceberg/src/encryption/io.rs
+++ b/crates/iceberg/src/encryption/io.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 
-use super::crypto::{AesGcmCipher, SecureKey};
+use super::crypto::AesGcmCipher;
 use super::key_metadata::StandardKeyMetadata;
 use super::stream::{AesGcmFileRead, AesGcmFileWrite};
 use crate::Result;
@@ -165,7 +165,7 @@ impl std::fmt::Debug for EncryptedOutputFile {
 }
 
 fn build_cipher(metadata: &StandardKeyMetadata) -> Result<Arc<AesGcmCipher>> {
-    let key = SecureKey::new(metadata.encryption_key().as_bytes())?;
+    let key = metadata.encryption_key().clone();
     Ok(Arc::new(AesGcmCipher::new(key)))
 }
 
@@ -175,7 +175,9 @@ mod tests {
     use crate::io::FileIO;
 
     fn key_metadata() -> StandardKeyMetadata {
-        StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"test-aad-prefix!")
+        StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!")
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/encryption/io.rs
+++ b/crates/iceberg/src/encryption/io.rs
@@ -175,7 +175,7 @@ mod tests {
     use crate::io::FileIO;
 
     fn key_metadata() -> StandardKeyMetadata {
-        StandardKeyMetadata::new(b"0123456789abcdef")
+        StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!")
     }

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -20,7 +20,7 @@
 
 use std::fmt;
 
-use super::{SecureKey, SensitiveBytes};
+use super::SecureKey;
 use crate::{Error, ErrorKind, Result};
 
 /// Standard key metadata for Iceberg table encryption.
@@ -32,7 +32,7 @@ use crate::{Error, ErrorKind, Result};
 /// Wire format: `[version byte (0x01)] [Avro binary datum]`
 #[derive(Clone, PartialEq, Eq)]
 pub struct StandardKeyMetadata {
-    encryption_key: SensitiveBytes,
+    encryption_key: SecureKey,
     aad_prefix: Option<Box<[u8]>>,
     file_length: Option<u64>,
 }
@@ -54,10 +54,15 @@ impl fmt::Debug for StandardKeyMetadata {
 }
 
 impl StandardKeyMetadata {
-    /// Creates a new `StandardKeyMetadata`.
-    pub fn new(encryption_key: &[u8]) -> Self {
+    /// Creates a new `StandardKeyMetadata` from raw key bytes.
+    pub fn new(encryption_key: &[u8]) -> Result<Self> {
+        Ok(Self::from_secure_key(SecureKey::new(encryption_key)?))
+    }
+
+    /// Creates a new `StandardKeyMetadata` from an already-validated key.
+    pub fn from_secure_key(encryption_key: SecureKey) -> Self {
         Self {
-            encryption_key: SensitiveBytes::new(encryption_key),
+            encryption_key,
             aad_prefix: None,
             file_length: None,
         }
@@ -76,7 +81,7 @@ impl StandardKeyMetadata {
     }
 
     /// Returns the plaintext Data Encryption Key.
-    pub fn encryption_key(&self) -> &SensitiveBytes {
+    pub fn encryption_key(&self) -> &SecureKey {
         &self.encryption_key
     }
 
@@ -97,17 +102,7 @@ impl StandardKeyMetadata {
 
     /// Decodes from Java-compatible format.
     pub fn decode(bytes: &[u8]) -> Result<Self> {
-        let metadata = _serde::StandardKeyMetadataV1::decode(bytes).map(Self::from)?;
-        // Validate the DEK is a usable AES key (16/24/32 bytes) up front, so a
-        // malformed key surfaces a clear error.
-        SecureKey::new(metadata.encryption_key.as_bytes()).map_err(|e| {
-            Error::new(
-                ErrorKind::DataInvalid,
-                "Invalid encryption key in key metadata",
-            )
-            .with_source(e)
-        })?;
-        Ok(metadata)
+        _serde::StandardKeyMetadataV1::decode(bytes).and_then(Self::try_from)
     }
 }
 
@@ -223,13 +218,22 @@ mod _serde {
         }
     }
 
-    impl From<StandardKeyMetadataV1> for StandardKeyMetadata {
-        fn from(v1: StandardKeyMetadataV1) -> Self {
-            Self {
-                encryption_key: SensitiveBytes::new(v1.encryption_key.into_vec()),
+    impl TryFrom<StandardKeyMetadataV1> for StandardKeyMetadata {
+        type Error = Error;
+
+        fn try_from(v1: StandardKeyMetadataV1) -> Result<Self> {
+            let encryption_key = SecureKey::new(&v1.encryption_key).map_err(|e| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    "Invalid encryption key in key metadata",
+                )
+                .with_source(e)
+            })?;
+            Ok(Self {
+                encryption_key,
                 aad_prefix: v1.aad_prefix.map(|b| b.into_vec().into_boxed_slice()),
                 file_length: v1.file_length,
-            }
+            })
         }
     }
 }
@@ -243,7 +247,7 @@ mod tests {
         let key = b"0123456789012345";
         let aad = b"1234567890123456";
 
-        let metadata = StandardKeyMetadata::new(key).with_aad_prefix(aad);
+        let metadata = StandardKeyMetadata::new(key).unwrap().with_aad_prefix(aad);
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
@@ -259,6 +263,7 @@ mod tests {
 
         let file_length = 100_000;
         let metadata = StandardKeyMetadata::new(key)
+            .unwrap()
             .with_aad_prefix(aad)
             .with_file_length(file_length);
         let serialized = metadata.encode().unwrap();
@@ -287,7 +292,7 @@ mod tests {
     #[test]
     fn test_roundtrip_without_aad() {
         let key = b"0123456789012345";
-        let metadata = StandardKeyMetadata::new(key);
+        let metadata = StandardKeyMetadata::new(key).unwrap();
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
@@ -296,17 +301,33 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_rejects_invalid_key_length() {
+    fn test_new_rejects_invalid_key_length() {
         // 24-byte (AES-192) and 32-byte (AES-256) keys are accepted.
         for len in [16usize, 24, 32] {
-            let metadata = StandardKeyMetadata::new(&vec![0u8; len]);
-            let serialized = metadata.encode().unwrap();
-            assert!(StandardKeyMetadata::decode(&serialized).is_ok());
+            assert!(StandardKeyMetadata::new(&vec![0u8; len]).is_ok());
         }
 
+        // Invalid lengths are rejected at construction, so an invalid
+        // `StandardKeyMetadata` can never exist.
         for len in [0usize, 4, 15, 20, 33] {
-            let metadata = StandardKeyMetadata::new(&vec![0u8; len]);
-            let serialized = metadata.encode().unwrap();
+            assert!(StandardKeyMetadata::new(&vec![0u8; len]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_decode_rejects_invalid_key_length() {
+        // Craft wire bytes carrying an invalid-length DEK directly via the
+        // serde struct (bypassing the validated public constructors) to prove
+        // `decode` still rejects malformed key material off the wire.
+        for len in [0usize, 4, 15, 20, 33] {
+            let serialized = _serde::StandardKeyMetadataV1 {
+                encryption_key: serde_bytes::ByteBuf::from(vec![0u8; len]),
+                aad_prefix: None,
+                file_length: None,
+            }
+            .encode()
+            .unwrap();
+
             let err = StandardKeyMetadata::decode(&serialized).unwrap_err();
             assert_eq!(err.kind(), ErrorKind::DataInvalid);
             assert!(

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -55,17 +55,8 @@ impl fmt::Debug for StandardKeyMetadata {
 
 impl StandardKeyMetadata {
     /// Creates a new `StandardKeyMetadata` from raw key bytes.
-    pub fn new(encryption_key: &[u8]) -> Result<Self> {
-        Ok(Self::from_secure_key(SecureKey::new(encryption_key)?))
-    }
-
-    /// Creates a new `StandardKeyMetadata` from an already-validated key.
-    pub fn from_secure_key(encryption_key: SecureKey) -> Self {
-        Self {
-            encryption_key,
-            aad_prefix: None,
-            file_length: None,
-        }
+    pub fn try_new(encryption_key: &[u8]) -> Result<Self> {
+        Ok(Self::from(SecureKey::new(encryption_key)?))
     }
 
     /// Adds an AAD prefix.
@@ -103,6 +94,17 @@ impl StandardKeyMetadata {
     /// Decodes from Java-compatible format.
     pub fn decode(bytes: &[u8]) -> Result<Self> {
         _serde::StandardKeyMetadataV1::decode(bytes).and_then(Self::try_from)
+    }
+}
+
+impl From<SecureKey> for StandardKeyMetadata {
+    /// Creates a `StandardKeyMetadata` from an already-validated key.
+    fn from(encryption_key: SecureKey) -> Self {
+        Self {
+            encryption_key,
+            aad_prefix: None,
+            file_length: None,
+        }
     }
 }
 
@@ -247,7 +249,9 @@ mod tests {
         let key = b"0123456789012345";
         let aad = b"1234567890123456";
 
-        let metadata = StandardKeyMetadata::new(key).unwrap().with_aad_prefix(aad);
+        let metadata = StandardKeyMetadata::try_new(key)
+            .unwrap()
+            .with_aad_prefix(aad);
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
@@ -262,7 +266,7 @@ mod tests {
         let aad = b"1234567890123456";
 
         let file_length = 100_000;
-        let metadata = StandardKeyMetadata::new(key)
+        let metadata = StandardKeyMetadata::try_new(key)
             .unwrap()
             .with_aad_prefix(aad)
             .with_file_length(file_length);
@@ -292,7 +296,7 @@ mod tests {
     #[test]
     fn test_roundtrip_without_aad() {
         let key = b"0123456789012345";
-        let metadata = StandardKeyMetadata::new(key).unwrap();
+        let metadata = StandardKeyMetadata::try_new(key).unwrap();
         let serialized = metadata.encode().unwrap();
         let parsed = StandardKeyMetadata::decode(&serialized).unwrap();
 
@@ -304,13 +308,13 @@ mod tests {
     fn test_new_rejects_invalid_key_length() {
         // 24-byte (AES-192) and 32-byte (AES-256) keys are accepted.
         for len in [16usize, 24, 32] {
-            assert!(StandardKeyMetadata::new(&vec![0u8; len]).is_ok());
+            assert!(StandardKeyMetadata::try_new(&vec![0u8; len]).is_ok());
         }
 
         // Invalid lengths are rejected at construction, so an invalid
         // `StandardKeyMetadata` can never exist.
         for len in [0usize, 4, 15, 20, 33] {
-            assert!(StandardKeyMetadata::new(&vec![0u8; len]).is_err());
+            assert!(StandardKeyMetadata::try_new(&vec![0u8; len]).is_err());
         }
     }
 

--- a/crates/iceberg/src/encryption/manager.rs
+++ b/crates/iceberg/src/encryption/manager.rs
@@ -153,7 +153,7 @@ impl EncryptionManager {
     pub fn encrypt(&self, raw_output: OutputFile) -> EncryptedOutputFile {
         let dek = SecureKey::generate(self.key_size);
         let aad_prefix = Self::generate_aad_prefix();
-        let metadata = StandardKeyMetadata::new(dek.as_bytes()).with_aad_prefix(&aad_prefix);
+        let metadata = StandardKeyMetadata::from_secure_key(dek).with_aad_prefix(&aad_prefix);
         EncryptedOutputFile::new(raw_output, metadata)
     }
 
@@ -460,7 +460,9 @@ mod tests {
     }
 
     fn sample_key_metadata() -> StandardKeyMetadata {
-        StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"test-aad-prefix!")
+        StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!")
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/encryption/manager.rs
+++ b/crates/iceberg/src/encryption/manager.rs
@@ -153,7 +153,7 @@ impl EncryptionManager {
     pub fn encrypt(&self, raw_output: OutputFile) -> EncryptedOutputFile {
         let dek = SecureKey::generate(self.key_size);
         let aad_prefix = Self::generate_aad_prefix();
-        let metadata = StandardKeyMetadata::from_secure_key(dek).with_aad_prefix(&aad_prefix);
+        let metadata = StandardKeyMetadata::from(dek).with_aad_prefix(&aad_prefix);
         EncryptedOutputFile::new(raw_output, metadata)
     }
 
@@ -460,7 +460,7 @@ mod tests {
     }
 
     fn sample_key_metadata() -> StandardKeyMetadata {
-        StandardKeyMetadata::new(b"0123456789abcdef")
+        StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!")
     }

--- a/crates/iceberg/src/spec/manifest_list/manifest_file.rs
+++ b/crates/iceberg/src/spec/manifest_list/manifest_file.rs
@@ -320,8 +320,9 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_decrypts_when_key_metadata_present() {
-        let key_metadata =
-            StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"test-aad-prefix!");
+        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!");
         let encoded_key_metadata = key_metadata.encode().unwrap().to_vec();
 
         let io = FileIO::new_with_memory();
@@ -340,8 +341,9 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_fails_with_wrong_key() {
-        let key_metadata =
-            StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"test-aad-prefix!");
+        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!");
 
         let io = FileIO::new_with_memory();
         let path = "memory:///test/wrong_key_manifest.avro";
@@ -351,8 +353,9 @@ mod test {
         // the same AAD prefix). The bytes on disk were encrypted with the
         // original key, so GCM authentication must fail rather than silently
         // returning garbage.
-        let wrong_key_metadata =
-            StandardKeyMetadata::new(b"fedcba9876543210").with_aad_prefix(b"test-aad-prefix!");
+        let wrong_key_metadata = StandardKeyMetadata::new(b"fedcba9876543210")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!");
         manifest_file.key_metadata = Some(wrong_key_metadata.encode().unwrap().to_vec());
 
         let err = manifest_file
@@ -364,8 +367,9 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_fails_with_wrong_aad() {
-        let key_metadata =
-            StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"test-aad-prefix!");
+        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"test-aad-prefix!");
 
         let io = FileIO::new_with_memory();
         let path = "memory:///test/wrong_aad_manifest.avro";
@@ -374,8 +378,9 @@ mod test {
         // Point the manifest file at key metadata carrying the correct DEK but a
         // different AAD prefix. The per-block AAD is `aad_prefix || block_index`,
         // so GCM authentication must fail even though the key is right.
-        let wrong_aad_metadata =
-            StandardKeyMetadata::new(b"0123456789abcdef").with_aad_prefix(b"wrong-aad-prefix");
+        let wrong_aad_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+            .unwrap()
+            .with_aad_prefix(b"wrong-aad-prefix");
         manifest_file.key_metadata = Some(wrong_aad_metadata.encode().unwrap().to_vec());
 
         let err = manifest_file

--- a/crates/iceberg/src/spec/manifest_list/manifest_file.rs
+++ b/crates/iceberg/src/spec/manifest_list/manifest_file.rs
@@ -320,7 +320,7 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_decrypts_when_key_metadata_present() {
-        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+        let key_metadata = StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!");
         let encoded_key_metadata = key_metadata.encode().unwrap().to_vec();
@@ -341,7 +341,7 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_fails_with_wrong_key() {
-        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+        let key_metadata = StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!");
 
@@ -353,7 +353,7 @@ mod test {
         // the same AAD prefix). The bytes on disk were encrypted with the
         // original key, so GCM authentication must fail rather than silently
         // returning garbage.
-        let wrong_key_metadata = StandardKeyMetadata::new(b"fedcba9876543210")
+        let wrong_key_metadata = StandardKeyMetadata::try_new(b"fedcba9876543210")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!");
         manifest_file.key_metadata = Some(wrong_key_metadata.encode().unwrap().to_vec());
@@ -367,7 +367,7 @@ mod test {
 
     #[tokio::test]
     async fn test_load_manifest_fails_with_wrong_aad() {
-        let key_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+        let key_metadata = StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"test-aad-prefix!");
 
@@ -378,7 +378,7 @@ mod test {
         // Point the manifest file at key metadata carrying the correct DEK but a
         // different AAD prefix. The per-block AAD is `aad_prefix || block_index`,
         // so GCM authentication must fail even though the key is right.
-        let wrong_aad_metadata = StandardKeyMetadata::new(b"0123456789abcdef")
+        let wrong_aad_metadata = StandardKeyMetadata::try_new(b"0123456789abcdef")
             .unwrap()
             .with_aad_prefix(b"wrong-aad-prefix");
         manifest_file.key_metadata = Some(wrong_aad_metadata.encode().unwrap().to_vec());


### PR DESCRIPTION
## Which issue does this PR close?
Follow up from https://github.com/apache/iceberg-rust/pull/2584

`StandardKeyMetadata` must include encryption keys which have a valid size according to the spec. Changing `StandardKeyMetadata` to store `SecureKey` rather than just `SecureBytes` means a `StandardKeyMetadata` can never exist without it being validated.

## What changes are included in this PR?
```
pub struct StandardKeyMetadata {
    - encryption_key: SensitiveBytes,
    + encryption_key: SecureKey,
    aad_prefix: Option<Box<[u8]>>,
    file_length: Option<u64>,
}
```
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->