### PR TITLE
chore(lint) check unused_qualifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ repository = "https://github.com/apache/iceberg-rust"
 # Check the MSRV policy in README.md before changing this
 rust-version = "1.94"
 
+[workspace.lints.rust]
+unused_qualifications = "deny"
+
 [workspace.dependencies]
 aes = { version = "0.8", features = ["zeroize"] }
 aes-gcm = "0.10"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -44,3 +44,6 @@ tokio = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = []
+
+[lints]
+workspace = true

--- a/bindings/python/src/manifest.rs
+++ b/bindings/python/src/manifest.rs
@@ -52,7 +52,7 @@ pub struct PyFieldSummary {
 }
 
 #[pymethods]
-impl crate::manifest::PyFieldSummary {
+impl PyFieldSummary {
     #[getter]
     fn contains_null(&self) -> bool {
         self.inner.contains_null
@@ -80,7 +80,7 @@ pub struct PyManifestFile {
 }
 
 #[pymethods]
-impl crate::manifest::PyManifestFile {
+impl PyManifestFile {
     #[getter]
     fn manifest_path(&self) -> &str {
         self.inner.manifest_path.as_str()
@@ -208,7 +208,7 @@ pub struct PyManifestList {
 }
 
 #[pymethods]
-impl crate::manifest::PyManifestList {
+impl PyManifestList {
     fn entries(&self) -> Vec<PyManifestFile> {
         self.inner
             .entries()

--- a/crates/catalog/glue/Cargo.toml
+++ b/crates/catalog/glue/Cargo.toml
@@ -41,3 +41,6 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
+
+[lints]
+workspace = true

--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -79,11 +79,7 @@ impl GlueSchemaBuilder {
 impl SchemaVisitor for GlueSchemaBuilder {
     type T = String;
 
-    fn schema(
-        &mut self,
-        _schema: &iceberg::spec::Schema,
-        value: Self::T,
-    ) -> iceberg::Result<String> {
+    fn schema(&mut self, _schema: &iceberg::spec::Schema, value: Self::T) -> Result<String> {
         Ok(value)
     }
 
@@ -96,7 +92,7 @@ impl SchemaVisitor for GlueSchemaBuilder {
         &mut self,
         r#_struct: &iceberg::spec::StructType,
         results: Vec<String>,
-    ) -> iceberg::Result<String> {
+    ) -> Result<String> {
         Ok(format!("struct<{}>", results.join(", ")))
     }
 
@@ -105,11 +101,7 @@ impl SchemaVisitor for GlueSchemaBuilder {
         Ok(())
     }
 
-    fn field(
-        &mut self,
-        field: &iceberg::spec::NestedFieldRef,
-        value: String,
-    ) -> iceberg::Result<String> {
+    fn field(&mut self, field: &iceberg::spec::NestedFieldRef, value: String) -> Result<String> {
         if self.is_inside_struct() {
             return Ok(format!("{}:{}", field.name, &value));
         }
@@ -142,7 +134,7 @@ impl SchemaVisitor for GlueSchemaBuilder {
         Ok(value)
     }
 
-    fn list(&mut self, _list: &iceberg::spec::ListType, value: String) -> iceberg::Result<String> {
+    fn list(&mut self, _list: &iceberg::spec::ListType, value: String) -> Result<String> {
         Ok(format!("array<{value}>"))
     }
 
@@ -151,11 +143,11 @@ impl SchemaVisitor for GlueSchemaBuilder {
         _map: &iceberg::spec::MapType,
         key_value: String,
         value: String,
-    ) -> iceberg::Result<String> {
+    ) -> Result<String> {
         Ok(format!("map<{key_value},{value}>"))
     }
 
-    fn primitive(&mut self, p: &iceberg::spec::PrimitiveType) -> iceberg::Result<Self::T> {
+    fn primitive(&mut self, p: &PrimitiveType) -> Result<Self::T> {
         let glue_type = match p {
             PrimitiveType::Boolean => "boolean".to_string(),
             PrimitiveType::Int => "int".to_string(),

--- a/crates/catalog/hms/Cargo.toml
+++ b/crates/catalog/hms/Cargo.toml
@@ -61,3 +61,6 @@ iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["faststr", "linkedbytes", "metainfo", "volo", "motore-macros"]
+
+[lints]
+workspace = true

--- a/crates/catalog/hms/src/schema.rs
+++ b/crates/catalog/hms/src/schema.rs
@@ -49,18 +49,11 @@ impl HiveSchemaBuilder {
 impl SchemaVisitor for HiveSchemaBuilder {
     type T = String;
 
-    fn schema(
-        &mut self,
-        _schema: &iceberg::spec::Schema,
-        value: String,
-    ) -> iceberg::Result<String> {
+    fn schema(&mut self, _schema: &Schema, value: String) -> Result<String> {
         Ok(value)
     }
 
-    fn before_struct_field(
-        &mut self,
-        _field: &iceberg::spec::NestedFieldRef,
-    ) -> iceberg::Result<()> {
+    fn before_struct_field(&mut self, _field: &iceberg::spec::NestedFieldRef) -> Result<()> {
         self.depth += 1;
         Ok(())
     }
@@ -69,23 +62,16 @@ impl SchemaVisitor for HiveSchemaBuilder {
         &mut self,
         r#_struct: &iceberg::spec::StructType,
         results: Vec<String>,
-    ) -> iceberg::Result<String> {
+    ) -> Result<String> {
         Ok(format!("struct<{}>", results.join(", ")))
     }
 
-    fn after_struct_field(
-        &mut self,
-        _field: &iceberg::spec::NestedFieldRef,
-    ) -> iceberg::Result<()> {
+    fn after_struct_field(&mut self, _field: &iceberg::spec::NestedFieldRef) -> Result<()> {
         self.depth -= 1;
         Ok(())
     }
 
-    fn field(
-        &mut self,
-        field: &iceberg::spec::NestedFieldRef,
-        value: String,
-    ) -> iceberg::Result<String> {
+    fn field(&mut self, field: &iceberg::spec::NestedFieldRef, value: String) -> Result<String> {
         if self.is_inside_struct() {
             return Ok(format!("{}:{}", field.name, value));
         }
@@ -99,7 +85,7 @@ impl SchemaVisitor for HiveSchemaBuilder {
         Ok(value)
     }
 
-    fn list(&mut self, _list: &iceberg::spec::ListType, value: String) -> iceberg::Result<String> {
+    fn list(&mut self, _list: &iceberg::spec::ListType, value: String) -> Result<String> {
         Ok(format!("array<{value}>"))
     }
 
@@ -108,11 +94,11 @@ impl SchemaVisitor for HiveSchemaBuilder {
         _map: &iceberg::spec::MapType,
         key_value: String,
         value: String,
-    ) -> iceberg::Result<String> {
+    ) -> Result<String> {
         Ok(format!("map<{key_value},{value}>"))
     }
 
-    fn primitive(&mut self, p: &iceberg::spec::PrimitiveType) -> iceberg::Result<String> {
+    fn primitive(&mut self, p: &PrimitiveType) -> Result<String> {
         let hive_type = match p {
             PrimitiveType::Boolean => "boolean".to_string(),
             PrimitiveType::Int => "int".to_string(),

--- a/crates/catalog/loader/Cargo.toml
+++ b/crates/catalog/loader/Cargo.toml
@@ -46,3 +46,6 @@ reqwest = { workspace = true }
 rstest = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "migrate"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -47,3 +47,6 @@ uuid = { workspace = true, features = ["v4"] }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/catalog/rest/src/endpoint.rs
+++ b/crates/catalog/rest/src/endpoint.rs
@@ -65,7 +65,7 @@ impl Endpoint {
 impl FromStr for Endpoint {
     type Err = Error;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         // The wire form is exactly `"<method> <path>"` separated by a single
         // space; paths never contain spaces, so require exactly two non-empty
         // parts and a valid HTTP method.
@@ -100,14 +100,14 @@ impl Display for Endpoint {
 }
 
 impl Serialize for Endpoint {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where S: Serializer {
         serializer.collect_str(self)
     }
 }
 
 impl<'de> Deserialize<'de> for Endpoint {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
         struct EndpointVisitor;
 
@@ -118,7 +118,7 @@ impl<'de> Deserialize<'de> for Endpoint {
                 f.write_str(r#"an endpoint string of the form "<method> <path>""#)
             }
 
-            fn visit_str<E>(self, v: &str) -> std::result::Result<Endpoint, E>
+            fn visit_str<E>(self, v: &str) -> Result<Endpoint, E>
             where E: DeError {
                 Endpoint::from_str(v).map_err(E::custom)
             }

--- a/crates/catalog/s3tables/Cargo.toml
+++ b/crates/catalog/s3tables/Cargo.toml
@@ -47,3 +47,6 @@ itertools = { workspace = true }
 parquet = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/catalog/sql/Cargo.toml
+++ b/crates/catalog/sql/Cargo.toml
@@ -47,3 +47,6 @@ sqlx = { version = "0.8.1", features = [
 ], default-features = false }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -467,7 +467,7 @@ impl Catalog for SqlCatalog {
 
         if exists {
             return Err(Error::new(
-                iceberg::ErrorKind::NamespaceAlreadyExists,
+                ErrorKind::NamespaceAlreadyExists,
                 format!("Namespace {namespace:?} already exists"),
             ));
         }
@@ -670,7 +670,7 @@ impl Catalog for SqlCatalog {
             let tables = self.list_tables(namespace).await?;
             if !tables.is_empty() {
                 return Err(Error::new(
-                    iceberg::ErrorKind::Unexpected,
+                    ErrorKind::Unexpected,
                     format!(
                         "Namespace {:?} is not empty. {} tables exist.",
                         namespace,
@@ -1076,7 +1076,7 @@ mod tests {
         temp_dir.path().to_str().unwrap().to_string()
     }
 
-    fn to_set<T: std::cmp::Eq + Hash>(vec: Vec<T>) -> HashSet<T> {
+    fn to_set<T: Eq + Hash>(vec: Vec<T>) -> HashSet<T> {
         HashSet::from_iter(vec)
     }
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -48,3 +48,6 @@ required-features = ["storage-oss"]
 [features]
 default = []
 storage-oss = ["iceberg-storage-opendal/opendal-oss"]
+
+[lints]
+workspace = true

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -97,3 +97,6 @@ tempfile = { workspace = true }
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["tap"]
+
+[lints]
+workspace = true

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -796,7 +796,7 @@ mod tests {
 
     /// Create a simple field with metadata.
     fn simple_field(name: &str, ty: DataType, nullable: bool, value: &str) -> Field {
-        arrow_schema::Field::new(name, ty, nullable).with_metadata(HashMap::from([(
+        Field::new(name, ty, nullable).with_metadata(HashMap::from([(
             PARQUET_FIELD_ID_META_KEY.to_string(),
             value.to_string(),
         )]))
@@ -833,15 +833,18 @@ mod tests {
             ]));
 
             let fields = vec![
-                Field::new("y", arrow_schema::DataType::Int64, true).with_metadata(HashMap::from(
-                    [(PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string())],
-                )),
-                Field::new("z", arrow_schema::DataType::Int64, true).with_metadata(HashMap::from(
-                    [(PARQUET_FIELD_ID_META_KEY.to_string(), "3".to_string())],
-                )),
-                Field::new("a", arrow_schema::DataType::Utf8, true).with_metadata(HashMap::from([
-                    (PARQUET_FIELD_ID_META_KEY.to_string(), "4".to_string()),
-                ])),
+                Field::new("y", DataType::Int64, true).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "2".to_string(),
+                )])),
+                Field::new("z", DataType::Int64, true).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "3".to_string(),
+                )])),
+                Field::new("a", DataType::Utf8, true).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "4".to_string(),
+                )])),
                 simple_field("s", struct_field, false, "5"),
                 simple_field("b", DataType::Binary, true, "8"),
             ];
@@ -939,18 +942,8 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    crate::spec::NestedField::required(
-                        1,
-                        "id",
-                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::Int),
-                    )
-                    .into(),
-                    crate::spec::NestedField::required(
-                        2,
-                        "data",
-                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::String),
-                    )
-                    .into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1039,18 +1032,8 @@ mod tests {
         let data_file_schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    crate::spec::NestedField::optional(
-                        2,
-                        "y",
-                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
-                    )
-                    .into(),
-                    crate::spec::NestedField::optional(
-                        3,
-                        "z",
-                        crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
-                    )
-                    .into(),
+                    NestedField::optional(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::optional(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1151,7 +1134,7 @@ mod tests {
         let col_y = Arc::new(Int64Array::from(col_y_vals)) as ArrayRef;
 
         let schema = Arc::new(arrow_schema::Schema::new(vec![
-            Field::new("y", arrow_schema::DataType::Int64, false).with_metadata(HashMap::from([(
+            Field::new("y", DataType::Int64, false).with_metadata(HashMap::from([(
                 PARQUET_FIELD_ID_META_KEY.to_string(),
                 "2".to_string(),
             )])),

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -498,7 +498,7 @@ pub(crate) mod tests {
             .with_start(0)
             .with_length(0)
             .with_data_file_path("data.parquet".to_string())
-            .with_data_file_format(crate::spec::DataFileFormat::Parquet)
+            .with_data_file_format(DataFileFormat::Parquet)
             .with_schema(schema.clone())
             .with_project_field_ids(vec![])
             .with_deletes(vec![

--- a/crates/iceberg/src/arrow/reader/projection.rs
+++ b/crates/iceberg/src/arrow/reader/projection.rs
@@ -1360,7 +1360,7 @@ message schema {
                     NestedField::required(
                         2,
                         "person",
-                        Type::Struct(crate::spec::StructType::new(vec![
+                        Type::Struct(StructType::new(vec![
                             NestedField::required(
                                 3,
                                 "name",
@@ -1900,7 +1900,7 @@ message schema {
                     NestedField::required(
                         1,
                         "person",
-                        Type::Struct(crate::spec::StructType::new(vec![
+                        Type::Struct(StructType::new(vec![
                             NestedField::required(
                                 5,
                                 "name",
@@ -1919,7 +1919,7 @@ message schema {
                             element_field: NestedField::required(
                                 7,
                                 "element",
-                                Type::Struct(crate::spec::StructType::new(vec![
+                                Type::Struct(StructType::new(vec![
                                     NestedField::required(
                                         8,
                                         "name",

--- a/crates/iceberg/src/arrow/reader/row_filter.rs
+++ b/crates/iceberg/src/arrow/reader/row_filter.rs
@@ -856,7 +856,7 @@ mod tests {
 
     fn simple_predicate(schema: SchemaRef) -> BoundPredicate {
         Reference::new("x")
-            .greater_than(crate::spec::Datum::int(0))
+            .greater_than(Datum::int(0))
             .bind(schema.clone(), false)
             .unwrap()
     }
@@ -1100,7 +1100,7 @@ mod tests {
         ])
         .unwrap();
 
-        let file = std::fs::File::create(&file_path).unwrap();
+        let file = File::create(&file_path).unwrap();
         let mut writer = ArrowWriter::try_new(file, arrow_schema.clone(), Some(props)).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
@@ -1108,7 +1108,7 @@ mod tests {
         // Truly exercising a file without column/offset index
         {
             use parquet::file::reader::{FileReader, SerializedFileReader};
-            let f = std::fs::File::open(&file_path).unwrap();
+            let f = File::open(&file_path).unwrap();
             let rdr = SerializedFileReader::new(f).unwrap();
             assert!(
                 rdr.metadata().column_index().is_none(),
@@ -1205,7 +1205,7 @@ mod tests {
             .set_statistics_enabled(EnabledStatistics::None)
             .build();
 
-        let pos_del_file = std::fs::File::create(&pos_del_path).unwrap();
+        let pos_del_file = File::create(&pos_del_path).unwrap();
         let mut pos_del_writer = ArrowWriter::try_new(
             pos_del_file,
             pos_del_arrow_schema.clone(),

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -559,9 +559,9 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 
     fn schema(
         &mut self,
-        _schema: &crate::spec::Schema,
+        _schema: &Schema,
         value: ArrowSchemaOrFieldOrType,
-    ) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    ) -> Result<ArrowSchemaOrFieldOrType> {
         let struct_type = match value {
             ArrowSchemaOrFieldOrType::Type(DataType::Struct(fields)) => fields,
             _ => unreachable!(),
@@ -573,9 +573,9 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 
     fn field(
         &mut self,
-        field: &crate::spec::NestedFieldRef,
+        field: &NestedFieldRef,
         value: ArrowSchemaOrFieldOrType,
-    ) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    ) -> Result<ArrowSchemaOrFieldOrType> {
         let ty = match value {
             ArrowSchemaOrFieldOrType::Type(ty) => ty,
             _ => unreachable!(),
@@ -602,9 +602,9 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 
     fn r#struct(
         &mut self,
-        _: &crate::spec::StructType,
+        _: &StructType,
         results: Vec<ArrowSchemaOrFieldOrType>,
-    ) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    ) -> Result<ArrowSchemaOrFieldOrType> {
         let fields = results
             .into_iter()
             .map(|result| match result {
@@ -617,9 +617,9 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 
     fn list(
         &mut self,
-        list: &crate::spec::ListType,
+        list: &ListType,
         value: ArrowSchemaOrFieldOrType,
-    ) -> crate::Result<Self::T> {
+    ) -> Result<Self::T> {
         // `field` already carries the element's field id, doc, and — for a variant element —
         // the arrow.parquet.variant extension type. Don't overwrite its metadata here (doing so
         // would drop the extension type for `list<variant>`).
@@ -634,10 +634,10 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 
     fn map(
         &mut self,
-        map: &crate::spec::MapType,
+        map: &MapType,
         key_value: ArrowSchemaOrFieldOrType,
         value: ArrowSchemaOrFieldOrType,
-    ) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    ) -> Result<ArrowSchemaOrFieldOrType> {
         let key_field = match self.field(&map.key_field, key_value)? {
             ArrowSchemaOrFieldOrType::Field(field) => field,
             _ => unreachable!(),
@@ -659,34 +659,25 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         )))
     }
 
-    fn primitive(
-        &mut self,
-        p: &crate::spec::PrimitiveType,
-    ) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    fn primitive(&mut self, p: &PrimitiveType) -> Result<ArrowSchemaOrFieldOrType> {
         match p {
-            crate::spec::PrimitiveType::Boolean => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Boolean))
-            }
-            crate::spec::PrimitiveType::Int => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Int32)),
-            crate::spec::PrimitiveType::Long => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Int64)),
-            crate::spec::PrimitiveType::Float => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Float32))
-            }
-            crate::spec::PrimitiveType::Double => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Float64))
-            }
-            crate::spec::PrimitiveType::Decimal { precision, scale } => {
+            PrimitiveType::Boolean => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Boolean)),
+            PrimitiveType::Int => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Int32)),
+            PrimitiveType::Long => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Int64)),
+            PrimitiveType::Float => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Float32)),
+            PrimitiveType::Double => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Float64)),
+            PrimitiveType::Decimal { precision, scale } => {
                 let (precision, scale) = {
                     let precision: u8 = precision.to_owned().try_into().map_err(|err| {
                         Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             "incompatible precision for decimal type convert",
                         )
                         .with_source(err)
                     })?;
                     let scale = scale.to_owned().try_into().map_err(|err| {
                         Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             "incompatible scale for decimal type convert",
                         )
                         .with_source(err)
@@ -696,7 +687,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
                 validate_decimal_precision_and_scale::<Decimal128Type>(precision, scale).map_err(
                     |err| {
                         Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             "incompatible precision and scale for decimal type convert",
                         )
                         .with_source(err)
@@ -706,45 +697,41 @@ impl SchemaVisitor for ToArrowSchemaConverter {
                     precision, scale,
                 )))
             }
-            crate::spec::PrimitiveType::Date => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Date32))
-            }
-            crate::spec::PrimitiveType::Time => Ok(ArrowSchemaOrFieldOrType::Type(
-                DataType::Time64(TimeUnit::Microsecond),
-            )),
-            crate::spec::PrimitiveType::Timestamp => Ok(ArrowSchemaOrFieldOrType::Type(
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-            )),
-            crate::spec::PrimitiveType::Timestamptz => Ok(ArrowSchemaOrFieldOrType::Type(
+            PrimitiveType::Date => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Date32)),
+            PrimitiveType::Time => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Time64(
+                TimeUnit::Microsecond,
+            ))),
+            PrimitiveType::Timestamp => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Timestamp(
+                TimeUnit::Microsecond,
+                None,
+            ))),
+            PrimitiveType::Timestamptz => Ok(ArrowSchemaOrFieldOrType::Type(
                 // Timestampz always stored as UTC
                 DataType::Timestamp(TimeUnit::Microsecond, Some(UTC_TIME_ZONE.into())),
             )),
-            crate::spec::PrimitiveType::TimestampNs => Ok(ArrowSchemaOrFieldOrType::Type(
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-            )),
-            crate::spec::PrimitiveType::TimestamptzNs => Ok(ArrowSchemaOrFieldOrType::Type(
+            PrimitiveType::TimestampNs => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                None,
+            ))),
+            PrimitiveType::TimestamptzNs => Ok(ArrowSchemaOrFieldOrType::Type(
                 // Store timestamptz_ns as UTC
                 DataType::Timestamp(TimeUnit::Nanosecond, Some(UTC_TIME_ZONE.into())),
             )),
-            crate::spec::PrimitiveType::String => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::Utf8))
-            }
-            crate::spec::PrimitiveType::Uuid => Ok(ArrowSchemaOrFieldOrType::Type(
-                DataType::FixedSizeBinary(16),
-            )),
-            crate::spec::PrimitiveType::Fixed(len) => Ok(ArrowSchemaOrFieldOrType::Type(
+            PrimitiveType::String => Ok(ArrowSchemaOrFieldOrType::Type(DataType::Utf8)),
+            PrimitiveType::Uuid => Ok(ArrowSchemaOrFieldOrType::Type(DataType::FixedSizeBinary(
+                16,
+            ))),
+            PrimitiveType::Fixed(len) => Ok(ArrowSchemaOrFieldOrType::Type(
                 i32::try_from(*len)
                     .ok()
                     .map(DataType::FixedSizeBinary)
                     .unwrap_or(DataType::LargeBinary),
             )),
-            crate::spec::PrimitiveType::Binary => {
-                Ok(ArrowSchemaOrFieldOrType::Type(DataType::LargeBinary))
-            }
+            PrimitiveType::Binary => Ok(ArrowSchemaOrFieldOrType::Type(DataType::LargeBinary)),
         }
     }
 
-    fn variant(&mut self, _v: &VariantType) -> crate::Result<ArrowSchemaOrFieldOrType> {
+    fn variant(&mut self, _v: &VariantType) -> Result<ArrowSchemaOrFieldOrType> {
         // Variant is stored as a struct of two binary sub-fields (no field IDs on sub-fields).
         // Uses Binary (not LargeBinary) matching the Parquet BINARY primitive directly.
         // `metadata` is always present; `value` is nullable, since in a shredded variant the
@@ -759,7 +746,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
 }
 
 /// Convert iceberg schema to an arrow schema.
-pub fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<ArrowSchema> {
+pub fn schema_to_arrow_schema(schema: &Schema) -> Result<ArrowSchema> {
     let mut converter = ToArrowSchemaConverter;
     match crate::spec::visit_schema(schema, &mut converter)? {
         ArrowSchemaOrFieldOrType::Schema(schema) => Ok(schema),
@@ -768,7 +755,7 @@ pub fn schema_to_arrow_schema(schema: &crate::spec::Schema) -> crate::Result<Arr
 }
 
 /// Convert iceberg type to an arrow type.
-pub fn type_to_arrow_type(ty: &crate::spec::Type) -> crate::Result<DataType> {
+pub fn type_to_arrow_type(ty: &Type) -> Result<DataType> {
     let mut converter = ToArrowSchemaConverter;
     match crate::spec::visit_type(ty, &mut converter)? {
         ArrowSchemaOrFieldOrType::Type(ty) => Ok(ty),
@@ -1131,18 +1118,18 @@ pub(crate) fn get_parquet_stat_max_as_datum(
     })
 }
 
-impl TryFrom<&ArrowSchema> for crate::spec::Schema {
+impl TryFrom<&ArrowSchema> for Schema {
     type Error = Error;
 
-    fn try_from(schema: &ArrowSchema) -> crate::Result<Self> {
+    fn try_from(schema: &ArrowSchema) -> Result<Self> {
         arrow_schema_to_schema(schema)
     }
 }
 
-impl TryFrom<&crate::spec::Schema> for ArrowSchema {
+impl TryFrom<&Schema> for ArrowSchema {
     type Error = Error;
 
-    fn try_from(schema: &crate::spec::Schema) -> crate::Result<Self> {
+    fn try_from(schema: &Schema) -> Result<Self> {
         schema_to_arrow_schema(schema)
     }
 }

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -615,11 +615,7 @@ impl SchemaVisitor for ToArrowSchemaConverter {
         Ok(ArrowSchemaOrFieldOrType::Type(DataType::Struct(fields)))
     }
 
-    fn list(
-        &mut self,
-        list: &ListType,
-        value: ArrowSchemaOrFieldOrType,
-    ) -> Result<Self::T> {
+    fn list(&mut self, list: &ListType, value: ArrowSchemaOrFieldOrType) -> Result<Self::T> {
         // `field` already carries the element's field id, doc, and — for a variant element —
         // the arrow.parquet.variant extension type. Don't overwrite its metadata here (doing so
         // would drop the extension type for `list<variant>`).

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -797,10 +797,10 @@ pub(crate) fn create_primitive_array_single_element(
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok(Arc::new(arrow_array::StructArray::new(
+            Ok(Arc::new(StructArray::new(
                 fields.clone(),
                 null_arrays,
-                Some(arrow_buffer::NullBuffer::new_null(1)),
+                Some(NullBuffer::new_null(1)),
             )))
         }
         _ => Err(Error::new(

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -303,7 +303,7 @@ pub(crate) fn avro_decimal_schema(precision: usize, scale: usize) -> Result<Avro
             name: Name::new(&format!("decimal_{precision}_{scale}")).unwrap(),
             aliases: None,
             doc: None,
-            size: crate::spec::Type::decimal_required_bytes(precision as u32)? as usize,
+            size: Type::decimal_required_bytes(precision as u32)? as usize,
             attributes: Default::default(),
             default: None,
         })),
@@ -1233,6 +1233,6 @@ mod tests {
             .build()
             .unwrap();
         let err = schema_to_avro_schema("t", &schema).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::FeatureUnsupported, "{err}");
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported, "{err}");
     }
 }

--- a/crates/iceberg/src/encryption/stream.rs
+++ b/crates/iceberg/src/encryption/stream.rs
@@ -971,7 +971,7 @@ mod tests {
 
     /// Shared-buffer FileWrite for testing AesGcmFileWrite output.
     struct SharedMemoryWrite {
-        buffer: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+        buffer: Arc<std::sync::Mutex<Vec<u8>>>,
     }
 
     /// FileWrite that fails after a configured number of successful writes.
@@ -1009,7 +1009,7 @@ mod tests {
 
     /// Helper: one-shot encrypt through AesGcmFileWrite, return encrypted bytes.
     async fn write_through_ags1(plaintext: &[u8], key: &[u8], aad_prefix: &[u8]) -> Vec<u8> {
-        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let buffer = Arc::new(std::sync::Mutex::new(Vec::new()));
         let inner: Box<dyn FileWrite> = Box::new(SharedMemoryWrite {
             buffer: buffer.clone(),
         });
@@ -1093,7 +1093,7 @@ mod tests {
         let key = b"0123456789abcdef";
         let aad_prefix = b"cross-block-aad!";
 
-        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let buffer = Arc::new(std::sync::Mutex::new(Vec::new()));
         let inner: Box<dyn FileWrite> = Box::new(SharedMemoryWrite {
             buffer: buffer.clone(),
         });

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -108,34 +108,30 @@ const IN_PREDICATE_LIMIT: usize = 200;
 impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
     type T = bool;
 
-    fn always_true(&mut self) -> crate::Result<bool> {
+    fn always_true(&mut self) -> Result<bool> {
         ROWS_MIGHT_MATCH
     }
 
-    fn always_false(&mut self) -> crate::Result<bool> {
+    fn always_false(&mut self) -> Result<bool> {
         ROWS_CANNOT_MATCH
     }
 
-    fn and(&mut self, lhs: bool, rhs: bool) -> crate::Result<bool> {
+    fn and(&mut self, lhs: bool, rhs: bool) -> Result<bool> {
         Ok(lhs && rhs)
     }
 
-    fn or(&mut self, lhs: bool, rhs: bool) -> crate::Result<bool> {
+    fn or(&mut self, lhs: bool, rhs: bool) -> Result<bool> {
         Ok(lhs || rhs)
     }
 
-    fn not(&mut self, _: bool) -> crate::Result<bool> {
+    fn not(&mut self, _: bool) -> Result<bool> {
         Err(Error::new(
             ErrorKind::Unexpected,
             "not operator is not supported in partition filter",
         ))
     }
 
-    fn is_null(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn is_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         Ok(self.field_summary_for_reference(reference).contains_null)
     }
 
@@ -143,7 +139,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         &mut self,
         reference: &BoundReference,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
 
         // contains_null encodes whether at least one partition value is null,
@@ -155,11 +151,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         }
     }
 
-    fn is_nan(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn is_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         if let Some(contains_nan) = field.contains_nan
             && !contains_nan
@@ -174,11 +166,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         ROWS_MIGHT_MATCH
     }
 
-    fn not_nan(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn not_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         if let Some(contains_nan) = field.contains_nan {
             // check if all values are nan
@@ -194,7 +182,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
 
         match &field.lower_bound {
@@ -218,7 +206,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         match &field.lower_bound {
             Some(bound_bytes) => {
@@ -241,7 +229,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         match &field.upper_bound {
             Some(bound_bytes) => {
@@ -264,7 +252,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         match &field.upper_bound {
             Some(bound_bytes) => {
@@ -287,7 +275,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
 
         if field.lower_bound.is_none() || field.upper_bound.is_none() {
@@ -322,7 +310,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         _reference: &BoundReference,
         _datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         // because the bounds are not necessarily a min or max value, this cannot be answered using
         // them. notEq(col, X) with (X, Y) doesn't guarantee that X is a value in col.
         ROWS_MIGHT_MATCH
@@ -333,7 +321,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
 
         if field.lower_bound.is_none() || field.upper_bound.is_none() {
@@ -368,7 +356,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
 
         if field.contains_null || field.lower_bound.is_none() || field.upper_bound.is_none() {
@@ -411,7 +399,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         reference: &BoundReference,
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field = self.field_summary_for_reference(reference);
         if field.lower_bound.is_none() {
             return ROWS_CANNOT_MATCH;
@@ -449,7 +437,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         _reference: &BoundReference,
         _literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         // because the bounds are not necessarily a min or max value, this cannot be answered using
         // them. notIn(col, {X, ...}) with (X, Y) doesn't guarantee that X is a value in col.
         ROWS_MIGHT_MATCH
@@ -479,7 +467,7 @@ impl ManifestFilterVisitor<'_> {
         all_null
     }
 
-    fn datum_as_str<'a>(bound: &'a Datum, err_msg: &str) -> crate::Result<&'a String> {
+    fn datum_as_str<'a>(bound: &'a Datum, err_msg: &str) -> Result<&'a String> {
         let PrimitiveLiteral::String(bound) = bound.literal() else {
             return Err(Error::new(ErrorKind::Unexpected, err_msg));
         };

--- a/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
@@ -51,7 +51,7 @@ impl<'a> StrictMetricsEvaluator<'a> {
     /// see if this `DataFile` contains data that could match
     /// the scan's filter.
     #[allow(dead_code)]
-    pub(crate) fn eval(filter: &'a BoundPredicate, data_file: &'a DataFile) -> crate::Result<bool> {
+    pub(crate) fn eval(filter: &'a BoundPredicate, data_file: &'a DataFile) -> Result<bool> {
         if data_file.record_count == 0 {
             return ROWS_MUST_MATCH;
         }
@@ -116,7 +116,7 @@ impl<'a> StrictMetricsEvaluator<'a> {
         datum: &Datum,
         cmp_fn: fn(&Datum, &Datum) -> bool,
         use_lower_bound: bool,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
@@ -142,34 +142,30 @@ impl<'a> StrictMetricsEvaluator<'a> {
 impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
     type T = bool;
 
-    fn always_true(&mut self) -> crate::Result<bool> {
+    fn always_true(&mut self) -> Result<bool> {
         ROWS_MUST_MATCH
     }
 
-    fn always_false(&mut self) -> crate::Result<bool> {
+    fn always_false(&mut self) -> Result<bool> {
         ROWS_MIGHT_NOT_MATCH
     }
 
-    fn and(&mut self, lhs: bool, rhs: bool) -> crate::Result<bool> {
+    fn and(&mut self, lhs: bool, rhs: bool) -> Result<bool> {
         Ok(lhs && rhs)
     }
 
-    fn or(&mut self, lhs: bool, rhs: bool) -> crate::Result<bool> {
+    fn or(&mut self, lhs: bool, rhs: bool) -> Result<bool> {
         Ok(lhs || rhs)
     }
 
-    fn not(&mut self, _inner: bool) -> crate::Result<bool> {
+    fn not(&mut self, _inner: bool) -> Result<bool> {
         Err(Error::new(
             ErrorKind::DataInvalid,
             "NOT should be rewritten",
         ))
     }
 
-    fn is_null(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn is_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.contains_nulls_only(field_id) {
@@ -183,7 +179,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         &mut self,
         reference: &BoundReference,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if let Some(&count) = self.null_count(field_id) {
@@ -196,11 +192,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         ROWS_MIGHT_NOT_MATCH
     }
 
-    fn is_nan(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn is_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         let field_id = reference.field().id;
 
         let contains_only = self.contains_nans_only(field_id);
@@ -212,11 +204,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         ROWS_MIGHT_NOT_MATCH
     }
 
-    fn not_nan(
-        &mut self,
-        reference: &BoundReference,
-        _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    fn not_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
         let field_id = reference.field().id;
 
         if let Some(&nan_count) = self.nan_count(field_id)
@@ -237,7 +225,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         self.visit_inequality(reference, datum, PartialOrd::lt, false)
     }
 
@@ -246,7 +234,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         self.visit_inequality(reference, datum, PartialOrd::le, false)
     }
 
@@ -255,7 +243,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if let Some(lower) = self.lower_bound(field_id)
@@ -272,7 +260,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         self.visit_inequality(reference, datum, PartialOrd::ge, true)
     }
 
@@ -281,7 +269,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
@@ -307,7 +295,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
@@ -340,7 +328,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         _reference: &BoundReference,
         _datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         ROWS_MIGHT_NOT_MATCH
     }
 
@@ -349,7 +337,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         _reference: &BoundReference,
         _datum: &Datum,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         ROWS_MIGHT_NOT_MATCH
     }
 
@@ -358,7 +346,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
@@ -382,7 +370,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
-    ) -> crate::Result<bool> {
+    ) -> Result<bool> {
         let field_id = reference.field().id;
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {

--- a/crates/iceberg/src/inspect/metadata_table.rs
+++ b/crates/iceberg/src/inspect/metadata_table.rs
@@ -55,7 +55,7 @@ impl MetadataTableType {
 impl TryFrom<&str> for MetadataTableType {
     type Error = String;
 
-    fn try_from(value: &str) -> std::result::Result<Self, String> {
+    fn try_from(value: &str) -> Result<Self, String> {
         match value {
             "snapshots" => Ok(Self::Snapshots),
             "manifests" => Ok(Self::Manifests),

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -252,12 +252,12 @@ pub trait FileRead: Send + Sync + Unpin + 'static {
     /// Read file content with given range.
     ///
     /// TODO: we can support reading non-contiguous bytes in the future.
-    async fn read(&self, range: Range<u64>) -> crate::Result<Bytes>;
+    async fn read(&self, range: Range<u64>) -> Result<Bytes>;
 }
 
 #[async_trait::async_trait]
 impl<T: AsRef<dyn FileRead> + Send + Sync + Unpin + 'static> FileRead for T {
-    async fn read(&self, range: Range<u64>) -> crate::Result<Bytes> {
+    async fn read(&self, range: Range<u64>) -> Result<Bytes> {
         self.as_ref().read(range).await
     }
 }
@@ -282,26 +282,26 @@ impl InputFile {
     }
 
     /// Check if file exists.
-    pub async fn exists(&self) -> crate::Result<bool> {
+    pub async fn exists(&self) -> Result<bool> {
         self.storage.exists(&self.path).await
     }
 
     /// Fetch and returns metadata of file.
-    pub async fn metadata(&self) -> crate::Result<FileMetadata> {
+    pub async fn metadata(&self) -> Result<FileMetadata> {
         self.storage.metadata(&self.path).await
     }
 
     /// Read and returns whole content of file.
     ///
     /// For continuous reading, use [`Self::reader`] instead.
-    pub async fn read(&self) -> crate::Result<Bytes> {
+    pub async fn read(&self) -> Result<Bytes> {
         self.storage.read(&self.path).await
     }
 
     /// Creates [`FileRead`] for continuous reading.
     ///
     /// For one-time reading, use [`Self::read`] instead.
-    pub async fn reader(&self) -> crate::Result<Box<dyn FileRead>> {
+    pub async fn reader(&self) -> Result<Box<dyn FileRead>> {
         self.storage.reader(&self.path).await
     }
 }
@@ -317,12 +317,12 @@ pub trait FileWrite: Send + Unpin + 'static {
     /// Write bytes to file.
     ///
     /// TODO: we can support writing non-contiguous bytes in the future.
-    async fn write(&mut self, bs: Bytes) -> crate::Result<()>;
+    async fn write(&mut self, bs: Bytes) -> Result<()>;
 
     /// Close file.
     ///
     /// Calling close on closed file will generate an error.
-    async fn close(&mut self) -> crate::Result<()>;
+    async fn close(&mut self) -> Result<()>;
 }
 
 /// Output file is used for writing to files..
@@ -370,7 +370,7 @@ impl OutputFile {
     ///
     /// Calling `write` will overwrite the file if it exists.
     /// For continuous writing, use [`Self::writer`].
-    pub async fn write(&self, bs: Bytes) -> crate::Result<()> {
+    pub async fn write(&self, bs: Bytes) -> Result<()> {
         self.storage.write(&self.path, bs).await
     }
 
@@ -379,7 +379,7 @@ impl OutputFile {
     /// # Notes
     ///
     /// For one-time writing, use [`Self::write`] instead.
-    pub async fn writer(&self) -> crate::Result<Box<dyn FileWrite>> {
+    pub async fn writer(&self) -> Result<Box<dyn FileWrite>> {
         self.storage.writer(&self.path).await
     }
 }

--- a/crates/iceberg/src/io/storage/config/s3.rs
+++ b/crates/iceberg/src/io/storage/config/s3.rs
@@ -140,7 +140,7 @@ impl Default for S3Config {
 }
 
 impl TryFrom<&StorageConfig> for S3Config {
-    type Error = crate::Error;
+    type Error = Error;
 
     fn try_from(config: &StorageConfig) -> Result<Self> {
         let props = config.props();

--- a/crates/iceberg/src/runtime/mod.rs
+++ b/crates/iceberg/src/runtime/mod.rs
@@ -39,7 +39,7 @@ pub struct JoinHandle<T>(task::JoinHandle<T>);
 impl<T> Unpin for JoinHandle<T> {}
 
 impl<T: Send + 'static> Future for JoinHandle<T> {
-    type Output = crate::Result<T>;
+    type Output = Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.get_mut().0).poll(cx).map(|r| {

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -1091,7 +1091,7 @@ pub mod tests {
         /// Writes identical Parquet data files (1.parquet, 2.parquet, 3.parquet)
         /// and returns the file size in bytes.
         fn write_parquet_data_files(&self) -> u64 {
-            std::fs::create_dir_all(&self.table_location).unwrap();
+            fs::create_dir_all(&self.table_location).unwrap();
 
             let schema = {
                 let fields = vec![
@@ -1205,7 +1205,7 @@ pub mod tests {
                 writer.close().unwrap();
             }
 
-            std::fs::metadata(format!("{}/1.parquet", &self.table_location))
+            fs::metadata(format!("{}/1.parquet", &self.table_location))
                 .unwrap()
                 .len()
         }
@@ -2317,7 +2317,7 @@ pub mod tests {
             let file_col = batch.column_by_name(RESERVED_COL_NAME_FILE).unwrap();
             let run_array = file_col
                 .as_any()
-                .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
+                .downcast_ref::<RunArray<Int32Type>>()
                 .expect("_file column should be a RunArray");
 
             let values = run_array.values();

--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -26,7 +26,7 @@ use std::sync::{Arc, OnceLock};
 
 use ::serde::de::{MapAccess, Visitor};
 use serde::de::{Error, IntoDeserializer};
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
 use super::values::Literal;
@@ -453,21 +453,21 @@ impl<'de> Deserialize<'de> for StructType {
                         Field::Type => {
                             let type_val: String = map.next_value()?;
                             if type_val != "struct" {
-                                return Err(serde::de::Error::custom(format!(
+                                return Err(Error::custom(format!(
                                     "expected type 'struct', got '{type_val}'"
                                 )));
                             }
                         }
                         Field::Fields => {
                             if fields.is_some() {
-                                return Err(serde::de::Error::duplicate_field("fields"));
+                                return Err(Error::duplicate_field("fields"));
                             }
                             fields = Some(map.next_value()?);
                         }
                     }
                 }
                 let fields: Vec<NestedFieldRef> =
-                    fields.ok_or_else(|| de::Error::missing_field("fields"))?;
+                    fields.ok_or_else(|| Error::missing_field("fields"))?;
 
                 Ok(StructType::new(fields))
             }
@@ -818,7 +818,7 @@ pub(super) mod _serde {
                     element_required: list.element_field.required,
                     element: Cow::Borrowed(&list.element_field.field_type),
                 },
-                Type::Map(map) => SerdeType::Map {
+                Map(map) => SerdeType::Map {
                     r#type: "map".to_string(),
                     key_id: map.key_field.id,
                     key: Cow::Borrowed(&map.key_field.field_type),

--- a/crates/iceberg/src/spec/manifest_list/manifest_file.rs
+++ b/crates/iceberg/src/spec/manifest_list/manifest_file.rs
@@ -167,7 +167,7 @@ impl TryFrom<i32> for ManifestContentType {
             0 => Ok(ManifestContentType::Data),
             1 => Ok(ManifestContentType::Deletes),
             _ => Err(Error::new(
-                crate::ErrorKind::DataInvalid,
+                ErrorKind::DataInvalid,
                 format!("Invalid manifest content type. Expected 0 or 1, got {value}"),
             )),
         }

--- a/crates/iceberg/src/spec/manifest_list/mod.rs
+++ b/crates/iceberg/src/spec/manifest_list/mod.rs
@@ -152,7 +152,7 @@ mod test {
         let bs = fs::read(full_path).expect("read_file must succeed");
 
         let parsed_manifest_list =
-            ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V1).unwrap();
+            ManifestList::parse_with_version(&bs, FormatVersion::V1).unwrap();
 
         assert_eq!(manifest_list, parsed_manifest_list);
     }
@@ -230,7 +230,7 @@ mod test {
         let bs = fs::read(full_path).expect("read_file must succeed");
 
         let parsed_manifest_list =
-            ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V2).unwrap();
+            ManifestList::parse_with_version(&bs, FormatVersion::V2).unwrap();
 
         assert_eq!(manifest_list, parsed_manifest_list);
     }
@@ -270,7 +270,7 @@ mod test {
         let bs = writer.into_inner().unwrap();
 
         let parsed_manifest_list =
-            ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V2).unwrap();
+            ManifestList::parse_with_version(&bs, FormatVersion::V2).unwrap();
 
         assert_eq!(manifest_list, parsed_manifest_list);
     }
@@ -349,7 +349,7 @@ mod test {
         let bs = fs::read(full_path).expect("read_file must succeed");
 
         let parsed_manifest_list =
-            ManifestList::parse_with_version(&bs, crate::spec::FormatVersion::V3).unwrap();
+            ManifestList::parse_with_version(&bs, FormatVersion::V3).unwrap();
 
         assert_eq!(manifest_list, parsed_manifest_list);
     }

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -1327,8 +1327,7 @@ mod tests {
     fn test_builder_disallows_variant_source() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
-                    .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
                 NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
             ])
             .build()

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -789,14 +789,8 @@ mod tests {
     fn test_is_unpartitioned() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -950,14 +944,8 @@ mod tests {
     fn test_new_unpartition() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -999,38 +987,13 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
+                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
                     .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
-                NestedField::required(
-                    3,
-                    "ts",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
-                NestedField::required(
-                    4,
-                    "ts_day",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
-                NestedField::required(
-                    5,
-                    "id_bucket",
-                    Type::Primitive(crate::spec::PrimitiveType::Int),
-                )
-                .into(),
-                NestedField::required(
-                    6,
-                    "id_truncate",
-                    Type::Primitive(crate::spec::PrimitiveType::Int),
-                )
-                .into(),
+                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1042,7 +1005,7 @@ mod tests {
             NestedField::optional(
                 partition_spec.fields[0].field_id,
                 &partition_spec.fields[0].name,
-                Type::Primitive(crate::spec::PrimitiveType::Date)
+                Type::Primitive(PrimitiveType::Date)
             )
         );
         assert_eq!(
@@ -1050,7 +1013,7 @@ mod tests {
             NestedField::optional(
                 partition_spec.fields[1].field_id,
                 &partition_spec.fields[1].name,
-                Type::Primitive(crate::spec::PrimitiveType::Int)
+                Type::Primitive(PrimitiveType::Int)
             )
         );
         assert_eq!(
@@ -1058,7 +1021,7 @@ mod tests {
             NestedField::optional(
                 partition_spec.fields[2].field_id,
                 &partition_spec.fields[2].name,
-                Type::Primitive(crate::spec::PrimitiveType::String)
+                Type::Primitive(PrimitiveType::String)
             )
         );
     }
@@ -1075,38 +1038,13 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
+                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
                     .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
-                NestedField::required(
-                    3,
-                    "ts",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
-                NestedField::required(
-                    4,
-                    "ts_day",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
-                NestedField::required(
-                    5,
-                    "id_bucket",
-                    Type::Primitive(crate::spec::PrimitiveType::Int),
-                )
-                .into(),
-                NestedField::required(
-                    6,
-                    "id_truncate",
-                    Type::Primitive(crate::spec::PrimitiveType::Int),
-                )
-                .into(),
+                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1142,14 +1080,8 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1170,14 +1102,8 @@ mod tests {
     fn test_builder_disallow_duplicate_field_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1202,20 +1128,9 @@ mod tests {
     fn test_builder_auto_assign_field_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
-                NestedField::required(
-                    3,
-                    "ts",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
             ])
             .build()
             .unwrap();
@@ -1255,14 +1170,8 @@ mod tests {
     fn test_builder_valid_schema() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1301,8 +1210,7 @@ mod tests {
     fn test_collision_with_schema_name() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1328,14 +1236,8 @@ mod tests {
     fn test_builder_collision_is_ok_for_identity_transforms() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "number",
-                    Type::Primitive(crate::spec::PrimitiveType::Int),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "number", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1373,20 +1275,9 @@ mod tests {
     fn test_builder_all_source_ids_must_exist() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
-                NestedField::required(
-                    3,
-                    "ts",
-                    Type::Primitive(crate::spec::PrimitiveType::Timestamp),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
             ])
             .build()
             .unwrap();
@@ -1436,7 +1327,7 @@ mod tests {
     fn test_builder_disallows_variant_source() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
                     .into(),
                 NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
             ])
@@ -1478,8 +1369,7 @@ mod tests {
     fn test_builder_incompatible_transforms_disallowed() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1523,14 +1413,8 @@ mod tests {
     fn test_is_compatible_with() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1566,8 +1450,7 @@ mod tests {
     fn test_not_compatible_with_transform_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();
@@ -1603,14 +1486,8 @@ mod tests {
     fn test_not_compatible_with_source_id_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1646,14 +1523,8 @@ mod tests {
     fn test_not_compatible_with_order_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1713,14 +1584,8 @@ mod tests {
     fn test_highest_field_id() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1751,14 +1616,8 @@ mod tests {
     fn test_has_sequential_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1791,14 +1650,8 @@ mod tests {
     fn test_sequential_ids_must_start_at_1000() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();
@@ -1831,14 +1684,8 @@ mod tests {
     fn test_sequential_ids_must_have_no_gaps() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(crate::spec::PrimitiveType::Int))
-                    .into(),
-                NestedField::required(
-                    2,
-                    "name",
-                    Type::Primitive(crate::spec::PrimitiveType::String),
-                )
-                .into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -527,7 +527,7 @@ mod tests {
 
     use bimap::BiHashMap;
 
-    use crate::spec::datatypes::Type::{List, Map, Primitive, Struct};
+    use crate::spec::datatypes::Type::{List, Map, Primitive, Struct, Variant};
     use crate::spec::datatypes::{
         ListType, MapType, NestedField, NestedFieldRef, PrimitiveType, StructType,
     };
@@ -545,7 +545,7 @@ mod tests {
 
         // Variant type requires v3.
         let variant = schema_with(vec![
-            NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+            NestedField::optional(1, "v", Variant(VariantType)).into(),
         ]);
         assert!(
             variant
@@ -560,7 +560,7 @@ mod tests {
 
         // A non-null initial default requires v3, even for a v1-compatible type.
         let with_default = schema_with(vec![
-            NestedField::optional(1, "a", Type::Primitive(PrimitiveType::Int))
+            NestedField::optional(1, "a", Primitive(PrimitiveType::Int))
                 .with_initial_default(Literal::Primitive(PrimitiveLiteral::Int(1)))
                 .into(),
         ]);
@@ -579,7 +579,7 @@ mod tests {
 
         // No default is fine at any version (an absent/null default never trips).
         let no_default = schema_with(vec![
-            NestedField::optional(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(1, "a", Primitive(PrimitiveType::Int)).into(),
         ]);
         assert!(
             no_default
@@ -592,8 +592,8 @@ mod tests {
             NestedField::required(
                 1,
                 "s",
-                Type::Struct(StructType::new(vec![
-                    NestedField::optional(2, "inner", Type::Primitive(PrimitiveType::Long))
+                Struct(StructType::new(vec![
+                    NestedField::optional(2, "inner", Primitive(PrimitiveType::Long))
                         .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(7)))
                         .into(),
                 ])),
@@ -610,8 +610,8 @@ mod tests {
             NestedField::required(
                 1,
                 "container",
-                Type::Struct(StructType::new(vec![
-                    NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+                Struct(StructType::new(vec![
+                    NestedField::optional(2, "v", Variant(VariantType)).into(),
                 ])),
             )
             .into(),
@@ -636,14 +636,14 @@ mod tests {
 
         // All v1-compatible types → V1.
         let v1 = schema_with(vec![
-            NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "b", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "a", Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(2, "b", Primitive(PrimitiveType::String)).into(),
         ]);
         assert_eq!(v1.calc_min_compatible_format(), FormatVersion::V1);
 
         // A top-level variant → V3.
         let variant = schema_with(vec![
-            NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+            NestedField::optional(1, "v", Variant(VariantType)).into(),
         ]);
         assert_eq!(variant.calc_min_compatible_format(), FormatVersion::V3);
 
@@ -652,15 +652,15 @@ mod tests {
             NestedField::required(
                 1,
                 "s",
-                Type::Struct(StructType::new(vec![
+                Struct(StructType::new(vec![
                     NestedField::optional(
                         2,
                         "l",
-                        Type::List(ListType::new(
+                        List(ListType::new(
                             NestedField::required(
                                 3,
                                 "element",
-                                Type::Primitive(PrimitiveType::TimestampNs),
+                                Primitive(PrimitiveType::TimestampNs),
                             )
                             .into(),
                         )),
@@ -682,11 +682,11 @@ mod tests {
         // with the type problem before the initial-default problem for field 2.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(3, "c", Type::Variant(VariantType)).into(),
-                NestedField::optional(2, "b", Type::Primitive(PrimitiveType::TimestampNs))
+                NestedField::optional(3, "c", Variant(VariantType)).into(),
+                NestedField::optional(2, "b", Primitive(PrimitiveType::TimestampNs))
                     .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(0)))
                     .into(),
-                NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "a", Primitive(PrimitiveType::Int)).into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -529,7 +529,7 @@ mod tests {
 
     use crate::spec::datatypes::Type::{List, Map, Primitive, Struct};
     use crate::spec::datatypes::{
-        ListType, MapType, NestedField, NestedFieldRef, PrimitiveType, StructType, Type,
+        ListType, MapType, NestedField, NestedFieldRef, PrimitiveType, StructType,
     };
     use crate::spec::schema::Schema;
     use crate::spec::values::Map as MapValue;
@@ -712,9 +712,9 @@ mod tests {
     #[test]
     fn test_construct_schema() {
         let field1: NestedFieldRef =
-            NestedField::required(1, "f1", Type::Primitive(PrimitiveType::Boolean)).into();
+            NestedField::required(1, "f1", Primitive(PrimitiveType::Boolean)).into();
         let field2: NestedFieldRef =
-            NestedField::optional(2, "f2", Type::Primitive(PrimitiveType::Int)).into();
+            NestedField::optional(2, "f2", Primitive(PrimitiveType::Int)).into();
 
         let schema = Schema::builder()
             .with_fields(vec![field1.clone()])
@@ -735,9 +735,9 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
             ])
             .build()
             .unwrap();
@@ -774,16 +774,16 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
                 NestedField::required(
                     4,
                     "qux",
-                    Type::List(ListType {
+                    List(ListType {
                         element_field: NestedField::list_element(
                             5,
-                            Type::Primitive(PrimitiveType::String),
+                            Primitive(PrimitiveType::String),
                             true,
                         )
                         .into(),
@@ -793,23 +793,23 @@ mod tests {
                 NestedField::required(
                     6,
                     "quux",
-                    Type::Map(MapType {
+                    Map(MapType {
                         key_field: NestedField::map_key_element(
                             7,
-                            Type::Primitive(PrimitiveType::String),
+                            Primitive(PrimitiveType::String),
                         )
                         .into(),
                         value_field: NestedField::map_value_element(
                             8,
-                            Type::Map(MapType {
+                            Map(MapType {
                                 key_field: NestedField::map_key_element(
                                     9,
-                                    Type::Primitive(PrimitiveType::String),
+                                    Primitive(PrimitiveType::String),
                                 )
                                 .into(),
                                 value_field: NestedField::map_value_element(
                                     10,
-                                    Type::Primitive(PrimitiveType::Int),
+                                    Primitive(PrimitiveType::Int),
                                     true,
                                 )
                                 .into(),
@@ -823,20 +823,20 @@ mod tests {
                 NestedField::required(
                     11,
                     "location",
-                    Type::List(ListType {
+                    List(ListType {
                         element_field: NestedField::list_element(
                             12,
-                            Type::Struct(StructType::new(vec![
+                            Struct(StructType::new(vec![
                                 NestedField::optional(
                                     13,
                                     "latitude",
-                                    Type::Primitive(PrimitiveType::Float),
+                                    Primitive(PrimitiveType::Float),
                                 )
                                 .into(),
                                 NestedField::optional(
                                     14,
                                     "longitude",
-                                    Type::Primitive(PrimitiveType::Float),
+                                    Primitive(PrimitiveType::Float),
                                 )
                                 .into(),
                             ])),
@@ -849,11 +849,9 @@ mod tests {
                 NestedField::optional(
                     15,
                     "person",
-                    Type::Struct(StructType::new(vec![
-                        NestedField::optional(16, "name", Type::Primitive(PrimitiveType::String))
-                            .into(),
-                        NestedField::required(17, "age", Type::Primitive(PrimitiveType::Int))
-                            .into(),
+                    Struct(StructType::new(vec![
+                        NestedField::optional(16, "name", Primitive(PrimitiveType::String)).into(),
+                        NestedField::required(17, "age", Primitive(PrimitiveType::Int)).into(),
                     ])),
                 )
                 .into(),
@@ -1063,10 +1061,10 @@ table {
                 NestedField::required(
                     4,
                     "qux",
-                    Type::List(ListType {
+                    List(ListType {
                         element_field: NestedField::list_element(
                             5,
-                            Type::Primitive(PrimitiveType::String),
+                            Primitive(PrimitiveType::String),
                             true,
                         )
                         .into(),
@@ -1195,21 +1193,19 @@ table {
                 NestedField::optional(
                     15,
                     "person",
-                    Type::Struct(StructType::new(vec![
-                        NestedField::optional(16, "name", Type::Primitive(PrimitiveType::String))
-                            .into(),
-                        NestedField::required(17, "age", Type::Primitive(PrimitiveType::Int))
-                            .into(),
+                    Struct(StructType::new(vec![
+                        NestedField::optional(16, "name", Primitive(PrimitiveType::String)).into(),
+                        NestedField::required(17, "age", Primitive(PrimitiveType::Int)).into(),
                     ])),
                 ),
             ),
             (
                 16,
-                NestedField::optional(16, "name", Type::Primitive(PrimitiveType::String)),
+                NestedField::optional(16, "name", Primitive(PrimitiveType::String)),
             ),
             (
                 17,
-                NestedField::required(17, "age", Type::Primitive(PrimitiveType::Int)),
+                NestedField::required(17, "age", Primitive(PrimitiveType::Int)),
             ),
         ]);
 
@@ -1318,9 +1314,9 @@ table {
             .with_identifier_field_ids(vec![5])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 3)]))
             .with_fields(vec![
-                NestedField::required(5, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(3, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::required(5, "foo", Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(3, "bar", Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
             ])
             .build()
             .unwrap_err();
@@ -1353,12 +1349,12 @@ table {
                     NestedField::required(
                         1,
                         "Map",
-                        Type::Map(MapType::new(
-                            NestedField::map_key_element(2, Type::Primitive(PrimitiveType::String))
+                        Map(MapType::new(
+                            NestedField::map_key_element(2, Primitive(PrimitiveType::String))
                                 .into(),
                             NestedField::map_value_element(
                                 3,
-                                Type::Primitive(PrimitiveType::Boolean),
+                                Primitive(PrimitiveType::Boolean),
                                 true,
                             )
                             .into(),
@@ -1377,12 +1373,12 @@ table {
                     NestedField::required(
                         1,
                         "Map",
-                        Type::Map(MapType::new(
-                            NestedField::map_key_element(2, Type::Primitive(PrimitiveType::String))
+                        Map(MapType::new(
+                            NestedField::map_key_element(2, Primitive(PrimitiveType::String))
                                 .into(),
                             NestedField::map_value_element(
                                 3,
-                                Type::Primitive(PrimitiveType::Boolean),
+                                Primitive(PrimitiveType::Boolean),
                                 true,
                             )
                             .into(),
@@ -1403,13 +1399,9 @@ table {
                     NestedField::required(
                         1,
                         "List",
-                        Type::List(ListType::new(
-                            NestedField::list_element(
-                                2,
-                                Type::Primitive(PrimitiveType::String),
-                                true
-                            )
-                            .into(),
+                        List(ListType::new(
+                            NestedField::list_element(2, Primitive(PrimitiveType::String), true)
+                                .into(),
                         )),
                     )
                     .into()
@@ -1427,15 +1419,10 @@ table {
                     NestedField::optional(
                         1,
                         "Struct",
-                        Type::Struct(StructType::new(vec![
-                            NestedField::required(
-                                2,
-                                "name",
-                                Type::Primitive(PrimitiveType::String)
-                            )
-                            .into(),
-                            NestedField::optional(3, "age", Type::Primitive(PrimitiveType::Int))
+                        Struct(StructType::new(vec![
+                            NestedField::required(2, "name", Primitive(PrimitiveType::String))
                                 .into(),
+                            NestedField::optional(3, "age", Primitive(PrimitiveType::Int)).into(),
                         ])),
                     )
                     .into()
@@ -1450,8 +1437,7 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Float", Type::Primitive(PrimitiveType::Float),)
-                        .into()
+                    NestedField::required(1, "Float", Primitive(PrimitiveType::Float),).into()
                 ])
                 .build()
                 .is_err()
@@ -1461,8 +1447,7 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Double", Type::Primitive(PrimitiveType::Double),)
-                        .into()
+                    NestedField::required(1, "Double", Primitive(PrimitiveType::Double),).into()
                 ])
                 .build()
                 .is_err()
@@ -1474,8 +1459,7 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Required", Type::Primitive(PrimitiveType::String),)
-                        .into()
+                    NestedField::required(1, "Required", Primitive(PrimitiveType::String),).into()
                 ])
                 .build()
                 .is_ok()
@@ -1485,8 +1469,7 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::optional(1, "Optional", Type::Primitive(PrimitiveType::String),)
-                        .into()
+                    NestedField::optional(1, "Optional", Primitive(PrimitiveType::String),).into()
                 ])
                 .build()
                 .is_err()

--- a/crates/iceberg/src/spec/schema/prune_columns.rs
+++ b/crates/iceberg/src/spec/schema/prune_columns.rs
@@ -257,7 +257,7 @@ mod tests {
         let expected_type = Type::from(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
                 ])
                 .build()
                 .unwrap()
@@ -276,7 +276,7 @@ mod tests {
         let expected_type = Type::from(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
                 ])
                 .build()
                 .unwrap()
@@ -301,7 +301,7 @@ mod tests {
                         Type::List(ListType {
                             element_field: NestedField::list_element(
                                 5,
-                                Type::Primitive(PrimitiveType::String),
+                                Primitive(PrimitiveType::String),
                                 true,
                             )
                             .into(),
@@ -340,7 +340,7 @@ mod tests {
                         Type::List(ListType {
                             element_field: NestedField::list_element(
                                 5,
-                                Type::Primitive(PrimitiveType::String),
+                                Primitive(PrimitiveType::String),
                                 true,
                             )
                             .into(),
@@ -371,7 +371,7 @@ mod tests {
                         Type::Map(MapType {
                             key_field: NestedField::map_key_element(
                                 7,
-                                Type::Primitive(PrimitiveType::String),
+                                Primitive(PrimitiveType::String),
                             )
                             .into(),
                             value_field: NestedField::map_value_element(
@@ -379,12 +379,12 @@ mod tests {
                                 Type::Map(MapType {
                                     key_field: NestedField::map_key_element(
                                         9,
-                                        Type::Primitive(PrimitiveType::String),
+                                        Primitive(PrimitiveType::String),
                                     )
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
-                                        Type::Primitive(PrimitiveType::Int),
+                                        Primitive(PrimitiveType::Int),
                                         true,
                                     )
                                     .into(),
@@ -427,7 +427,7 @@ mod tests {
                         Type::Map(MapType {
                             key_field: NestedField::map_key_element(
                                 7,
-                                Type::Primitive(PrimitiveType::String),
+                                Primitive(PrimitiveType::String),
                             )
                             .into(),
                             value_field: NestedField::map_value_element(
@@ -435,12 +435,12 @@ mod tests {
                                 Type::Map(MapType {
                                     key_field: NestedField::map_key_element(
                                         9,
-                                        Type::Primitive(PrimitiveType::String),
+                                        Primitive(PrimitiveType::String),
                                     )
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
-                                        Type::Primitive(PrimitiveType::Int),
+                                        Primitive(PrimitiveType::Int),
                                         true,
                                     )
                                     .into(),
@@ -475,7 +475,7 @@ mod tests {
                         Type::Map(MapType {
                             key_field: NestedField::map_key_element(
                                 7,
-                                Type::Primitive(PrimitiveType::String),
+                                Primitive(PrimitiveType::String),
                             )
                             .into(),
                             value_field: NestedField::map_value_element(
@@ -483,12 +483,12 @@ mod tests {
                                 Type::Map(MapType {
                                     key_field: NestedField::map_key_element(
                                         9,
-                                        Type::Primitive(PrimitiveType::String),
+                                        Primitive(PrimitiveType::String),
                                     )
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
-                                        Type::Primitive(PrimitiveType::Int),
+                                        Primitive(PrimitiveType::Int),
                                         true,
                                     )
                                     .into(),
@@ -521,12 +521,8 @@ mod tests {
                         15,
                         "person",
                         Type::Struct(StructType::new(vec![
-                            NestedField::optional(
-                                16,
-                                "name",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
+                            NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                                .into(),
                         ])),
                     )
                     .into(),
@@ -552,12 +548,8 @@ mod tests {
                         15,
                         "person",
                         Type::Struct(StructType::new(vec![
-                            NestedField::optional(
-                                16,
-                                "name",
-                                Type::Primitive(PrimitiveType::String),
-                            )
-                            .into(),
+                            NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                                .into(),
                         ])),
                     )
                     .into(),
@@ -633,11 +625,8 @@ mod tests {
                     6,
                     "id_to_person",
                     Type::Map(MapType {
-                        key_field: NestedField::map_key_element(
-                            7,
-                            Type::Primitive(PrimitiveType::Int),
-                        )
-                        .into(),
+                        key_field: NestedField::map_key_element(7, Primitive(PrimitiveType::Int))
+                            .into(),
                         value_field: NestedField::map_value_element(
                             8,
                             Type::Struct(StructType::new(vec![
@@ -664,7 +653,7 @@ mod tests {
                         Type::Map(MapType {
                             key_field: NestedField::map_key_element(
                                 7,
-                                Type::Primitive(PrimitiveType::Int),
+                                Primitive(PrimitiveType::Int),
                             )
                             .into(),
                             value_field: NestedField::map_value_element(
@@ -699,11 +688,8 @@ mod tests {
                     6,
                     "id_to_person",
                     Type::Map(MapType {
-                        key_field: NestedField::map_key_element(
-                            7,
-                            Type::Primitive(PrimitiveType::Int),
-                        )
-                        .into(),
+                        key_field: NestedField::map_key_element(7, Primitive(PrimitiveType::Int))
+                            .into(),
                         value_field: NestedField::map_value_element(
                             8,
                             Type::Struct(StructType::new(vec![
@@ -730,7 +716,7 @@ mod tests {
                         Type::Map(MapType {
                             key_field: NestedField::map_key_element(
                                 7,
-                                Type::Primitive(PrimitiveType::Int),
+                                Primitive(PrimitiveType::Int),
                             )
                             .into(),
                             value_field: NestedField::map_value_element(
@@ -771,7 +757,7 @@ mod tests {
         // foo (String, id=1) + v (Variant, id=2).
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
                 NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
             ])
             .build()
@@ -789,7 +775,7 @@ mod tests {
 
         // Selecting a sibling prunes the variant out.
         let only_foo = Type::Struct(StructType::new(vec![
-            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
         ]));
         let result = prune_columns(&schema, HashSet::from([1]), false).unwrap();
         assert_eq!(result, only_foo);

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -953,7 +953,7 @@ pub(super) mod _serde {
 
     impl TryFrom<TableMetadataV3> for TableMetadata {
         type Error = Error;
-        fn try_from(value: TableMetadataV3) -> Result<Self, self::Error> {
+        fn try_from(value: TableMetadataV3) -> Result<Self, Error> {
             let TableMetadataV3 {
                 format_version: _,
                 shared: value,
@@ -1071,7 +1071,7 @@ pub(super) mod _serde {
 
     impl TryFrom<TableMetadataV2> for TableMetadata {
         type Error = Error;
-        fn try_from(value: TableMetadataV2) -> Result<Self, self::Error> {
+        fn try_from(value: TableMetadataV2) -> Result<Self, Error> {
             let snapshots = value.snapshots;
             let value = value.shared;
             let current_snapshot_id = if value.current_snapshot_id == Some(EMPTY_SNAPSHOT_ID) {
@@ -3644,7 +3644,7 @@ mod tests {
         let compressed = CompressionCodec::gzip_default()
             .compress(json.into_bytes())
             .expect("failed to compress metadata");
-        std::fs::write(&metadata_location, &compressed).expect("failed to write metadata");
+        fs::write(&metadata_location, &compressed).expect("failed to write metadata");
 
         // Read the metadata back
         let file_io = FileIO::new_with_fs();
@@ -3712,7 +3712,7 @@ mod tests {
         assert!(std::path::Path::new(&metadata_location_str).exists());
 
         // Read the raw file and check it's gzip compressed
-        let raw_content = std::fs::read(&metadata_location_str).unwrap();
+        let raw_content = fs::read(&metadata_location_str).unwrap();
         assert!(raw_content.len() > 2);
         assert_eq!(raw_content[0], 0x1F); // gzip magic number
         assert_eq!(raw_content[1], 0x8B); // gzip magic number

--- a/crates/iceberg/src/spec/values/datum.rs
+++ b/crates/iceberg/src/spec/values/datum.rs
@@ -98,27 +98,27 @@ impl<'de> Deserialize<'de> for Datum {
 
         struct DatumVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for DatumVisitor {
+        impl<'de> de::Visitor<'de> for DatumVisitor {
             type Value = Datum;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("struct Datum")
             }
 
             fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
-            where A: serde::de::SeqAccess<'de> {
+            where A: de::SeqAccess<'de> {
                 let r#type = seq
                     .next_element::<PrimitiveType>()?
-                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
                 let value = seq
                     .next_element::<RawLiteral>()?
-                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 let Literal::Primitive(primitive) = value
                     .try_into(&Type::Primitive(r#type.clone()))
-                    .map_err(serde::de::Error::custom)?
-                    .ok_or_else(|| serde::de::Error::custom("None value"))?
+                    .map_err(de::Error::custom)?
+                    .ok_or_else(|| de::Error::custom("None value"))?
                 else {
-                    return Err(serde::de::Error::custom("Invalid value"));
+                    return Err(de::Error::custom("Invalid value"));
                 };
 
                 Ok(Datum::new(r#type, primitive))
@@ -145,17 +145,17 @@ impl<'de> Deserialize<'de> for Datum {
                     }
                 }
                 let Some(r#type) = r#type else {
-                    return Err(serde::de::Error::missing_field("type"));
+                    return Err(de::Error::missing_field("type"));
                 };
                 let Some(raw_primitive) = raw_primitive else {
-                    return Err(serde::de::Error::missing_field("literal"));
+                    return Err(de::Error::missing_field("literal"));
                 };
                 let Literal::Primitive(primitive) = raw_primitive
                     .try_into(&Type::Primitive(r#type.clone()))
-                    .map_err(serde::de::Error::custom)?
-                    .ok_or_else(|| serde::de::Error::custom("None value"))?
+                    .map_err(de::Error::custom)?
+                    .ok_or_else(|| de::Error::custom("None value"))?
                 else {
-                    return Err(serde::de::Error::custom("Invalid value"));
+                    return Err(de::Error::custom("Invalid value"));
                 };
                 Ok(Datum::new(r#type, primitive))
             }

--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -436,7 +436,7 @@ impl Literal {
                         number
                             .as_i64()
                             .ok_or(Error::new(
-                                crate::ErrorKind::DataInvalid,
+                                ErrorKind::DataInvalid,
                                 "Failed to convert json number to int",
                             ))?
                             .try_into()?,
@@ -444,19 +444,19 @@ impl Literal {
                 }
                 (PrimitiveType::Long, JsonValue::Number(number)) => Ok(Some(Literal::Primitive(
                     PrimitiveLiteral::Long(number.as_i64().ok_or(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "Failed to convert json number to long",
                     ))?),
                 ))),
                 (PrimitiveType::Float, JsonValue::Number(number)) => Ok(Some(Literal::Primitive(
                     PrimitiveLiteral::Float(OrderedFloat(number.as_f64().ok_or(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "Failed to convert json number to float",
                     ))? as f32)),
                 ))),
                 (PrimitiveType::Double, JsonValue::Number(number)) => Ok(Some(Literal::Primitive(
                     PrimitiveLiteral::Double(OrderedFloat(number.as_f64().ok_or(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "Failed to convert json number to double",
                     ))?)),
                 ))),
@@ -470,7 +470,7 @@ impl Literal {
                         number
                             .as_i64()
                             .ok_or(Error::new(
-                                crate::ErrorKind::DataInvalid,
+                                ErrorKind::DataInvalid,
                                 "Failed to convert json number to date (days since epoch)",
                             ))?
                             .try_into()?,
@@ -497,7 +497,7 @@ impl Literal {
                     let ndt = NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f")?;
                     let nanos = timestamp::datetime_to_nanoseconds(&ndt).ok_or_else(|| {
                         Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             format!(
                                 "Timestamp is outside the representable nanosecond range: {ndt}"
                             ),
@@ -512,7 +512,7 @@ impl Literal {
                     )?);
                     let nanos = timestamptz::datetimetz_to_nanoseconds(&dt).ok_or_else(|| {
                         Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             format!(
                                 "Timestamptz is outside the representable nanosecond range: {dt}"
                             ),
@@ -549,7 +549,7 @@ impl Literal {
                 }
                 (_, JsonValue::Null) => Ok(None),
                 (i, j) => Err(Error::new(
-                    crate::ErrorKind::DataInvalid,
+                    ErrorKind::DataInvalid,
                     format!("The json value {j} doesn't fit to the iceberg type {i}."),
                 )),
             },
@@ -571,7 +571,7 @@ impl Literal {
                     ))))
                 } else {
                     Err(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "The json value for a struct type must be an object.",
                     ))
                 }
@@ -588,7 +588,7 @@ impl Literal {
                     )))
                 } else {
                     Err(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "The json value for a list type must be an array.",
                     ))
                 }
@@ -617,13 +617,13 @@ impl Literal {
                         ))))
                     } else {
                         Err(Error::new(
-                            crate::ErrorKind::DataInvalid,
+                            ErrorKind::DataInvalid,
                             "The json value for a list type must be an array.",
                         ))
                     }
                 } else {
                     Err(Error::new(
-                        crate::ErrorKind::DataInvalid,
+                        ErrorKind::DataInvalid,
                         "The json value for a list type must be an array.",
                     ))
                 }

--- a/crates/iceberg/src/spec/values/temporal.rs
+++ b/crates/iceberg/src/spec/values/temporal.rs
@@ -32,7 +32,7 @@ pub(crate) mod date {
 
     pub(crate) fn days_to_date(days: i32) -> NaiveDate {
         // This shouldn't fail until the year 262000
-        (chrono::DateTime::UNIX_EPOCH + TimeDelta::try_days(days as i64).unwrap())
+        (DateTime::UNIX_EPOCH + TimeDelta::try_days(days as i64).unwrap())
             .naive_utc()
             .date()
     }

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -31,7 +31,6 @@ use crate::spec::Schema;
 use crate::spec::Type::Primitive;
 use crate::spec::datatypes::{ListType, MapType, NestedField, PrimitiveType, StructType, Type};
 use crate::spec::values::datum::{INT_MAX, INT_MIN, LONG_MAX, LONG_MIN};
-use crate::spec::values::serde::_serde;
 use crate::spec::values::{Datum, Literal, Map, PrimitiveLiteral, RawLiteral, Struct};
 
 fn check_json_serde(json: &str, expected_literal: Literal, expected_type: &Type) {
@@ -122,7 +121,7 @@ fn json_boolean() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Boolean(true)),
-        &Type::Primitive(PrimitiveType::Boolean),
+        &Primitive(PrimitiveType::Boolean),
     );
 }
 
@@ -133,7 +132,7 @@ fn json_int() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Int(32)),
-        &Type::Primitive(PrimitiveType::Int),
+        &Primitive(PrimitiveType::Int),
     );
 }
 
@@ -144,7 +143,7 @@ fn json_long() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(32)),
-        &Type::Primitive(PrimitiveType::Long),
+        &Primitive(PrimitiveType::Long),
     );
 }
 
@@ -155,7 +154,7 @@ fn json_float() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Float(OrderedFloat(1.0))),
-        &Type::Primitive(PrimitiveType::Float),
+        &Primitive(PrimitiveType::Float),
     );
 }
 
@@ -166,7 +165,7 @@ fn json_double() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Double(OrderedFloat(1.0))),
-        &Type::Primitive(PrimitiveType::Double),
+        &Primitive(PrimitiveType::Double),
     );
 }
 
@@ -177,7 +176,7 @@ fn json_date() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Int(17486)),
-        &Type::Primitive(PrimitiveType::Date),
+        &Primitive(PrimitiveType::Date),
     );
 }
 
@@ -188,7 +187,7 @@ fn json_time() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(81068123456)),
-        &Type::Primitive(PrimitiveType::Time),
+        &Primitive(PrimitiveType::Time),
     );
 }
 
@@ -199,7 +198,7 @@ fn json_timestamp() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456)),
-        &Type::Primitive(PrimitiveType::Timestamp),
+        &Primitive(PrimitiveType::Timestamp),
     );
 }
 
@@ -210,7 +209,7 @@ fn json_timestamptz() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456)),
-        &Type::Primitive(PrimitiveType::Timestamptz),
+        &Primitive(PrimitiveType::Timestamptz),
     );
 }
 
@@ -221,7 +220,7 @@ fn json_timestamp_ns() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456789)),
-        &Type::Primitive(PrimitiveType::TimestampNs),
+        &Primitive(PrimitiveType::TimestampNs),
     );
 }
 
@@ -232,7 +231,7 @@ fn json_timestamptz_ns() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456789)),
-        &Type::Primitive(PrimitiveType::TimestamptzNs),
+        &Primitive(PrimitiveType::TimestamptzNs),
     );
 }
 
@@ -242,7 +241,7 @@ fn json_timestamptz_ns_rejects_non_utc_offset() {
     // SingleValueParser enforces the same (DateTimeUtil.isUTCTimestamptz). A non-UTC offset is not a
     // valid encoding and must be rejected, not silently re-based to UTC.
     let record = serde_json::Value::String("2017-11-16T22:31:08.123456789+05:00".to_string());
-    let result = Literal::try_from_json(record, &Type::Primitive(PrimitiveType::TimestamptzNs));
+    let result = Literal::try_from_json(record, &Primitive(PrimitiveType::TimestamptzNs));
     assert!(
         result.is_err(),
         "non-UTC offset must be rejected for timestamptz_ns, got {result:?}"
@@ -254,7 +253,7 @@ fn json_timestamptz_rejects_non_utc_offset() {
     // Micros-precision counterpart, mirroring Java's TestSingleValueParser.testInvalidTimestamptz:
     // the offset must be "+00:00", so a non-UTC offset is rejected.
     let record = serde_json::Value::String("2017-11-16T22:31:08.123456+05:00".to_string());
-    let result = Literal::try_from_json(record, &Type::Primitive(PrimitiveType::Timestamptz));
+    let result = Literal::try_from_json(record, &Primitive(PrimitiveType::Timestamptz));
     assert!(
         result.is_err(),
         "non-UTC offset must be rejected for timestamptz, got {result:?}"
@@ -268,7 +267,7 @@ fn json_string() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::String("iceberg".to_string())),
-        &Type::Primitive(PrimitiveType::String),
+        &Primitive(PrimitiveType::String),
     );
 }
 
@@ -283,7 +282,7 @@ fn json_uuid() {
                 .unwrap()
                 .as_u128(),
         )),
-        &Type::Primitive(PrimitiveType::Uuid),
+        &Primitive(PrimitiveType::Uuid),
     );
 }
 
@@ -305,7 +304,7 @@ fn json_binary() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Binary(vec![0, 1, 15, 255])),
-        &Type::Primitive(PrimitiveType::Binary),
+        &Primitive(PrimitiveType::Binary),
     );
 }
 
@@ -316,7 +315,7 @@ fn json_fixed() {
     check_json_serde(
         record,
         Literal::Primitive(PrimitiveLiteral::Binary(vec![0, 1, 15, 255])),
-        &Type::Primitive(PrimitiveType::Fixed(4)),
+        &Primitive(PrimitiveType::Fixed(4)),
     );
 }
 
@@ -324,7 +323,7 @@ fn json_fixed() {
 fn test_should_parse_json_binary_if_hex_uses_uppercase_digits() {
     let result = Literal::try_from_json(
         serde_json::json!("00010FFF"),
-        &Type::Primitive(PrimitiveType::Binary),
+        &Primitive(PrimitiveType::Binary),
     )
     .unwrap();
 
@@ -339,33 +338,23 @@ fn test_should_parse_json_binary_if_hex_uses_uppercase_digits() {
 #[test]
 fn test_should_reject_json_binary_if_hex_is_invalid() {
     assert!(
-        Literal::try_from_json(
-            serde_json::json!("f"),
-            &Type::Primitive(PrimitiveType::Binary),
-        )
-        .is_err()
+        Literal::try_from_json(serde_json::json!("f"), &Primitive(PrimitiveType::Binary),).is_err()
     );
     assert!(
-        Literal::try_from_json(
-            serde_json::json!("fg"),
-            &Type::Primitive(PrimitiveType::Binary),
-        )
-        .is_err()
+        Literal::try_from_json(serde_json::json!("fg"), &Primitive(PrimitiveType::Binary),)
+            .is_err()
     );
 }
 
 #[test]
 fn test_should_reject_json_fixed_if_length_does_not_match() {
     assert!(
-        Literal::try_from_json(
-            serde_json::json!("ff"),
-            &Type::Primitive(PrimitiveType::Fixed(2)),
-        )
-        .is_err()
+        Literal::try_from_json(serde_json::json!("ff"), &Primitive(PrimitiveType::Fixed(2)),)
+            .is_err()
     );
     assert!(
         Literal::Primitive(PrimitiveLiteral::Binary(vec![255]))
-            .try_into_json(&Type::Primitive(PrimitiveType::Fixed(2)))
+            .try_into_json(&Primitive(PrimitiveType::Fixed(2)))
             .is_err()
     );
 }
@@ -384,9 +373,9 @@ fn json_struct() {
             None,
         ])),
         &Type::Struct(StructType::new(vec![
-            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(3, "address", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "id", Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(2, "name", Primitive(PrimitiveType::String)).into(),
+            NestedField::optional(3, "address", Primitive(PrimitiveType::String)).into(),
         ])),
     );
 }
@@ -404,8 +393,7 @@ fn json_list() {
             None,
         ]),
         &Type::List(ListType {
-            element_field: NestedField::list_element(0, Type::Primitive(PrimitiveType::Int), true)
-                .into(),
+            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true).into(),
         }),
     );
 }
@@ -431,14 +419,9 @@ fn json_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(0, Type::Primitive(PrimitiveType::String))
+            key_field: NestedField::map_key_element(0, Primitive(PrimitiveType::String)).into(),
+            value_field: NestedField::map_value_element(1, Primitive(PrimitiveType::Int), true)
                 .into(),
-            value_field: NestedField::map_value_element(
-                1,
-                Type::Primitive(PrimitiveType::Int),
-                true,
-            )
-            .into(),
         }),
     );
 }
@@ -550,7 +533,7 @@ fn check_raw_literal_bytes_serde_via_avro(
 
     // Create an Avro bytes value and deserialize it through the RawLiteral path
     let avro_value = Value::Bytes(input_bytes);
-    let raw_literal: _serde::RawLiteral = apache_avro::from_value(&avro_value).unwrap();
+    let raw_literal: RawLiteral = apache_avro::from_value(&avro_value).unwrap();
     let result = raw_literal.try_into(expected_type).unwrap();
     assert_eq!(result, Some(expected_literal));
 }
@@ -559,7 +542,7 @@ fn check_raw_literal_bytes_error_via_avro(input_bytes: Vec<u8>, expected_type: &
     use apache_avro::types::Value;
 
     let avro_value = Value::Bytes(input_bytes);
-    let raw_literal: _serde::RawLiteral = apache_avro::from_value(&avro_value).unwrap();
+    let raw_literal: RawLiteral = apache_avro::from_value(&avro_value).unwrap();
     let result = raw_literal.try_into(expected_type);
     assert!(result.is_err(), "Expected error but got: {result:?}");
 }
@@ -570,7 +553,7 @@ fn test_raw_literal_bytes_binary() {
     check_raw_literal_bytes_serde_via_avro(
         bytes.clone(),
         Literal::binary(bytes),
-        &Type::Primitive(PrimitiveType::Binary),
+        &Primitive(PrimitiveType::Binary),
     );
 }
 
@@ -580,7 +563,7 @@ fn test_raw_literal_bytes_binary_empty() {
     check_raw_literal_bytes_serde_via_avro(
         bytes.clone(),
         Literal::binary(bytes),
-        &Type::Primitive(PrimitiveType::Binary),
+        &Primitive(PrimitiveType::Binary),
     );
 }
 
@@ -590,14 +573,14 @@ fn test_raw_literal_bytes_fixed_correct_length() {
     check_raw_literal_bytes_serde_via_avro(
         bytes.clone(),
         Literal::fixed(bytes),
-        &Type::Primitive(PrimitiveType::Fixed(4)),
+        &Primitive(PrimitiveType::Fixed(4)),
     );
 }
 
 #[test]
 fn test_raw_literal_bytes_fixed_wrong_length() {
     let bytes = vec![1u8, 2u8, 3u8]; // 3 bytes, but expecting 4
-    check_raw_literal_bytes_error_via_avro(bytes, &Type::Primitive(PrimitiveType::Fixed(4)));
+    check_raw_literal_bytes_error_via_avro(bytes, &Primitive(PrimitiveType::Fixed(4)));
 }
 
 #[test]
@@ -606,7 +589,7 @@ fn test_raw_literal_bytes_fixed_empty_correct_length() {
     check_raw_literal_bytes_serde_via_avro(
         bytes.clone(),
         Literal::fixed(bytes),
-        &Type::Primitive(PrimitiveType::Fixed(0)),
+        &Primitive(PrimitiveType::Fixed(0)),
     );
 }
 
@@ -623,14 +606,14 @@ fn test_raw_literal_bytes_uuid_correct_length() {
     check_raw_literal_bytes_serde_via_avro(
         uuid_bytes,
         Literal::Primitive(PrimitiveLiteral::UInt128(expected_uuid)),
-        &Type::Primitive(PrimitiveType::Uuid),
+        &Primitive(PrimitiveType::Uuid),
     );
 }
 
 #[test]
 fn test_raw_literal_bytes_uuid_wrong_length() {
     let bytes = vec![1u8, 2u8, 3u8]; // 3 bytes, but UUID needs 16
-    check_raw_literal_bytes_error_via_avro(bytes, &Type::Primitive(PrimitiveType::Uuid));
+    check_raw_literal_bytes_error_via_avro(bytes, &Primitive(PrimitiveType::Uuid));
 }
 
 #[test]
@@ -641,7 +624,7 @@ fn test_raw_literal_bytes_decimal_precision_4_scale_2() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 4,
             scale: 2,
         }),
@@ -656,7 +639,7 @@ fn test_raw_literal_bytes_decimal_precision_4_negative() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 4,
             scale: 2,
         }),
@@ -671,7 +654,7 @@ fn test_raw_literal_bytes_decimal_precision_9_scale_2() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 9,
             scale: 2,
         }),
@@ -686,7 +669,7 @@ fn test_raw_literal_bytes_decimal_precision_18_scale_2() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 18,
             scale: 2,
         }),
@@ -704,7 +687,7 @@ fn test_raw_literal_bytes_decimal_precision_38_scale_2() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 38,
             scale: 2,
         }),
@@ -719,7 +702,7 @@ fn test_raw_literal_bytes_decimal_precision_1_scale_0() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 1,
             scale: 0,
         }),
@@ -734,7 +717,7 @@ fn test_raw_literal_bytes_decimal_precision_1_negative() {
     check_raw_literal_bytes_serde_via_avro(
         decimal_bytes,
         Literal::Primitive(PrimitiveLiteral::Int128(expected_decimal)),
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 1,
             scale: 0,
         }),
@@ -747,7 +730,7 @@ fn test_raw_literal_bytes_decimal_wrong_length() {
     let bytes = vec![1u8, 2u8, 3u8];
     check_raw_literal_bytes_error_via_avro(
         bytes,
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 4,
             scale: 2,
         }),
@@ -760,7 +743,7 @@ fn test_raw_literal_bytes_decimal_wrong_length_too_few() {
     let bytes = vec![0x42];
     check_raw_literal_bytes_error_via_avro(
         bytes,
-        &Type::Primitive(PrimitiveType::Decimal {
+        &Primitive(PrimitiveType::Decimal {
             precision: 9,
             scale: 2,
         }),
@@ -770,14 +753,14 @@ fn test_raw_literal_bytes_decimal_wrong_length_too_few() {
 #[test]
 fn test_raw_literal_bytes_unsupported_type() {
     let bytes = vec![1u8, 2u8, 3u8, 4u8];
-    check_raw_literal_bytes_error_via_avro(bytes, &Type::Primitive(PrimitiveType::Int));
+    check_raw_literal_bytes_error_via_avro(bytes, &Primitive(PrimitiveType::Int));
 }
 
 #[test]
 fn avro_convert_test_int() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Int(32)),
-        &Type::Primitive(PrimitiveType::Int),
+        &Primitive(PrimitiveType::Int),
     );
 }
 
@@ -785,7 +768,7 @@ fn avro_convert_test_int() {
 fn avro_convert_test_long() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Long(32)),
-        &Type::Primitive(PrimitiveType::Long),
+        &Primitive(PrimitiveType::Long),
     );
 }
 
@@ -793,7 +776,7 @@ fn avro_convert_test_long() {
 fn avro_convert_test_float() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Float(OrderedFloat(1.0))),
-        &Type::Primitive(PrimitiveType::Float),
+        &Primitive(PrimitiveType::Float),
     );
 }
 
@@ -801,7 +784,7 @@ fn avro_convert_test_float() {
 fn avro_convert_test_double() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Double(OrderedFloat(1.0))),
-        &Type::Primitive(PrimitiveType::Double),
+        &Primitive(PrimitiveType::Double),
     );
 }
 
@@ -809,7 +792,7 @@ fn avro_convert_test_double() {
 fn avro_convert_test_string() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::String("iceberg".to_string())),
-        &Type::Primitive(PrimitiveType::String),
+        &Primitive(PrimitiveType::String),
     );
 }
 
@@ -817,7 +800,7 @@ fn avro_convert_test_string() {
 fn avro_convert_test_date() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Int(17486)),
-        &Type::Primitive(PrimitiveType::Date),
+        &Primitive(PrimitiveType::Date),
     );
 }
 
@@ -825,7 +808,7 @@ fn avro_convert_test_date() {
 fn avro_convert_test_time() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Long(81068123456)),
-        &Type::Primitive(PrimitiveType::Time),
+        &Primitive(PrimitiveType::Time),
     );
 }
 
@@ -833,7 +816,7 @@ fn avro_convert_test_time() {
 fn avro_convert_test_timestamp() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456)),
-        &Type::Primitive(PrimitiveType::Timestamp),
+        &Primitive(PrimitiveType::Timestamp),
     );
 }
 
@@ -841,7 +824,7 @@ fn avro_convert_test_timestamp() {
 fn avro_convert_test_timestamptz() {
     check_convert_with_avro(
         Literal::Primitive(PrimitiveLiteral::Long(1510871468123456)),
-        &Type::Primitive(PrimitiveType::Timestamptz),
+        &Primitive(PrimitiveType::Timestamptz),
     );
 }
 
@@ -855,7 +838,7 @@ fn avro_convert_test_list() {
             None,
         ]),
         &Type::List(ListType {
-            element_field: NestedField::list_element(0, Type::Primitive(PrimitiveType::Int), false)
+            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), false)
                 .into(),
         }),
     );
@@ -867,8 +850,7 @@ fn avro_convert_test_list() {
             Some(Literal::Primitive(PrimitiveLiteral::Int(3))),
         ]),
         &Type::List(ListType {
-            element_field: NestedField::list_element(0, Type::Primitive(PrimitiveType::Int), true)
-                .into(),
+            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true).into(),
         }),
     );
 }
@@ -925,13 +907,9 @@ fn avro_convert_test_map() {
             (Literal::Primitive(PrimitiveLiteral::Int(3)), None),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Type::Primitive(PrimitiveType::Int)).into(),
-            value_field: NestedField::map_value_element(
-                3,
-                Type::Primitive(PrimitiveType::Long),
-                false,
-            )
-            .into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int)).into(),
+            value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Long), false)
+                .into(),
         }),
     );
 
@@ -951,13 +929,9 @@ fn avro_convert_test_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Type::Primitive(PrimitiveType::Int)).into(),
-            value_field: NestedField::map_value_element(
-                3,
-                Type::Primitive(PrimitiveType::Long),
-                true,
-            )
-            .into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int)).into(),
+            value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Long), true)
+                .into(),
         }),
     );
 }
@@ -980,14 +954,9 @@ fn avro_convert_test_string_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Type::Primitive(PrimitiveType::String))
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String)).into(),
+            value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Int), false)
                 .into(),
-            value_field: NestedField::map_value_element(
-                3,
-                Type::Primitive(PrimitiveType::Int),
-                false,
-            )
-            .into(),
         }),
     );
 
@@ -1007,14 +976,9 @@ fn avro_convert_test_string_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Type::Primitive(PrimitiveType::String))
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String)).into(),
+            value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Int), true)
                 .into(),
-            value_field: NestedField::map_value_element(
-                3,
-                Type::Primitive(PrimitiveType::Int),
-                true,
-            )
-            .into(),
         }),
     );
 }
@@ -1030,9 +994,9 @@ fn avro_convert_test_record() {
             None,
         ])),
         &Type::Struct(StructType::new(vec![
-            NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(4, "address", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(2, "id", Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(3, "name", Primitive(PrimitiveType::String)).into(),
+            NestedField::optional(4, "address", Primitive(PrimitiveType::String)).into(),
         ])),
     );
 }
@@ -1044,7 +1008,7 @@ fn avro_convert_test_record() {
 #[test]
 fn avro_convert_test_binary_ser() {
     let literal = Literal::Primitive(PrimitiveLiteral::Binary(vec![1, 2, 3, 4, 5]));
-    let ty = Type::Primitive(PrimitiveType::Binary);
+    let ty = Primitive(PrimitiveType::Binary);
     let expect_value = Value::Bytes(vec![1, 2, 3, 4, 5]);
     check_serialize_avro(literal, &ty, expect_value);
 }
@@ -1052,7 +1016,7 @@ fn avro_convert_test_binary_ser() {
 #[test]
 fn avro_convert_test_decimal_ser() {
     let literal = Literal::decimal(12345);
-    let ty = Type::Primitive(PrimitiveType::Decimal {
+    let ty = Primitive(PrimitiveType::Decimal {
         precision: 9,
         scale: 8,
     });
@@ -1497,8 +1461,7 @@ fn test_date_from_json_as_number() {
 
     // Test Date as number (days since epoch) - used in initial-default from add_files
     let date_number = json!(18628); // 2021-01-01 is 18628 days since 1970-01-01
-    let result =
-        Literal::try_from_json(date_number, &Type::Primitive(PrimitiveType::Date)).unwrap();
+    let result = Literal::try_from_json(date_number, &Primitive(PrimitiveType::Date)).unwrap();
     assert_eq!(
         result,
         Some(Literal::Primitive(PrimitiveLiteral::Int(18628)))
@@ -1506,8 +1469,7 @@ fn test_date_from_json_as_number() {
 
     // Test Date as string - traditional format
     let date_string = json!("2021-01-01");
-    let result =
-        Literal::try_from_json(date_string, &Type::Primitive(PrimitiveType::Date)).unwrap();
+    let result = Literal::try_from_json(date_string, &Primitive(PrimitiveType::Date)).unwrap();
     assert_eq!(
         result,
         Some(Literal::Primitive(PrimitiveLiteral::Int(18628)))
@@ -1518,7 +1480,7 @@ fn test_date_from_json_as_number() {
 
 #[test]
 fn test_datum_to_decimal_narrows_precision_when_scale_matches() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 9,
         scale: 2,
     });
@@ -1535,7 +1497,7 @@ fn test_datum_to_decimal_narrows_precision_when_scale_matches() {
 
 #[test]
 fn test_datum_to_decimal_widens_precision_when_scale_matches() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 38,
         scale: 2,
     });
@@ -1552,7 +1514,7 @@ fn test_datum_to_decimal_widens_precision_when_scale_matches() {
 
 #[test]
 fn test_datum_to_decimal_accepts_zero_mantissa() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 1,
         scale: 0,
     });
@@ -1569,7 +1531,7 @@ fn test_datum_to_decimal_accepts_zero_mantissa() {
 
 #[test]
 fn test_datum_to_decimal_accepts_negative_mantissa() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 2,
         scale: 1,
     });
@@ -1586,7 +1548,7 @@ fn test_datum_to_decimal_accepts_negative_mantissa() {
 
 #[test]
 fn test_datum_to_decimal_rejects_precision_too_narrow() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 1,
         scale: 1,
     });
@@ -1600,7 +1562,7 @@ fn test_datum_to_decimal_rejects_precision_too_narrow() {
 
 #[test]
 fn test_datum_to_decimal_rejects_value_that_fits_storage_bytes_but_not_precision() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 1,
         scale: 1,
     });
@@ -1614,7 +1576,7 @@ fn test_datum_to_decimal_rejects_value_that_fits_storage_bytes_but_not_precision
 
 #[test]
 fn test_datum_to_decimal_accepts_single_digit_mantissa_for_precision_one() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 1,
         scale: 1,
     });
@@ -1650,7 +1612,7 @@ fn test_datum_decimal_with_precision_accepts_value_that_fits_digit_precision() {
 
 #[test]
 fn test_datum_to_decimal_rejects_scale_change() {
-    let target_type = Type::Primitive(PrimitiveType::Decimal {
+    let target_type = Primitive(PrimitiveType::Decimal {
         precision: 9,
         scale: 3,
     });

--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -271,7 +271,7 @@ pub(super) mod _serde {
         pub(super) versions: Vec<ViewVersionV1>,
         pub(super) version_log: Vec<ViewVersionLog>,
         pub(super) schemas: Vec<SchemaV2>,
-        pub(super) properties: Option<std::collections::HashMap<String, String>>,
+        pub(super) properties: Option<HashMap<String, String>>,
     }
 
     impl Serialize for ViewMetadata {
@@ -305,7 +305,7 @@ pub(super) mod _serde {
 
     impl TryFrom<ViewMetadataV1> for ViewMetadata {
         type Error = Error;
-        fn try_from(value: ViewMetadataV1) -> Result<Self, self::Error> {
+        fn try_from(value: ViewMetadataV1) -> Result<Self, Error> {
             let schemas = HashMap::from_iter(
                 value
                     .schemas

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -537,7 +537,7 @@ mod tests {
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
 
         let mut file_seq = 0u32;
-        let mut append_file = |table: &crate::table::Table, record_count: u64, file_size: u64| {
+        let mut append_file = |table: &Table, record_count: u64, file_size: u64| {
             file_seq += 1;
             let file = DataFileBuilder::default()
                 .content(DataContentType::Data)
@@ -607,7 +607,7 @@ mod tests {
             .identifier(TableIdent::from_strs(["ns1", "test1"]).unwrap())
             .file_io(FileIO::new_with_memory())
             .kms_client(kms)
-            .runtime(crate::test_utils::test_runtime())
+            .runtime(test_runtime())
             .build()
             .unwrap();
 

--- a/crates/iceberg/src/transform/bucket.rs
+++ b/crates/iceberg/src/transform/bucket.rs
@@ -295,7 +295,7 @@ mod test {
     };
     use crate::spec::Type::{Primitive, Struct};
     use crate::spec::decimal_utils::decimal_new;
-    use crate::spec::{Datum, NestedField, PrimitiveType, StructType, Transform, Type};
+    use crate::spec::{Datum, NestedField, PrimitiveType, StructType, Transform};
     use crate::transform::TransformFunction;
     use crate::transform::test::{TestProjectionFixture, TestTransformFixture};
 
@@ -354,7 +354,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Uuid)),
+            NestedField::required(1, "value", Primitive(Uuid)),
         );
 
         fixture.assert_projection(
@@ -414,11 +414,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(
-                1,
-                "value",
-                Type::Primitive(PrimitiveType::Fixed(value.len() as u64)),
-            ),
+            NestedField::required(1, "value", Primitive(Fixed(value.len() as u64))),
         );
 
         fixture.assert_projection(
@@ -481,7 +477,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
         );
 
         fixture.assert_projection(
@@ -545,7 +541,7 @@ mod test {
             NestedField::required(
                 1,
                 "value",
-                Type::Primitive(PrimitiveType::Decimal {
+                Primitive(Decimal {
                     precision: 9,
                     scale: 2,
                 }),
@@ -617,7 +613,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Long)),
+            NestedField::required(1, "value", Primitive(Long)),
         );
 
         fixture.assert_projection(
@@ -677,7 +673,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Int)),
+            NestedField::required(1, "value", Primitive(Int)),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/transform/mod.rs
+++ b/crates/iceberg/src/transform/mod.rs
@@ -64,8 +64,8 @@ pub fn create_transform_function(transform: &Transform) -> Result<BoxedTransform
         Transform::Hour => Ok(Box::new(temporal::Hour {})),
         Transform::Bucket(mod_n) => Ok(Box::new(bucket::Bucket::new(*mod_n))),
         Transform::Truncate(width) => Ok(Box::new(truncate::Truncate::new(*width))),
-        Transform::Unknown => Err(crate::error::Error::new(
-            crate::ErrorKind::FeatureUnsupported,
+        Transform::Unknown => Err(Error::new(
+            ErrorKind::FeatureUnsupported,
             "Transform Unknown is not implemented",
         )),
     }

--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -78,7 +78,7 @@ impl TransformFunction for Year {
         ))
     }
 
-    fn transform_literal(&self, input: &crate::spec::Datum) -> Result<Option<crate::spec::Datum>> {
+    fn transform_literal(&self, input: &Datum) -> Result<Option<Datum>> {
         let val = match (input.data_type(), input.literal()) {
             (PrimitiveType::Date, PrimitiveLiteral::Int(v)) => {
                 Date32Type::to_naive_date_opt(*v).unwrap().year() - UNIX_EPOCH_YEAR
@@ -96,8 +96,8 @@ impl TransformFunction for Year {
                 Self::timestamp_to_year_nanos(*v)?
             }
             _ => {
-                return Err(crate::Error::new(
-                    crate::ErrorKind::FeatureUnsupported,
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
                     format!(
                         "Unsupported data type for year transform: {:?}",
                         input.data_type()
@@ -175,7 +175,7 @@ impl TransformFunction for Month {
         ))
     }
 
-    fn transform_literal(&self, input: &crate::spec::Datum) -> Result<Option<crate::spec::Datum>> {
+    fn transform_literal(&self, input: &Datum) -> Result<Option<Datum>> {
         let val = match (input.data_type(), input.literal()) {
             (PrimitiveType::Date, PrimitiveLiteral::Int(v)) => {
                 (Date32Type::to_naive_date_opt(*v).unwrap().year() - UNIX_EPOCH_YEAR) * 12
@@ -194,8 +194,8 @@ impl TransformFunction for Month {
                 Self::timestamp_to_month_nanos(*v)?
             }
             _ => {
-                return Err(crate::Error::new(
-                    crate::ErrorKind::FeatureUnsupported,
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
                     format!(
                         "Unsupported data type for month transform: {:?}",
                         input.data_type()
@@ -297,7 +297,7 @@ impl TransformFunction for Day {
         Ok(Arc::new(res))
     }
 
-    fn transform_literal(&self, input: &crate::spec::Datum) -> Result<Option<crate::spec::Datum>> {
+    fn transform_literal(&self, input: &Datum) -> Result<Option<Datum>> {
         let val = match (input.data_type(), input.literal()) {
             (PrimitiveType::Date, PrimitiveLiteral::Int(v)) => *v,
             (PrimitiveType::Timestamp, PrimitiveLiteral::Long(v)) => Self::day_timestamp_micro(*v)?,
@@ -311,8 +311,8 @@ impl TransformFunction for Day {
                 Self::day_timestamp_nano(*v)?
             }
             _ => {
-                return Err(crate::Error::new(
-                    crate::ErrorKind::FeatureUnsupported,
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
                     format!(
                         "Unsupported data type for day transform: {:?}",
                         input.data_type()
@@ -349,8 +349,8 @@ impl TransformFunction for Hour {
                 .unwrap()
                 .unary(|v| -> i32 { Self::hour_timestamp_micro(v) }),
             _ => {
-                return Err(crate::Error::new(
-                    crate::ErrorKind::FeatureUnsupported,
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
                     format!(
                         "Unsupported data type for hour transform: {:?}",
                         input.data_type()
@@ -361,7 +361,7 @@ impl TransformFunction for Hour {
         Ok(Arc::new(res))
     }
 
-    fn transform_literal(&self, input: &crate::spec::Datum) -> Result<Option<crate::spec::Datum>> {
+    fn transform_literal(&self, input: &Datum) -> Result<Option<Datum>> {
         let val = match (input.data_type(), input.literal()) {
             (PrimitiveType::Timestamp, PrimitiveLiteral::Long(v)) => Self::hour_timestamp_micro(*v),
             (PrimitiveType::Timestamptz, PrimitiveLiteral::Long(v)) => {
@@ -374,8 +374,8 @@ impl TransformFunction for Hour {
                 Self::hour_timestamp_nano(*v)
             }
             _ => {
-                return Err(crate::Error::new(
-                    crate::ErrorKind::FeatureUnsupported,
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
                     format!(
                         "Unsupported data type for hour transform: {:?}",
                         input.data_type()
@@ -401,7 +401,7 @@ mod test {
         TimestampNs, Timestamptz, TimestamptzNs, Uuid,
     };
     use crate::spec::Type::{Primitive, Struct};
-    use crate::spec::{Datum, NestedField, PrimitiveType, StructType, Transform, Type};
+    use crate::spec::{Datum, NestedField, StructType, Transform};
     use crate::transform::test::{TestProjectionFixture, TestTransformFixture};
     use crate::transform::{BoxedTransformFunction, TransformFunction};
 
@@ -611,7 +611,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Hour,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -685,7 +685,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Hour,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -757,7 +757,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -829,7 +829,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -901,7 +901,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -973,7 +973,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1044,7 +1044,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1116,7 +1116,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1190,7 +1190,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1264,7 +1264,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1338,7 +1338,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1412,7 +1412,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1486,7 +1486,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)),
         );
 
         fixture.assert_projection(
@@ -1560,7 +1560,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1628,7 +1628,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1696,7 +1696,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1764,7 +1764,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1832,7 +1832,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1900,7 +1900,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -1968,7 +1968,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -2035,7 +2035,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -2103,7 +2103,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -2171,7 +2171,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(
@@ -2239,7 +2239,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Date)),
+            NestedField::required(1, "value", Primitive(Date)),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/transform/truncate.rs
+++ b/crates/iceberg/src/transform/truncate.rs
@@ -137,7 +137,7 @@ impl TransformFunction for Truncate {
                 );
                 Ok(Arc::new(res))
             }
-            _ => Err(crate::Error::new(
+            _ => Err(Error::new(
                 crate::ErrorKind::FeatureUnsupported,
                 format!(
                     "Unsupported data type for truncate transform: {:?}",
@@ -173,7 +173,7 @@ impl TransformFunction for Truncate {
                 let len = self.width as usize;
                 Datum::string(Self::truncate_str(v, len).to_string())
             })),
-            _ => Err(crate::Error::new(
+            _ => Err(Error::new(
                 crate::ErrorKind::FeatureUnsupported,
                 format!(
                     "Unsupported data type for truncate transform: {:?}",
@@ -200,7 +200,7 @@ mod test {
     };
     use crate::spec::Type::{Primitive, Struct};
     use crate::spec::decimal_utils::decimal_new;
-    use crate::spec::{Datum, NestedField, PrimitiveType, StructType, Transform, Type};
+    use crate::spec::{Datum, NestedField, PrimitiveType, StructType, Transform};
     use crate::transform::TransformFunction;
     use crate::transform::test::{TestProjectionFixture, TestTransformFixture};
 
@@ -262,7 +262,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(5),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
         );
 
         fixture.assert_projection(
@@ -296,7 +296,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(5),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
         );
 
         fixture.assert_projection(
@@ -355,7 +355,7 @@ mod test {
             NestedField::required(
                 1,
                 "value",
-                Type::Primitive(PrimitiveType::Decimal {
+                Primitive(Decimal {
                     precision: 9,
                     scale: 2,
                 }),
@@ -425,7 +425,7 @@ mod test {
             NestedField::required(
                 1,
                 "value",
-                Type::Primitive(PrimitiveType::Decimal {
+                Primitive(Decimal {
                     precision: 9,
                     scale: 2,
                 }),
@@ -490,7 +490,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Long)),
+            NestedField::required(1, "value", Primitive(Long)),
         );
 
         fixture.assert_projection(
@@ -545,7 +545,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Long)),
+            NestedField::required(1, "value", Primitive(Long)),
         );
 
         fixture.assert_projection(
@@ -600,7 +600,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Int)),
+            NestedField::required(1, "value", Primitive(Int)),
         );
 
         fixture.assert_projection(
@@ -655,7 +655,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Type::Primitive(PrimitiveType::Int)),
+            NestedField::required(1, "value", Primitive(Int)),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -193,7 +193,7 @@ pub(crate) mod test {
         );
 
         // test default data location
-        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/table/data/part-00000-test.parquet");
@@ -203,7 +203,7 @@ pub(crate) mod test {
             WRITE_FOLDER_STORAGE_LOCATION.to_string(),
             "s3://data.db/table/data_1".to_string(),
         );
-        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -215,7 +215,7 @@ pub(crate) mod test {
             WRITE_DATA_LOCATION.to_string(),
             "s3://data.db/table/data_2".to_string(),
         );
-        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(
@@ -228,7 +228,7 @@ pub(crate) mod test {
             // invalid table location
             "s3://data.db/data_3".to_string(),
         );
-        let location_generator = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let location_generator = DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location =
             location_generator.generate_location(None, &file_name_generator.generate_file_name());
         assert_eq!(location, "s3://data.db/data_3/part-00003-test.parquet");
@@ -298,7 +298,7 @@ pub(crate) mod test {
         };
 
         // Test with DefaultLocationGenerator
-        let default_location_gen = super::DefaultLocationGenerator::new(&table_metadata).unwrap();
+        let default_location_gen = DefaultLocationGenerator::new(&table_metadata).unwrap();
         let location = default_location_gen.generate_location(Some(&partition_key), file_name);
         assert_eq!(
             location,

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -841,7 +841,7 @@ mod tests {
             .unwrap();
         let mut visitor = IndexByParquetPathName::new();
         let err = visit_schema(&schema, &mut visitor).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::FeatureUnsupported, "{err}");
+        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported, "{err}");
     }
 
     #[tokio::test]
@@ -950,11 +950,11 @@ mod tests {
             (0..1024).map(|n| n.to_string()),
         )) as ArrayRef;
         let col3 = Arc::new({
-            let list_parts = arrow_array::ListArray::from_iter_primitive::<Int64Type, _, _>(
+            let list_parts = ListArray::from_iter_primitive::<Int64Type, _, _>(
                 (0..1024).map(|n| Some(vec![Some(n)])),
             )
             .into_parts();
-            arrow_array::ListArray::new(
+            ListArray::new(
                 {
                     if let DataType::List(field) = arrow_schema.field(3).data_type() {
                         field.clone()
@@ -1052,7 +1052,7 @@ mod tests {
                     nulls,
                 )
             };
-            arrow_array::MapArray::new(
+            MapArray::new(
                 {
                     if let DataType::Map(map_field, _) = arrow_schema.field(5).data_type() {
                         map_field.clone()
@@ -1087,7 +1087,7 @@ mod tests {
             .next()
             .unwrap()
             // Put dummy field for build successfully.
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1163,13 +1163,13 @@ mod tests {
         ])) as ArrayRef;
         let col1 = Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)])) as ArrayRef;
         let col2 = Arc::new(Int64Array::from(vec![Some(1), Some(2), None, Some(4)])) as ArrayRef;
-        let col3 = Arc::new(arrow_array::Float32Array::from(vec![
+        let col3 = Arc::new(Float32Array::from(vec![
             Some(0.5),
             Some(2.0),
             None,
             Some(3.5),
         ])) as ArrayRef;
-        let col4 = Arc::new(arrow_array::Float64Array::from(vec![
+        let col4 = Arc::new(Float64Array::from(vec![
             Some(0.5),
             Some(2.0),
             None,
@@ -1220,7 +1220,7 @@ mod tests {
                 .with_timezone_utc(),
         ) as ArrayRef;
         let col13 = Arc::new(
-            arrow_array::Decimal128Array::from(vec![Some(1), Some(2), None, Some(100)])
+            Decimal128Array::from(vec![Some(1), Some(2), None, Some(100)])
                 .with_precision_and_scale(10, 5)
                 .unwrap(),
         ) as ArrayRef;
@@ -1251,7 +1251,7 @@ mod tests {
             .unwrap(),
         ) as ArrayRef;
         let col16 = Arc::new(
-            arrow_array::Decimal128Array::from(vec![Some(1), Some(2), None, Some(100)])
+            Decimal128Array::from(vec![Some(1), Some(2), None, Some(100)])
                 .with_precision_and_scale(38, 5)
                 .unwrap(),
         ) as ArrayRef;
@@ -1277,7 +1277,7 @@ mod tests {
             .next()
             .unwrap()
             // Put dummy field for build successfully.
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1428,7 +1428,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1480,7 +1480,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1541,7 +1541,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1639,11 +1639,13 @@ mod tests {
 
         // Test that file will create if data to write
         let schema = {
-            let fields = vec![
-                arrow_schema::Field::new("col", arrow_schema::DataType::Int64, true).with_metadata(
-                    HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "0".to_string())]),
-                ),
-            ];
+            let fields =
+                vec![
+                    Field::new("col", DataType::Int64, true).with_metadata(HashMap::from([(
+                        PARQUET_FIELD_ID_META_KEY.to_string(),
+                        "0".to_string(),
+                    )])),
+                ];
             Arc::new(arrow_schema::Schema::new(fields))
         };
         let col = Arc::new(Int64Array::from_iter_values(0..1024)) as ArrayRef;
@@ -1690,12 +1692,14 @@ mod tests {
         // prepare data
         let arrow_schema = {
             let fields = vec![
-                Field::new("col", arrow_schema::DataType::Float32, false).with_metadata(
-                    HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "0".to_string())]),
-                ),
-                Field::new("col2", arrow_schema::DataType::Float64, false).with_metadata(
-                    HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string())]),
-                ),
+                Field::new("col", DataType::Float32, false).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "0".to_string(),
+                )])),
+                Field::new("col2", DataType::Float64, false).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "1".to_string(),
+                )])),
             ];
             Arc::new(arrow_schema::Schema::new(fields))
         };
@@ -1732,7 +1736,7 @@ mod tests {
             .next()
             .unwrap()
             // Put dummy field for build successfully.
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -1792,7 +1796,7 @@ mod tests {
         let schema_struct_nested_fields = Fields::from(vec![
             Field::new(
                 "col6",
-                arrow_schema::DataType::Struct(schema_struct_nested_float_fields.clone()),
+                DataType::Struct(schema_struct_nested_float_fields.clone()),
                 false,
             )
             .with_metadata(HashMap::from([(
@@ -1806,7 +1810,7 @@ mod tests {
             let fields = vec![
                 Field::new(
                     "col3",
-                    arrow_schema::DataType::Struct(schema_struct_float_fields.clone()),
+                    DataType::Struct(schema_struct_float_fields.clone()),
                     false,
                 )
                 .with_metadata(HashMap::from([(
@@ -1815,7 +1819,7 @@ mod tests {
                 )])),
                 Field::new(
                     "col5",
-                    arrow_schema::DataType::Struct(schema_struct_nested_fields.clone()),
+                    DataType::Struct(schema_struct_nested_fields.clone()),
                     false,
                 )
                 .with_metadata(HashMap::from([(
@@ -1872,7 +1876,7 @@ mod tests {
             .next()
             .unwrap()
             // Put dummy field for build successfully.
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -2036,7 +2040,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()
@@ -2217,7 +2221,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .content(crate::spec::DataContentType::Data)
+            .content(DataContentType::Data)
             .partition(Struct::empty())
             .partition_spec_id(0)
             .build()

--- a/crates/iceberg/src/writer/partitioning/clustered_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/clustered_writer.rs
@@ -186,10 +186,9 @@ mod tests {
 
         // Create partition spec and key
         let partition_spec = crate::spec::PartitionSpec::builder(schema.clone()).build()?;
-        let partition_value =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
+        let partition_value = Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
         let partition_key =
-            crate::spec::PartitionKey::new(partition_spec, schema.clone(), partition_value.clone());
+            PartitionKey::new(partition_spec, schema.clone(), partition_value.clone());
 
         // Create writer builder
         let parquet_writer_builder =
@@ -285,25 +284,22 @@ mod tests {
         let partition_spec = crate::spec::PartitionSpec::builder(schema.clone()).build()?;
 
         // Create partition keys for different regions (in sorted order)
-        let partition_value_asia =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("ASIA"))]);
-        let partition_key_asia = crate::spec::PartitionKey::new(
+        let partition_value_asia = Struct::from_iter([Some(crate::spec::Literal::string("ASIA"))]);
+        let partition_key_asia = PartitionKey::new(
             partition_spec.clone(),
             schema.clone(),
             partition_value_asia.clone(),
         );
 
-        let partition_value_eu =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("EU"))]);
-        let partition_key_eu = crate::spec::PartitionKey::new(
+        let partition_value_eu = Struct::from_iter([Some(crate::spec::Literal::string("EU"))]);
+        let partition_key_eu = PartitionKey::new(
             partition_spec.clone(),
             schema.clone(),
             partition_value_eu.clone(),
         );
 
-        let partition_value_us =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
-        let partition_key_us = crate::spec::PartitionKey::new(
+        let partition_value_us = Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
+        let partition_key_us = PartitionKey::new(
             partition_spec.clone(),
             schema.clone(),
             partition_value_us.clone(),
@@ -378,7 +374,7 @@ mod tests {
         );
 
         // Verify that we have files for each partition
-        let mut partitions_found = std::collections::HashSet::new();
+        let mut partitions_found = HashSet::new();
         for data_file in &data_files {
             partitions_found.insert(data_file.partition.clone());
         }
@@ -426,17 +422,15 @@ mod tests {
         let partition_spec = crate::spec::PartitionSpec::builder(schema.clone()).build()?;
 
         // Create partition keys for different regions
-        let partition_value_us =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
-        let partition_key_us = crate::spec::PartitionKey::new(
+        let partition_value_us = Struct::from_iter([Some(crate::spec::Literal::string("US"))]);
+        let partition_key_us = PartitionKey::new(
             partition_spec.clone(),
             schema.clone(),
             partition_value_us.clone(),
         );
 
-        let partition_value_eu =
-            crate::spec::Struct::from_iter([Some(crate::spec::Literal::string("EU"))]);
-        let partition_key_eu = crate::spec::PartitionKey::new(
+        let partition_value_eu = Struct::from_iter([Some(crate::spec::Literal::string("EU"))]);
+        let partition_key_eu = PartitionKey::new(
             partition_spec.clone(),
             schema.clone(),
             partition_value_eu.clone(),

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -37,3 +37,6 @@ ordered-float = "2.10.1"
 parquet = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/integrations/cache-moka/Cargo.toml
+++ b/crates/integrations/cache-moka/Cargo.toml
@@ -33,3 +33,6 @@ version = { workspace = true }
 [dependencies]
 iceberg = { workspace = true }
 moka = { version = "0.12.10", features = ["sync"] }
+
+[lints]
+workspace = true

--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -44,3 +44,6 @@ uuid = { workspace = true }
 expect-test = { workspace = true }
 parquet = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/integrations/datafusion/src/physical_plan/metadata_scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/metadata_scan.rs
@@ -66,21 +66,21 @@ impl ExecutionPlan for IcebergMetadataScan {
         &self.properties
     }
 
-    fn children(&self) -> Vec<&std::sync::Arc<dyn ExecutionPlan>> {
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![]
     }
 
     fn with_new_children(
-        self: std::sync::Arc<Self>,
-        _children: Vec<std::sync::Arc<dyn ExecutionPlan>>,
-    ) -> datafusion::error::Result<std::sync::Arc<dyn ExecutionPlan>> {
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         Ok(self)
     }
 
     fn execute(
         &self,
         _partition: usize,
-        _context: std::sync::Arc<datafusion::execution::TaskContext>,
+        _context: Arc<datafusion::execution::TaskContext>,
     ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
         let fut = self.provider.clone().scan();
         let stream = futures::stream::once(fut).try_flatten();

--- a/crates/integrations/datafusion/src/physical_plan/project.rs
+++ b/crates/integrations/datafusion/src/physical_plan/project.rs
@@ -205,7 +205,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(Arc::new(table_schema.clone()))
+        let partition_spec = PartitionSpec::builder(Arc::new(table_schema.clone()))
             .add_partition_field("id", "id_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -230,7 +230,7 @@ mod tests {
             .unwrap();
 
         let partition_spec = Arc::new(
-            iceberg::spec::PartitionSpec::builder(Arc::new(table_schema.clone()))
+            PartitionSpec::builder(Arc::new(table_schema.clone()))
                 .add_partition_field("id", "id_partition", Transform::Identity)
                 .unwrap()
                 .build()
@@ -276,7 +276,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(Arc::new(table_schema.clone()))
+        let partition_spec = PartitionSpec::builder(Arc::new(table_schema.clone()))
             .add_partition_field("id", "id_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -337,7 +337,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(Arc::new(table_schema.clone()))
+        let partition_spec = PartitionSpec::builder(Arc::new(table_schema.clone()))
             .add_partition_field("address.city", "city_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -410,7 +410,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(table_schema.clone())
+        let partition_spec = PartitionSpec::builder(table_schema.clone())
             .add_partition_field("id", "id_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -440,7 +440,7 @@ mod tests {
 
         let input = Arc::new(EmptyExec::new(arrow_schema));
 
-        let table = iceberg::table::Table::builder()
+        let table = Table::builder()
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
@@ -469,7 +469,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(table_schema.clone())
+        let partition_spec = PartitionSpec::builder(table_schema.clone())
             .add_partition_field("id", "id_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -499,7 +499,7 @@ mod tests {
 
         let input = Arc::new(EmptyExec::new(arrow_schema));
 
-        let table = iceberg::table::Table::builder()
+        let table = Table::builder()
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())
@@ -539,7 +539,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let partition_spec = iceberg::spec::PartitionSpec::builder(table_schema.clone())
+        let partition_spec = PartitionSpec::builder(table_schema.clone())
             .add_partition_field("id", "id_partition", Transform::Identity)
             .unwrap()
             .build()
@@ -555,7 +555,7 @@ mod tests {
             sort_order,
             "/test/table".to_string(),
             FormatVersion::V2,
-            std::collections::HashMap::new(),
+            HashMap::new(),
         )
         .unwrap();
 
@@ -572,7 +572,7 @@ mod tests {
 
         let input = Arc::new(EmptyExec::new(arrow_schema));
 
-        let table = iceberg::table::Table::builder()
+        let table = Table::builder()
             .metadata(table_metadata.metadata)
             .identifier(TableIdent::from_strs(["test", "table"]).unwrap())
             .file_io(FileIO::new_with_fs())

--- a/crates/integrations/datafusion/src/physical_plan/repartition.rs
+++ b/crates/integrations/datafusion/src/physical_plan/repartition.rs
@@ -206,7 +206,7 @@ mod tests {
         let partition_spec = iceberg::spec::PartitionSpec::builder(schema.clone())
             .build()
             .unwrap();
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
         let table_metadata_builder = iceberg::spec::TableMetadataBuilder::new(
             schema,
             partition_spec,
@@ -244,7 +244,7 @@ mod tests {
         let repartitioned_plan = repartition(
             input.clone(),
             table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
+            NonZeroUsize::new(4).unwrap(),
         )
         .unwrap();
 
@@ -257,12 +257,8 @@ mod tests {
         let table = create_test_table();
         let input = Arc::new(EmptyExec::new(create_test_arrow_schema()));
 
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(8).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(8).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         match partitioning {
@@ -278,7 +274,7 @@ mod tests {
         let _table = create_test_table();
         let _input = Arc::new(EmptyExec::new(create_test_arrow_schema()));
 
-        let result = std::num::NonZeroUsize::new(0);
+        let result = NonZeroUsize::new(0);
         assert!(result.is_none(), "NonZeroUsize::new(0) should return None");
 
         // Test that we can't call repartition with 0 partitions
@@ -295,7 +291,7 @@ mod tests {
         let repartitioned_plan = repartition(
             input,
             table.metadata_ref(),
-            std::num::NonZeroUsize::new(target_partitions).unwrap(),
+            NonZeroUsize::new(target_partitions).unwrap(),
         )
         .unwrap();
 
@@ -313,12 +309,8 @@ mod tests {
         let table = create_test_table();
         let input = Arc::new(EmptyExec::new(create_test_arrow_schema()));
 
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(3).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(3).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         match partitioning {
@@ -391,12 +383,8 @@ mod tests {
             ArrowField::new("category", ArrowDataType::Utf8, false),
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         // For bucketed tables without _partition column, should use round-robin
@@ -483,12 +471,8 @@ mod tests {
             ),
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         match partitioning {
@@ -531,7 +515,7 @@ mod tests {
         let partition_spec = iceberg::spec::PartitionSpec::builder(schema.clone())
             .build()
             .unwrap();
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
 
         let mut properties = std::collections::HashMap::new();
         properties.insert("write.distribution-mode".to_string(), "none".to_string());
@@ -557,12 +541,8 @@ mod tests {
             .unwrap();
 
         let input = Arc::new(EmptyExec::new(create_test_arrow_schema()));
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         assert!(
@@ -608,7 +588,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
         let table_metadata_builder = iceberg::spec::TableMetadataBuilder::new(
             schema,
             partition_spec,
@@ -639,12 +619,8 @@ mod tests {
             ),
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         assert!(
@@ -684,7 +660,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
         let table_metadata_builder = iceberg::spec::TableMetadataBuilder::new(
             schema,
             partition_spec,
@@ -716,12 +692,8 @@ mod tests {
             ),
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         match partitioning {
@@ -767,7 +739,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
         let table_metadata_builder = iceberg::spec::TableMetadataBuilder::new(
             schema,
             partition_spec,
@@ -803,12 +775,8 @@ mod tests {
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
 
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         assert!(
@@ -841,7 +809,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let sort_order = iceberg::spec::SortOrder::builder().build(&schema).unwrap();
+        let sort_order = SortOrder::builder().build(&schema).unwrap();
         let table_metadata_builder = iceberg::spec::TableMetadataBuilder::new(
             schema,
             partition_spec,
@@ -873,12 +841,8 @@ mod tests {
         ]));
         let input = Arc::new(EmptyExec::new(arrow_schema));
 
-        let repartitioned_plan = repartition(
-            input,
-            table.metadata_ref(),
-            std::num::NonZeroUsize::new(4).unwrap(),
-        )
-        .unwrap();
+        let repartitioned_plan =
+            repartition(input, table.metadata_ref(), NonZeroUsize::new(4).unwrap()).unwrap();
 
         let partitioning = repartitioned_plan.properties().output_partitioning();
         assert!(

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -667,8 +667,7 @@ mod tests {
         let mut properties = HashMap::new();
         if let Some(enabled) = fanout_enabled {
             properties.insert(
-                iceberg::spec::TableProperties::PROPERTY_DATAFUSION_WRITE_FANOUT_ENABLED
-                    .to_string(),
+                TableProperties::PROPERTY_DATAFUSION_WRITE_FANOUT_ENABLED.to_string(),
                 enabled.to_string(),
             );
         }

--- a/crates/integrations/datafusion/src/task_writer.rs
+++ b/crates/integrations/datafusion/src/task_writer.rs
@@ -397,7 +397,7 @@ mod tests {
 
     /// Helper to verify partition data files
     fn verify_partition_files(
-        data_files: &[iceberg::spec::DataFile],
+        data_files: &[DataFile],
         expected_total: u64,
     ) -> HashMap<String, u64> {
         let total_records: u64 = data_files.iter().map(|f| f.record_count()).sum();

--- a/crates/integrations/playground/Cargo.toml
+++ b/crates/integrations/playground/Cargo.toml
@@ -48,3 +48,6 @@ tracing-subscriber = { workspace = true }
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["stacker", "mimalloc", "home"]
+
+[lints]
+workspace = true

--- a/crates/sqllogictest/Cargo.toml
+++ b/crates/sqllogictest/Cargo.toml
@@ -53,3 +53,6 @@ path = "tests/sqllogictests.rs"
 [package.metadata.cargo-machete]
 # These dependencies are added to ensure minimal dependency version
 ignored = ["enum-ordinalize"]
+
+[lints]
+workspace = true

--- a/crates/storage/opendal/Cargo.toml
+++ b/crates/storage/opendal/Cargo.toml
@@ -66,3 +66,6 @@ async-trait = { workspace = true }
 iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 reqwest = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -18,8 +18,8 @@
 //! OpenDAL-based storage implementation for Apache Iceberg.
 //!
 //! This crate provides [`OpenDalStorage`] and [`OpenDalStorageFactory`],
-//! which implement the [`Storage`](iceberg::io::Storage) and
-//! [`StorageFactory`](iceberg::io::StorageFactory) traits from the `iceberg` crate
+//! which implement the [`Storage`](Storage) and
+//! [`StorageFactory`](StorageFactory) traits from the `iceberg` crate
 //! using [OpenDAL](https://opendal.apache.org/) as the backend.
 
 mod utils;
@@ -117,7 +117,7 @@ pub enum OpenDalStorageFactory {
     S3 {
         /// Custom AWS credential loader.
         #[serde(skip)]
-        customized_credential_load: Option<s3::CustomAwsCredentialLoader>,
+        customized_credential_load: Option<CustomAwsCredentialLoader>,
     },
     /// GCS storage factory.
     #[cfg(feature = "opendal-gcs")]
@@ -209,7 +209,7 @@ pub enum OpenDalStorage {
         config: Arc<S3Config>,
         /// Custom AWS credential loader.
         #[serde(skip)]
-        customized_credential_load: Option<s3::CustomAwsCredentialLoader>,
+        customized_credential_load: Option<CustomAwsCredentialLoader>,
     },
     /// GCS storage variant.
     #[cfg(feature = "opendal-gcs")]
@@ -462,7 +462,7 @@ impl OpenDalStorage {
             }
             #[cfg(feature = "opendal-hf")]
             OpenDalStorage::Hf { .. } => {
-                let parsed = hf::HfUri::parse(path).ok_or_else(|| {
+                let parsed = HfUri::parse(path).ok_or_else(|| {
                     Error::new(ErrorKind::DataInvalid, format!("Invalid hf url: {path}"))
                 })?;
                 Ok(&path[path.len() - parsed.path.len()..])

--- a/crates/storage/opendal/tests/file_io_gcs_test.rs
+++ b/crates/storage/opendal/tests/file_io_gcs_test.rs
@@ -74,7 +74,7 @@ mod tests {
         let file_io = get_file_io_gcs().await;
         let output = file_io.new_output(&gs_file).unwrap();
         output
-            .write(bytes::Bytes::from_static(b"iceberg-gcs!"))
+            .write(Bytes::from_static(b"iceberg-gcs!"))
             .await
             .expect("Write to test output file");
         assert!(file_io.exists(gs_file).await.unwrap())
@@ -86,7 +86,7 @@ mod tests {
         let file_io = get_file_io_gcs().await;
         let output = file_io.new_output(&gs_file).unwrap();
         output
-            .write(bytes::Bytes::from_static(b"iceberg!"))
+            .write(Bytes::from_static(b"iceberg!"))
             .await
             .expect("Write to test output file");
         assert!(file_io.exists(&gs_file).await.unwrap());

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -32,3 +32,6 @@ tracing-subscriber = { workspace = true }
 
 [features]
 tests = []
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

We have inconsistency across the repo when it comes to using `used_qualifications` which makes code harder to read and maintain in a consistent style. 

I did an audit of some popular crate to see if other folks enforce this lint and I found that our friends in the Datafusion community do use this https://github.com/apache/datafusion/pull/13086. But also aware that repos like tokio choose not to.

- Closes #.

## What changes are included in this PR?

This PR adds `unused_qualifications = "deny"` to the root `Cargo.toml` 

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->