### PR TITLE
fix(transform): floor nanosecond timestamps before bucket hashing

### DIFF
--- a/crates/iceberg/src/transform/bucket.rs
+++ b/crates/iceberg/src/transform/bucket.rs
@@ -23,6 +23,8 @@ use arrow_schema::{DataType, TimeUnit};
 use super::TransformFunction;
 use crate::spec::{Datum, PrimitiveLiteral, PrimitiveType};
 
+const NANOSECONDS_PER_MICROSECOND: i64 = 1_000;
+
 #[derive(Debug)]
 pub struct Bucket {
     mod_n: u32,
@@ -146,6 +148,11 @@ impl Bucket {
     fn bucket_bytes(&self, v: &[u8]) -> i32 {
         self.bucket_n(Self::hash_bytes(v))
     }
+
+    #[inline]
+    fn nanos_to_micros(v: i64) -> i64 {
+        v.div_euclid(NANOSECONDS_PER_MICROSECOND)
+    }
 }
 
 impl TransformFunction for Bucket {
@@ -185,12 +192,12 @@ impl TransformFunction for Bucket {
                 .as_any()
                 .downcast_ref::<arrow_array::Time64NanosecondArray>()
                 .unwrap()
-                .unary(|v| self.bucket_time(v / 1000)),
+                .unary(|v| self.bucket_time(Self::nanos_to_micros(v))),
             DataType::Timestamp(TimeUnit::Nanosecond, _) => input
                 .as_any()
                 .downcast_ref::<arrow_array::TimestampNanosecondArray>()
                 .unwrap()
-                .unary(|v| self.bucket_timestamp(v / 1000)),
+                .unary(|v| self.bucket_timestamp(Self::nanos_to_micros(v))),
             DataType::Utf8 => arrow_array::Int32Array::from_iter(
                 input
                     .as_any()
@@ -254,10 +261,10 @@ impl TransformFunction for Bucket {
             (PrimitiveType::Timestamp, PrimitiveLiteral::Long(v)) => self.bucket_timestamp(*v),
             (PrimitiveType::Timestamptz, PrimitiveLiteral::Long(v)) => self.bucket_timestamp(*v),
             (PrimitiveType::TimestampNs, PrimitiveLiteral::Long(v)) => {
-                self.bucket_timestamp(*v / 1000)
+                self.bucket_timestamp(Self::nanos_to_micros(*v))
             }
             (PrimitiveType::TimestamptzNs, PrimitiveLiteral::Long(v)) => {
-                self.bucket_timestamp(*v / 1000)
+                self.bucket_timestamp(Self::nanos_to_micros(*v))
             }
             (PrimitiveType::String, PrimitiveLiteral::String(v)) => self.bucket_str(v.as_str()),
             (PrimitiveType::Uuid, PrimitiveLiteral::UInt128(v)) => {
@@ -998,5 +1005,47 @@ mod test {
             .unwrap();
 
         assert_eq!(micro_result.value(0), nano_result.value(0));
+    }
+
+    #[test]
+    fn test_nanos_to_micros_uses_floor_division() {
+        assert_eq!(Bucket::nanos_to_micros(i64::MIN), -9_223_372_036_854_776);
+        assert_eq!(Bucket::nanos_to_micros(1_001), 1);
+        assert_eq!(Bucket::nanos_to_micros(1_000), 1);
+        assert_eq!(Bucket::nanos_to_micros(0), 0);
+        assert_eq!(Bucket::nanos_to_micros(-1_000), -1);
+        assert_eq!(Bucket::nanos_to_micros(-1_001), -2);
+        assert_eq!(Bucket::nanos_to_micros(i64::MAX), 9_223_372_036_854_775);
+    }
+
+    #[test]
+    fn test_negative_timestamp_nanos_round_down_to_micros() {
+        let bucket = Bucket::new(100);
+        let micros_value = -1_510_871_468_000_001;
+        let nanos_value = micros_value * 1000 + 999;
+
+        let expected = bucket
+            .transform_literal(&Datum::timestamp_micros(micros_value))
+            .unwrap();
+        assert_eq!(
+            bucket
+                .transform_literal(&Datum::timestamp_nanos(nanos_value))
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            bucket
+                .transform_literal(&Datum::timestamptz_nanos(nanos_value))
+                .unwrap(),
+            expected
+        );
+
+        let micro_array = TimestampMicrosecondArray::from_iter_values([micros_value]);
+        let nano_array = TimestampNanosecondArray::from_iter_values([nanos_value]);
+        let micro_result = bucket.transform(Arc::new(micro_array)).unwrap();
+        let nano_result = bucket.transform(Arc::new(nano_array)).unwrap();
+        let micro_result = micro_result.as_any().downcast_ref::<Int32Array>().unwrap();
+        let nano_result = nano_result.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(micro_result, nano_result);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Found while comparing the Rust bucket transform with the Java reference implementation.

## What changes are included in this PR?

Rust integer division truncates toward zero, while Iceberg Java converts nanoseconds to microseconds with floor division before bucket hashing. For negative values that are not exactly microsecond-aligned, dividing by 1,000 therefore hashed the wrong microsecond. For example, `-1,001 ns` became `-1 µs` instead of `-2 µs`, which could place pre-epoch values in a different partition bucket across implementations.

This PR centralizes nanosecond-to-microsecond conversion with Euclidean division and uses it for:

- Arrow `Time64` values with nanosecond precision
- Arrow `Timestamp` values with nanosecond precision
- `timestamp_ns` and `timestamptz_ns` literals

Positive and exactly microsecond-aligned values are unchanged.

## Are these changes tested?

Yes. Unit tests assert the conversion directly for positive, aligned-negative, and unaligned-negative values, then verify that pre-epoch nanosecond literals and Arrow arrays bucket identically to their equivalent microsecond values.

Validated with:

- `cargo test -p iceberg transform::bucket::test --lib`
- `cargo clippy -p iceberg --lib -- -D warnings`
