### PR TITLE
fix(puffin): return DataInvalid instead of panicking on malformed footer length

### DIFF
--- a/crates/iceberg/src/puffin/metadata.rs
+++ b/crates/iceberg/src/puffin/metadata.rs
@@ -174,6 +174,11 @@ impl FileMetadata {
     pub(crate) const FOOTER_STRUCT_LENGTH: u8 =
         FileMetadata::FOOTER_STRUCT_MAGIC_OFFSET + FileMetadata::MAGIC_LENGTH;
 
+    /// Smallest possible Puffin file: the file header magic, followed by a footer
+    /// holding an empty payload (footer magic + FOOTER_STRUCT).
+    const MIN_FILE_LENGTH: u64 =
+        (FileMetadata::MAGIC_LENGTH as u64) * 2 + (FileMetadata::FOOTER_STRUCT_LENGTH as u64);
+
     /// Constructs new puffin `FileMetadata`
     pub fn new(blobs: Vec<BlobMetadata>, properties: HashMap<String, String>) -> Self {
         Self { blobs, properties }
@@ -215,7 +220,16 @@ impl FileMetadata {
         let footer_length = footer_payload_length as u64
             + FileMetadata::FOOTER_STRUCT_LENGTH as u64
             + FileMetadata::MAGIC_LENGTH as u64;
-        let start = input_file_length - footer_length;
+        let start = input_file_length
+            .checked_sub(footer_length)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::DataInvalid,
+                    format!(
+                        "Footer length {footer_length} exceeds file length {input_file_length}"
+                    ),
+                )
+            })?;
         let end = input_file_length;
         file_read.read(start..end).await
     }
@@ -280,10 +294,21 @@ impl FileMetadata {
     pub(crate) async fn read(input_file: &InputFile) -> Result<FileMetadata> {
         let file_read = input_file.reader().await?;
 
+        let input_file_length = input_file.metadata().await?.size;
+        if input_file_length < FileMetadata::MIN_FILE_LENGTH {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "File length {} is too short to be a Puffin file, expected at least {} bytes",
+                    input_file_length,
+                    FileMetadata::MIN_FILE_LENGTH
+                ),
+            ));
+        }
+
         let first_four_bytes = file_read.read(0..FileMetadata::MAGIC_LENGTH.into()).await?;
         FileMetadata::check_magic(&first_four_bytes)?;
 
-        let input_file_length = input_file.metadata().await?.size;
         let footer_payload_length =
             FileMetadata::read_footer_payload_length(file_read.as_ref(), input_file_length).await?;
         let footer_bytes = FileMetadata::read_footer_bytes(
@@ -622,6 +647,44 @@ mod tests {
                 .to_string(),
             "DataInvalid => Footer is not a valid UTF-8 string, source: invalid utf-8 sequence of 1 bytes from index 1",
         )
+    }
+
+    #[tokio::test]
+    async fn test_file_shorter_than_minimum_length_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Only the file header magic, nothing else.
+        let input_file = input_file_with_bytes(&temp_dir, &FileMetadata::MAGIC).await;
+
+        let err = FileMetadata::read(&input_file).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(
+            err.to_string().contains("too short to be a Puffin file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_footer_payload_length_larger_than_file_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let mut bytes = vec![];
+        bytes.extend(FileMetadata::MAGIC.to_vec());
+        bytes.extend(FileMetadata::MAGIC.to_vec());
+        bytes.extend(empty_footer_payload_bytes());
+        // Declared footer payload length is far larger than the file itself.
+        bytes.extend(u32::to_le_bytes(u32::MAX));
+        bytes.extend(vec![0, 0, 0, 0]);
+        bytes.extend(FileMetadata::MAGIC);
+
+        let input_file = input_file_with_bytes(&temp_dir, &bytes).await;
+
+        let err = FileMetadata::read(&input_file).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(
+            err.to_string().contains("exceeds file length"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changes are included in this PR?

`FileMetadata::read` locates the footer by subtracting from the file size, but never checks the file is big enough first. Two subtractions can underflow:

- `read_footer_payload_length` does `input_file_length - FOOTER_STRUCT_LENGTH`, so any file shorter than 12 bytes underflows.
- `read_footer_bytes` does `input_file_length - footer_length`, where `footer_length` is derived from `footer_payload_length`, the u32 read out of the FooterPayloadSize field of the file being parsed. A file that declares a payload larger than itself underflows here.

In debug builds both panic with "attempt to subtract with overflow". In release the subtraction wraps and you get a bogus read range instead.

Worth saying up front: I'm treating this as robustness, not a security issue. Puffin files are table statistics written by the engines that already write the table, so I'm not claiming a meaningful trust boundary. The point is narrower - a truncated or corrupt file should surface as a `DataInvalid` error, the way the magic checks and the bounds checks in `decode_flags` / `extract_footer_payload_as_str` already do in this same file, rather than panicking on the caller.

The fix adds a `MIN_FILE_LENGTH` check in `read` and switches the second subtraction to `checked_sub`, both returning `ErrorKind::DataInvalid`.

I left `read_with_prefetch` alone. Its `prefetch_hint > 16` and `prefetch_hint <= input_file_length` guards already keep its own slicing in range, and when the declared footer is larger than the hint it falls back to `read`, which is now checked.

## Are these changes tested?

Two unit tests, one per case. Both panic before the fix:

```
thread 'puffin::metadata::tests::test_file_shorter_than_minimum_length_returns_error'
panicked at crates/iceberg/src/puffin/metadata.rs:201:21:
attempt to subtract with overflow

thread 'puffin::metadata::tests::test_footer_payload_length_larger_than_file_returns_error'
panicked at crates/iceberg/src/puffin/metadata.rs:218:21:
attempt to subtract with overflow
```

After the fix, `cargo test -p iceberg --lib puffin` gives 39 passed, 0 failed. Full crate `cargo test -p iceberg --lib` is 1444 passed, 0 failed, and `cargo clippy -p iceberg --all-targets` is clean.
