### PR TITLE
chore(ci): Add check to Python release to verify workflow is running on expected tag

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -66,6 +66,8 @@ jobs:
           DESIRED_REF="refs/tags/${RELEASE_TAG}"
           if [[ "${GITHUB_REF}" != "${DESIRED_REF}" ]]; then
             echo "❌ Error: expected workflow execution on ref ${DESIRED_REF}, got ref: ${GITHUB_REF}"
+            echo "Workflow must be dispatched against the tag ref for the desired release."
+            echo "Dispatching workflow from main or another branch is not supported."
             exit 1
           fi
 

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -65,7 +65,7 @@ jobs:
           # Verify that the workflow is being run on the same version as the release tag
           DESIRED_REF="refs/tags/${RELEASE_TAG}"
           if [[ "${GITHUB_REF}" != "${DESIRED_REF}" ]]; then
-            echo "Error: expected workflow execution on ref ${DESIRED_REF}, got ref: ${GITHUB_REF}"
+            echo "❌ Error: expected workflow execution on ref ${DESIRED_REF}, got ref: ${GITHUB_REF}"
             exit 1
           fi
 

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -61,11 +61,18 @@ jobs:
             exit 1
           fi
           echo "✅ Release tag format is valid: $RELEASE_TAG"
-          
+
+          # Verify that the workflow is being run on the same version as the release tag
+          DESIRED_REF="refs/tags/${RELEASE_TAG}"
+          if [[ "${GITHUB_REF}" != "${DESIRED_REF}" ]]; then
+            echo "Error: expected workflow execution on ref ${DESIRED_REF}, got ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
           # Strip 'v' prefix for cargo version
           CARGO_VERSION="${RELEASE_TAG#v}"
           echo "Cargo version (without v prefix): $CARGO_VERSION"
-          
+
           # For manual triggers, validate that the tag matches the version in Cargo.toml
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # Extract base version (without -rc.X suffix) for comparison with Cargo.toml


### PR DESCRIPTION
## Which issue does this PR close?

Addresses issue where pyiceberg-core was released from `main` rather than the release branch.
The change should prevent this scenario from recurring.

## What changes are included in this PR?

The code will checkout the ref it was executed with, and this change asserts that we're on a tagged commit.

It may be worth removing the input version argument and simply using the tag that the workflow was invoked with - this is enough information. However, I wanted to keep changes simple for now.

## Are these changes tested?

Yes, manually:

- Invoked from a branch rather than a tag: https://github.com/dannycjones/iceberg-rust/actions/runs/30254503263/job/89939838125
- Invoked correctly (but the actually packages are wrong so fails anyway): https://github.com/dannycjones/iceberg-rust/actions/runs/30254526325/job/89939906112