### PR TITLE
chore(ci): Update ASF allowlist check action dependency to track versioned releases

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -39,4 +39,4 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: apache/infrastructure-actions/allowlist-check@5d6d53e66c7f6f831d4fd0c8fd1a610054ed8a26  # zizmor: ignore[ref-version-mismatch] action does not support tag-based releases yet; pinned from main
+    - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # allowlist-check/v1.0.0


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## What changes are included in this PR?

Updates GH Actions CI to track versioned tags for the ASF allowlist check. The ASF allowlist check recently started publishing tagged releases, so there is no longer a need to track `main` branch.

Related ASF action change: https://github.com/apache/infrastructure-actions/pull/1032

## Are these changes tested?

The CI changes will be run on the PR introducing this change.
Zizmor passes locally.