### PR TITLE
fix(spec): format pre-epoch timestamptz values

### DIFF
--- a/crates/iceberg/src/spec/values/temporal.rs
+++ b/crates/iceberg/src/spec/values/temporal.rs
@@ -98,15 +98,12 @@ pub(crate) mod timestamptz {
     }
 
     pub(crate) fn microseconds_to_datetimetz(micros: i64) -> DateTime<Utc> {
-        let (secs, rem) = (micros / 1_000_000, micros % 1_000_000);
-
-        DateTime::from_timestamp(secs, rem as u32 * 1_000).unwrap()
+        // This shouldn't fail until the year 262000
+        DateTime::from_timestamp_micros(micros).unwrap()
     }
 
     pub(crate) fn nanoseconds_to_datetimetz(nanos: i64) -> DateTime<Utc> {
-        let (secs, rem) = (nanos / 1_000_000_000, nanos % 1_000_000_000);
-
-        DateTime::from_timestamp(secs, rem as u32).unwrap()
+        DateTime::from_timestamp_nanos(nanos)
     }
 
     /// Nanoseconds since the Unix epoch, or `None` if outside the representable `i64` range

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -1066,6 +1066,29 @@ fn test_parse_timestamptz() {
 }
 
 #[test]
+fn test_pre_epoch_timestamptz_formatting() {
+    assert_eq!(
+        Datum::timestamptz_micros(-1).to_string(),
+        "1969-12-31 23:59:59.999999 UTC"
+    );
+    assert_eq!(
+        Datum::timestamptz_nanos(-1).to_string(),
+        "1969-12-31 23:59:59.999999999 UTC"
+    );
+
+    check_json_serde(
+        r#""1969-12-31T23:59:59.999999+00:00""#,
+        Literal::long(-1),
+        &Primitive(PrimitiveType::Timestamptz),
+    );
+    check_json_serde(
+        r#""1969-12-31T23:59:59.999999999+00:00""#,
+        Literal::long(-1),
+        &Primitive(PrimitiveType::TimestamptzNs),
+    );
+}
+
+#[test]
 fn test_datum_ser_deser() {
     let test_fn = |datum: Datum| {
         let json = serde_json::to_value(&datum).unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Found while auditing temporal conversions for values before the Unix epoch.

## What changes are included in this PR?

Formatting a timestamptz immediately before the Unix epoch could panic. The conversion split the value with integer division and remainder, then cast the negative remainder to an unsigned nanosecond value before constructing the timestamp.

This PR uses Chrono timestamp constructors for both microsecond and nanosecond timestamptz values. These constructors normalize negative timestamps correctly and match the conversion already used for timestamps without a timezone.

## Are these changes tested?

Yes. A regression test covers display formatting and JSON round trips for values one microsecond and one nanosecond before the Unix epoch.

Validated with:

- `cargo test -p iceberg --lib`
- `cargo clippy -p iceberg --lib -- -D warnings`
