### PR TITLE
docs: fix references in public docs

### DIFF
--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -564,7 +564,7 @@ impl RestCatalog {
 }
 
 /// All requests and expected responses are derived from the REST catalog API spec:
-/// https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
+/// <https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml>
 #[async_trait]
 impl Catalog for RestCatalog {
     async fn list_namespaces(

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3233,24 +3233,16 @@ impl iceberg::transaction::ExpireSnapshotsAction
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_older_than_ms(self, older_than_ms: i64) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_snapshot_ids(self, snapshot_ids: impl core::iter::traits::collect::IntoIterator<Item = i64>) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::retain_last(self, retain_last: usize) -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
-pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::FastAppendAction
 impl iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
 pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
-pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::ReplaceSortOrderAction
 impl iceberg::transaction::ReplaceSortOrderAction
 pub fn iceberg::transaction::ReplaceSortOrderAction::asc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
 pub fn iceberg::transaction::ReplaceSortOrderAction::desc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
-impl core::default::Default for iceberg::transaction::ReplaceSortOrderAction
-pub fn iceberg::transaction::ReplaceSortOrderAction::default() -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
-pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
@@ -3268,61 +3260,25 @@ pub fn iceberg::transaction::Transaction::clone(&self) -> iceberg::transaction::
 pub struct iceberg::transaction::UpdateLocationAction
 impl iceberg::transaction::UpdateLocationAction
 pub fn iceberg::transaction::UpdateLocationAction::set_location(self, location: alloc::string::String) -> Self
-impl core::default::Default for iceberg::transaction::UpdateLocationAction
-pub fn iceberg::transaction::UpdateLocationAction::default() -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
-pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdatePropertiesAction
 impl iceberg::transaction::UpdatePropertiesAction
 pub fn iceberg::transaction::UpdatePropertiesAction::remove(self, key: alloc::string::String) -> Self
 pub fn iceberg::transaction::UpdatePropertiesAction::set(self, key: alloc::string::String, value: alloc::string::String) -> Self
-impl core::default::Default for iceberg::transaction::UpdatePropertiesAction
-pub fn iceberg::transaction::UpdatePropertiesAction::default() -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
-pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateSchemaAction
 impl iceberg::transaction::UpdateSchemaAction
 pub fn iceberg::transaction::UpdateSchemaAction::add_column(self, add_column: iceberg::transaction::AddColumn) -> Self
 pub fn iceberg::transaction::UpdateSchemaAction::delete_column(self, name: impl alloc::string::ToString) -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
-pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateStatisticsAction
 impl iceberg::transaction::UpdateStatisticsAction
 pub fn iceberg::transaction::UpdateStatisticsAction::remove_statistics(self, snapshot_id: i64) -> Self
 pub fn iceberg::transaction::UpdateStatisticsAction::set_statistics(self, statistics_file: iceberg::spec::StatisticsFile) -> Self
-impl core::default::Default for iceberg::transaction::UpdateStatisticsAction
-pub fn iceberg::transaction::UpdateStatisticsAction::default() -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
-pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpgradeFormatVersionAction
 impl iceberg::transaction::UpgradeFormatVersionAction
 pub fn iceberg::transaction::UpgradeFormatVersionAction::set_format_version(self, format_version: iceberg::spec::FormatVersion) -> Self
-impl core::default::Default for iceberg::transaction::UpgradeFormatVersionAction
-pub fn iceberg::transaction::UpgradeFormatVersionAction::default() -> Self
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
-pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
-impl<T: iceberg::transaction::TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
+impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
 pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
-pub trait iceberg::transaction::TransactionAction: as_any::AsAny + core::marker::Sync + core::marker::Send
-pub fn iceberg::transaction::TransactionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
-pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
-pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
-pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
-pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
-pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
-pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
-pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
-impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
-pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3193,18 +3193,24 @@ impl iceberg::transaction::ExpireSnapshotsAction
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_older_than_ms(self, older_than_ms: i64) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_snapshot_ids(self, snapshot_ids: impl core::iter::traits::collect::IntoIterator<Item = i64>) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::retain_last(self, retain_last: usize) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::FastAppendAction
 impl iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
 pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::ReplaceSortOrderAction
 impl iceberg::transaction::ReplaceSortOrderAction
 pub fn iceberg::transaction::ReplaceSortOrderAction::asc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
 pub fn iceberg::transaction::ReplaceSortOrderAction::desc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
 impl core::default::Default for iceberg::transaction::ReplaceSortOrderAction
 pub fn iceberg::transaction::ReplaceSortOrderAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
@@ -3224,31 +3230,59 @@ impl iceberg::transaction::UpdateLocationAction
 pub fn iceberg::transaction::UpdateLocationAction::set_location(self, location: alloc::string::String) -> Self
 impl core::default::Default for iceberg::transaction::UpdateLocationAction
 pub fn iceberg::transaction::UpdateLocationAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdatePropertiesAction
 impl iceberg::transaction::UpdatePropertiesAction
 pub fn iceberg::transaction::UpdatePropertiesAction::remove(self, key: alloc::string::String) -> Self
 pub fn iceberg::transaction::UpdatePropertiesAction::set(self, key: alloc::string::String, value: alloc::string::String) -> Self
 impl core::default::Default for iceberg::transaction::UpdatePropertiesAction
 pub fn iceberg::transaction::UpdatePropertiesAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateSchemaAction
 impl iceberg::transaction::UpdateSchemaAction
 pub fn iceberg::transaction::UpdateSchemaAction::add_column(self, add_column: iceberg::transaction::AddColumn) -> Self
 pub fn iceberg::transaction::UpdateSchemaAction::delete_column(self, name: impl alloc::string::ToString) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateStatisticsAction
 impl iceberg::transaction::UpdateStatisticsAction
 pub fn iceberg::transaction::UpdateStatisticsAction::remove_statistics(self, snapshot_id: i64) -> Self
 pub fn iceberg::transaction::UpdateStatisticsAction::set_statistics(self, statistics_file: iceberg::spec::StatisticsFile) -> Self
 impl core::default::Default for iceberg::transaction::UpdateStatisticsAction
 pub fn iceberg::transaction::UpdateStatisticsAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpgradeFormatVersionAction
 impl iceberg::transaction::UpgradeFormatVersionAction
 pub fn iceberg::transaction::UpgradeFormatVersionAction::set_format_version(self, format_version: iceberg::spec::FormatVersion) -> Self
 impl core::default::Default for iceberg::transaction::UpgradeFormatVersionAction
 pub fn iceberg::transaction::UpgradeFormatVersionAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
-impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
+impl<T: iceberg::transaction::TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
 pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
+pub trait iceberg::transaction::TransactionAction: as_any::AsAny + core::marker::Sync + core::marker::Send
+pub fn iceberg::transaction::TransactionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3228,24 +3228,67 @@ pub fn iceberg::transaction::AddColumn::optional(name: impl alloc::string::ToStr
 pub fn iceberg::transaction::AddColumn::required(name: impl alloc::string::ToString, field_type: iceberg::spec::Type, initial_default: iceberg::spec::Literal) -> Self
 impl iceberg::transaction::AddColumn
 pub fn iceberg::transaction::AddColumn::builder() -> AddColumnBuilder<((), (), (), (), (), (), ())>
+pub struct iceberg::transaction::ExpireSnapshotsAction
+impl iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::expire_older_than_ms(self, older_than_ms: i64) -> Self
+pub fn iceberg::transaction::ExpireSnapshotsAction::expire_snapshot_ids(self, snapshot_ids: impl core::iter::traits::collect::IntoIterator<Item = i64>) -> Self
+pub fn iceberg::transaction::ExpireSnapshotsAction::retain_last(self, retain_last: usize) -> Self
+pub struct iceberg::transaction::FastAppendAction
+impl iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
+pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
+pub struct iceberg::transaction::ReplaceSortOrderAction
+impl iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::asc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
+pub fn iceberg::transaction::ReplaceSortOrderAction::desc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
+impl core::default::Default for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::default() -> Self
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
-pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::expire_snapshots::ExpireSnapshotsAction
-pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
+pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
-pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
-pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
-pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
-pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction
-pub fn iceberg::transaction::Transaction::update_table_properties(&self) -> iceberg::transaction::update_properties::UpdatePropertiesAction
-pub fn iceberg::transaction::Transaction::upgrade_table_version(&self) -> iceberg::transaction::upgrade_format_version::UpgradeFormatVersionAction
+pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::Transaction::update_table_properties(&self) -> iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::Transaction::upgrade_table_version(&self) -> iceberg::transaction::UpgradeFormatVersionAction
 impl core::clone::Clone for iceberg::transaction::Transaction
 pub fn iceberg::transaction::Transaction::clone(&self) -> iceberg::transaction::Transaction
+pub struct iceberg::transaction::UpdateLocationAction
+impl iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::set_location(self, location: alloc::string::String) -> Self
+impl core::default::Default for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::default() -> Self
+pub struct iceberg::transaction::UpdatePropertiesAction
+impl iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::remove(self, key: alloc::string::String) -> Self
+pub fn iceberg::transaction::UpdatePropertiesAction::set(self, key: alloc::string::String, value: alloc::string::String) -> Self
+impl core::default::Default for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::default() -> Self
+pub struct iceberg::transaction::UpdateSchemaAction
+impl iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::add_column(self, add_column: iceberg::transaction::AddColumn) -> Self
+pub fn iceberg::transaction::UpdateSchemaAction::delete_column(self, name: impl alloc::string::ToString) -> Self
+pub struct iceberg::transaction::UpdateStatisticsAction
+impl iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::remove_statistics(self, snapshot_id: i64) -> Self
+pub fn iceberg::transaction::UpdateStatisticsAction::set_statistics(self, statistics_file: iceberg::spec::StatisticsFile) -> Self
+impl core::default::Default for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::default() -> Self
+pub struct iceberg::transaction::UpgradeFormatVersionAction
+impl iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::set_format_version(self, format_version: iceberg::spec::FormatVersion) -> Self
+impl core::default::Default for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::default() -> Self
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
 impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
-pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction> where Self: core::marker::Sized
+pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>
@@ -3648,6 +3691,11 @@ impl core::fmt::Debug for iceberg::Error
 pub fn iceberg::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for iceberg::Error
 pub fn iceberg::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct iceberg::JoinHandle<T>(_)
+impl<T: core::marker::Send + 'static> core::future::future::Future for iceberg::JoinHandle<T>
+pub type iceberg::JoinHandle<T>::Output = core::result::Result<T, iceberg::Error>
+pub fn iceberg::JoinHandle<T>::poll(self: core::pin::Pin<&mut Self>, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<Self::Output>
+impl<T> core::marker::Unpin for iceberg::JoinHandle<T>
 pub struct iceberg::MemoryCatalog
 impl core::fmt::Debug for iceberg::memory::MemoryCatalog
 pub fn iceberg::memory::MemoryCatalog::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -3746,8 +3794,8 @@ impl core::fmt::Debug for iceberg::Runtime
 pub fn iceberg::Runtime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct iceberg::RuntimeHandle
 impl iceberg::RuntimeHandle
-pub fn iceberg::RuntimeHandle::spawn<F>(&self, future: F) -> iceberg::runtime::JoinHandle<<F as core::future::future::Future>::Output> where F: core::future::future::Future + core::marker::Send + 'static, <F as core::future::future::Future>::Output: core::marker::Send + 'static
-pub fn iceberg::RuntimeHandle::spawn_blocking<F, T>(&self, f: F) -> iceberg::runtime::JoinHandle<T> where F: core::ops::function::FnOnce() -> T + core::marker::Send + 'static, T: core::marker::Send + 'static
+pub fn iceberg::RuntimeHandle::spawn<F>(&self, future: F) -> iceberg::JoinHandle<<F as core::future::future::Future>::Output> where F: core::future::future::Future + core::marker::Send + 'static, <F as core::future::future::Future>::Output: core::marker::Send + 'static
+pub fn iceberg::RuntimeHandle::spawn_blocking<F, T>(&self, f: F) -> iceberg::JoinHandle<T> where F: core::ops::function::FnOnce() -> T + core::marker::Send + 'static, T: core::marker::Send + 'static
 impl core::clone::Clone for iceberg::RuntimeHandle
 pub fn iceberg::RuntimeHandle::clone(&self) -> iceberg::RuntimeHandle
 impl core::fmt::Debug for iceberg::RuntimeHandle

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3233,18 +3233,24 @@ impl iceberg::transaction::ExpireSnapshotsAction
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_older_than_ms(self, older_than_ms: i64) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::expire_snapshot_ids(self, snapshot_ids: impl core::iter::traits::collect::IntoIterator<Item = i64>) -> Self
 pub fn iceberg::transaction::ExpireSnapshotsAction::retain_last(self, retain_last: usize) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::FastAppendAction
 impl iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
 pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
 pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::ReplaceSortOrderAction
 impl iceberg::transaction::ReplaceSortOrderAction
 pub fn iceberg::transaction::ReplaceSortOrderAction::asc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
 pub fn iceberg::transaction::ReplaceSortOrderAction::desc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
 impl core::default::Default for iceberg::transaction::ReplaceSortOrderAction
 pub fn iceberg::transaction::ReplaceSortOrderAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
@@ -3264,31 +3270,59 @@ impl iceberg::transaction::UpdateLocationAction
 pub fn iceberg::transaction::UpdateLocationAction::set_location(self, location: alloc::string::String) -> Self
 impl core::default::Default for iceberg::transaction::UpdateLocationAction
 pub fn iceberg::transaction::UpdateLocationAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdatePropertiesAction
 impl iceberg::transaction::UpdatePropertiesAction
 pub fn iceberg::transaction::UpdatePropertiesAction::remove(self, key: alloc::string::String) -> Self
 pub fn iceberg::transaction::UpdatePropertiesAction::set(self, key: alloc::string::String, value: alloc::string::String) -> Self
 impl core::default::Default for iceberg::transaction::UpdatePropertiesAction
 pub fn iceberg::transaction::UpdatePropertiesAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateSchemaAction
 impl iceberg::transaction::UpdateSchemaAction
 pub fn iceberg::transaction::UpdateSchemaAction::add_column(self, add_column: iceberg::transaction::AddColumn) -> Self
 pub fn iceberg::transaction::UpdateSchemaAction::delete_column(self, name: impl alloc::string::ToString) -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpdateStatisticsAction
 impl iceberg::transaction::UpdateStatisticsAction
 pub fn iceberg::transaction::UpdateStatisticsAction::remove_statistics(self, snapshot_id: i64) -> Self
 pub fn iceberg::transaction::UpdateStatisticsAction::set_statistics(self, statistics_file: iceberg::spec::StatisticsFile) -> Self
 impl core::default::Default for iceberg::transaction::UpdateStatisticsAction
 pub fn iceberg::transaction::UpdateStatisticsAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::transaction::UpgradeFormatVersionAction
 impl iceberg::transaction::UpgradeFormatVersionAction
 pub fn iceberg::transaction::UpgradeFormatVersionAction::set_format_version(self, format_version: iceberg::spec::FormatVersion) -> Self
 impl core::default::Default for iceberg::transaction::UpgradeFormatVersionAction
 pub fn iceberg::transaction::UpgradeFormatVersionAction::default() -> Self
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
-impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
+impl<T: iceberg::transaction::TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
 pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
+pub trait iceberg::transaction::TransactionAction: as_any::AsAny + core::marker::Sync + core::marker::Send
+pub fn iceberg::transaction::TransactionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::transaction::TransactionAction for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::commit<'life0, 'async_trait>(self: alloc::sync::Arc<Self>, _table: &'life0 iceberg::table::Table) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::ActionCommit>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3188,24 +3188,67 @@ pub fn iceberg::transaction::AddColumn::optional(name: impl alloc::string::ToStr
 pub fn iceberg::transaction::AddColumn::required(name: impl alloc::string::ToString, field_type: iceberg::spec::Type, initial_default: iceberg::spec::Literal) -> Self
 impl iceberg::transaction::AddColumn
 pub fn iceberg::transaction::AddColumn::builder() -> AddColumnBuilder<((), (), (), (), (), (), ())>
+pub struct iceberg::transaction::ExpireSnapshotsAction
+impl iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::ExpireSnapshotsAction::expire_older_than_ms(self, older_than_ms: i64) -> Self
+pub fn iceberg::transaction::ExpireSnapshotsAction::expire_snapshot_ids(self, snapshot_ids: impl core::iter::traits::collect::IntoIterator<Item = i64>) -> Self
+pub fn iceberg::transaction::ExpireSnapshotsAction::retain_last(self, retain_last: usize) -> Self
+pub struct iceberg::transaction::FastAppendAction
+impl iceberg::transaction::FastAppendAction
+pub fn iceberg::transaction::FastAppendAction::add_data_files(self, data_files: impl core::iter::traits::collect::IntoIterator<Item = iceberg::spec::DataFile>) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_commit_uuid(self, commit_uuid: uuid::Uuid) -> Self
+pub fn iceberg::transaction::FastAppendAction::set_snapshot_properties(self, snapshot_properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
+pub fn iceberg::transaction::FastAppendAction::with_check_duplicate(self, v: bool) -> Self
+pub struct iceberg::transaction::ReplaceSortOrderAction
+impl iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::asc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
+pub fn iceberg::transaction::ReplaceSortOrderAction::desc(self, name: &str, null_order: iceberg::spec::NullOrder) -> Self
+impl core::default::Default for iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::ReplaceSortOrderAction::default() -> Self
 pub struct iceberg::transaction::Transaction
 impl iceberg::transaction::Transaction
 pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn iceberg::Catalog) -> iceberg::Result<iceberg::table::Table>
-pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::expire_snapshots::ExpireSnapshotsAction
-pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
+pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::ExpireSnapshotsAction
+pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
-pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
-pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
-pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
-pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction
-pub fn iceberg::transaction::Transaction::update_table_properties(&self) -> iceberg::transaction::update_properties::UpdatePropertiesAction
-pub fn iceberg::transaction::Transaction::upgrade_table_version(&self) -> iceberg::transaction::upgrade_format_version::UpgradeFormatVersionAction
+pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::Transaction::update_table_properties(&self) -> iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::Transaction::upgrade_table_version(&self) -> iceberg::transaction::UpgradeFormatVersionAction
 impl core::clone::Clone for iceberg::transaction::Transaction
 pub fn iceberg::transaction::Transaction::clone(&self) -> iceberg::transaction::Transaction
+pub struct iceberg::transaction::UpdateLocationAction
+impl iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::set_location(self, location: alloc::string::String) -> Self
+impl core::default::Default for iceberg::transaction::UpdateLocationAction
+pub fn iceberg::transaction::UpdateLocationAction::default() -> Self
+pub struct iceberg::transaction::UpdatePropertiesAction
+impl iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::remove(self, key: alloc::string::String) -> Self
+pub fn iceberg::transaction::UpdatePropertiesAction::set(self, key: alloc::string::String, value: alloc::string::String) -> Self
+impl core::default::Default for iceberg::transaction::UpdatePropertiesAction
+pub fn iceberg::transaction::UpdatePropertiesAction::default() -> Self
+pub struct iceberg::transaction::UpdateSchemaAction
+impl iceberg::transaction::UpdateSchemaAction
+pub fn iceberg::transaction::UpdateSchemaAction::add_column(self, add_column: iceberg::transaction::AddColumn) -> Self
+pub fn iceberg::transaction::UpdateSchemaAction::delete_column(self, name: impl alloc::string::ToString) -> Self
+pub struct iceberg::transaction::UpdateStatisticsAction
+impl iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::remove_statistics(self, snapshot_id: i64) -> Self
+pub fn iceberg::transaction::UpdateStatisticsAction::set_statistics(self, statistics_file: iceberg::spec::StatisticsFile) -> Self
+impl core::default::Default for iceberg::transaction::UpdateStatisticsAction
+pub fn iceberg::transaction::UpdateStatisticsAction::default() -> Self
+pub struct iceberg::transaction::UpgradeFormatVersionAction
+impl iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::set_format_version(self, format_version: iceberg::spec::FormatVersion) -> Self
+impl core::default::Default for iceberg::transaction::UpgradeFormatVersionAction
+pub fn iceberg::transaction::UpgradeFormatVersionAction::default() -> Self
 pub trait iceberg::transaction::ApplyTransactionAction
 pub fn iceberg::transaction::ApplyTransactionAction::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction>
 impl<T: TransactionAction + 'static> iceberg::transaction::ApplyTransactionAction for T
-pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> iceberg::Result<iceberg::transaction::Transaction> where Self: core::marker::Sized
+pub fn T::apply(self, tx: iceberg::transaction::Transaction) -> core::result::Result<iceberg::transaction::Transaction, iceberg::Error>
 pub mod iceberg::transform
 pub trait iceberg::transform::TransformFunction: core::marker::Send + core::marker::Sync + core::fmt::Debug
 pub fn iceberg::transform::TransformFunction::transform(&self, input: arrow_array::array::ArrayRef) -> iceberg::Result<arrow_array::array::ArrayRef>
@@ -3616,6 +3659,11 @@ impl core::fmt::Debug for iceberg::Error
 pub fn iceberg::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for iceberg::Error
 pub fn iceberg::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct iceberg::JoinHandle<T>(_)
+impl<T: core::marker::Send + 'static> core::future::future::Future for iceberg::JoinHandle<T>
+pub type iceberg::JoinHandle<T>::Output = core::result::Result<T, iceberg::Error>
+pub fn iceberg::JoinHandle<T>::poll(self: core::pin::Pin<&mut Self>, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<Self::Output>
+impl<T> core::marker::Unpin for iceberg::JoinHandle<T>
 pub struct iceberg::MemoryCatalog
 impl core::fmt::Debug for iceberg::memory::MemoryCatalog
 pub fn iceberg::memory::MemoryCatalog::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -3714,8 +3762,8 @@ impl core::fmt::Debug for iceberg::Runtime
 pub fn iceberg::Runtime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct iceberg::RuntimeHandle
 impl iceberg::RuntimeHandle
-pub fn iceberg::RuntimeHandle::spawn<F>(&self, future: F) -> iceberg::runtime::JoinHandle<<F as core::future::future::Future>::Output> where F: core::future::future::Future + core::marker::Send + 'static, <F as core::future::future::Future>::Output: core::marker::Send + 'static
-pub fn iceberg::RuntimeHandle::spawn_blocking<F, T>(&self, f: F) -> iceberg::runtime::JoinHandle<T> where F: core::ops::function::FnOnce() -> T + core::marker::Send + 'static, T: core::marker::Send + 'static
+pub fn iceberg::RuntimeHandle::spawn<F>(&self, future: F) -> iceberg::JoinHandle<<F as core::future::future::Future>::Output> where F: core::future::future::Future + core::marker::Send + 'static, <F as core::future::future::Future>::Output: core::marker::Send + 'static
+pub fn iceberg::RuntimeHandle::spawn_blocking<F, T>(&self, f: F) -> iceberg::JoinHandle<T> where F: core::ops::function::FnOnce() -> T + core::marker::Send + 'static, T: core::marker::Send + 'static
 impl core::clone::Clone for iceberg::RuntimeHandle
 pub fn iceberg::RuntimeHandle::clone(&self) -> iceberg::RuntimeHandle
 impl core::fmt::Debug for iceberg::RuntimeHandle

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -102,7 +102,7 @@ impl ExtensionType for VariantExtensionType {
 
 /// A post order arrow schema visitor.
 ///
-/// For order of methods called, please refer to [`visit_schema`].
+/// For order of methods called, please refer to the internal `visit_schema` function.
 pub trait ArrowSchemaVisitor {
     /// Return type of this visitor on arrow field.
     type T;

--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -34,7 +34,7 @@ use crate::{Error, ErrorKind, Result};
 
 /// Wrapper for sensitive byte data (encryption keys, DEKs, etc.) that:
 /// - Zeroizes memory on drop
-/// - Redacts content in [`Debug`] and [`Display`] output
+/// - Redacts content in [`Debug`](std::fmt::Debug) and [`Display`](std::fmt::Display) output
 /// - Provides only `&[u8]` access via [`as_bytes()`](Self::as_bytes)
 /// - Uses `Box<[u8]>` (immutable boxed slice) since key bytes never grow
 ///
@@ -217,7 +217,7 @@ impl AesGcmCipher {
     /// * `aad` - Additional authenticated data (optional)
     ///
     /// # Returns
-    /// The encrypted data in the format: [12-byte nonce][ciphertext][16-byte auth tag]
+    /// The encrypted data in the format: `[12-byte nonce][ciphertext][16-byte auth tag]`
     /// This matches the Java implementation format for compatibility.
     pub fn encrypt(&self, plaintext: &[u8], aad: Option<&[u8]>) -> Result<Vec<u8>> {
         match self.key_size {

--- a/crates/iceberg/src/encryption/crypto.rs
+++ b/crates/iceberg/src/encryption/crypto.rs
@@ -169,7 +169,7 @@ impl AesGcmCipher {
     /// * `aad` - Additional authenticated data (optional)
     ///
     /// # Returns
-    /// The encrypted data in the format: [12-byte nonce][ciphertext][16-byte auth tag]
+    /// The encrypted data in the format: `[12-byte nonce][ciphertext][16-byte auth tag]`
     /// This matches the Java implementation format for compatibility.
     pub fn encrypt(&self, plaintext: &[u8], aad: Option<&[u8]>) -> Result<Vec<u8>> {
         match self.key_size {

--- a/crates/iceberg/src/encryption/manager.rs
+++ b/crates/iceberg/src/encryption/manager.rs
@@ -161,7 +161,7 @@ impl EncryptionManager {
     ///
     /// Stores the resulting wrapped entry (and any newly created KEK) in the
     /// manager's internal `encryption_keys` map. Callers persist the full set
-    /// at commit time via [`Self::encryption_keys`].
+    /// at commit time via the manager's `encryption_keys`.
     ///
     /// Returns the `key_id` of the wrapped entry, which should be recorded on
     /// the snapshot as `encryption_key_id` so readers can locate it later.

--- a/crates/iceberg/src/encryption/manager.rs
+++ b/crates/iceberg/src/encryption/manager.rs
@@ -157,7 +157,7 @@ impl EncryptionManager {
     ///
     /// Stores the resulting wrapped entry (and any newly created KEK) in the
     /// manager's internal `encryption_keys` map. Callers persist the full set
-    /// at commit time via [`Self::encryption_keys`].
+    /// at commit time via the manager's `encryption_keys`.
     ///
     /// Returns the `key_id` of the wrapped entry, which should be recorded on
     /// the snapshot as `encryption_key_id` so readers can locate it later.

--- a/crates/iceberg/src/io/storage/config/azdls.rs
+++ b/crates/iceberg/src/io/storage/config/azdls.rs
@@ -51,7 +51,6 @@ pub const ADLS_AUTHORITY_HOST: &str = "adls.authority-host";
 ///
 /// This struct contains all the configuration options for connecting to Azure Data Lake Storage.
 /// Use the builder pattern via `AzdlsConfig::builder()` to construct instances.
-/// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, TypedBuilder)]
 pub struct AzdlsConfig {
     /// Connection string.

--- a/crates/iceberg/src/io/storage/config/gcs.rs
+++ b/crates/iceberg/src/io/storage/config/gcs.rs
@@ -18,7 +18,7 @@
 //! Google Cloud Storage configuration.
 //!
 //! This module provides configuration constants and types for Google Cloud Storage.
-//! Reference: https://github.com/apache/iceberg/blob/main/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+//! Reference: <https://github.com/apache/iceberg/blob/main/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java>
 
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
@@ -52,7 +52,6 @@ pub const GCS_DISABLE_CONFIG_LOAD: &str = "gcs.disable-config-load";
 ///
 /// This struct contains all the configuration options for connecting to Google Cloud Storage.
 /// Use the builder pattern via `GcsConfig::builder()` to construct instances.
-/// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, TypedBuilder)]
 pub struct GcsConfig {
     /// Google Cloud Project ID.

--- a/crates/iceberg/src/io/storage/config/mod.rs
+++ b/crates/iceberg/src/io/storage/config/mod.rs
@@ -50,7 +50,6 @@ use serde::{Deserialize, Serialize};
 /// This struct contains only configuration properties without specifying
 /// which storage backend to use. The storage type is determined by the
 /// explicit factory selection.
-/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct StorageConfig {
     /// Configuration properties for the storage backend

--- a/crates/iceberg/src/io/storage/config/oss.rs
+++ b/crates/iceberg/src/io/storage/config/oss.rs
@@ -36,7 +36,6 @@ pub const OSS_ACCESS_KEY_SECRET: &str = "oss.access-key-secret";
 ///
 /// This struct contains all the configuration options for connecting to Alibaba Cloud OSS.
 /// Use the builder pattern via `OssConfig::builder()` to construct instances.
-/// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, TypedBuilder)]
 pub struct OssConfig {
     /// OSS endpoint URL.

--- a/crates/iceberg/src/io/storage/local_fs.rs
+++ b/crates/iceberg/src/io/storage/local_fs.rs
@@ -50,7 +50,6 @@ use crate::{Error, ErrorKind, Result};
 /// - `file:///path/to/file` -> `/path/to/file`
 /// - `file:/path/to/file` -> `/path/to/file`
 /// - `/path/to/file` -> `/path/to/file`
-/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LocalFsStorage;
 

--- a/crates/iceberg/src/io/storage/memory.rs
+++ b/crates/iceberg/src/io/storage/memory.rs
@@ -58,7 +58,6 @@ use crate::{Error, ErrorKind, Result};
 /// deserialized, it creates a new empty instance. This is intentional
 /// because in-memory data cannot be meaningfully serialized across
 /// process boundaries.
-/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MemoryStorage {
     #[serde(skip, default = "default_memory_data")]

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -90,7 +90,7 @@ pub mod transaction;
 pub mod transform;
 
 mod runtime;
-pub use runtime::{Runtime, RuntimeHandle};
+pub use runtime::{JoinHandle, Runtime, RuntimeHandle};
 
 pub mod arrow;
 pub(crate) mod delete_file_index;

--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -94,7 +94,7 @@ pub mod transaction;
 pub mod transform;
 
 mod runtime;
-pub use runtime::{Runtime, RuntimeHandle};
+pub use runtime::{JoinHandle, Runtime, RuntimeHandle};
 
 pub mod arrow;
 pub(crate) mod delete_file_index;

--- a/crates/iceberg/src/puffin/blob.rs
+++ b/crates/iceberg/src/puffin/blob.rs
@@ -37,7 +37,7 @@ pub struct Blob {
 
 impl Blob {
     #[inline]
-    /// See blob types: https://iceberg.apache.org/puffin-spec/#blob-types
+    /// See blob types: <https://iceberg.apache.org/puffin-spec/#blob-types>
     pub fn blob_type(&self) -> &str {
         &self.r#type
     }

--- a/crates/iceberg/src/puffin/metadata.rs
+++ b/crates/iceberg/src/puffin/metadata.rs
@@ -29,7 +29,7 @@ use crate::{Error, ErrorKind, Result};
 pub const CREATED_BY_PROPERTY: &str = "created-by";
 
 /// Metadata about a blob.
-/// For more information, see: https://iceberg.apache.org/puffin-spec/#blobmetadata
+/// For more information, see: <https://iceberg.apache.org/puffin-spec/#blobmetadata>
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct BlobMetadata {
@@ -49,7 +49,7 @@ pub struct BlobMetadata {
 
 impl BlobMetadata {
     #[inline]
-    /// See blob types: https://iceberg.apache.org/puffin-spec/#blob-types
+    /// See blob types: <https://iceberg.apache.org/puffin-spec/#blob-types>
     pub fn blob_type(&self) -> &str {
         &self.r#type
     }
@@ -129,7 +129,7 @@ impl Flag {
 
 /// Metadata about a puffin file.
 ///
-/// For more information, see: https://iceberg.apache.org/puffin-spec/#filemetadata
+/// For more information, see: <https://iceberg.apache.org/puffin-spec/#filemetadata>
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct FileMetadata {
     pub(crate) blobs: Vec<BlobMetadata>,

--- a/crates/iceberg/src/runtime/mod.rs
+++ b/crates/iceberg/src/runtime/mod.rs
@@ -22,19 +22,19 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use tokio::task;
+use tokio::task::JoinHandle as TokioJoinHandle;
 
 use crate::{Error, ErrorKind, Result};
 
-/// Wrapper around tokio's [`tokio::task::JoinHandle`] that converts task failures into
-/// [`iceberg::Error`].
+/// Wrapper around tokio's [`TokioJoinHandle`] that converts task failures into
+/// [`crate::Error`].
 ///
 /// Tokio's `JoinHandle<T>` resolves to `Result<T, JoinError>`, where a
-/// `JoinError` means the task either panicked or was cancelled (typically from
-/// runtime shutdown or `abort`). Both are surfaced here as
-/// `ErrorKind::Unexpected` with the original `JoinError` preserved as the
-/// source.
-pub struct JoinHandle<T>(task::JoinHandle<T>);
+/// [`tokio::task::JoinError`] means the task either panicked or was cancelled
+/// (typically from runtime shutdown or `abort`).
+/// Both are surfaced here as `ErrorKind::Unexpected` with the original
+/// [`tokio::task::JoinError`] preserved as the source.
+pub struct JoinHandle<T>(TokioJoinHandle<T>);
 
 impl<T> Unpin for JoinHandle<T> {}
 
@@ -52,8 +52,8 @@ impl<T: Send + 'static> Future for JoinHandle<T> {
 ///
 /// Wraps a [`tokio::runtime::Handle`], which is cheap to clone. The caller is
 /// responsible for keeping the underlying runtime alive while this handle is
-/// in use; spawning on a shut-down runtime will surface as a `JoinError` via
-/// the returned `JoinHandle`.
+/// in use; spawning on a shut-down runtime will surface as a [`tokio::task::JoinError`]
+/// via the returned [`JoinHandle`].
 #[derive(Clone)]
 pub struct RuntimeHandle {
     handle: tokio::runtime::Handle,
@@ -98,8 +98,8 @@ impl RuntimeHandle {
 ///
 /// # Lifetime
 ///
-/// A `Runtime` stores only `tokio::runtime::Handle`s (weak references). The
-/// caller owns the tokio runtime's lifetime. If the underlying runtime is
+/// A `Runtime` stores only `tokio::runtime::Handle`s (weak references).
+/// The caller owns the tokio runtime's lifetime. If the underlying runtime is
 /// dropped while iceberg is still using it, subsequent spawns will surface as
 /// task cancellation errors via the returned `JoinHandle`.
 ///

--- a/crates/iceberg/src/runtime/mod.rs
+++ b/crates/iceberg/src/runtime/mod.rs
@@ -26,7 +26,7 @@ use tokio::task;
 
 use crate::{Error, ErrorKind, Result};
 
-/// Wrapper around tokio's `JoinHandle` that converts task failures into
+/// Wrapper around tokio's [`tokio::task::JoinHandle`] that converts task failures into
 /// [`iceberg::Error`].
 ///
 /// Tokio's `JoinHandle<T>` resolves to `Result<T, JoinError>`, where a
@@ -53,7 +53,7 @@ impl<T: Send + 'static> Future for JoinHandle<T> {
 /// Wraps a [`tokio::runtime::Handle`], which is cheap to clone. The caller is
 /// responsible for keeping the underlying runtime alive while this handle is
 /// in use; spawning on a shut-down runtime will surface as a `JoinError` via
-/// [`JoinHandle`].
+/// the returned `JoinHandle`.
 #[derive(Clone)]
 pub struct RuntimeHandle {
     handle: tokio::runtime::Handle,
@@ -101,7 +101,7 @@ impl RuntimeHandle {
 /// A `Runtime` stores only `tokio::runtime::Handle`s (weak references). The
 /// caller owns the tokio runtime's lifetime. If the underlying runtime is
 /// dropped while iceberg is still using it, subsequent spawns will surface as
-/// task cancellation errors via [`JoinHandle`].
+/// task cancellation errors via the returned `JoinHandle`.
 ///
 /// Cloning is cheap.
 #[derive(Clone)]

--- a/crates/iceberg/src/sensitive.rs
+++ b/crates/iceberg/src/sensitive.rs
@@ -37,7 +37,7 @@ use zeroize::Zeroizing;
 /// ```
 ///
 /// # Display
-/// [`SensitiveString`] does **not** implement [`Display`] to prevent bugs like:
+/// [`SensitiveString`] does **not** implement [`std::fmt::Display`] to prevent bugs like:
 ///
 /// ```compile_fail
 /// # use iceberg::sensitive::SensitiveString;
@@ -83,7 +83,7 @@ impl From<String> for SensitiveString {
 
 /// Wrapper for sensitive byte data (encryption keys, DEKs, etc.) that:
 /// - Zeroizes memory on drop
-/// - Redacts content in [`Debug`] and [`Display`] output
+/// - Redacts content in [`Debug`] and [`std::fmt::Display`] output
 /// - Provides only `&[u8]` access via [`as_bytes()`](Self::as_bytes)
 /// - Uses `Box<[u8]>` (immutable boxed slice) since key bytes never grow
 ///

--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -167,7 +167,7 @@ impl Type {
         }
     }
 
-    /// Return max precision for decimal given [`num_bytes`] bytes.
+    /// Return max precision for decimal given `num_bytes` bytes.
     #[inline(always)]
     pub fn decimal_max_precision(num_bytes: u32) -> Result<u32> {
         ensure_data_valid!(
@@ -177,7 +177,7 @@ impl Type {
         Ok(MAX_PRECISION[num_bytes as usize - 1])
     }
 
-    /// Returns minimum bytes required for decimal with [`precision`].
+    /// Returns minimum bytes required for decimal with `precision`.
     #[inline(always)]
     pub fn decimal_required_bytes(precision: u32) -> Result<u32> {
         ensure_data_valid!(

--- a/crates/iceberg/src/spec/manifest/data_file.rs
+++ b/crates/iceberg/src/spec/manifest/data_file.rs
@@ -155,7 +155,7 @@ pub struct DataFile {
     /// field id: 142
     ///
     /// The _row_id for the first row in the data file.
-    /// For more details, refer to https://github.com/apache/iceberg/blob/main/format/spec.md#first-row-id-inheritance
+    /// For more details, refer to <https://github.com/apache/iceberg/blob/main/format/spec.md#first-row-id-inheritance>
     #[builder(default)]
     pub(crate) first_row_id: Option<i64>,
     /// This field is not included in spec. It is just store in memory representation used

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -364,7 +364,7 @@ impl Schema {
             .and_then(|id| self.field_by_id(*id))
     }
 
-    /// Returns the `highest_field_id`.
+    /// Returns the highest field ID assigned in this schema.
     #[inline]
     pub fn highest_field_id(&self) -> i32 {
         self.highest_field_id

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -364,25 +364,25 @@ impl Schema {
             .and_then(|id| self.field_by_id(*id))
     }
 
-    /// Returns [`highest_field_id`].
+    /// Returns the `highest_field_id`.
     #[inline]
     pub fn highest_field_id(&self) -> i32 {
         self.highest_field_id
     }
 
-    /// Returns [`schema_id`].
+    /// Returns the `schema_id`.
     #[inline]
     pub fn schema_id(&self) -> SchemaId {
         self.schema_id
     }
 
-    /// Returns [`r#struct`].
+    /// Returns the `r#struct`.
     #[inline]
     pub fn as_struct(&self) -> &StructType {
         &self.r#struct
     }
 
-    /// Returns [`identifier_field_ids`].
+    /// Returns the `identifier_field_ids`.
     #[inline]
     pub fn identifier_field_ids(&self) -> impl ExactSizeIterator<Item = i32> + '_ {
         self.identifier_field_ids.iter().copied()

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -370,19 +370,19 @@ impl Schema {
         self.highest_field_id
     }
 
-    /// Returns the `schema_id`.
+    /// Returns the Schema's ID.
     #[inline]
     pub fn schema_id(&self) -> SchemaId {
         self.schema_id
     }
 
-    /// Returns the `r#struct`.
+    /// Returns the type for the struct.
     #[inline]
     pub fn as_struct(&self) -> &StructType {
         &self.r#struct
     }
 
-    /// Returns the `identifier_field_ids`.
+    /// Returns the IDs of the fields.
     #[inline]
     pub fn identifier_field_ids(&self) -> impl ExactSizeIterator<Item = i32> + '_ {
         self.identifier_field_ids.iter().copied()

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1605,7 +1605,7 @@ pub struct SnapshotLog {
 }
 
 impl SnapshotLog {
-    /// Returns the last updated timestamp as a DateTime<Utc> with millisecond precision
+    /// Returns the last updated timestamp as a `DateTime<Utc>` with millisecond precision
     pub fn timestamp(self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1606,7 +1606,7 @@ pub struct SnapshotLog {
 }
 
 impl SnapshotLog {
-    /// Returns the last updated timestamp as a `DateTime<Utc>` with millisecond precision
+    /// Returns the last updated timestamp as a [`DateTime<Utc>`] with millisecond precision
     pub fn timestamp(self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1606,7 +1606,7 @@ pub struct SnapshotLog {
 }
 
 impl SnapshotLog {
-    /// Returns the last updated timestamp as a DateTime<Utc> with millisecond precision
+    /// Returns the last updated timestamp as a `DateTime<Utc>` with millisecond precision
     pub fn timestamp(self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1605,7 +1605,7 @@ pub struct SnapshotLog {
 }
 
 impl SnapshotLog {
-    /// Returns the last updated timestamp as a `DateTime<Utc>` with millisecond precision
+    /// Returns the last updated timestamp as a [`DateTime<Utc>`] with millisecond precision
     pub fn timestamp(self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -331,7 +331,7 @@ pub struct TableProperties {
     /// Deprecated table property for data file write location, with any trailing slash trimmed.
     ///
     /// Property will be removed at a later date.
-    /// Superseded by [write_data_location].
+    /// Superseded by [`TableProperties::write_data_location`].
     #[property(
         key = Self::PROPERTY_WRITE_FOLDER_STORAGE_LOCATION,
         default = None,
@@ -343,7 +343,7 @@ pub struct TableProperties {
     /// with any trailing slash trimmed.
     ///
     /// Property will be removed at a later date.
-    /// Superseded by [write_data_location].
+    /// Superseded by [`TableProperties::write_data_location`].
     #[property(
         key = Self::PROPERTY_WRITE_OBJECT_STORAGE_LOCATION,
         default = None,
@@ -543,14 +543,14 @@ impl TableProperties {
     pub const PROPERTY_ENCRYPTION_DATA_KEY_LENGTH_DEFAULT: usize = 16;
     /// Property key for the base directory for data files
     pub const PROPERTY_WRITE_DATA_LOCATION: &str = "write.data.path";
-    /// Property key for deprecated [write_folder_storage_location]
+    /// Property key for deprecated [`TableProperties::write_folder_storage_location`]
     pub const PROPERTY_WRITE_FOLDER_STORAGE_LOCATION: &str = "write.folder-storage.path";
     /// Property key for deprecated object storage path, kept as a fallback for compatibility.
     pub const PROPERTY_WRITE_OBJECT_STORAGE_LOCATION: &str = "write.object-storage.path";
     /// Property key for controlling whether partition values are included in object storage paths.
     pub const PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS: &str =
         "write.object-storage.partitioned-paths";
-    /// Default value for [PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS]
+    /// Default value for [`TableProperties::PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS`]
     pub const PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS_DEFAULT: bool = true;
 
     /// The AES key size to use when generating data encryption keys, derived

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -534,7 +534,7 @@ impl TableProperties {
     pub const PROPERTY_PARQUET_DICT_SIZE_BYTES_DEFAULT: usize = 2 * 1024 * 1024;
 
     /// Property key for the master key id used to encrypt the table's manifest
-    /// list and data files as defined in https://iceberg.apache.org/docs/nightly/encryption/.
+    /// list and data files as defined in <https://iceberg.apache.org/docs/nightly/encryption/>.
     pub const PROPERTY_ENCRYPTION_KEY_ID: &str = "encryption.key-id";
 
     /// Property key for the encryption data encryption key (DEK) length in bytes.

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -252,12 +252,12 @@ pub struct TableProperties {
     /// Deprecated table property for data file write location.
     ///
     /// Property will be removed at a later date.
-    /// Superseded by [write_data_location].
+    /// Superseded by [`TableProperties::write_data_location`].
     pub write_folder_storage_location: Option<String>,
     /// Deprecated table property for data file write location for object storage location generator.
     ///
     /// Property will be removed at a later date.
-    /// Superseded by [write_data_location].
+    /// Superseded by [`TableProperties::write_data_location`].
     pub write_object_storage_location: Option<String>,
     /// Whether partition values are included in object storage paths.
     pub write_object_storage_partitioned_paths: bool,
@@ -446,14 +446,14 @@ impl TableProperties {
     pub const PROPERTY_ENCRYPTION_DATA_KEY_LENGTH_DEFAULT: usize = 16;
     /// Property key for the base directory for data files
     pub const PROPERTY_WRITE_DATA_LOCATION: &str = "write.data.path";
-    /// Property key for deprecated [write_folder_storage_location]
+    /// Property key for deprecated [`TableProperties::write_folder_storage_location`]
     pub const PROPERTY_WRITE_FOLDER_STORAGE_LOCATION: &str = "write.folder-storage.path";
     /// Property key for deprecated object storage path, kept as a fallback for compatibility.
     pub const PROPERTY_WRITE_OBJECT_STORAGE_LOCATION: &str = "write.object-storage.path";
     /// Property key for controlling whether partition values are included in object storage paths.
     pub const PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS: &str =
         "write.object-storage.partitioned-paths";
-    /// Default value for [PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS]
+    /// Default value for [`TableProperties::PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS`]
     pub const PROPERTY_WRITE_OBJECT_STORAGE_PARTITIONED_PATHS_DEFAULT: bool = true;
 }
 

--- a/crates/iceberg/src/spec/table_properties.rs
+++ b/crates/iceberg/src/spec/table_properties.rs
@@ -437,7 +437,7 @@ impl TableProperties {
     pub const PROPERTY_PARQUET_DICT_SIZE_BYTES_DEFAULT: usize = 2 * 1024 * 1024;
 
     /// Property key for the master key id used to encrypt the table's manifest
-    /// list and data files as defined in https://iceberg.apache.org/docs/nightly/encryption/.
+    /// list and data files as defined in <https://iceberg.apache.org/docs/nightly/encryption/>.
     pub const PROPERTY_ENCRYPTION_KEY_ID: &str = "encryption.key-id";
 
     /// Property key for the encryption data encryption key (DEK) length in bytes.

--- a/crates/iceberg/src/spec/values/datum.rs
+++ b/crates/iceberg/src/spec/values/datum.rs
@@ -822,7 +822,7 @@ impl Datum {
         Self::timestamp_micros(dt.and_utc().timestamp_micros())
     }
 
-    /// Parse a timestamp in [`%Y-%m-%dT%H:%M:%S%.f`] format.
+    /// Parse a timestamp in `%Y-%m-%dT%H:%M:%S%.f` format.
     ///
     /// See [`NaiveDateTime::from_str`].
     ///
@@ -1240,7 +1240,7 @@ impl Datum {
     /// Returns a human-readable string representation of this literal.
     ///
     /// For string literals, this returns the raw string value without quotes.
-    /// For all other literals, it falls back to [`to_string()`].
+    /// For all other literals, it falls back to [`to_string()`](ToString::to_string).
     pub fn to_human_string(&self) -> String {
         match self.literal() {
             PrimitiveLiteral::String(s) => s.to_string(),

--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -225,7 +225,7 @@ impl ViewVersionLog {
         self.timestamp_ms
     }
 
-    /// Returns the last updated timestamp as a DateTime<Utc> with millisecond precision.
+    /// Returns the last updated timestamp as a `DateTime<Utc>` with millisecond precision.
     pub fn timestamp(&self) -> Result<DateTime<Utc>> {
         timestamp_ms_to_utc(self.timestamp_ms)
     }

--- a/crates/iceberg/src/test_utils.rs
+++ b/crates/iceberg/src/test_utils.rs
@@ -34,7 +34,7 @@ use crate::spec::TableMetadata;
 use crate::table::Table;
 
 /// Returns a process-wide [`Runtime`] suitable for tests that need to construct
-/// a [`Table`](crate::table::Table) outside a tokio context.
+/// a [`Table`] outside a tokio context.
 ///
 /// The returned [`Runtime`] wraps a single shared multi-thread tokio runtime
 /// that is lazily built on first call and lives until process exit. Cloning is

--- a/crates/iceberg/src/test_utils.rs
+++ b/crates/iceberg/src/test_utils.rs
@@ -36,7 +36,7 @@ use crate::spec::TableMetadata;
 use crate::table::Table;
 
 /// Returns a process-wide [`Runtime`] suitable for tests that need to construct
-/// a [`Table`](crate::table::Table) outside a tokio context.
+/// a [`Table`] outside a tokio context.
 ///
 /// The returned [`Runtime`] wraps a single shared multi-thread tokio runtime
 /// that is lazily built on first call and lives until process exit. Cloning is

--- a/crates/iceberg/src/transaction/action.rs
+++ b/crates/iceberg/src/transaction/action.rs
@@ -34,7 +34,7 @@ pub(crate) type BoxedTransactionAction = Arc<dyn TransactionAction>;
 /// Each action is responsible for generating the updates and requirements needed
 /// to modify the table metadata.
 #[async_trait]
-pub trait TransactionAction: AsAny + Sync + Send {
+pub(crate) trait TransactionAction: AsAny + Sync + Send {
     /// Commits this action against the provided table and returns the resulting updates.
     /// NOTE: This function is intended for internal use only and should not be called directly by users.
     ///

--- a/crates/iceberg/src/transaction/action.rs
+++ b/crates/iceberg/src/transaction/action.rs
@@ -34,7 +34,7 @@ pub(crate) type BoxedTransactionAction = Arc<dyn TransactionAction>;
 /// Each action is responsible for generating the updates and requirements needed
 /// to modify the table metadata.
 #[async_trait]
-pub(crate) trait TransactionAction: AsAny + Sync + Send {
+pub trait TransactionAction: AsAny + Sync + Send {
     /// Commits this action against the provided table and returns the resulting updates.
     /// NOTE: This function is intended for internal use only and should not be called directly by users.
     ///

--- a/crates/iceberg/src/transaction/expire_snapshots.rs
+++ b/crates/iceberg/src/transaction/expire_snapshots.rs
@@ -74,8 +74,7 @@ impl ExpireSnapshotsAction {
     /// alone.
     ///
     /// Ids accumulate across calls (like [`add_data_files`](crate::transaction::Transaction::fast_append)).
-    /// An id that is still referenced by a branch or tag cannot be expired and causes
-    /// [`commit`](TransactionAction::commit) to fail.
+    /// An id that is still referenced by a branch or tag cannot be expired and causes commits to fail.
     pub fn expire_snapshot_ids(mut self, snapshot_ids: impl IntoIterator<Item = i64>) -> Self {
         self.explicit_ids_to_remove.extend(snapshot_ids);
         self
@@ -91,8 +90,7 @@ impl ExpireSnapshotsAction {
     /// (defaults to the table's `history.expire.min-snapshots-to-keep`, must be at least 1).
     ///
     /// This only bounds the age cutoff; it does not protect snapshots named via
-    /// [`expire_snapshot_ids`](Self::expire_snapshot_ids). Setting it to 0 makes
-    /// [`commit`](TransactionAction::commit) fail.
+    /// [`expire_snapshot_ids`](Self::expire_snapshot_ids). Setting it to 0 makes commit fail.
     pub fn retain_last(mut self, retain_last: usize) -> Self {
         self.retain_last = Some(retain_last);
         self

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -73,14 +73,14 @@ use crate::error::Result;
 use crate::spec::TableProperties;
 use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
-use crate::transaction::append::FastAppendAction;
-use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
-use crate::transaction::sort_order::ReplaceSortOrderAction;
-use crate::transaction::update_location::UpdateLocationAction;
-use crate::transaction::update_properties::UpdatePropertiesAction;
-use crate::transaction::update_schema::UpdateSchemaAction;
-use crate::transaction::update_statistics::UpdateStatisticsAction;
-use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
+pub use crate::transaction::append::FastAppendAction;
+pub use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
+pub use crate::transaction::sort_order::ReplaceSortOrderAction;
+pub use crate::transaction::update_location::UpdateLocationAction;
+pub use crate::transaction::update_properties::UpdatePropertiesAction;
+pub use crate::transaction::update_schema::UpdateSchemaAction;
+pub use crate::transaction::update_statistics::UpdateStatisticsAction;
+pub use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
 use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
 
 /// Table transaction.

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -73,15 +73,15 @@ use crate::error::Result;
 use crate::spec::TableProperties;
 use crate::table::Table;
 use crate::transaction::action::BoxedTransactionAction;
-use crate::transaction::append::FastAppendAction;
-use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
-use crate::transaction::sort_order::ReplaceSortOrderAction;
-use crate::transaction::update_location::UpdateLocationAction;
-use crate::transaction::update_properties::UpdatePropertiesAction;
-use crate::transaction::update_schema::UpdateSchemaAction;
-use crate::transaction::update_statistics::UpdateStatisticsAction;
-use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
-use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
+pub use crate::transaction::append::FastAppendAction;
+pub use crate::transaction::expire_snapshots::ExpireSnapshotsAction;
+pub use crate::transaction::sort_order::ReplaceSortOrderAction;
+pub use crate::transaction::update_location::UpdateLocationAction;
+pub use crate::transaction::update_properties::UpdatePropertiesAction;
+pub use crate::transaction::update_schema::UpdateSchemaAction;
+pub use crate::transaction::update_statistics::UpdateStatisticsAction;
+pub use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
+use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
 
 /// Table transaction.
 #[derive(Clone)]

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -81,7 +81,7 @@ use crate::transaction::update_properties::UpdatePropertiesAction;
 use crate::transaction::update_schema::UpdateSchemaAction;
 use crate::transaction::update_statistics::UpdateStatisticsAction;
 use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
-use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
+use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
 
 /// Table transaction.
 #[derive(Clone)]

--- a/crates/iceberg/src/transaction/sort_order.rs
+++ b/crates/iceberg/src/transaction/sort_order.rs
@@ -91,12 +91,6 @@ impl ReplaceSortOrderAction {
     }
 }
 
-impl Default for ReplaceSortOrderAction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl TransactionAction for ReplaceSortOrderAction {
     async fn commit(self: Arc<Self>, table: &Table) -> Result<ActionCommit> {

--- a/crates/iceberg/src/transaction/sort_order.rs
+++ b/crates/iceberg/src/transaction/sort_order.rs
@@ -59,7 +59,7 @@ pub struct ReplaceSortOrderAction {
 }
 
 impl ReplaceSortOrderAction {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         ReplaceSortOrderAction {
             pending_sort_fields: vec![],
         }

--- a/crates/iceberg/src/transaction/update_location.rs
+++ b/crates/iceberg/src/transaction/update_location.rs
@@ -27,7 +27,7 @@ use crate::{Error, ErrorKind, Result, TableUpdate};
 ///
 /// This action is used to explicitly set a new metadata location during a transaction,
 /// typically as part of advanced commit or recovery flows. The location is optional until
-/// explicitly set via [`set_location`].
+/// explicitly set via [`UpdateLocationAction::set_location`].
 pub struct UpdateLocationAction {
     location: Option<String>,
 }

--- a/crates/iceberg/src/transaction/update_location.rs
+++ b/crates/iceberg/src/transaction/update_location.rs
@@ -53,12 +53,6 @@ impl UpdateLocationAction {
     }
 }
 
-impl Default for UpdateLocationAction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl TransactionAction for UpdateLocationAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {

--- a/crates/iceberg/src/transaction/update_location.rs
+++ b/crates/iceberg/src/transaction/update_location.rs
@@ -34,7 +34,7 @@ pub struct UpdateLocationAction {
 
 impl UpdateLocationAction {
     /// Creates a new [`UpdateLocationAction`] with no location set.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         UpdateLocationAction { location: None }
     }
 

--- a/crates/iceberg/src/transaction/update_properties.rs
+++ b/crates/iceberg/src/transaction/update_properties.rs
@@ -37,7 +37,7 @@ pub struct UpdatePropertiesAction {
 
 impl UpdatePropertiesAction {
     /// Creates a new [`UpdatePropertiesAction`] with no updates or removals.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         UpdatePropertiesAction {
             updates: HashMap::default(),
             removals: HashSet::default(),

--- a/crates/iceberg/src/transaction/update_properties.rs
+++ b/crates/iceberg/src/transaction/update_properties.rs
@@ -74,12 +74,6 @@ impl UpdatePropertiesAction {
     }
 }
 
-impl Default for UpdatePropertiesAction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl TransactionAction for UpdatePropertiesAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {

--- a/crates/iceberg/src/transaction/update_schema.rs
+++ b/crates/iceberg/src/transaction/update_schema.rs
@@ -32,12 +32,11 @@ use crate::{Error, ErrorKind, Result, TableRequirement, TableUpdate};
 // Default ID for a new column. This will be re-assigned to a fresh ID at commit time.
 const DEFAULT_FIELD_ID: i32 = 0;
 
-/// Declarative specification for adding a column in [`UpdateSchemaAction`].
+/// Declarative specification for adding a column in an `UpdateSchemaAction`.
 ///
 /// Use helper constructors such as [`AddColumn::optional`] and [`AddColumn::required`],
-/// optionally combined with [`AddColumn::with_parent`] and [`AddColumn::with_doc`], then pass
-/// the value to
-/// [`UpdateSchemaAction::add_column`].
+/// optionally combined with the builder's `parent` and `doc` setters via
+/// [`AddColumn::builder`], then pass the value to `UpdateSchemaAction::add_column`.
 #[derive(TypedBuilder)]
 pub struct AddColumn {
     #[builder(default = None, setter(strip_option, into))]

--- a/crates/iceberg/src/transaction/update_schema.rs
+++ b/crates/iceberg/src/transaction/update_schema.rs
@@ -32,11 +32,11 @@ use crate::{Error, ErrorKind, Result, TableRequirement, TableUpdate};
 // Default ID for a new column. This will be re-assigned to a fresh ID at commit time.
 const DEFAULT_FIELD_ID: i32 = 0;
 
-/// Declarative specification for adding a column in an `UpdateSchemaAction`.
+/// Declarative specification for adding a column in an [`UpdateSchemaAction`].
 ///
 /// Use helper constructors such as [`AddColumn::optional`] and [`AddColumn::required`],
 /// optionally combined with the builder's `parent` and `doc` setters via
-/// [`AddColumn::builder`], then pass the value to `UpdateSchemaAction::add_column`.
+/// [`AddColumn::builder`], then pass the value to [`UpdateSchemaAction::add_column`].
 #[derive(TypedBuilder)]
 pub struct AddColumn {
     #[builder(default = None, setter(strip_option, into))]

--- a/crates/iceberg/src/transaction/update_schema.rs
+++ b/crates/iceberg/src/transaction/update_schema.rs
@@ -131,7 +131,7 @@ impl UpdateSchemaAction {
     /// Add a column to the table schema.
     ///
     /// To add a root-level column, leave `AddColumn::parent` as `None`.
-    /// For nested additions, set a parent path (for example via [`AddColumn::with_parent`]).
+    /// For nested additions, set a parent path.
     /// If the parent resolves to a map/list, the column is added to map value/list element.
     pub fn add_column(mut self, add_column: AddColumn) -> Self {
         self.additions.push(add_column);

--- a/crates/iceberg/src/transaction/update_statistics.rs
+++ b/crates/iceberg/src/transaction/update_statistics.rs
@@ -68,12 +68,6 @@ impl UpdateStatisticsAction {
     }
 }
 
-impl Default for UpdateStatisticsAction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl TransactionAction for UpdateStatisticsAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {

--- a/crates/iceberg/src/transaction/update_statistics.rs
+++ b/crates/iceberg/src/transaction/update_statistics.rs
@@ -31,7 +31,7 @@ pub struct UpdateStatisticsAction {
 }
 
 impl UpdateStatisticsAction {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             statistics_to_set: HashMap::default(),
         }

--- a/crates/iceberg/src/transaction/upgrade_format_version.rs
+++ b/crates/iceberg/src/transaction/upgrade_format_version.rs
@@ -29,7 +29,7 @@ use crate::{Error, ErrorKind, Result};
 ///
 /// This action is used within a transaction to indicate that the
 /// table's format version should be upgraded to a specified version.
-/// The location remains optional until explicitly set via [`set_format_version`].
+/// The location remains optional until explicitly set via [`UpgradeFormatVersionAction::set_format_version`].
 pub struct UpgradeFormatVersionAction {
     format_version: Option<FormatVersion>,
 }

--- a/crates/iceberg/src/transaction/upgrade_format_version.rs
+++ b/crates/iceberg/src/transaction/upgrade_format_version.rs
@@ -36,7 +36,7 @@ pub struct UpgradeFormatVersionAction {
 
 impl UpgradeFormatVersionAction {
     /// Creates a new `UpgradeFormatVersionAction` with no version set.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         UpgradeFormatVersionAction {
             format_version: None,
         }

--- a/crates/iceberg/src/transaction/upgrade_format_version.rs
+++ b/crates/iceberg/src/transaction/upgrade_format_version.rs
@@ -57,12 +57,6 @@ impl UpgradeFormatVersionAction {
     }
 }
 
-impl Default for UpgradeFormatVersionAction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[async_trait]
 impl TransactionAction for UpgradeFormatVersionAction {
     async fn commit(self: Arc<Self>, _table: &Table) -> Result<ActionCommit> {

--- a/crates/integrations/datafusion/src/table/metadata_table.rs
+++ b/crates/integrations/datafusion/src/table/metadata_table.rs
@@ -34,8 +34,8 @@ use iceberg::table::Table;
 use crate::physical_plan::metadata_scan::IcebergMetadataScan;
 use crate::to_datafusion_error;
 
-/// Represents a [`TableProvider`] for the Iceberg [`Catalog`],
-/// managing access to a [`MetadataTable`].
+/// Represents a [`TableProvider`] for the Iceberg [`iceberg::Catalog`],
+/// managing access to a [`iceberg::inspect::MetadataTable`].
 #[derive(Debug, Clone)]
 pub struct IcebergMetadataTableProvider {
     pub(crate) table: Table,

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -18,8 +18,8 @@
 //! OpenDAL-based storage implementation for Apache Iceberg.
 //!
 //! This crate provides [`OpenDalStorage`] and [`OpenDalStorageFactory`],
-//! which implement the [`Storage`](Storage) and
-//! [`StorageFactory`](StorageFactory) traits from the `iceberg` crate
+//! which implement the [`Storage`] and
+//! [`StorageFactory`] traits from the `iceberg` crate
 //! using [OpenDAL](https://opendal.apache.org/) as the backend.
 
 mod utils;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #2938 

## What changes are included in this PR?

 * Links to external sites are made clickable. This is changing from `https://example.com` to `<https://example.com>`.
 * References to internal APIs are removed. The comment is the same, but the doc link is gone.
 * Trailing triple slash opening a code snippet, but never closing it, are removed.

The following items were previously mentioned in the docs, but were not public. They are now publicaly exported:
```
iceberg::transaction::ExpireSnapshotsAction
iceberg::transaction::FastAppendAction
iceberg::transaction::ReplaceSortOrderAction
iceberg::transaction::UpdateLocationAction
iceberg::transaction::UpdatePropertiesAction
iceberg::transaction::UpdateSchemaAction
iceberg::transaction::UpdateStatisticsAction
iceberg::transaction::UpgradeFormatVersionAction
iceberg::JoinHandle
```

## Are these changes tested?

These changes were QA'd by running `cargo doc --no-deps`.

## AI Disclosure

I got Claude to do most of the changes in this PR.
