### PR TITLE
fix(catalog): reject dropping non-empty MemoryCatalog namespaces

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3370,6 +3370,7 @@ pub iceberg::ErrorKind::CatalogCommitConflicts
 pub iceberg::ErrorKind::DataInvalid
 pub iceberg::ErrorKind::FeatureUnsupported
 pub iceberg::ErrorKind::NamespaceAlreadyExists
+pub iceberg::ErrorKind::NamespaceNotEmpty
 pub iceberg::ErrorKind::NamespaceNotFound
 pub iceberg::ErrorKind::PreconditionFailed
 pub iceberg::ErrorKind::TableAlreadyExists

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -1134,7 +1134,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_drop_namespace_throws_error_if_namespace_has_children() {
+    async fn test_drop_namespace_returns_error_if_namespace_has_children() {
         let catalog = new_memory_catalog().await;
         let namespace_ident_a = NamespaceIdent::new("a".into());
         let namespace_ident_a_b = NamespaceIdent::from_strs(vec!["a", "b"]).unwrap();
@@ -1145,11 +1145,11 @@ pub(crate) mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert_eq!(error.kind(), ErrorKind::NamespaceNotEmpty);
         assert_eq!(
             error.to_string(),
             format!(
-                "Unexpected => Namespace {namespace_ident_a:?} is not empty: contains 1 child namespace(s) and 0 table(s)."
+                "NamespaceNotEmpty => Namespace {namespace_ident_a:?} is not empty: contains 1 child namespace(s) and 0 table(s)."
             )
         );
         assert!(catalog.namespace_exists(&namespace_ident_a).await.unwrap());
@@ -1162,7 +1162,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_drop_namespace_throws_error_if_namespace_has_tables() {
+    async fn test_drop_namespace_returns_error_if_namespace_has_tables() {
         let catalog = new_memory_catalog().await;
         let namespace_ident = NamespaceIdent::new("a".into());
         create_namespace(&catalog, &namespace_ident).await;
@@ -1171,11 +1171,11 @@ pub(crate) mod tests {
 
         let error = catalog.drop_namespace(&namespace_ident).await.unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert_eq!(error.kind(), ErrorKind::NamespaceNotEmpty);
         assert_eq!(
             error.to_string(),
             format!(
-                "Unexpected => Namespace {namespace_ident:?} is not empty: contains 0 child namespace(s) and 1 table(s)."
+                "NamespaceNotEmpty => Namespace {namespace_ident:?} is not empty: contains 0 child namespace(s) and 1 table(s)."
             )
         );
         assert!(catalog.namespace_exists(&namespace_ident).await.unwrap());

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -1134,21 +1134,54 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_dropping_a_namespace_also_drops_namespaces_nested_under_that_one() {
+    async fn test_drop_namespace_throws_error_if_namespace_has_children() {
         let catalog = new_memory_catalog().await;
         let namespace_ident_a = NamespaceIdent::new("a".into());
         let namespace_ident_a_b = NamespaceIdent::from_strs(vec!["a", "b"]).unwrap();
         create_namespaces(&catalog, &vec![&namespace_ident_a, &namespace_ident_a_b]).await;
 
-        catalog.drop_namespace(&namespace_ident_a).await.unwrap();
+        let error = catalog
+            .drop_namespace(&namespace_ident_a)
+            .await
+            .unwrap_err();
 
-        assert!(!catalog.namespace_exists(&namespace_ident_a).await.unwrap());
-
+        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Unexpected => Namespace {namespace_ident_a:?} is not empty: contains 1 child namespace(s) and 0 table(s)."
+            )
+        );
+        assert!(catalog.namespace_exists(&namespace_ident_a).await.unwrap());
         assert!(
-            !catalog
+            catalog
                 .namespace_exists(&namespace_ident_a_b)
                 .await
                 .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drop_namespace_throws_error_if_namespace_has_tables() {
+        let catalog = new_memory_catalog().await;
+        let namespace_ident = NamespaceIdent::new("a".into());
+        create_namespace(&catalog, &namespace_ident).await;
+        let table_ident = TableIdent::new(namespace_ident.clone(), "table".into());
+        create_table(&catalog, &table_ident).await;
+
+        let error = catalog.drop_namespace(&namespace_ident).await.unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Unexpected);
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Unexpected => Namespace {namespace_ident:?} is not empty: contains 0 child namespace(s) and 1 table(s)."
+            )
+        );
+        assert!(catalog.namespace_exists(&namespace_ident).await.unwrap());
+        assert!(
+            catalog.table_exists(&table_ident).await.unwrap(),
+            "the table must remain registered after the rejected drop"
         );
     }
 

--- a/crates/iceberg/src/catalog/memory/namespace_state.rs
+++ b/crates/iceberg/src/catalog/memory/namespace_state.rs
@@ -186,13 +186,26 @@ impl NamespaceState {
         let (parent_namespace_state, child_namespace_name) =
             self.get_mut_parent_namespace_of(namespace_ident)?;
 
-        match parent_namespace_state
-            .namespaces
-            .remove(&child_namespace_name)
-        {
-            None => no_such_namespace_err(namespace_ident),
-            Some(_) => Ok(()),
+        let Some(namespace_state) = parent_namespace_state.namespaces.get(&child_namespace_name)
+        else {
+            return no_such_namespace_err(namespace_ident);
+        };
+
+        let child_namespace_count = namespace_state.namespaces.len();
+        let table_count = namespace_state.table_metadata_locations.len();
+        if child_namespace_count > 0 || table_count > 0 {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "Namespace {namespace_ident:?} is not empty: contains {child_namespace_count} child namespace(s) and {table_count} table(s)."
+                ),
+            ));
         }
+
+        let _ = parent_namespace_state
+            .namespaces
+            .remove(&child_namespace_name);
+        Ok(())
     }
 
     // Returns the properties of the given namespace or an error if doesn't exist

--- a/crates/iceberg/src/catalog/memory/namespace_state.rs
+++ b/crates/iceberg/src/catalog/memory/namespace_state.rs
@@ -195,7 +195,7 @@ impl NamespaceState {
         let table_count = namespace_state.table_metadata_locations.len();
         if child_namespace_count > 0 || table_count > 0 {
             return Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::NamespaceNotEmpty,
                 format!(
                     "Namespace {namespace_ident:?} is not empty: contains {child_namespace_count} child namespace(s) and {table_count} table(s)."
                 ),

--- a/crates/iceberg/src/error.rs
+++ b/crates/iceberg/src/error.rs
@@ -48,6 +48,9 @@ pub enum ErrorKind {
     /// Iceberg namespace already exists at creation.
     NamespaceAlreadyExists,
 
+    /// Iceberg namespace is not empty.
+    NamespaceNotEmpty,
+
     /// Iceberg table already exists at creation.
     TableAlreadyExists,
 
@@ -82,6 +85,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::TableAlreadyExists => "TableAlreadyExists",
             ErrorKind::TableNotFound => "TableNotFound",
             ErrorKind::NamespaceAlreadyExists => "NamespaceAlreadyExists",
+            ErrorKind::NamespaceNotEmpty => "NamespaceNotEmpty",
             ErrorKind::NamespaceNotFound => "NamespaceNotFound",
             ErrorKind::PreconditionFailed => "PreconditionFailed",
             ErrorKind::CatalogCommitConflicts => "CatalogCommitConflicts",


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Found while comparing `MemoryCatalog` namespace behavior with the Java reference implementation and other catalog implementations.

## What changes are included in this PR?

`MemoryCatalog` previously removed a namespace state directly. Because that state owns its child namespaces and table registrations, dropping a non-empty namespace silently discarded the subtree and made registered tables unreachable.

This PR checks for child namespaces and registered tables before removal while holding the same catalog mutation lock. A non-empty namespace now returns an error that reports the remaining child and table counts, and no catalog state is modified.

## Are these changes tested?

Yes. Unit tests verify that drops are rejected for namespaces containing child namespaces or tables, and that the rejected operation preserves the namespace, its children, and its tables.

Validated with:

- `cargo test -p iceberg --lib`
- `cargo clippy -p iceberg --lib -- -D warnings`
