### PR TITLE
fix(ci): install the wheel just built, not the published one

### DIFF
--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -109,8 +109,10 @@ jobs:
       - name: Install built wheel
         working-directory: "bindings/python"
         shell: bash
+        # --no-index keeps resolution inside dist/: --find-links alone only adds a
+        # source, so a newer PyPI release would win and be tested instead.
         run: |
-          uv pip install --no-build --reinstall --find-links dist/ pyiceberg-core
+          uv pip install --no-build --reinstall --no-index --find-links dist/ pyiceberg-core
       - name: Run tests
         working-directory: "bindings/python"
         shell: bash

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -208,7 +208,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core
+          uv pip install --no-build --reinstall --system --no-index --find-links dist/ pyiceberg-core
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -136,7 +136,7 @@ jobs:
         working-directory: "bindings/python"
         shell: bash
         run: |
-          uv pip install --no-build --reinstall --system --find-links dist/ pyiceberg-core
+          uv pip install --no-build --reinstall --system --no-index --find-links dist/ pyiceberg-core
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #2948.

## What changes are included in this PR?

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

Adds `--no-index` to the three `uv pip install ... --find-links dist/ pyiceberg-core` calls, in `bindings_python_ci.yml`, `release_python.yml` and `release_python_nightly.yml`.

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Only the macOS leg is confirmed. The Linux and Windows legs are cancelled by the matrix `fail-fast` once macOS aborts, so I cannot say whether they fail too.

## AI Disclosure

<!--
https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions
-->

This change was developed with AI assistance, using Claude Code with Claude Opus 5.