### PR TITLE
chore: Update crossbeam-epoch to 0.9.20, pin CI ruff version to 0.15.22

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -56,7 +56,7 @@ jobs:
           enable-cache: true
       - name: Install tools
         run: |
-          uv tool install ruff
+          uv tool install ruff@0.15.22
       - name: Check format
         working-directory: "bindings/python"
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Which issue does this PR close?

Small changes needed for 0.10.1.

## What changes are included in this PR?

First, address advisory in crossbeam-epoch with patch version update.

Second, to address CI, pin Ruff linter for Python to version available when iceberg-rust 0.10.0 was released.

## Are these changes tested?

Already covered by CI.