### PR TITLE
feat(catalog-rest): add rustls TLS features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
             cargo check -p "$pkg" --all-targets || exit 1
           done
 
-  # Verifies the core iceberg crate compiles without default features, ensuring
-  # optional functionality is properly gated behind feature flags.
+  # Verifies crates with feature flags compile without default features, ensuring
+  # optional functionality is properly gated.
   build_with_no_default_features:
     needs: lint
     runs-on: ${{ matrix.os }}
@@ -178,7 +178,9 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build
-        run: cargo build -p iceberg --no-default-features
+        run: |
+          cargo build -p iceberg --no-default-features
+          cargo build -p iceberg-catalog-rest --no-default-features
 
   tests:
     needs: lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6373,6 +6374,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -29,6 +29,11 @@ keywords = ["iceberg", "rest", "catalog"]
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["rustls-tls-native-roots"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/catalog/rest/README.md
+++ b/crates/catalog/rest/README.md
@@ -25,3 +25,21 @@
 This crate contains the official Native Rust implementation of Apache Iceberg Rest Catalog.
 
 See the [API documentation](https://docs.rs/iceberg-catalog-rest/latest) for examples and the full API.
+
+## Crate Features
+
+| Feature                   | Default | Description                                                                          |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| `rustls-tls-native-roots` | Yes     | TLS via rustls, validating certificates against the operating system's trust store    |
+| `rustls-tls`              | No      | TLS via rustls, validating certificates against a compiled-in webpki root bundle      |
+
+With the default features, `https://` catalog URIs work out of the box. To build without a
+TLS stack, disable default features:
+
+```toml
+[dependencies]
+iceberg-catalog-rest = { version = "x.y.z", default-features = false }
+```
+
+For custom TLS settings such as client certificates or additional trusted roots, pass a
+preconfigured `reqwest::Client` to `RestCatalogBuilder::with_client`.

--- a/crates/catalog/rest/src/lib.rs
+++ b/crates/catalog/rest/src/lib.rs
@@ -48,6 +48,16 @@
 //!         .unwrap();
 //! }
 //! ```
+//!
+//! # TLS
+//!
+//! `https://` catalog URIs work out of the box: the default `rustls-tls-native-roots`
+//! feature enables reqwest's rustls backend with the operating system's trust store, so
+//! CAs installed on the host are honored. The `rustls-tls` feature uses a compiled-in
+//! webpki root bundle instead. Disable default features to build without a TLS stack.
+//! For custom TLS settings (client certificates, additional roots, accepting invalid
+//! certs), pass a preconfigured `reqwest::Client` via
+//! [`RestCatalogBuilder::with_client`].
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2888 .

## What changes are included in this PR?

TLS passthrough features for iceberg-catalog-rest so https:// catalog URIs work out of the box:
- `rustls-tls-native-roots` (default): rustls validating against the OS trust store
- `rustls-tls`: rustls validating against the compiled-in webpki root bundle
- `default-features = false` builds without a TLS stack
- Feature table in the crate README, TLS section in the crate rustdoc
- CI: the no-default-features job now also builds iceberg-catalog-rest

No code changes. Custom TLS settings (client certificates, extra roots) remain available by passing a preconfigured client to `RestCatalogBuilder::with_client`.

## Are these changes tested?

Feature wiring only, no runtime code. Verified with cargo check for the default feature set, --no-default-features, and rustls-tls.
Adds the iceberg-catalog-rest to the existing "no-default-features" CI check.