### PR TITLE
feat: materialize _last_updated_sequence_number metadata column

### DIFF
--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -43,9 +43,9 @@ use crate::encryption::StandardKeyMetadata;
 use crate::error::Result;
 use crate::io::{FileIO, FileMetadata, FileRead};
 use crate::metadata_columns::{
-    RESERVED_COL_NAME_POS, RESERVED_FIELD_ID_FILE, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
-    RESERVED_FIELD_ID_PARTITION, RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_SPEC_ID,
-    is_metadata_field,
+    RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER, RESERVED_COL_NAME_POS, RESERVED_FIELD_ID_FILE,
+    RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER, RESERVED_FIELD_ID_PARTITION,
+    RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_SPEC_ID, is_metadata_field,
 };
 use crate::scan::{ArrowRecordBatchStream, FileScanTask, FileScanTaskStream};
 use crate::spec::{Datum, PartitionSpec, Struct};
@@ -312,17 +312,28 @@ impl FileScanTaskReader {
             // null. That per-row coalesce is not implemented yet, so rather than silently
             // overwrite genuine per-row values with the derived value, reject the file
             // loudly. Checks the full pre-projection file schema, since the column is
-            // stripped from the projection mask.
-            let file_has_column = record_batch_stream_builder
-                .schema()
-                .fields()
-                .iter()
-                .any(|f| {
-                    f.metadata()
-                        .get(PARQUET_FIELD_ID_META_KEY)
-                        .and_then(|id| id.parse::<i32>().ok())
-                        == Some(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
-                });
+            // stripped from the projection mask. Matches on the embedded field id when
+            // present (propagating a malformed id rather than treating it as absent) and
+            // falls back to the column name, so a file read via name mapping or positional
+            // fallback ids (which never equal the reserved id) is still caught.
+            let mut file_has_column = false;
+            for field in record_batch_stream_builder.schema().fields() {
+                let field_id = match field.metadata().get(PARQUET_FIELD_ID_META_KEY) {
+                    Some(id) => Some(id.parse::<i32>().map_err(|e| {
+                        Error::new(
+                            ErrorKind::DataInvalid,
+                            format!("field id not parseable as an i32: {e}"),
+                        )
+                    })?),
+                    None => None,
+                };
+                if field_id == Some(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+                    || field.name() == RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER
+                {
+                    file_has_column = true;
+                    break;
+                }
+            }
             if file_has_column {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
@@ -332,21 +343,32 @@ impl FileScanTaskReader {
                 ));
             }
 
-            // Derive the column from the data file's sequence number, gated on
-            // `first_row_id`: per the spec's Row Lineage read rules, a data file with a
-            // non-null `first_row_id` inherits `_last_updated_sequence_number` from its
-            // data sequence number, while a file with a null `first_row_id` (v1/v2, or a
-            // pre-upgrade v3 snapshot) produces null.
+            // Derive the column, gated on the data file's `first_row_id`. Java gates
+            // both lineage columns this way (`ValueReaders.lastUpdated` returns nulls
+            // when the base row id is null); the spec itself only says the column is
+            // assigned the manifest entry's sequence number on read.
             record_batch_transformer_builder = match (task.first_row_id, task.data_sequence_number)
             {
+                // Non-null first_row_id: inherit from the data sequence number.
                 (Some(_), Some(seq)) => record_batch_transformer_builder.with_constant(
                     RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
                     Datum::long(seq),
                 ),
-                // (None, _) is the null gate. (Some, None), first_row_id present but no
-                // data sequence number (a malformed manifest), also yields null.
-                _ => record_batch_transformer_builder
-                    .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER),
+                // Null first_row_id (v1/v2, or a pre-upgrade v3 snapshot): the column is null.
+                (None, _) => record_batch_transformer_builder
+                    .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)?,
+                // first_row_id present but no data sequence number: after manifest
+                // inheritance a committed entry always has one, so this is a malformed
+                // manifest rather than a legitimate null.
+                (Some(_), None) => {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        format!(
+                            "Data file {} has a first_row_id but no data sequence number",
+                            task.data_file_path
+                        ),
+                    ));
+                }
             };
         }
 
@@ -1023,6 +1045,29 @@ mod tests {
             .build()
     }
 
+    /// Asserts the logical per-row values of the `_last_updated_sequence_number`
+    /// column across all batches, independent of the physical (run-end) encoding.
+    fn assert_last_updated_seq_column(batches: &[RecordBatch], expected: &[Option<i64>]) {
+        use arrow_array::cast::AsArray;
+        use arrow_cast::cast;
+        use arrow_schema::DataType;
+
+        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let mut actual = Vec::new();
+        for batch in batches {
+            let col = batch
+                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+                .expect("_last_updated_sequence_number column should be present");
+            let logical = cast(col, &DataType::Int64).unwrap();
+            let values = logical.as_primitive::<arrow_array::types::Int64Type>();
+            for i in 0..values.len() {
+                actual.push((!values.is_null(i)).then(|| values.value(i)));
+            }
+        }
+        assert_eq!(actual, expected);
+    }
+
     #[tokio::test]
     async fn test_last_updated_sequence_number_null_when_no_first_row_id() {
         let tmp_dir = TempDir::new().unwrap();
@@ -1044,64 +1089,35 @@ mod tests {
             .await
             .unwrap();
 
-        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
-        let seq_col = batches[0]
-            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
-            .expect("column should be present")
-            .as_any()
-            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
-            .expect("_last_updated_sequence_number should be a RunArray");
-        assert_eq!(seq_col.len(), 3);
-        let values = seq_col
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("REE values should be Int64Array");
-        assert_eq!(values.len(), 1);
-        assert!(values.is_null(0));
+        assert_last_updated_seq_column(&batches, &[None, None, None]);
     }
 
     #[tokio::test]
-    async fn test_last_updated_sequence_number_null_when_no_data_seq() {
-        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
-
+    async fn test_last_updated_sequence_number_error_when_no_data_seq() {
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
         let file_path = write_plain_parquet(dir, "no_data_seq.parquet", vec![], vec![]);
 
-        // first_row_id present but data_sequence_number absent (a malformed manifest)
-        // also yields a null column, matching Java's dual gate. Pins the (Some, None)
-        // arm so a future match collapse cannot silently unwrap it.
+        // first_row_id present but data_sequence_number absent: after manifest
+        // inheritance a committed entry always has one, so this is a malformed
+        // manifest and must error rather than fabricate or null the column.
         let task = last_updated_seq_task(file_path, Some(42), None);
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
-        let batches: Vec<RecordBatch> = reader
-            .read(tasks)
-            .unwrap()
-            .stream()
-            .try_collect()
-            .await
-            .unwrap();
+        let result: Result<Vec<RecordBatch>, _> =
+            reader.read(tasks).unwrap().stream().try_collect().await;
 
-        let seq_col = batches[0]
-            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
-            .expect("column should be present")
-            .as_any()
-            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
-            .expect("_last_updated_sequence_number should be a RunArray");
-        let values = seq_col
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("REE values should be Int64Array");
-        assert!(values.is_null(0));
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::DataInvalid);
+        assert!(
+            format!("{err}").contains("no data sequence number"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
     async fn test_last_updated_sequence_number_derived_from_data_seq() {
-        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
-
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
         let file_path = write_plain_parquet(dir, "with_first_row_id.parquet", vec![], vec![]);
@@ -1120,21 +1136,7 @@ mod tests {
             .await
             .unwrap();
 
-        let seq_col = batches[0]
-            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
-            .expect("column should be present")
-            .as_any()
-            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
-            .expect("_last_updated_sequence_number should be a RunArray");
-        assert_eq!(seq_col.len(), 3);
-        let values = seq_col
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("REE values should be Int64Array");
-        assert_eq!(values.len(), 1);
-        assert!(!values.is_null(0));
-        assert_eq!(values.value(0), 7);
+        assert_last_updated_seq_column(&batches, &[Some(7), Some(7), Some(7)]);
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -43,8 +43,9 @@ use crate::encryption::StandardKeyMetadata;
 use crate::error::Result;
 use crate::io::{FileIO, FileMetadata, FileRead};
 use crate::metadata_columns::{
-    RESERVED_COL_NAME_POS, RESERVED_FIELD_ID_FILE, RESERVED_FIELD_ID_PARTITION,
-    RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_SPEC_ID, is_metadata_field,
+    RESERVED_COL_NAME_POS, RESERVED_FIELD_ID_FILE, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+    RESERVED_FIELD_ID_PARTITION, RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_SPEC_ID,
+    is_metadata_field,
 };
 use crate::scan::{ArrowRecordBatchStream, FileScanTask, FileScanTaskStream};
 use crate::spec::{Datum, PartitionSpec, Struct};
@@ -298,6 +299,55 @@ impl FileScanTaskReader {
             let spec_id_datum = Datum::int(partition_spec.spec_id());
             record_batch_transformer_builder = record_batch_transformer_builder
                 .with_constant(RESERVED_FIELD_ID_SPEC_ID, spec_id_datum);
+        }
+
+        if task
+            .project_field_ids()
+            .contains(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+        {
+            // A data file may physically carry a per-row `_last_updated_sequence_number`
+            // column, e.g. one written by another engine such as Iceberg Java when carrying
+            // rows forward across a rewrite. The spec requires reading such non-null
+            // per-row values unmodified, falling back to the derived value only where
+            // null. That per-row coalesce is not implemented yet, so rather than silently
+            // overwrite genuine per-row values with the derived value, reject the file
+            // loudly. Checks the full pre-projection file schema, since the column is
+            // stripped from the projection mask.
+            let file_has_column = record_batch_stream_builder
+                .schema()
+                .fields()
+                .iter()
+                .any(|f| {
+                    f.metadata()
+                        .get(PARQUET_FIELD_ID_META_KEY)
+                        .and_then(|id| id.parse::<i32>().ok())
+                        == Some(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+                });
+            if file_has_column {
+                return Err(Error::new(
+                    ErrorKind::FeatureUnsupported,
+                    "Reading a physically-stored _last_updated_sequence_number column is \
+                     not yet supported; only the derived (data-sequence-number) value is \
+                     implemented",
+                ));
+            }
+
+            // Derive the column from the data file's sequence number, gated on
+            // `first_row_id`: per the spec's Row Lineage read rules, a data file with a
+            // non-null `first_row_id` inherits `_last_updated_sequence_number` from its
+            // data sequence number, while a file with a null `first_row_id` (v1/v2, or a
+            // pre-upgrade v3 snapshot) produces null.
+            record_batch_transformer_builder = match (task.first_row_id, task.data_sequence_number)
+            {
+                (Some(_), Some(seq)) => record_batch_transformer_builder.with_constant(
+                    RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                    Datum::long(seq),
+                ),
+                // (None, _) is the null gate. (Some, None), first_row_id present but no
+                // data sequence number (a malformed manifest), also yields null.
+                _ => record_batch_transformer_builder
+                    .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER),
+            };
         }
 
         if let (Some(partition_spec), Some(partition_data)) =
@@ -576,7 +626,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::cast::AsArray;
-    use arrow_array::{Array, ArrayRef, Int32Array, RecordBatch};
+    use arrow_array::{Array, ArrayRef, Int32Array, Int64Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use futures::TryStreamExt;
     use parquet::arrow::{ArrowWriter, PARQUET_FIELD_ID_META_KEY};
@@ -906,6 +956,257 @@ mod tests {
         assert!(
             err_str.contains("decryption properties were not provided"),
             "Expected error about missing decryption properties, got: {err_str}"
+        );
+    }
+
+    /// Writes a plain (unencrypted) single-column Int32 "id" parquet file with the
+    /// given extra Arrow fields/columns appended, returning the file path.
+    fn write_plain_parquet(
+        dir: &str,
+        name: &str,
+        extra_fields: Vec<Field>,
+        extra_columns: Vec<ArrayRef>,
+    ) -> String {
+        let mut fields =
+            vec![
+                Field::new("id", DataType::Int32, false).with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    "1".to_string(),
+                )])),
+            ];
+        fields.extend(extra_fields);
+        let arrow_schema = Arc::new(ArrowSchema::new(fields));
+
+        let mut columns: Vec<ArrayRef> = vec![Arc::new(Int32Array::from(vec![1, 2, 3]))];
+        columns.extend(extra_columns);
+        let batch = RecordBatch::try_new(arrow_schema.clone(), columns).unwrap();
+
+        let file_path = format!("{dir}/{name}");
+        let file = File::create(&file_path).unwrap();
+        let props = WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        file_path
+    }
+
+    fn last_updated_seq_task(
+        file_path: String,
+        first_row_id: Option<i64>,
+        data_sequence_number: Option<i64>,
+    ) -> FileScanTask {
+        use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        FileScanTask::builder()
+            .with_file_size_in_bytes(std::fs::metadata(&file_path).unwrap().len())
+            .with_start(0)
+            .with_length(0)
+            .with_data_file_path(file_path)
+            .with_data_file_format(DataFileFormat::Parquet)
+            .with_schema(schema)
+            .with_project_field_ids(vec![1, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER])
+            .with_first_row_id(first_row_id)
+            .with_data_sequence_number(data_sequence_number)
+            .with_case_sensitive(false)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_null_when_no_first_row_id() {
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        let file_path = write_plain_parquet(dir, "no_first_row_id.parquet", vec![], vec![]);
+
+        // A file with a null first_row_id (v1/v2, or a pre-upgrade v3 snapshot) produces
+        // a null _last_updated_sequence_number column, even though it has a data
+        // sequence number; the spec gates both lineage columns on first_row_id.
+        let task = last_updated_seq_task(file_path, None, Some(9));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
+        let seq_col = batches[0]
+            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+            .expect("column should be present")
+            .as_any()
+            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
+            .expect("_last_updated_sequence_number should be a RunArray");
+        assert_eq!(seq_col.len(), 3);
+        let values = seq_col
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("REE values should be Int64Array");
+        assert_eq!(values.len(), 1);
+        assert!(values.is_null(0));
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_null_when_no_data_seq() {
+        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        let file_path = write_plain_parquet(dir, "no_data_seq.parquet", vec![], vec![]);
+
+        // first_row_id present but data_sequence_number absent (a malformed manifest)
+        // also yields a null column, matching Java's dual gate. Pins the (Some, None)
+        // arm so a future match collapse cannot silently unwrap it.
+        let task = last_updated_seq_task(file_path, Some(42), None);
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let seq_col = batches[0]
+            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+            .expect("column should be present")
+            .as_any()
+            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
+            .expect("_last_updated_sequence_number should be a RunArray");
+        let values = seq_col
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("REE values should be Int64Array");
+        assert!(values.is_null(0));
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_derived_from_data_seq() {
+        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        let file_path = write_plain_parquet(dir, "with_first_row_id.parquet", vec![], vec![]);
+
+        // Non-null first_row_id + data sequence number -> the derived value (the data
+        // sequence number) for every row. This is the only value-producing arm.
+        let task = last_updated_seq_task(file_path, Some(42), Some(7));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let seq_col = batches[0]
+            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+            .expect("column should be present")
+            .as_any()
+            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
+            .expect("_last_updated_sequence_number should be a RunArray");
+        assert_eq!(seq_col.len(), 3);
+        let values = seq_col
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("REE values should be Int64Array");
+        assert_eq!(values.len(), 1);
+        assert!(!values.is_null(0));
+        assert_eq!(values.value(0), 7);
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_mixed_files_share_schema() {
+        use arrow_select::concat::concat_batches;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+
+        // Two files in one scan: one with first_row_id (derived value -> REE constant),
+        // one without (null gate -> REE null). Both must produce the same Arrow type for
+        // the column, or concatenation fails; the regression this branch fixes.
+        let with_id = last_updated_seq_task(
+            write_plain_parquet(dir, "with_id.parquet", vec![], vec![]),
+            Some(42),
+            Some(7),
+        );
+        let without_id = last_updated_seq_task(
+            write_plain_parquet(dir, "without_id.parquet", vec![], vec![]),
+            None,
+            Some(7),
+        );
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(with_id), Ok(without_id)]))
+            as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_eq!(batches.len(), 2);
+        // Identical schema across files -> concat succeeds.
+        let schema = batches[0].schema();
+        concat_batches(&schema, &batches)
+            .expect("batches from value and null files must share one schema");
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_physical_column_unsupported() {
+        use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        // A file that physically carries the _last_updated_sequence_number column, as
+        // Iceberg Java writes when carrying rows forward across a rewrite.
+        let seq_field = Field::new("_last_updated_sequence_number", DataType::Int64, true)
+            .with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER.to_string(),
+            )]));
+        let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
+        let file_path =
+            write_plain_parquet(dir, "with_seq.parquet", vec![seq_field], vec![seq_col]);
+
+        // first_row_id present so the gate would otherwise materialize the constant;
+        // the physically-present column must trigger the fail-loud guard first.
+        let task = last_updated_seq_task(file_path, Some(100), Some(9));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let result: Result<Vec<RecordBatch>, _> =
+            reader.read(tasks).unwrap().stream().try_collect().await;
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::FeatureUnsupported);
+        assert!(
+            format!("{err}").contains("physically-stored _last_updated_sequence_number"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -308,15 +308,18 @@ impl RecordBatchTransformerBuilder {
     /// `_last_updated_sequence_number` when the file has a null `first_row_id`).
     pub(crate) fn with_null_metadata_column(mut self, field_id: i32) -> Result<Self> {
         let iceberg_field = get_metadata_field(field_id)?;
-        let prim_type = iceberg_field.field_type.as_primitive_type().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Unexpected,
-                format!(
-                    "Metadata column {} has non-primitive type {:?}",
-                    iceberg_field.name, iceberg_field.field_type
-                ),
-            )
-        })?;
+        let prim_type = iceberg_field
+            .field_type
+            .as_primitive_type()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    format!(
+                        "Metadata column {} has non-primitive type {:?}",
+                        iceberg_field.name, iceberg_field.field_type
+                    ),
+                )
+            })?;
         // Use the same run-end-encoded type as the non-null constant path, so a
         // column keeps one Arrow type whether a given file resolves it to a value
         // or to null.

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -38,8 +38,8 @@ use crate::metadata_columns::{
     RESERVED_COL_NAME_PARTITION, RESERVED_FIELD_ID_PARTITION, get_metadata_field,
 };
 use crate::spec::{
-    Datum, Literal, NestedField, PartitionSpec, PrimitiveLiteral, Schema as IcebergSchema, Struct,
-    StructType, Transform,
+    Datum, Literal, PartitionSpec, PrimitiveLiteral, Schema as IcebergSchema, Struct, StructType,
+    Transform,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -54,24 +54,6 @@ fn field_with_id(
         PARQUET_FIELD_ID_META_KEY.to_string(),
         field_id.to_string(),
     )]))
-}
-
-/// The Arrow type for an all-null metadata column. Uses the same run-end-encoded
-/// type as the non-null constant path (`datum_to_arrow_type_with_ree`), so a
-/// metadata column keeps one Arrow type whether a given file resolves it to a
-/// value or to null; otherwise mixed files in one scan produce incompatible
-/// batch schemas.
-fn null_metadata_column_arrow_type(field: &NestedField) -> Result<DataType> {
-    let prim_type = field.field_type.as_primitive_type().ok_or_else(|| {
-        Error::new(
-            ErrorKind::Unexpected,
-            format!(
-                "Metadata column {} has non-primitive type {:?}",
-                field.name, field.field_type
-            ),
-        )
-    })?;
-    Ok(primitive_type_to_arrow_type_with_ree(prim_type))
 }
 
 /// Build a map of field ID to constant value (as Datum) for identity-partitioned fields.
@@ -256,11 +238,12 @@ pub(crate) enum ColumnConstant {
     /// A struct constant (the `_partition` column). Each child is a primitive constant
     /// or null (for partition evolution gaps).
     Struct(StructConstant),
-    /// An all-null metadata column. Used when a metadata column resolves to null
-    /// (e.g. `_last_updated_sequence_number` for a file with a null `first_row_id`).
-    /// The field id is the map key. A distinct variant (rather than `Scalar` with a
-    /// null value) because `Datum` always represents a non-null value.
-    Null,
+    /// An all-null metadata column, carrying its Arrow type. Used when a metadata
+    /// column resolves to null (e.g. `_last_updated_sequence_number` for a file
+    /// with a null `first_row_id`). A distinct variant (rather than `Scalar` with a
+    /// null value) because `Datum` always represents a non-null value; the type is
+    /// computed once so the schema and column-source paths cannot derive it apart.
+    Null(DataType),
 }
 
 /// Pre-computed data for a struct constant column.
@@ -323,9 +306,24 @@ impl RecordBatchTransformerBuilder {
     /// Add an all-null metadata column for a specific field ID.
     /// Used for metadata columns that resolve to null (e.g.
     /// `_last_updated_sequence_number` when the file has a null `first_row_id`).
-    pub(crate) fn with_null_metadata_column(mut self, field_id: i32) -> Self {
-        self.constant_fields.insert(field_id, ColumnConstant::Null);
-        self
+    pub(crate) fn with_null_metadata_column(mut self, field_id: i32) -> Result<Self> {
+        let iceberg_field = get_metadata_field(field_id)?;
+        let prim_type = iceberg_field.field_type.as_primitive_type().ok_or_else(|| {
+            Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "Metadata column {} has non-primitive type {:?}",
+                    iceberg_field.name, iceberg_field.field_type
+                ),
+            )
+        })?;
+        // Use the same run-end-encoded type as the non-null constant path, so a
+        // column keeps one Arrow type whether a given file resolves it to a value
+        // or to null.
+        let arrow_type = primitive_type_to_arrow_type_with_ree(prim_type);
+        self.constant_fields
+            .insert(field_id, ColumnConstant::Null(arrow_type));
+        Ok(self)
     }
 
     /// Set partition spec and data together for identifying identity-transformed partition columns.
@@ -528,13 +526,16 @@ impl RecordBatchTransformer {
                         // Identity partition constant -- fall through to use the
                         // mapped schema field (read from file if present).
                     }
-                    Some(ColumnConstant::Null) => {
+                    Some(ColumnConstant::Null(arrow_type)) => {
                         let iceberg_field = get_metadata_field(*field_id)?;
-                        let arrow_type = null_metadata_column_arrow_type(iceberg_field)?;
                         // Always nullable: this arm produces an all-null column regardless
                         // of the field's declared optionality.
-                        let arrow_field =
-                            field_with_id(&iceberg_field.name, arrow_type, true, iceberg_field.id);
+                        let arrow_field = field_with_id(
+                            &iceberg_field.name,
+                            arrow_type.clone(),
+                            true,
+                            iceberg_field.id,
+                        );
                         return Ok(Arc::new(arrow_field));
                     }
                     None => {}
@@ -706,12 +707,10 @@ impl RecordBatchTransformer {
                         // Identity partition field present in the file -- fall through
                         // to read from the file instead of using the constant.
                     }
-                    Some(ColumnConstant::Null) => {
-                        let iceberg_field = get_metadata_field(*field_id)?;
-                        let arrow_type = null_metadata_column_arrow_type(iceberg_field)?;
+                    Some(ColumnConstant::Null(arrow_type)) => {
                         return Ok(ColumnSource::Add {
                             value: None,
-                            target_type: arrow_type,
+                            target_type: arrow_type.clone(),
                         });
                     }
                     None => {}
@@ -1003,6 +1002,7 @@ mod test {
         Array, Date32Array, Float32Array, Float64Array, Int32Array, Int64Array, RecordBatch,
         StringArray,
     };
+    use arrow_cast::cast;
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 
     use super::field_with_id;
@@ -2194,9 +2194,6 @@ mod test {
 
     #[test]
     fn last_updated_sequence_number_constant() {
-        use arrow_array::RunArray;
-        use arrow_array::types::Int32Type;
-
         use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
         use crate::spec::Datum;
 
@@ -2240,22 +2237,12 @@ mod test {
         assert_eq!(result.num_columns(), 2);
         assert_eq!(result.num_rows(), 3);
 
-        // The metadata column is a run-end-encoded Long constant of 7 for every row.
-        let seq_col = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<RunArray<Int32Type>>()
-            .expect("_last_updated_sequence_number should be a RunArray");
+        // Every row's logical value is 7 (the data sequence number), regardless of
+        // the physical (run-end) encoding.
+        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
+        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
         assert_eq!(seq_col.len(), 3);
-        let values = seq_col
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("REE values should be Int64Array");
-        // A single run spanning all rows, non-null, value 7.
-        assert_eq!(values.len(), 1);
-        assert!(!values.is_null(0));
-        assert_eq!(values.value(0), 7);
+        assert!((0..3).all(|i| !seq_col.is_null(i) && seq_col.value(i) == 7));
     }
 
     #[test]
@@ -2285,6 +2272,7 @@ mod test {
         let mut transformer =
             RecordBatchTransformerBuilder::new(snapshot_schema, &projected_field_ids)
                 .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+                .unwrap()
                 .build();
 
         let parquet_batch =
@@ -2295,20 +2283,11 @@ mod test {
 
         let result = transformer.process_record_batch(parquet_batch).unwrap();
 
-        // Run-end-encoded (same type as the constant path), a single null run.
-        let seq_col = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
-            .expect("_last_updated_sequence_number should be a RunArray");
+        // Every row's logical value is null.
+        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
+        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
         assert_eq!(seq_col.len(), 3);
-        let values = seq_col
-            .values()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("REE values should be Int64Array");
-        assert_eq!(values.len(), 1);
-        assert!(values.is_null(0));
+        assert!((0..3).all(|i| seq_col.is_null(i)));
     }
 
     /// field 1 and RESERVED_FIELD_ID_POS are of identical type

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -30,13 +30,16 @@ use arrow_schema::{
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 
 use crate::arrow::value::{create_primitive_array_repeated, create_primitive_array_single_element};
-use crate::arrow::{datum_to_arrow_type_with_ree, schema_to_arrow_schema, type_to_arrow_type};
+use crate::arrow::{
+    datum_to_arrow_type_with_ree, primitive_type_to_arrow_type_with_ree, schema_to_arrow_schema,
+    type_to_arrow_type,
+};
 use crate::metadata_columns::{
     RESERVED_COL_NAME_PARTITION, RESERVED_FIELD_ID_PARTITION, get_metadata_field,
 };
 use crate::spec::{
-    Datum, Literal, PartitionSpec, PrimitiveLiteral, Schema as IcebergSchema, Struct, StructType,
-    Transform,
+    Datum, Literal, NestedField, PartitionSpec, PrimitiveLiteral, Schema as IcebergSchema, Struct,
+    StructType, Transform,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -51,6 +54,24 @@ fn field_with_id(
         PARQUET_FIELD_ID_META_KEY.to_string(),
         field_id.to_string(),
     )]))
+}
+
+/// The Arrow type for an all-null metadata column. Uses the same run-end-encoded
+/// type as the non-null constant path (`datum_to_arrow_type_with_ree`), so a
+/// metadata column keeps one Arrow type whether a given file resolves it to a
+/// value or to null; otherwise mixed files in one scan produce incompatible
+/// batch schemas.
+fn null_metadata_column_arrow_type(field: &NestedField) -> Result<DataType> {
+    let prim_type = field.field_type.as_primitive_type().ok_or_else(|| {
+        Error::new(
+            ErrorKind::Unexpected,
+            format!(
+                "Metadata column {} has non-primitive type {:?}",
+                field.name, field.field_type
+            ),
+        )
+    })?;
+    Ok(primitive_type_to_arrow_type_with_ree(prim_type))
 }
 
 /// Build a map of field ID to constant value (as Datum) for identity-partitioned fields.
@@ -235,6 +256,11 @@ pub(crate) enum ColumnConstant {
     /// A struct constant (the `_partition` column). Each child is a primitive constant
     /// or null (for partition evolution gaps).
     Struct(StructConstant),
+    /// An all-null metadata column. Used when a metadata column resolves to null
+    /// (e.g. `_last_updated_sequence_number` for a file with a null `first_row_id`).
+    /// The field id is the map key. A distinct variant (rather than `Scalar` with a
+    /// null value) because `Datum` always represents a non-null value.
+    Null,
 }
 
 /// Pre-computed data for a struct constant column.
@@ -291,6 +317,14 @@ impl RecordBatchTransformerBuilder {
     pub(crate) fn with_constant(mut self, field_id: i32, datum: Datum) -> Self {
         self.constant_fields
             .insert(field_id, ColumnConstant::Scalar(datum));
+        self
+    }
+
+    /// Add an all-null metadata column for a specific field ID.
+    /// Used for metadata columns that resolve to null (e.g.
+    /// `_last_updated_sequence_number` when the file has a null `first_row_id`).
+    pub(crate) fn with_null_metadata_column(mut self, field_id: i32) -> Self {
+        self.constant_fields.insert(field_id, ColumnConstant::Null);
         self
     }
 
@@ -494,6 +528,15 @@ impl RecordBatchTransformer {
                         // Identity partition constant -- fall through to use the
                         // mapped schema field (read from file if present).
                     }
+                    Some(ColumnConstant::Null) => {
+                        let iceberg_field = get_metadata_field(*field_id)?;
+                        let arrow_type = null_metadata_column_arrow_type(iceberg_field)?;
+                        // Always nullable: this arm produces an all-null column regardless
+                        // of the field's declared optionality.
+                        let arrow_field =
+                            field_with_id(&iceberg_field.name, arrow_type, true, iceberg_field.id);
+                        return Ok(Arc::new(arrow_field));
+                    }
                     None => {}
                 }
 
@@ -662,6 +705,14 @@ impl RecordBatchTransformer {
                         }
                         // Identity partition field present in the file -- fall through
                         // to read from the file instead of using the constant.
+                    }
+                    Some(ColumnConstant::Null) => {
+                        let iceberg_field = get_metadata_field(*field_id)?;
+                        let arrow_type = null_metadata_column_arrow_type(iceberg_field)?;
+                        return Ok(ColumnSource::Add {
+                            value: None,
+                            target_type: arrow_type,
+                        });
                     }
                     None => {}
                 }
@@ -2139,6 +2190,125 @@ mod test {
 
         assert_eq!(pos_col.len(), 3);
         assert_eq!(pos_col.values(), &[0, 1, 2]);
+    }
+
+    #[test]
+    fn last_updated_sequence_number_constant() {
+        use arrow_array::RunArray;
+        use arrow_array::types::Int32Type;
+
+        use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
+        use crate::spec::Datum;
+
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(0)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        // The column is not physically present in the file; it is materialized as
+        // a per-file constant equal to the data sequence number.
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![field_with_id(
+            "id",
+            DataType::Int32,
+            false,
+            1,
+        )]));
+
+        let projected_field_ids = [1, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER];
+
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_field_ids)
+                .with_constant(
+                    RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                    Datum::long(7),
+                )
+                .build();
+
+        let parquet_batch =
+            RecordBatch::try_new(parquet_schema, vec![Arc::new(Int32Array::from(vec![
+                10, 20, 30,
+            ]))])
+            .unwrap();
+
+        let result = transformer.process_record_batch(parquet_batch).unwrap();
+
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.num_rows(), 3);
+
+        // The metadata column is a run-end-encoded Long constant of 7 for every row.
+        let seq_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<RunArray<Int32Type>>()
+            .expect("_last_updated_sequence_number should be a RunArray");
+        assert_eq!(seq_col.len(), 3);
+        let values = seq_col
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("REE values should be Int64Array");
+        // A single run spanning all rows, non-null, value 7.
+        assert_eq!(values.len(), 1);
+        assert!(!values.is_null(0));
+        assert_eq!(values.value(0), 7);
+    }
+
+    #[test]
+    fn last_updated_sequence_number_null_column() {
+        use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(0)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![field_with_id(
+            "id",
+            DataType::Int32,
+            false,
+            1,
+        )]));
+
+        let projected_field_ids = [1, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER];
+
+        // The null-gate path (a file with a null first_row_id): the whole column is null.
+        let mut transformer =
+            RecordBatchTransformerBuilder::new(snapshot_schema, &projected_field_ids)
+                .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+                .build();
+
+        let parquet_batch =
+            RecordBatch::try_new(parquet_schema, vec![Arc::new(Int32Array::from(vec![
+                10, 20, 30,
+            ]))])
+            .unwrap();
+
+        let result = transformer.process_record_batch(parquet_batch).unwrap();
+
+        // Run-end-encoded (same type as the constant path), a single null run.
+        let seq_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow_array::RunArray<arrow_array::types::Int32Type>>()
+            .expect("_last_updated_sequence_number should be a RunArray");
+        assert_eq!(seq_col.len(), 3);
+        let values = seq_col
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("REE values should be Int64Array");
+        assert_eq!(values.len(), 1);
+        assert!(values.is_null(0));
     }
 
     /// field 1 and RESERVED_FIELD_ID_POS are of identical type

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -1192,6 +1192,13 @@ impl TryFrom<&Schema> for ArrowSchema {
 /// // Returns: RunEndEncoded(Int32, Utf8)
 /// ```
 pub fn datum_to_arrow_type_with_ree(datum: &Datum) -> DataType {
+    primitive_type_to_arrow_type_with_ree(datum.data_type())
+}
+
+/// Returns the run-end-encoded Arrow type used to materialize a per-file constant
+/// column of the given Iceberg primitive type. Shared by both the value and the
+/// all-null constant paths so a column keeps one Arrow type across files.
+pub(crate) fn primitive_type_to_arrow_type_with_ree(primitive_type: &PrimitiveType) -> DataType {
     // Helper to create REE type with the given values type.
     // Note: values field is nullable as Arrow expects this when building the
     // final Arrow schema with `RunArray::try_new`.
@@ -1201,8 +1208,7 @@ pub fn datum_to_arrow_type_with_ree(datum: &Datum) -> DataType {
         DataType::RunEndEncoded(run_ends_field, values_field)
     };
 
-    // Match on the PrimitiveType from the Datum to determine the Arrow type
-    match datum.data_type() {
+    match primitive_type {
         PrimitiveType::Boolean => make_ree(DataType::Boolean),
         PrimitiveType::Int => make_ree(DataType::Int32),
         PrimitiveType::Long => make_ree(DataType::Int64),

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -662,9 +662,9 @@ pub mod tests {
     use crate::io::{FileIO, OutputFile};
     use crate::metadata_columns::{
         RESERVED_COL_NAME_DELETE_FILE_PATH, RESERVED_COL_NAME_DELETE_FILE_POS,
-        RESERVED_COL_NAME_FILE, RESERVED_COL_NAME_POS, RESERVED_COL_NAME_SPEC_ID,
-        RESERVED_FIELD_ID_DELETE_FILE_PATH, RESERVED_FIELD_ID_DELETE_FILE_POS,
-        RESERVED_FIELD_ID_POS,
+        RESERVED_COL_NAME_FILE, RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+        RESERVED_COL_NAME_POS, RESERVED_COL_NAME_SPEC_ID, RESERVED_FIELD_ID_DELETE_FILE_PATH,
+        RESERVED_FIELD_ID_DELETE_FILE_POS, RESERVED_FIELD_ID_POS,
     };
     use crate::scan::FileScanTask;
     use crate::spec::{
@@ -3147,6 +3147,92 @@ pub mod tests {
 
         // Verify 'z' column exists
         assert!(batches[0].column_by_name("z").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_select_with_last_updated_sequence_number_column() {
+        // A v2 fixture: data files have a null first_row_id. Per the spec's Row
+        // Lineage read rules, a file with a null first_row_id produces a null
+        // _last_updated_sequence_number for all rows; both lineage columns are
+        // gated on first_row_id.
+        let mut fixture = TableTestFixture::new();
+        fixture.setup_manifest_files().await;
+
+        let table_scan = fixture
+            .table
+            .scan()
+            .select(["x", RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER])
+            .with_row_selection_enabled(true)
+            .build()
+            .unwrap();
+
+        let batches: Vec<_> = table_scan
+            .to_arrow()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        // Every row's value is null (v2 files have no first_row_id).
+        for batch in &batches {
+            let seq_col = batch
+                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+                .expect("_last_updated_sequence_number column should be present")
+                .as_any()
+                .downcast_ref::<RunArray<Int32Type>>()
+                .expect("_last_updated_sequence_number should be a RunArray");
+            let values = seq_col
+                .values()
+                .as_primitive::<arrow_array::types::Int64Type>();
+            assert!(
+                (0..values.len()).all(|i| values.is_null(i)),
+                "all values must be null for a file with null first_row_id"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_select_with_last_updated_sequence_number_column_v3() {
+        // A v3 fixture: the data file inherits first_row_id=42 and data
+        // sequence number=1 through manifest read. End to end, the projected
+        // _last_updated_sequence_number materializes to the data sequence
+        // number (1) for every row, exercising the full inherit, populate and
+        // materialize wiring, not just a hand-built task.
+        let mut fixture = TableTestFixture::new();
+        fixture.setup_v3_manifest_files().await;
+
+        let table_scan = fixture
+            .table
+            .scan()
+            .select(["x", RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER])
+            .with_row_selection_enabled(true)
+            .build()
+            .unwrap();
+
+        let batches: Vec<_> = table_scan
+            .to_arrow()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        for batch in &batches {
+            let seq_col = batch
+                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+                .expect("_last_updated_sequence_number column should be present")
+                .as_any()
+                .downcast_ref::<RunArray<Int32Type>>()
+                .expect("_last_updated_sequence_number should be a RunArray");
+            let values = seq_col
+                .values()
+                .as_primitive::<arrow_array::types::Int64Type>();
+            assert!(
+                (0..values.len()).all(|i| !values.is_null(i) && values.value(i) == 1),
+                "every row must equal the data sequence number (1)"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -684,6 +684,25 @@ pub mod tests {
         env.render_str(template, ctx).unwrap()
     }
 
+    /// Asserts every row of the `_last_updated_sequence_number` column across all
+    /// batches equals `expected` (or is null when `expected` is `None`), decoding
+    /// the logical value independent of the physical (run-end) encoding.
+    fn assert_last_updated_seq_all(batches: &[RecordBatch], expected: Option<i64>) {
+        use arrow_cast::cast;
+        use arrow_schema::DataType;
+        for batch in batches {
+            let col = batch
+                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+                .expect("_last_updated_sequence_number column should be present");
+            let logical = cast(col, &DataType::Int64).unwrap();
+            let values = logical.as_primitive::<arrow_array::types::Int64Type>();
+            for i in 0..values.len() {
+                let actual = (!values.is_null(i)).then(|| values.value(i));
+                assert_eq!(actual, expected, "row {i}");
+            }
+        }
+    }
+
     pub struct TableTestFixture {
         pub table_location: String,
         pub table: Table,
@@ -3175,32 +3194,27 @@ pub mod tests {
             .unwrap();
 
         // Every row's value is null (v2 files have no first_row_id).
-        for batch in &batches {
-            let seq_col = batch
-                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
-                .expect("_last_updated_sequence_number column should be present")
-                .as_any()
-                .downcast_ref::<RunArray<Int32Type>>()
-                .expect("_last_updated_sequence_number should be a RunArray");
-            let values = seq_col
-                .values()
-                .as_primitive::<arrow_array::types::Int64Type>();
-            assert!(
-                (0..values.len()).all(|i| values.is_null(i)),
-                "all values must be null for a file with null first_row_id"
-            );
-        }
+        assert_last_updated_seq_all(&batches, None);
     }
 
     #[tokio::test]
     async fn test_select_with_last_updated_sequence_number_column_v3() {
-        // A v3 fixture: the data file inherits first_row_id=42 and data
-        // sequence number=1 through manifest read. End to end, the projected
-        // _last_updated_sequence_number materializes to the data sequence
-        // number (1) for every row, exercising the full inherit, populate and
+        // A v3 fixture: the data file inherits a first_row_id and a data sequence
+        // number through manifest read. End to end, the projected
+        // _last_updated_sequence_number materializes to the file's data sequence
+        // number for every row, exercising the full inherit, populate and
         // materialize wiring, not just a hand-built task.
         let mut fixture = TableTestFixture::new();
         fixture.setup_v3_manifest_files().await;
+
+        // The added file inherits the current snapshot's sequence number; derive it
+        // from the fixture rather than hardcoding so the assertion tracks the fixture.
+        let expected_seq = fixture
+            .table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .sequence_number();
 
         let table_scan = fixture
             .table
@@ -3218,21 +3232,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        for batch in &batches {
-            let seq_col = batch
-                .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
-                .expect("_last_updated_sequence_number column should be present")
-                .as_any()
-                .downcast_ref::<RunArray<Int32Type>>()
-                .expect("_last_updated_sequence_number should be a RunArray");
-            let values = seq_col
-                .values()
-                .as_primitive::<arrow_array::types::Int64Type>();
-            assert!(
-                (0..values.len()).all(|i| !values.is_null(i) && values.value(i) == 1),
-                "every row must equal the data sequence number (1)"
-            );
-        }
+        assert_last_updated_seq_all(&batches, Some(expected_seq));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

Refs https://github.com/apache/iceberg-rust/issues/2879

## What changes are included in this PR?

Reading the `_last_updated_sequence_number` metadata column is not supported currently. This PR fixes it.

Note: A file may physically carry a per-row column (e.g. written by Iceberg Java when carrying rows forward across a rewrite). The spec reads such non-null per-row values unmodified; that per-row coalesce is not implemented yet, so such files are rejected with `FeatureUnsupported`.

The per-row coalesce, and the `_row_id` column, follow in later PRs.

## Are these changes tested?

unit tests