### PR TITLE
feat(io): add read_all to FileRead

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -264,6 +264,7 @@ pub fn iceberg::encryption::AesGcmFileRead::new(inner: alloc::boxed::Box<dyn ice
 pub fn iceberg::encryption::AesGcmFileRead::plaintext_length(&self) -> u64
 impl iceberg::io::FileRead for iceberg::encryption::AesGcmFileRead
 pub fn iceberg::encryption::AesGcmFileRead::read<'life0, 'async_trait>(&'life0 self, range: core::ops::range::Range<u64>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg::encryption::AesGcmFileRead::read_all<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::encryption::AesGcmFileWrite
 impl iceberg::encryption::AesGcmFileWrite
 pub fn iceberg::encryption::AesGcmFileWrite::new(inner: alloc::boxed::Box<dyn iceberg::io::FileWrite>, cipher: alloc::sync::Arc<iceberg::encryption::AesGcmCipher>, aad_prefix: impl core::convert::Into<alloc::boxed::Box<[u8]>>) -> Self
@@ -1026,10 +1027,13 @@ pub const iceberg::io::S3_SSE_MD5: &str
 pub const iceberg::io::S3_SSE_TYPE: &str
 pub trait iceberg::io::FileRead: core::marker::Send + core::marker::Sync + core::marker::Unpin + 'static
 pub fn iceberg::io::FileRead::read<'life0, 'async_trait>(&'life0 self, range: core::ops::range::Range<u64>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg::io::FileRead::read_all<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 impl iceberg::io::FileRead for iceberg::encryption::AesGcmFileRead
 pub fn iceberg::encryption::AesGcmFileRead::read<'life0, 'async_trait>(&'life0 self, range: core::ops::range::Range<u64>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn iceberg::encryption::AesGcmFileRead::read_all<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 impl<T: core::convert::AsRef<dyn iceberg::io::FileRead> + core::marker::Send + core::marker::Sync + core::marker::Unpin + 'static> iceberg::io::FileRead for T
 pub fn T::read<'life0, 'async_trait>(&'life0 self, range: core::ops::range::Range<u64>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn T::read_all<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bytes::bytes::Bytes>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg::io::FileWrite: core::marker::Send + core::marker::Unpin + 'static
 pub fn iceberg::io::FileWrite::close<'life0, 'async_trait>(&'life0 mut self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub fn iceberg::io::FileWrite::write<'life0, 'async_trait>(&'life0 mut self, bs: bytes::bytes::Bytes) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait

--- a/crates/iceberg/src/arrow/reader/file_reader.rs
+++ b/crates/iceberg/src/arrow/reader/file_reader.rs
@@ -240,6 +240,10 @@ mod tests {
         async fn read(&self, range: Range<u64>) -> crate::Result<bytes::Bytes> {
             Ok(self.data.slice(range.start as usize..range.end as usize))
         }
+
+        async fn read_all(&self) -> crate::Result<bytes::Bytes> {
+            Ok(self.data.clone())
+        }
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/arrow/scan_metrics.rs
+++ b/crates/iceberg/src/arrow/scan_metrics.rs
@@ -47,6 +47,13 @@ impl<F: FileRead> FileRead for CountingFileRead<F> {
             .fetch_add(range.end - range.start, Ordering::Relaxed);
         self.inner.read(range).await
     }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        let bytes = self.inner.read_all().await?;
+        self.bytes_read
+            .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+        Ok(bytes)
+    }
 }
 
 /// Metrics collected during an Iceberg scan.

--- a/crates/iceberg/src/encryption/io.rs
+++ b/crates/iceberg/src/encryption/io.rs
@@ -67,9 +67,7 @@ impl EncryptedInputFile {
 
     /// Read and returns whole content of file (decrypted plaintext).
     pub async fn read(&self) -> Result<Bytes> {
-        let meta = self.metadata().await?;
-        let reader = self.reader().await?;
-        reader.read(0..meta.size).await
+        self.reader().await?.read_all().await
     }
 
     /// Creates a reader that transparently decrypts on each read.

--- a/crates/iceberg/src/encryption/stream.rs
+++ b/crates/iceberg/src/encryption/stream.rs
@@ -357,6 +357,10 @@ impl FileRead for AesGcmFileRead {
 
         Ok(result.freeze())
     }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        self.read(0..self.plain_stream_size).await
+    }
 }
 
 /// Transparent encryption of AGS1 stream-encrypted files.
@@ -612,6 +616,10 @@ mod tests {
             }
             Ok(self.0.slice(start..end))
         }
+
+        async fn read_all(&self) -> Result<Bytes> {
+            Ok(self.0.clone())
+        }
     }
 
     #[tokio::test]
@@ -638,6 +646,10 @@ mod tests {
         // Reading empty range should return empty bytes
         let result = reader.read(0..0).await.unwrap();
         assert!(result.is_empty());
+
+        // read_all on an empty file should also return empty bytes
+        let all = reader.read_all().await.unwrap();
+        assert!(all.is_empty());
     }
 
     #[tokio::test]
@@ -720,6 +732,10 @@ mod tests {
         // Read entire file
         let result = reader.read(0..plaintext.len() as u64).await.unwrap();
         assert_eq!(&result[..], &plaintext[..]);
+
+        // read_all must recover the full plaintext across block boundaries
+        let all = reader.read_all().await.unwrap();
+        assert_eq!(&all[..], &plaintext[..]);
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -253,12 +253,19 @@ pub trait FileRead: Send + Sync + Unpin + 'static {
     ///
     /// TODO: we can support reading non-contiguous bytes in the future.
     async fn read(&self, range: Range<u64>) -> Result<Bytes>;
+
+    /// Read the entire content of the file.
+    async fn read_all(&self) -> Result<Bytes>;
 }
 
 #[async_trait::async_trait]
 impl<T: AsRef<dyn FileRead> + Send + Sync + Unpin + 'static> FileRead for T {
     async fn read(&self, range: Range<u64>) -> Result<Bytes> {
         self.as_ref().read(range).await
+    }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        self.as_ref().read_all().await
     }
 }
 

--- a/crates/iceberg/src/io/storage/local_fs.rs
+++ b/crates/iceberg/src/io/storage/local_fs.rs
@@ -261,6 +261,28 @@ impl FileRead for LocalFsFileRead {
 
         Ok(Bytes::from(buffer))
     }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        let mut file = self.file.lock().map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to acquire file lock: {e}"),
+            )
+        })?;
+
+        file.seek(SeekFrom::Start(0)).map_err(|e| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                format!("Failed to seek to start of file: {e}"),
+            )
+        })?;
+
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| Error::new(ErrorKind::DataInvalid, format!("Failed to read file: {e}")))?;
+
+        Ok(Bytes::from(buffer))
+    }
 }
 
 /// File writer for local filesystem storage.
@@ -472,6 +494,14 @@ mod tests {
         // Test partial read
         let partial = reader.read(0..5).await.unwrap();
         assert_eq!(partial, Bytes::from("Hello"));
+
+        // Test whole-file read
+        let all = reader.read_all().await.unwrap();
+        assert_eq!(all, content);
+
+        // read_all must be independent of any prior seek position
+        let all_again = reader.read_all().await.unwrap();
+        assert_eq!(all_again, content);
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/io/storage/memory.rs
+++ b/crates/iceberg/src/io/storage/memory.rs
@@ -286,6 +286,10 @@ impl FileRead for MemoryFileRead {
 
         Ok(self.data.slice(start..end))
     }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        Ok(self.data.clone())
+    }
 }
 
 /// File writer for in-memory storage.
@@ -487,6 +491,10 @@ mod tests {
         // Test partial read
         let partial = reader.read(0..5).await.unwrap();
         assert_eq!(partial, Bytes::from("Hello"));
+
+        // Test whole-file read
+        let all = reader.read_all().await.unwrap();
+        assert_eq!(all, content);
     }
 
     #[tokio::test]

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -606,6 +606,13 @@ impl FileRead for OpenDalReader {
             .map_err(from_opendal_error)?
             .to_bytes())
     }
+
+    async fn read_all(&self) -> Result<Bytes> {
+        Ok(opendal::Reader::read(&self.0, ..)
+            .await
+            .map_err(from_opendal_error)?
+            .to_bytes())
+    }
 }
 
 /// Wrapper around `opendal::Writer` that implements `FileWrite`.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Add a `read_all` method to the `FileRead` trait for reading an entire file's content without the caller having to know its length. Each implementation knows its own size, and for encrypted readers (`AesGcmFileRead`) it returns the decrypted plaintext.

This will allow a future `ManifestReader` to store just a `dyn FileRead` with a `new(InputFile)` and `new_from_encrypted(EncryptedInputFile)` constructor.

Working towards https://github.com/apache/iceberg-rust/issues/2881

## What changes are included in this PR?

Add a `read_all` method to the `FileRead` trait 
<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->