### PR TITLE
chore: Bump version to 0.10.1, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.10.1] - 2026-07-28
+
+* chore: Update crossbeam-epoch to 0.9.20, pin CI ruff version to 0.15.22 by @dannycjones in https://github.com/apache/iceberg-rust/pull/2911
+
 ## [v0.10.0] - 2026-07-07
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-cache-moka"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "iceberg",
  "moka",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-glue"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-hms"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-loader"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "iceberg",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-s3tables"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-sql"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "iceberg",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-datafusion"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-examples"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "futures",
  "iceberg",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-integration-tests"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-playground"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-sqllogictest"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg-storage-opendal"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_test_utils"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "iceberg",
  "tracing-subscriber",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "pyiceberg_core_rust"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arrow",
  "datafusion-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 edition = "2024"
 homepage = "https://rust.iceberg.apache.org/"
 publish = false
-version = "0.10.0"
+version = "0.10.1"
 
 license = "Apache-2.0"
 repository = "https://github.com/apache/iceberg-rust"

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -111,7 +111,7 @@ cpufeatures@0.3.0		X									X
 crc32c@0.6.8		X									X						
 crc32fast@1.5.0		X									X						
 crossbeam-channel@0.5.15		X									X						
-crossbeam-epoch@0.9.18		X									X						
+crossbeam-epoch@0.9.20		X									X						
 crossbeam-utils@0.8.21		X									X						
 crunchy@0.2.4											X						
 crypto-common@0.1.7		X									X						
@@ -237,10 +237,10 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X						
 iana-time-zone@0.1.65		X									X						
 iana-time-zone-haiku@0.1.2		X									X						
-iceberg@0.10.0		X															
-iceberg-datafusion@0.10.0		X															
-iceberg-storage-opendal@0.10.0		X															
-iceberg_test_utils@0.10.0		X															
+iceberg@0.10.1		X															
+iceberg-datafusion@0.10.1		X															
+iceberg-storage-opendal@0.10.1		X															
+iceberg_test_utils@0.10.1		X															
 icu_collections@2.1.1														X			
 icu_locale_core@2.1.1														X			
 icu_normalizer@2.1.1														X			
@@ -372,7 +372,7 @@ proc-macro2@1.0.106		X									X
 prost@0.14.3		X															
 prost-derive@0.14.3		X															
 psm@0.1.30		X									X						
-pyiceberg_core_rust@0.10.0		X															
+pyiceberg_core_rust@0.10.1		X															
 pyo3@0.28.3		X									X						
 pyo3-build-config@0.28.3		X									X						
 pyo3-ffi@0.28.3		X									X						

--- a/crates/catalog/glue/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/glue/DEPENDENCIES.rust.tsv
@@ -84,7 +84,7 @@ cpufeatures@0.2.17		X									X
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-channel@0.5.15		X									X				
-crossbeam-epoch@0.9.18		X									X				
+crossbeam-epoch@0.9.20		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
 crypto-common@0.1.7		X									X				
@@ -157,10 +157,10 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X				
 iana-time-zone@0.1.65		X									X				
 iana-time-zone-haiku@0.1.2		X									X				
-iceberg@0.10.0		X													
-iceberg-catalog-glue@0.10.0		X													
-iceberg-storage-opendal@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-catalog-glue@0.10.1		X													
+iceberg-storage-opendal@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1													X		
 icu_locale_core@2.1.1													X		
 icu_normalizer@2.1.1													X		

--- a/crates/catalog/hms/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/hms/DEPENDENCIES.rust.tsv
@@ -66,7 +66,7 @@ cpufeatures@0.2.17		X									X
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-channel@0.5.15		X									X				
-crossbeam-epoch@0.9.18		X									X				
+crossbeam-epoch@0.9.20		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
 crypto-common@0.1.7		X									X				
@@ -138,10 +138,10 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X				
 iana-time-zone@0.1.65		X									X				
 iana-time-zone-haiku@0.1.2		X									X				
-iceberg@0.10.0		X													
-iceberg-catalog-hms@0.10.0		X													
-iceberg-storage-opendal@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-catalog-hms@0.10.1		X													
+iceberg-storage-opendal@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1													X		
 icu_locale_core@2.1.1													X		
 icu_normalizer@2.1.1													X		

--- a/crates/catalog/loader/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/loader/DEPENDENCIES.rust.tsv
@@ -91,7 +91,7 @@ crc-catalog@2.4.0		X									X
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-channel@0.5.15		X									X				
-crossbeam-epoch@0.9.18		X									X				
+crossbeam-epoch@0.9.20		X									X				
 crossbeam-queue@0.3.12		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
@@ -174,15 +174,15 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X				
 iana-time-zone@0.1.65		X									X				
 iana-time-zone-haiku@0.1.2		X									X				
-iceberg@0.10.0		X													
-iceberg-catalog-glue@0.10.0		X													
-iceberg-catalog-hms@0.10.0		X													
-iceberg-catalog-loader@0.10.0		X													
-iceberg-catalog-rest@0.10.0		X													
-iceberg-catalog-s3tables@0.10.0		X													
-iceberg-catalog-sql@0.10.0		X													
-iceberg-storage-opendal@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-catalog-glue@0.10.1		X													
+iceberg-catalog-hms@0.10.1		X													
+iceberg-catalog-loader@0.10.1		X													
+iceberg-catalog-rest@0.10.1		X													
+iceberg-catalog-s3tables@0.10.1		X													
+iceberg-catalog-sql@0.10.1		X													
+iceberg-storage-opendal@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1													X		
 icu_locale_core@2.1.1													X		
 icu_normalizer@2.1.1													X		

--- a/crates/catalog/rest/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/rest/DEPENDENCIES.rust.tsv
@@ -54,7 +54,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X			
 crc32fast@1.5.0		X								X			
 crossbeam-channel@0.5.15		X								X			
-crossbeam-epoch@0.9.18		X								X			
+crossbeam-epoch@0.9.20		X								X			
 crossbeam-utils@0.8.21		X								X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7		X								X			
@@ -113,9 +113,9 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65		X								X			
 iana-time-zone-haiku@0.1.2		X								X			
-iceberg@0.10.0		X											
-iceberg-catalog-rest@0.10.0		X											
-iceberg_test_utils@0.10.0		X											
+iceberg@0.10.1		X											
+iceberg-catalog-rest@0.10.1		X											
+iceberg_test_utils@0.10.1		X											
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		

--- a/crates/catalog/s3tables/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/s3tables/DEPENDENCIES.rust.tsv
@@ -84,7 +84,7 @@ cpufeatures@0.2.17		X									X
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-channel@0.5.15		X									X				
-crossbeam-epoch@0.9.18		X									X				
+crossbeam-epoch@0.9.20		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
 crypto-common@0.1.7		X									X				
@@ -157,10 +157,10 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X				
 iana-time-zone@0.1.65		X									X				
 iana-time-zone-haiku@0.1.2		X									X				
-iceberg@0.10.0		X													
-iceberg-catalog-s3tables@0.10.0		X													
-iceberg-storage-opendal@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-catalog-s3tables@0.10.1		X													
+iceberg-storage-opendal@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1													X		
 icu_locale_core@2.1.1													X		
 icu_normalizer@2.1.1													X		

--- a/crates/catalog/sql/DEPENDENCIES.rust.tsv
+++ b/crates/catalog/sql/DEPENDENCIES.rust.tsv
@@ -57,7 +57,7 @@ crc@3.4.0		X									X
 crc-catalog@2.4.0		X									X			
 crc32fast@1.5.0		X									X			
 crossbeam-channel@0.5.15		X									X			
-crossbeam-epoch@0.9.18		X									X			
+crossbeam-epoch@0.9.20		X									X			
 crossbeam-queue@0.3.12		X									X			
 crossbeam-utils@0.8.21		X									X			
 crunchy@0.2.4											X			
@@ -120,9 +120,9 @@ hyper@1.8.1											X
 hyper-util@0.1.20											X			
 iana-time-zone@0.1.65		X									X			
 iana-time-zone-haiku@0.1.2		X									X			
-iceberg@0.10.0		X												
-iceberg-catalog-sql@0.10.0		X												
-iceberg_test_utils@0.10.0		X												
+iceberg@0.10.1		X												
+iceberg-catalog-sql@0.10.1		X												
+iceberg_test_utils@0.10.1		X												
 icu_collections@2.1.1												X		
 icu_locale_core@2.1.1												X		
 icu_normalizer@2.1.1												X		

--- a/crates/examples/DEPENDENCIES.rust.tsv
+++ b/crates/examples/DEPENDENCIES.rust.tsv
@@ -54,7 +54,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X			
 crc32fast@1.5.0		X								X			
 crossbeam-channel@0.5.15		X								X			
-crossbeam-epoch@0.9.18		X								X			
+crossbeam-epoch@0.9.20		X								X			
 crossbeam-utils@0.8.21		X								X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7		X								X			
@@ -114,10 +114,10 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65		X								X			
 iana-time-zone-haiku@0.1.2		X								X			
-iceberg@0.10.0		X											
-iceberg-catalog-rest@0.10.0		X											
-iceberg-examples@0.10.0		X											
-iceberg_test_utils@0.10.0		X											
+iceberg@0.10.1		X											
+iceberg-catalog-rest@0.10.1		X											
+iceberg-examples@0.10.1		X											
+iceberg_test_utils@0.10.1		X											
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		

--- a/crates/iceberg/DEPENDENCIES.rust.tsv
+++ b/crates/iceberg/DEPENDENCIES.rust.tsv
@@ -54,7 +54,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X			
 crc32fast@1.5.0		X								X			
 crossbeam-channel@0.5.15		X								X			
-crossbeam-epoch@0.9.18		X								X			
+crossbeam-epoch@0.9.20		X								X			
 crossbeam-utils@0.8.21		X								X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7		X								X			
@@ -111,8 +111,8 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65		X								X			
 iana-time-zone-haiku@0.1.2		X								X			
-iceberg@0.10.0		X											
-iceberg_test_utils@0.10.0		X											
+iceberg@0.10.1		X											
+iceberg_test_utils@0.10.1		X											
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -63,7 +63,7 @@ cpufeatures@0.2.17		X									X
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-channel@0.5.15		X									X				
-crossbeam-epoch@0.9.18		X									X				
+crossbeam-epoch@0.9.20		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
 crypto-common@0.1.7		X									X				
@@ -134,11 +134,11 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X				
 iana-time-zone@0.1.65		X									X				
 iana-time-zone-haiku@0.1.2		X									X				
-iceberg@0.10.0		X													
-iceberg-catalog-rest@0.10.0		X													
-iceberg-integration-tests@0.10.0		X													
-iceberg-storage-opendal@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-catalog-rest@0.10.1		X													
+iceberg-integration-tests@0.10.1		X													
+iceberg-storage-opendal@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1													X		
 icu_locale_core@2.1.1													X		
 icu_normalizer@2.1.1													X		

--- a/crates/integrations/cache-moka/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/cache-moka/DEPENDENCIES.rust.tsv
@@ -54,7 +54,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X			
 crc32fast@1.5.0		X								X			
 crossbeam-channel@0.5.15		X								X			
-crossbeam-epoch@0.9.18		X								X			
+crossbeam-epoch@0.9.20		X								X			
 crossbeam-utils@0.8.21		X								X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7		X								X			
@@ -111,9 +111,9 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65		X								X			
 iana-time-zone-haiku@0.1.2		X								X			
-iceberg@0.10.0		X											
-iceberg-cache-moka@0.10.0		X											
-iceberg_test_utils@0.10.0		X											
+iceberg@0.10.1		X											
+iceberg-cache-moka@0.10.1		X											
+iceberg_test_utils@0.10.1		X											
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -71,7 +71,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X					
 crc32fast@1.5.0		X								X					
 crossbeam-channel@0.5.15		X								X					
-crossbeam-epoch@0.9.18		X								X					
+crossbeam-epoch@0.9.20		X								X					
 crossbeam-utils@0.8.21		X								X					
 crunchy@0.2.4										X					
 crypto-common@0.1.7		X								X					
@@ -171,9 +171,9 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X					
 iana-time-zone@0.1.65		X								X					
 iana-time-zone-haiku@0.1.2		X								X					
-iceberg@0.10.0		X													
-iceberg-datafusion@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-datafusion@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1												X			
 icu_locale_core@2.1.1												X			
 icu_normalizer@2.1.1												X			

--- a/crates/integrations/playground/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/playground/DEPENDENCIES.rust.tsv
@@ -111,7 +111,7 @@ cpufeatures@0.2.17		X								X
 cpufeatures@0.3.0		X								X						
 crc32fast@1.5.0		X								X						
 crossbeam-channel@0.5.15		X								X						
-crossbeam-epoch@0.9.18		X								X						
+crossbeam-epoch@0.9.20		X								X						
 crossbeam-utils@0.8.21		X								X						
 crunchy@0.2.4										X						
 crypto-common@0.1.7		X								X						
@@ -231,11 +231,11 @@ hyper-rustls@0.27.7		X						X		X
 hyper-util@0.1.20										X						
 iana-time-zone@0.1.65		X								X						
 iana-time-zone-haiku@0.1.2		X								X						
-iceberg@0.10.0		X														
-iceberg-catalog-rest@0.10.0		X														
-iceberg-datafusion@0.10.0		X														
-iceberg-playground@0.10.0		X														
-iceberg_test_utils@0.10.0		X														
+iceberg@0.10.1		X														
+iceberg-catalog-rest@0.10.1		X														
+iceberg-datafusion@0.10.1		X														
+iceberg-playground@0.10.1		X														
+iceberg_test_utils@0.10.1		X														
 icu_collections@2.1.1													X			
 icu_locale_core@2.1.1													X			
 icu_normalizer@2.1.1													X			

--- a/crates/sqllogictest/DEPENDENCIES.rust.tsv
+++ b/crates/sqllogictest/DEPENDENCIES.rust.tsv
@@ -85,7 +85,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X					
 crc32fast@1.5.0		X								X					
 crossbeam-channel@0.5.15		X								X					
-crossbeam-epoch@0.9.18		X								X					
+crossbeam-epoch@0.9.20		X								X					
 crossbeam-utils@0.8.21		X								X					
 crunchy@0.2.4										X					
 crypto-common@0.1.7		X								X					
@@ -198,10 +198,10 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X					
 iana-time-zone@0.1.65		X								X					
 iana-time-zone-haiku@0.1.2		X								X					
-iceberg@0.10.0		X													
-iceberg-datafusion@0.10.0		X													
-iceberg-sqllogictest@0.10.0		X													
-iceberg_test_utils@0.10.0		X													
+iceberg@0.10.1		X													
+iceberg-datafusion@0.10.1		X													
+iceberg-sqllogictest@0.10.1		X													
+iceberg_test_utils@0.10.1		X													
 icu_collections@2.1.1												X			
 icu_locale_core@2.1.1												X			
 icu_normalizer@2.1.1												X			

--- a/crates/storage/opendal/DEPENDENCIES.rust.tsv
+++ b/crates/storage/opendal/DEPENDENCIES.rust.tsv
@@ -90,7 +90,7 @@ cpufeatures@0.3.0		X									X
 crc32c@0.6.8		X									X					
 crc32fast@1.5.0		X									X					
 crossbeam-channel@0.5.15		X									X					
-crossbeam-epoch@0.9.18		X									X					
+crossbeam-epoch@0.9.20		X									X					
 crossbeam-utils@0.8.21		X									X					
 crunchy@0.2.4											X					
 crypto-common@0.1.7		X									X					
@@ -175,9 +175,9 @@ hyper-rustls@0.27.7		X							X		X
 hyper-util@0.1.20											X					
 iana-time-zone@0.1.65		X									X					
 iana-time-zone-haiku@0.1.2		X									X					
-iceberg@0.10.0		X														
-iceberg-storage-opendal@0.10.0		X														
-iceberg_test_utils@0.10.0		X														
+iceberg@0.10.1		X														
+iceberg-storage-opendal@0.10.1		X														
+iceberg_test_utils@0.10.1		X														
 icu_collections@2.1.1														X		
 icu_locale_core@2.1.1														X		
 icu_normalizer@2.1.1														X		

--- a/crates/test_utils/DEPENDENCIES.rust.tsv
+++ b/crates/test_utils/DEPENDENCIES.rust.tsv
@@ -54,7 +54,7 @@ core-foundation-sys@0.8.7		X								X
 cpufeatures@0.2.17		X								X			
 crc32fast@1.5.0		X								X			
 crossbeam-channel@0.5.15		X								X			
-crossbeam-epoch@0.9.18		X								X			
+crossbeam-epoch@0.9.20		X								X			
 crossbeam-utils@0.8.21		X								X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7		X								X			
@@ -111,8 +111,8 @@ hyper@1.8.1										X
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65		X								X			
 iana-time-zone-haiku@0.1.2		X								X			
-iceberg@0.10.0		X											
-iceberg_test_utils@0.10.0		X											
+iceberg@0.10.1		X											
+iceberg_test_utils@0.10.1		X											
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		


### PR DESCRIPTION
## Which issue does this PR close?

This bumps the crate and pyiceberg-core version to 0.10.1, for the 0.10.1 release.

Additionally, it pins ruff to 0.15.22 which was the version used for iceberg-rust 0.10.0.

## What changes are included in this PR?

Version bump, updated dependency TSV manifests, updated changelog.

Pins CI version of ruff Python linter.

## Are these changes tested?

N/A