### PR TITLE
fix(python): handle missing manifest partition summaries

### DIFF
--- a/bindings/python/src/manifest.rs
+++ b/bindings/python/src/manifest.rs
@@ -148,8 +148,8 @@ impl PyManifestFile {
     fn partitions(&self) -> Vec<PyFieldSummary> {
         self.inner
             .partitions
-            .clone()
-            .unwrap()
+            .as_deref()
+            .unwrap_or_default()
             .iter()
             .map(|s| PyFieldSummary { inner: s.clone() })
             .collect()
@@ -237,4 +237,37 @@ pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
     py.import("sys")?
         .getattr("modules")?
         .set_item("pyiceberg_core.manifest", this)
+}
+
+#[cfg(test)]
+mod tests {
+    use iceberg::spec::ManifestContentType;
+
+    use super::*;
+
+    #[test]
+    fn test_manifest_partitions_without_summaries() {
+        let manifest_file = PyManifestFile {
+            inner: ManifestFile {
+                manifest_path: "memory://manifest.avro".to_string(),
+                manifest_length: 1,
+                partition_spec_id: 0,
+                content: ManifestContentType::Data,
+                sequence_number: 0,
+                min_sequence_number: 0,
+                added_snapshot_id: 1,
+                added_files_count: Some(1),
+                existing_files_count: Some(0),
+                deleted_files_count: Some(0),
+                added_rows_count: Some(1),
+                existing_rows_count: Some(0),
+                deleted_rows_count: Some(0),
+                partitions: None,
+                key_metadata: None,
+                first_row_id: None,
+            },
+        };
+
+        assert!(manifest_file.partitions().is_empty());
+    }
 }

--- a/bindings/python/src/manifest.rs
+++ b/bindings/python/src/manifest.rs
@@ -145,14 +145,13 @@ impl PyManifestFile {
     }
 
     #[getter]
-    fn partitions(&self) -> Vec<PyFieldSummary> {
-        self.inner
-            .partitions
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(|s| PyFieldSummary { inner: s.clone() })
-            .collect()
+    fn partitions(&self) -> Option<Vec<PyFieldSummary>> {
+        self.inner.partitions.as_ref().map(|partitions| {
+            partitions
+                .iter()
+                .map(|s| PyFieldSummary { inner: s.clone() })
+                .collect()
+        })
     }
 
     #[getter]
@@ -268,6 +267,6 @@ mod tests {
             },
         };
 
-        assert!(manifest_file.partitions().is_empty());
+        assert!(manifest_file.partitions().is_none());
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2883.

## What changes are included in this PR?

The Python `ManifestFile.partitions` getter now returns `None` when the optional core partition summaries are absent. Previously, the getter unconditionally unwrapped the optional value and triggered a Rust/PyO3 panic for valid manifest entries with `partitions: None`.

The optional return type preserves the distinction between absent summaries and a present empty list, avoids cloning the entire summaries vector before converting its entries, and a focused regression test covers the absent-summary case.

## Are these changes tested?

Yes. The regression test constructs a valid `ManifestFile` with `partitions: None` and verifies that the getter returns `None`.

- `cargo test --locked -p pyiceberg_core_rust test_manifest_partitions_without_summaries -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p pyiceberg_core_rust --all-targets --all-features -- -D warnings`
