### PR TITLE
fix: avoid lost-wakeup hang when waiting for a positional delete load

### DIFF
--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -241,11 +241,11 @@ impl CachingDeleteFileLoader {
             DataContentType::PositionDeletes => {
                 match del_filter.try_start_pos_del_load(&task.file_path) {
                     PosDelLoadAction::AlreadyLoaded => Ok(DeleteFileContext::ExistingPosDel),
-                    PosDelLoadAction::WaitFor(notify) => {
+                    PosDelLoadAction::WaitFor(notified) => {
                         // Positional deletes are accessed synchronously by ArrowReader.
                         // We must wait here to ensure the data is ready before returning,
                         // otherwise ArrowReader might get an empty/partial result.
-                        notify.notified().await;
+                        notified.await;
                         Ok(DeleteFileContext::ExistingPosDel)
                     }
                     PosDelLoadAction::Load => Ok(DeleteFileContext::PosDels {

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
 use tokio::sync::Notify;
+use tokio::sync::futures::OwnedNotified;
 use tokio::sync::oneshot::Receiver;
 
 use crate::delete_vector::DeleteVector;
@@ -67,9 +68,11 @@ pub(crate) enum PosDelLoadAction {
     /// The file is already loaded, nothing to do.
     AlreadyLoaded,
     /// The file is currently being loaded by another task.
-    /// The caller *must* wait for this notifier to ensure data availability
-    /// before returning, as subsequent access (get_delete_vector) is synchronous.
-    WaitFor(Arc<Notify>),
+    /// The caller *must* await this future to ensure data availability before
+    /// returning, as subsequent access (get_delete_vector) is synchronous. The
+    /// future is created under the state lock so it cannot miss the loader's
+    /// `notify_waiters()` (which stores no permit).
+    WaitFor(OwnedNotified),
 }
 
 impl DeleteFilter {
@@ -127,7 +130,9 @@ impl DeleteFilter {
         if let Some(state) = state.positional_deletes.get(file_path) {
             match state {
                 PosDelState::Loaded => return PosDelLoadAction::AlreadyLoaded,
-                PosDelState::Loading(notify) => return PosDelLoadAction::WaitFor(notify.clone()),
+                PosDelState::Loading(notify) => {
+                    return PosDelLoadAction::WaitFor(notify.clone().notified_owned());
+                }
             }
         }
 
@@ -295,6 +300,38 @@ pub(crate) mod tests {
 
     const FIELD_ID_POSITIONAL_DELETE_FILE_PATH: u64 = 2147483546;
     const FIELD_ID_POSITIONAL_DELETE_POS: u64 = 2147483545;
+
+    // Regression test for the positional-delete lost-wakeup hang.
+    //
+    // Drives the real API through the losing interleaving: the loader fires
+    // `notify_waiters()` (via `finish_pos_del_load`) *before* the waiter awaits the notifier
+    // handed back by `WaitFor`. `notify_waiters()` stores no permit, so this only completes if
+    // the waiter's `Notified` was created before the signal. Because `WaitFor` now carries an
+    // `OwnedNotified` created under the lock in `try_start_pos_del_load`, it is; on the old
+    // `WaitFor(Arc<Notify>)` contract the waiter created its `Notified` too late and hung.
+    #[tokio::test]
+    async fn test_wait_for_completes_when_load_finishes_before_await() {
+        let filter = DeleteFilter::new(Runtime::current());
+        let path = "s3://bucket/pos-delete.parquet";
+
+        assert!(matches!(
+            filter.try_start_pos_del_load(path),
+            PosDelLoadAction::Load
+        ));
+
+        let PosDelLoadAction::WaitFor(notified) = filter.try_start_pos_del_load(path) else {
+            panic!("expected WaitFor for an in-progress load");
+        };
+
+        // Loader completes and signals before the waiter awaits.
+        filter.finish_pos_del_load(path);
+
+        let waited = tokio::time::timeout(std::time::Duration::from_secs(5), notified).await;
+        assert!(
+            waited.is_ok(),
+            "WaitFor future must resolve after finish_pos_del_load"
+        );
+    }
 
     #[tokio::test]
     async fn test_delete_file_filter_load_deletes() {


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No issue; concurrency bug found while reviewing the delete-file loading paths. -->

N/A — a latent concurrency bug in the positional-delete loading path.

## What changes are included in this PR?

Fixes a lost-wakeup hang on the positional-delete wait path (`PosDelLoadAction::WaitFor` in `arrow/delete_filter.rs`, awaited in `arrow/caching_delete_file_loader.rs`).

`tokio::sync::Notify::notify_waiters()` stores no permit and only wakes `Notified` futures that already exist. Previously `WaitFor` carried a raw `Arc<Notify>`, and the waiter turned it into a `Notified` only later, at `.notified().await` — after releasing the state lock. The exact losing interleaving:

1. Loader calls `try_start_pos_del_load(path)` → `Load` (claims the load).
2. Waiter calls `try_start_pos_del_load(path)` → `WaitFor(Arc<Notify>)` — a raw notifier, **not yet a `Notified`**. The lock is released as the call returns.
3. Loader calls `finish_pos_del_load(path)` → sets `Loaded`, fires `notify_waiters()`. No `Notified` exists yet, so the wakeup is dropped.
4. Waiter calls `notify.notified().await`, creating its `Notified` **after** step 3.
5. That `Notified` waits for the next `notify_waiters()`, which never comes → hangs forever. Since positional-delete retrieval (`get_delete_vector`) is synchronous, this waiter must not proceed early, so the hang is on the critical path.

**Fix:** create the `Notified` under the state lock in `try_start_pos_del_load` and carry it in `WaitFor(OwnedNotified)`. The loader cannot fire `notify_waiters()` until it takes the write lock, so the waiter's `Notified` is guaranteed to exist before the signal.

This is latent today (the loader does real parquet I/O before signaling, so the window is rarely hit), but is one scheduling hiccup from a permanent hang. It is the same bug class as the `DeleteFileIndex` site in #2696.

## Are these changes tested?

Yes — adds a unit test (`wait_for_completes_when_load_finishes_before_await`) that drives the exact interleaving above through the real API and asserts the waiter completes after `finish_pos_del_load`. It passes with this change and hangs (times out) on the old `WaitFor(Arc<Notify>)` contract. No test seam is needed because `WaitFor` hands the notifier to the caller.