### PR TITLE
feat: coalesce physically-stored _last_updated_sequence_number

### DIFF
--- a/crates/iceberg/src/arrow/reader/mod.rs
+++ b/crates/iceberg/src/arrow/reader/mod.rs
@@ -44,7 +44,9 @@ mod row_filter;
 pub use file_reader::ArrowFileReader;
 pub(crate) use options::ParquetReadOptions;
 use predicate_visitor::{CollectFieldIdVisitor, PredicateConverter};
-use projection::{add_fallback_field_ids_to_arrow_schema, apply_name_mapping_to_arrow_schema};
+use projection::{
+    add_fallback_field_ids_to_arrow_schema, apply_name_mapping_to_arrow_schema, build_field_id_map,
+};
 
 /// Builder to create ArrowReader
 pub struct ArrowReaderBuilder {

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -260,9 +260,9 @@ impl FileScanTaskReader {
             .contains(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER);
 
         // Parquet leaf index of the physical column, if present by embedded field id.
-        // `build_field_id_map` is all-or-nothing (`None` if any column lacks an id), so a
-        // file mixing id-bearing and id-less columns is rejected below rather than
-        // coalesced -- safe, and consistent with the rest of the reader.
+        // `build_field_id_map` is all-or-nothing: a file mixing id-bearing and id-less
+        // columns yields `None` and is rejected below rather than coalesced, even if the
+        // physical column itself carries its reserved id.
         let phys_last_updated_seq_leaf = if project_last_updated_seq {
             build_field_id_map(record_batch_stream_builder.parquet_schema())?.and_then(|m| {
                 m.get(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
@@ -282,9 +282,10 @@ impl FileScanTaskReader {
                 .iter()
                 .any(|f| f.name() == RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER);
 
-        // We read + coalesce the physical column only when it is present by id AND the file
-        // is row-lineage-bearing (first_row_id set) with a data sequence number to fall
-        // back to. When first_row_id is null the column is nulled, so we must not read it.
+        // Read the physical column only when first_row_id is set (with a data sequence
+        // number to fall back to). A null first_row_id drops the leaf and nulls the whole
+        // column below, discarding any per-row values the file carries -- matching Java
+        // (`ValueReaders.lastUpdated` nulls when the base row id is null).
         let coalesce_last_updated_seq_leaf = phys_last_updated_seq_leaf
             .filter(|_| task.first_row_id.is_some() && task.data_sequence_number.is_some());
 
@@ -361,7 +362,7 @@ impl FileScanTaskReader {
                     if coalesce_last_updated_seq_leaf.is_some() {
                         // The file physically carries the column: read the per-row value,
                         // falling back to the data sequence number only where null.
-                        record_batch_transformer_builder.with_coalesced_metadata_column(
+                        record_batch_transformer_builder.with_coalesced_last_updated_seq_column(
                             RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
                             datum,
                         )
@@ -370,6 +371,9 @@ impl FileScanTaskReader {
                         // positional fallback). The transformer keys the source column by
                         // field id, so we can't thread it; no real writer produces this, so
                         // reject loudly rather than silently overwrite with the constant.
+                        // Arm-local by design: only this arm reads the physical column, so
+                        // only here can a name-only column defeat us. The `(None, _)` arm
+                        // nulls the column without reading it, so it needs no such guard.
                         return Err(Error::new(
                             ErrorKind::FeatureUnsupported,
                             "Reading a physically-stored _last_updated_sequence_number column \
@@ -1393,6 +1397,36 @@ mod tests {
         assert_eq!(err.kind(), crate::ErrorKind::FeatureUnsupported);
         assert!(
             format!("{err}").contains("without an embedded field id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_physical_column_first_row_id_without_data_seq() {
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
+        let file_path = write_plain_parquet(
+            dir,
+            "with_seq_no_data_seq.parquet",
+            vec![physical_last_updated_seq_field()],
+            vec![seq_col],
+        );
+
+        // first_row_id set but no data sequence number: after manifest inheritance a
+        // committed entry always has one, so this is a malformed manifest, rejected loudly
+        // rather than nulled.
+        let task = last_updated_seq_task(file_path, Some(100), None);
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let result: Result<Vec<RecordBatch>, _> =
+            reader.read(tasks).unwrap().stream().try_collect().await;
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::DataInvalid);
+        assert!(
+            format!("{err}").contains("no data sequence number"),
             "unexpected error: {err}"
         );
     }

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -273,7 +273,7 @@ impl FileScanTaskReader {
         };
 
         // Present by name but not by the embedded id (only meaningful when no by-id column
-        // was found) -- an unthreadable shape we reject rather than mis-coalesce.
+        // was found). An unthreadable shape we reject rather than coalesce incorrectly.
         let last_updated_seq_present_by_name_only = project_last_updated_seq
             && phys_last_updated_seq_leaf.is_none()
             && record_batch_stream_builder

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -27,12 +27,14 @@ use std::sync::atomic::AtomicU64;
 use arrow_schema::{DataType, Field};
 use futures::{StreamExt, TryStreamExt};
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
-use parquet::arrow::{PARQUET_FIELD_ID_META_KEY, ParquetRecordBatchStreamBuilder, RowNumber};
+use parquet::arrow::{
+    PARQUET_FIELD_ID_META_KEY, ParquetRecordBatchStreamBuilder, ProjectionMask, RowNumber,
+};
 use parquet::encryption::decrypt::FileDecryptionProperties;
 
 use super::{
     ArrowFileReader, ArrowReader, ParquetReadOptions, add_fallback_field_ids_to_arrow_schema,
-    apply_name_mapping_to_arrow_schema,
+    apply_name_mapping_to_arrow_schema, build_field_id_map,
 };
 use crate::arrow::build_partition_constant;
 use crate::arrow::caching_delete_file_loader::CachingDeleteFileLoader;
@@ -250,6 +252,42 @@ impl FileScanTaskReader {
         let mut record_batch_stream_builder =
             ParquetRecordBatchStreamBuilder::new_with_metadata(parquet_file_reader, arrow_metadata);
 
+        // Whether the file physically carries the `_last_updated_sequence_number` column
+        // (some engines, e.g. Iceberg Java on rewrite, write it per-row), resolved by its
+        // embedded field id against the Parquet schema.
+        let project_last_updated_seq = task
+            .project_field_ids()
+            .contains(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER);
+
+        // Parquet leaf index of the physical column, if present by embedded field id.
+        // `build_field_id_map` is all-or-nothing (`None` if any column lacks an id), so a
+        // file mixing id-bearing and id-less columns is rejected below rather than
+        // coalesced -- safe, and consistent with the rest of the reader.
+        let phys_last_updated_seq_leaf = if project_last_updated_seq {
+            build_field_id_map(record_batch_stream_builder.parquet_schema())?.and_then(|m| {
+                m.get(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
+                    .copied()
+            })
+        } else {
+            None
+        };
+
+        // Present by name but not by the embedded id (only meaningful when no by-id column
+        // was found) -- an unthreadable shape we reject rather than mis-coalesce.
+        let last_updated_seq_present_by_name_only = project_last_updated_seq
+            && phys_last_updated_seq_leaf.is_none()
+            && record_batch_stream_builder
+                .schema()
+                .fields()
+                .iter()
+                .any(|f| f.name() == RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER);
+
+        // We read + coalesce the physical column only when it is present by id AND the file
+        // is row-lineage-bearing (first_row_id set) with a data sequence number to fall
+        // back to. When first_row_id is null the column is nulled, so we must not read it.
+        let coalesce_last_updated_seq_leaf = phys_last_updated_seq_leaf
+            .filter(|_| task.first_row_id.is_some() && task.data_sequence_number.is_some());
+
         // Filter out metadata fields for Parquet projection (they don't exist in files)
         let project_field_ids_without_metadata: Vec<i32> = task
             .project_field_ids
@@ -263,13 +301,23 @@ impl FileScanTaskReader {
         // - If name mapping applied: field-ID-based projection using the IDs the name
         //   mapping assigned to the Arrow schema
         // - Otherwise: position-based fallback projection
-        let projection_mask = ArrowReader::get_arrow_projection_mask(
+        let mut projection_mask = ArrowReader::get_arrow_projection_mask(
             &project_field_ids_without_metadata,
             &task.schema,
             record_batch_stream_builder.parquet_schema(),
             record_batch_stream_builder.schema(),
             use_position_fallback, // Whether to use position-based (true) or field-ID-based (false) projection
         )?;
+
+        // Union in the physical `_last_updated_sequence_number` column when we will
+        // coalesce it. The metadata field id is not in the task schema, so it can't be
+        // requested through `get_arrow_projection_mask` (which resolves ids against the
+        // task schema); add its Parquet leaf directly.
+        if let Some(leaf) = coalesce_last_updated_seq_leaf {
+            let phys_mask =
+                ProjectionMask::leaves(record_batch_stream_builder.parquet_schema(), vec![leaf]);
+            projection_mask.union(&phys_mask);
+        }
 
         record_batch_stream_builder =
             record_batch_stream_builder.with_projection(projection_mask.clone());
@@ -301,59 +349,38 @@ impl FileScanTaskReader {
                 .with_constant(RESERVED_FIELD_ID_SPEC_ID, spec_id_datum);
         }
 
-        if task
-            .project_field_ids()
-            .contains(&RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
-        {
-            // A data file may physically carry a per-row `_last_updated_sequence_number`
-            // column, e.g. one written by another engine such as Iceberg Java when carrying
-            // rows forward across a rewrite. The spec requires reading such non-null
-            // per-row values unmodified, falling back to the derived value only where
-            // null. That per-row coalesce is not implemented yet, so rather than silently
-            // overwrite genuine per-row values with the derived value, reject the file
-            // loudly. Checks the full pre-projection file schema, since the column is
-            // stripped from the projection mask. Matches on the embedded field id when
-            // present (propagating a malformed id rather than treating it as absent) and
-            // falls back to the column name, so a file read via name mapping or positional
-            // fallback ids (which never equal the reserved id) is still caught.
-            let mut file_has_column = false;
-            for field in record_batch_stream_builder.schema().fields() {
-                let field_id = match field.metadata().get(PARQUET_FIELD_ID_META_KEY) {
-                    Some(id) => Some(id.parse::<i32>().map_err(|e| {
-                        Error::new(
-                            ErrorKind::DataInvalid,
-                            format!("field id not parseable as an i32: {e}"),
-                        )
-                    })?),
-                    None => None,
-                };
-                if field_id == Some(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)
-                    || field.name() == RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER
-                {
-                    file_has_column = true;
-                    break;
-                }
-            }
-            if file_has_column {
-                return Err(Error::new(
-                    ErrorKind::FeatureUnsupported,
-                    "Reading a physically-stored _last_updated_sequence_number column is \
-                     not yet supported; only the derived (data-sequence-number) value is \
-                     implemented",
-                ));
-            }
-
-            // Derive the column, gated on the data file's `first_row_id`. Java gates
-            // both lineage columns this way (`ValueReaders.lastUpdated` returns nulls
-            // when the base row id is null); the spec itself only says the column is
-            // assigned the manifest entry's sequence number on read.
+        if project_last_updated_seq {
+            // Materialize the column, gated on the data file's `first_row_id`. Java gates
+            // it this way (`ValueReaders.lastUpdated` returns nulls when the base row id is
+            // null); the spec itself only says the column is assigned the manifest entry's
+            // sequence number on read.
             record_batch_transformer_builder = match (task.first_row_id, task.data_sequence_number)
             {
-                // Non-null first_row_id: inherit from the data sequence number.
-                (Some(_), Some(seq)) => record_batch_transformer_builder.with_constant(
-                    RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
-                    Datum::long(seq),
-                ),
+                (Some(_), Some(seq)) => {
+                    let datum = Datum::long(seq);
+                    if coalesce_last_updated_seq_leaf.is_some() {
+                        // The file physically carries the column: read the per-row value,
+                        // falling back to the data sequence number only where null.
+                        record_batch_transformer_builder.with_coalesced_metadata_column(
+                            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                            datum,
+                        )
+                    } else if last_updated_seq_present_by_name_only {
+                        // Present by name but without the embedded field id (name mapping /
+                        // positional fallback). The transformer keys the source column by
+                        // field id, so we can't thread it; no real writer produces this, so
+                        // reject loudly rather than silently overwrite with the constant.
+                        return Err(Error::new(
+                            ErrorKind::FeatureUnsupported,
+                            "Reading a physically-stored _last_updated_sequence_number column \
+                             without an embedded field id is not supported",
+                        ));
+                    } else {
+                        // Column absent: derive it from the data sequence number.
+                        record_batch_transformer_builder
+                            .with_constant(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER, datum)
+                    }
+                }
                 // Null first_row_id (v1/v2, or a pre-upgrade v3 snapshot): the column is null.
                 (None, _) => record_batch_transformer_builder
                     .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)?,
@@ -1146,23 +1173,38 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
 
-        // Two files in one scan: one with first_row_id (derived value -> REE constant),
-        // one without (null gate -> REE null). Both must produce the same Arrow type for
-        // the column, or concatenation fails; the regression this branch fixes.
-        let with_id = last_updated_seq_task(
-            write_plain_parquet(dir, "with_id.parquet", vec![], vec![]),
+        // Three files in one scan exercising all three column paths, which must all
+        // produce the SAME Arrow type (run-end-encoded) or concatenation fails:
+        //   - constant: first_row_id set, no physical column -> derived constant
+        //   - null gate: no first_row_id -> null column
+        //   - coalesce: first_row_id set, physical column present -> per-row + fallback
+        let constant = last_updated_seq_task(
+            write_plain_parquet(dir, "constant.parquet", vec![], vec![]),
             Some(42),
             Some(7),
         );
-        let without_id = last_updated_seq_task(
-            write_plain_parquet(dir, "without_id.parquet", vec![], vec![]),
+        let nulled = last_updated_seq_task(
+            write_plain_parquet(dir, "nulled.parquet", vec![], vec![]),
             None,
+            Some(7),
+        );
+        let coalesced = last_updated_seq_task(
+            write_plain_parquet(
+                dir,
+                "coalesced.parquet",
+                vec![physical_last_updated_seq_field()],
+                vec![Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef],
+            ),
+            Some(50),
             Some(7),
         );
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
-        let tasks = Box::pin(futures::stream::iter(vec![Ok(with_id), Ok(without_id)]))
-            as FileScanTaskStream;
+        let tasks = Box::pin(futures::stream::iter(vec![
+            Ok(constant),
+            Ok(nulled),
+            Ok(coalesced),
+        ])) as FileScanTaskStream;
         let batches: Vec<RecordBatch> = reader
             .read(tasks)
             .unwrap()
@@ -1171,32 +1213,175 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(batches.len(), 2);
-        // Identical schema across files -> concat succeeds.
+        assert_eq!(batches.len(), 3);
+        // Identical schema across all three paths -> concat succeeds.
         let schema = batches[0].schema();
         concat_batches(&schema, &batches)
-            .expect("batches from value and null files must share one schema");
+            .expect("constant, null and coalesce files must share one column type");
+    }
+
+    /// A parquet field carrying the embedded `_last_updated_sequence_number` field id.
+    fn physical_last_updated_seq_field() -> Field {
+        use crate::metadata_columns::{
+            RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+        };
+        Field::new(
+            RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+            DataType::Int64,
+            true,
+        )
+        .with_metadata(HashMap::from([(
+            PARQUET_FIELD_ID_META_KEY.to_string(),
+            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER.to_string(),
+        )]))
     }
 
     #[tokio::test]
-    async fn test_last_updated_sequence_number_physical_column_unsupported() {
-        use crate::metadata_columns::RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER;
+    async fn test_last_updated_sequence_number_physical_column_coalesced() {
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        // A file that physically carries the column, as Iceberg Java writes when
+        // carrying rows forward across a rewrite: some rows have a stored value, some
+        // are null (added/modified rows, inherited on read).
+        let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
+        let file_path = write_plain_parquet(
+            dir,
+            "with_seq.parquet",
+            vec![physical_last_updated_seq_field()],
+            vec![seq_col],
+        );
+
+        let task = last_updated_seq_task(file_path, Some(100), Some(9));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        // Per-row value where non-null; the data sequence number (9) where null.
+        assert_last_updated_seq_column(&batches, &[Some(5), Some(9), Some(8)]);
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_coalesced_with_pos_column() {
+        use crate::metadata_columns::{
+            RESERVED_COL_NAME_POS, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+            RESERVED_FIELD_ID_POS,
+        };
 
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
-        // A file that physically carries the _last_updated_sequence_number column, as
-        // Iceberg Java writes when carrying rows forward across a rewrite.
-        let seq_field = Field::new("_last_updated_sequence_number", DataType::Int64, true)
-            .with_metadata(HashMap::from([(
-                PARQUET_FIELD_ID_META_KEY.to_string(),
-                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER.to_string(),
-            )]));
+        let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
+        let file_path = write_plain_parquet(
+            dir,
+            "with_seq_and_pos.parquet",
+            vec![physical_last_updated_seq_field()],
+            vec![seq_col],
+        );
+
+        // Co-project `_pos` (a virtual column appended to the Arrow output schema) with the
+        // physical coalesce column. This guards that the physical column's index is
+        // resolved in the Parquet schema, not the Arrow schema (whose indices shift once
+        // virtual columns are appended).
+        let schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let task = FileScanTask::builder()
+            .with_file_size_in_bytes(std::fs::metadata(&file_path).unwrap().len())
+            .with_start(0)
+            .with_length(0)
+            .with_data_file_path(file_path)
+            .with_data_file_format(DataFileFormat::Parquet)
+            .with_schema(schema)
+            .with_project_field_ids(vec![
+                1,
+                RESERVED_FIELD_ID_POS,
+                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+            ])
+            .with_first_row_id(Some(100))
+            .with_data_sequence_number(Some(9))
+            .with_case_sensitive(false)
+            .build();
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        // The seq column still coalesces correctly...
+        assert_last_updated_seq_column(&batches, &[Some(5), Some(9), Some(8)]);
+        // ...and `_pos` is the row position, unaffected by the physical-column union.
+        let pos_col = batches[0]
+            .column_by_name(RESERVED_COL_NAME_POS)
+            .expect("_pos column should be present")
+            .as_primitive::<arrow_array::types::Int64Type>();
+        assert_eq!(pos_col.values(), &[0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_physical_column_nulled_without_first_row_id() {
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
+        let file_path = write_plain_parquet(
+            dir,
+            "with_seq_no_first_row_id.parquet",
+            vec![physical_last_updated_seq_field()],
+            vec![seq_col],
+        );
+
+        // Null first_row_id: the whole column is null even though the file physically
+        // carries per-row values -- the gate wins, and the physical column is not read.
+        let task = last_updated_seq_task(file_path, None, Some(9));
+
+        let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
+        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let batches: Vec<RecordBatch> = reader
+            .read(tasks)
+            .unwrap()
+            .stream()
+            .try_collect()
+            .await
+            .unwrap();
+
+        assert_last_updated_seq_column(&batches, &[None, None, None]);
+    }
+
+    #[tokio::test]
+    async fn test_last_updated_sequence_number_present_by_name_without_id_unsupported() {
+        let tmp_dir = TempDir::new().unwrap();
+        let dir = tmp_dir.path().to_str().unwrap();
+        // Column present by name but WITHOUT the embedded field id (e.g. name mapping /
+        // positional fallback). The transformer keys the source column by field id, so
+        // this shape can't be threaded and is rejected loudly.
+        let seq_field = Field::new(
+            crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+            DataType::Int64,
+            true,
+        );
         let seq_col = Arc::new(Int64Array::from(vec![Some(5), None, Some(8)])) as ArrayRef;
         let file_path =
-            write_plain_parquet(dir, "with_seq.parquet", vec![seq_field], vec![seq_col]);
+            write_plain_parquet(dir, "with_seq_by_name.parquet", vec![seq_field], vec![
+                seq_col,
+            ]);
 
-        // first_row_id present so the gate would otherwise materialize the constant;
-        // the physically-present column must trigger the fail-loud guard first.
         let task = last_updated_seq_task(file_path, Some(100), Some(9));
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
@@ -1207,7 +1392,7 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.kind(), crate::ErrorKind::FeatureUnsupported);
         assert!(
-            format!("{err}").contains("physically-stored _last_updated_sequence_number"),
+            format!("{err}").contains("without an embedded field id"),
             "unexpected error: {err}"
         );
     }

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -2346,10 +2346,7 @@ mod test {
 
         // Every row's logical value is 7 (the data sequence number), regardless of
         // the physical (run-end) encoding.
-        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
-        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(seq_col.len(), 3);
-        assert!((0..3).all(|i| !seq_col.is_null(i) && seq_col.value(i) == 7));
+        assert_last_updated_seq_column(&result, &[Some(7), Some(7), Some(7)]);
     }
 
     #[test]
@@ -2391,10 +2388,7 @@ mod test {
         let result = transformer.process_record_batch(parquet_batch).unwrap();
 
         // Every row's logical value is null.
-        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
-        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(seq_col.len(), 3);
-        assert!((0..3).all(|i| seq_col.is_null(i)));
+        assert_last_updated_seq_column(&result, &[None, None, None]);
     }
 
     /// Builds a transformer + a file batch for the coalesce case: `id` plus a physical
@@ -2443,10 +2437,9 @@ mod test {
         (transformer, batch)
     }
 
-    /// Reads the coalesced `_last_updated_sequence_number` column by name (encoding-
-    /// agnostic: casts through the run-end-encoding to logical Int64) and asserts its
-    /// per-row values.
-    fn assert_coalesced_seq_column(result: &RecordBatch, expected: &[Option<i64>]) {
+    /// Reads the `_last_updated_sequence_number` column by name (encoding-agnostic: casts
+    /// through the run-end-encoding to logical Int64) and asserts its per-row values.
+    fn assert_last_updated_seq_column(result: &RecordBatch, expected: &[Option<i64>]) {
         use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
 
         let col = result
@@ -2467,7 +2460,7 @@ mod test {
         let result = transformer.process_record_batch(batch).unwrap();
 
         // Per-row value where non-null; the fallback (9) where null.
-        assert_coalesced_seq_column(&result, &[Some(5), Some(9), Some(8)]);
+        assert_last_updated_seq_column(&result, &[Some(5), Some(9), Some(8)]);
     }
 
     #[test]
@@ -2478,7 +2471,7 @@ mod test {
             coalesce_transformer_and_batch(vec![None, None, None], vec![10, 20, 30], 9);
         let result = transformer.process_record_batch(batch).unwrap();
 
-        assert_coalesced_seq_column(&result, &[Some(9), Some(9), Some(9)]);
+        assert_last_updated_seq_column(&result, &[Some(9), Some(9), Some(9)]);
     }
 
     #[test]
@@ -2489,7 +2482,7 @@ mod test {
             coalesce_transformer_and_batch(vec![Some(5), Some(6), Some(7)], vec![10, 20, 30], 9);
         let result = transformer.process_record_batch(batch).unwrap();
 
-        assert_coalesced_seq_column(&result, &[Some(5), Some(6), Some(7)]);
+        assert_last_updated_seq_column(&result, &[Some(5), Some(6), Some(7)]);
     }
 
     #[test]
@@ -2500,7 +2493,7 @@ mod test {
         let result = transformer.process_record_batch(batch).unwrap();
 
         assert_eq!(result.num_rows(), 0);
-        assert_coalesced_seq_column(&result, &[]);
+        assert_last_updated_seq_column(&result, &[]);
     }
 
     /// field 1 and RESERVED_FIELD_ID_POS are of identical type

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -176,7 +176,7 @@ pub(crate) enum ColumnSource {
     // Used for `_last_updated_sequence_number` when the file physically carries
     // the per-row column. The result is cast to `target_type` so it matches the
     // (run-end-encoded) type the constant and null paths produce for the column.
-    Coalesce {
+    CoalesceLastUpdatedSeq {
         source_index: usize,
         fallback: PrimitiveLiteral,
         target_type: DataType,
@@ -262,7 +262,7 @@ pub(crate) enum ColumnConstant {
     /// a per-file fallback: read the per-row value, substitute this Datum where the
     /// per-row value is null (e.g. `_last_updated_sequence_number` on a file that
     /// carries the column, falling back to the data sequence number).
-    Coalesce(Datum),
+    CoalesceLastUpdatedSeq(Datum),
 }
 
 /// Pre-computed data for a struct constant column.
@@ -322,12 +322,16 @@ impl RecordBatchTransformerBuilder {
         self
     }
 
-    /// Add a coalesced metadata column for a specific field ID: the file's per-row
-    /// value where non-null, falling back to `datum` where null. Used for
-    /// `_last_updated_sequence_number` when the file physically carries the column.
-    pub(crate) fn with_coalesced_metadata_column(mut self, field_id: i32, datum: Datum) -> Self {
+    /// Add a coalesced `_last_updated_sequence_number` column for a specific field ID:
+    /// the file's per-row value where non-null, falling back to `datum` where null.
+    /// Used when the file physically carries the column.
+    pub(crate) fn with_coalesced_last_updated_seq_column(
+        mut self,
+        field_id: i32,
+        datum: Datum,
+    ) -> Self {
         self.constant_fields
-            .insert(field_id, ColumnConstant::Coalesce(datum));
+            .insert(field_id, ColumnConstant::CoalesceLastUpdatedSeq(datum));
         self
     }
 
@@ -569,7 +573,7 @@ impl RecordBatchTransformer {
                         );
                         return Ok(Arc::new(arrow_field));
                     }
-                    Some(ColumnConstant::Coalesce(datum)) => {
+                    Some(ColumnConstant::CoalesceLastUpdatedSeq(datum)) => {
                         // Same run-end-encoded type as the constant/null paths, so the
                         // column has one Arrow type whether a file coalesces, uses the
                         // constant, or is nulled.
@@ -757,9 +761,10 @@ impl RecordBatchTransformer {
                             target_type: arrow_type.clone(),
                         });
                     }
-                    Some(ColumnConstant::Coalesce(datum)) => {
-                        // The physical column must be present in the file (the pipeline only
-                        // registers a coalesce when it detected the embedded field id).
+                    Some(ColumnConstant::CoalesceLastUpdatedSeq(datum)) => {
+                        // Registered only for `_last_updated_sequence_number`, and only after
+                        // the pipeline detects the embedded field id, so the source column is
+                        // always present in the file.
                         let (_, source_index) =
                             field_id_to_source_schema_map.get(field_id).ok_or_else(|| {
                                 Error::new(
@@ -770,7 +775,7 @@ impl RecordBatchTransformer {
                                     ),
                                 )
                             })?;
-                        return Ok(ColumnSource::Coalesce {
+                        return Ok(ColumnSource::CoalesceLastUpdatedSeq {
                             source_index: *source_index,
                             fallback: datum.literal().clone(),
                             target_type: datum_to_arrow_type_with_ree(datum),
@@ -931,7 +936,7 @@ impl RecordBatchTransformer {
                         child_values,
                     } => Self::create_struct_column(fields, child_values, num_rows)?,
 
-                    ColumnSource::Coalesce {
+                    ColumnSource::CoalesceLastUpdatedSeq {
                         source_index,
                         fallback,
                         target_type,
@@ -955,11 +960,8 @@ impl RecordBatchTransformer {
     ) -> Result<ArrayRef> {
         if source.data_type() != &DataType::Int64 {
             return Err(Error::new(
-                ErrorKind::Unexpected,
-                format!(
-                    "coalesce source must be Int64, got {:?}",
-                    source.data_type()
-                ),
+                ErrorKind::DataInvalid,
+                format!("coalesce source must be Int64, got {}", source.data_type()),
             ));
         }
         let PrimitiveLiteral::Long(seq) = fallback else {
@@ -2428,7 +2430,7 @@ mod test {
         ]));
         let projected_field_ids = [1, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER];
         let transformer = RecordBatchTransformerBuilder::new(snapshot_schema, &projected_field_ids)
-            .with_coalesced_metadata_column(
+            .with_coalesced_last_updated_seq_column(
                 RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
                 Datum::long(fallback),
             )
@@ -2441,6 +2443,23 @@ mod test {
         (transformer, batch)
     }
 
+    /// Reads the coalesced `_last_updated_sequence_number` column by name (encoding-
+    /// agnostic: casts through the run-end-encoding to logical Int64) and asserts its
+    /// per-row values.
+    fn assert_coalesced_seq_column(result: &RecordBatch, expected: &[Option<i64>]) {
+        use crate::metadata_columns::RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER;
+
+        let col = result
+            .column_by_name(RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER)
+            .expect("_last_updated_sequence_number column should be present");
+        let logical = cast(col, &DataType::Int64).unwrap();
+        let values = logical.as_any().downcast_ref::<Int64Array>().unwrap();
+        let actual: Vec<Option<i64>> = (0..values.len())
+            .map(|i| (!values.is_null(i)).then(|| values.value(i)))
+            .collect();
+        assert_eq!(&actual, expected);
+    }
+
     #[test]
     fn last_updated_sequence_number_coalesce_column() {
         let (mut transformer, batch) =
@@ -2448,12 +2467,29 @@ mod test {
         let result = transformer.process_record_batch(batch).unwrap();
 
         // Per-row value where non-null; the fallback (9) where null.
-        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
-        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(seq_col.len(), 3);
-        assert_eq!(seq_col.value(0), 5);
-        assert_eq!(seq_col.value(1), 9);
-        assert_eq!(seq_col.value(2), 8);
+        assert_coalesced_seq_column(&result, &[Some(5), Some(9), Some(8)]);
+    }
+
+    #[test]
+    fn last_updated_sequence_number_coalesce_all_null() {
+        // Every row falls back. This is the only input that distinguishes the `is_not_null`
+        // mask from `is_null` -- a mixed input passes under either polarity.
+        let (mut transformer, batch) =
+            coalesce_transformer_and_batch(vec![None, None, None], vec![10, 20, 30], 9);
+        let result = transformer.process_record_batch(batch).unwrap();
+
+        assert_coalesced_seq_column(&result, &[Some(9), Some(9), Some(9)]);
+    }
+
+    #[test]
+    fn last_updated_sequence_number_coalesce_all_non_null() {
+        // Nothing falls back: every per-row value passes through, and the run-end-encoding
+        // cast still yields a valid array.
+        let (mut transformer, batch) =
+            coalesce_transformer_and_batch(vec![Some(5), Some(6), Some(7)], vec![10, 20, 30], 9);
+        let result = transformer.process_record_batch(batch).unwrap();
+
+        assert_coalesced_seq_column(&result, &[Some(5), Some(6), Some(7)]);
     }
 
     #[test]
@@ -2464,9 +2500,7 @@ mod test {
         let result = transformer.process_record_batch(batch).unwrap();
 
         assert_eq!(result.num_rows(), 0);
-        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
-        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(seq_col.len(), 0);
+        assert_coalesced_seq_column(&result, &[]);
     }
 
     /// field 1 and RESERVED_FIELD_ID_POS are of identical type

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -18,15 +18,17 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use arrow_arith::boolean::is_not_null;
 use arrow_array::{
-    Array as ArrowArray, ArrayRef, Int32Array, RecordBatch, RecordBatchOptions, RunArray,
-    StructArray,
+    Array as ArrowArray, ArrayRef, Int32Array, Int64Array, RecordBatch, RecordBatchOptions,
+    RunArray, StructArray,
 };
 use arrow_cast::cast;
 use arrow_schema::{
     DataType, Field, FieldRef, Fields, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
     SchemaRef,
 };
+use arrow_select::zip::zip;
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 
 use crate::arrow::value::{create_primitive_array_repeated, create_primitive_array_single_element};
@@ -168,6 +170,17 @@ pub(crate) enum ColumnSource {
         fields: Fields,
         child_values: Vec<Option<PrimitiveLiteral>>,
     },
+
+    // A metadata column read from the file and coalesced with a per-file
+    // fallback: the source column's value where non-null, else `fallback`.
+    // Used for `_last_updated_sequence_number` when the file physically carries
+    // the per-row column. The result is cast to `target_type` so it matches the
+    // (run-end-encoded) type the constant and null paths produce for the column.
+    Coalesce {
+        source_index: usize,
+        fallback: PrimitiveLiteral,
+        target_type: DataType,
+    },
     // The iceberg spec refers to other permissible schema evolution actions
     // (see https://iceberg.apache.org/spec/#schema-evolution):
     // renaming fields, deleting fields and reordering fields.
@@ -226,10 +239,11 @@ pub(crate) struct RecordBatchTransformerBuilder {
     virtual_fields: HashSet<i32>,
 }
 
-/// A per-file constant value for a column.
+/// How a metadata (or identity-partition) column's values are supplied.
 ///
-/// Covers both scalar constants (metadata columns like `_file` and `_spec_id`,
-/// as well as identity partition source fields) and the struct `_partition` column.
+/// Covers scalar constants (metadata columns like `_file` and `_spec_id`, and
+/// identity partition source fields), the struct `_partition` column, an all-null
+/// column, and a per-row column coalesced with a per-file fallback.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ColumnConstant {
     /// A scalar constant (e.g., `_file` path, `_spec_id`, identity partition values).
@@ -244,6 +258,11 @@ pub(crate) enum ColumnConstant {
     /// null value) because `Datum` always represents a non-null value; the type is
     /// computed once so the schema and column-source paths cannot derive it apart.
     Null(DataType),
+    /// A metadata column physically present in the file that must be coalesced with
+    /// a per-file fallback: read the per-row value, substitute this Datum where the
+    /// per-row value is null (e.g. `_last_updated_sequence_number` on a file that
+    /// carries the column, falling back to the data sequence number).
+    Coalesce(Datum),
 }
 
 /// Pre-computed data for a struct constant column.
@@ -300,6 +319,15 @@ impl RecordBatchTransformerBuilder {
     pub(crate) fn with_constant(mut self, field_id: i32, datum: Datum) -> Self {
         self.constant_fields
             .insert(field_id, ColumnConstant::Scalar(datum));
+        self
+    }
+
+    /// Add a coalesced metadata column for a specific field ID: the file's per-row
+    /// value where non-null, falling back to `datum` where null. Used for
+    /// `_last_updated_sequence_number` when the file physically carries the column.
+    pub(crate) fn with_coalesced_metadata_column(mut self, field_id: i32, datum: Datum) -> Self {
+        self.constant_fields
+            .insert(field_id, ColumnConstant::Coalesce(datum));
         self
     }
 
@@ -541,6 +569,19 @@ impl RecordBatchTransformer {
                         );
                         return Ok(Arc::new(arrow_field));
                     }
+                    Some(ColumnConstant::Coalesce(datum)) => {
+                        // Same run-end-encoded type as the constant/null paths, so the
+                        // column has one Arrow type whether a file coalesces, uses the
+                        // constant, or is nulled.
+                        let iceberg_field = get_metadata_field(*field_id)?;
+                        let arrow_field = field_with_id(
+                            &iceberg_field.name,
+                            datum_to_arrow_type_with_ree(datum),
+                            true,
+                            iceberg_field.id,
+                        );
+                        return Ok(Arc::new(arrow_field));
+                    }
                     None => {}
                 }
 
@@ -716,6 +757,25 @@ impl RecordBatchTransformer {
                             target_type: arrow_type.clone(),
                         });
                     }
+                    Some(ColumnConstant::Coalesce(datum)) => {
+                        // The physical column must be present in the file (the pipeline only
+                        // registers a coalesce when it detected the embedded field id).
+                        let (_, source_index) =
+                            field_id_to_source_schema_map.get(field_id).ok_or_else(|| {
+                                Error::new(
+                                    ErrorKind::Unexpected,
+                                    format!(
+                                        "coalesce registered for field id {field_id} but the \
+                                         column is absent from the file batch"
+                                    ),
+                                )
+                            })?;
+                        return Ok(ColumnSource::Coalesce {
+                            source_index: *source_index,
+                            fallback: datum.literal().clone(),
+                            target_type: datum_to_arrow_type_with_ree(datum),
+                        });
+                    }
                     None => {}
                 }
 
@@ -870,9 +930,51 @@ impl RecordBatchTransformer {
                         fields,
                         child_values,
                     } => Self::create_struct_column(fields, child_values, num_rows)?,
+
+                    ColumnSource::Coalesce {
+                        source_index,
+                        fallback,
+                        target_type,
+                    } => Self::create_coalesce_column(
+                        &columns[*source_index],
+                        fallback,
+                        target_type,
+                    )?,
                 })
             })
             .collect()
+    }
+
+    /// Builds a coalesced column: the source column's per-row value where non-null,
+    /// else the scalar `fallback`, cast to `target_type` (the run-end-encoded type
+    /// the column's other paths produce).
+    fn create_coalesce_column(
+        source: &ArrayRef,
+        fallback: &PrimitiveLiteral,
+        target_type: &DataType,
+    ) -> Result<ArrayRef> {
+        if source.data_type() != &DataType::Int64 {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "coalesce source must be Int64, got {:?}",
+                    source.data_type()
+                ),
+            ));
+        }
+        let PrimitiveLiteral::Long(seq) = fallback else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!("coalesce fallback must be a long, got {fallback:?}"),
+            ));
+        };
+        let scalar = Int64Array::new_scalar(*seq);
+        let mask = is_not_null(source)?;
+        let coalesced = zip(&mask, source, &scalar)?;
+        // Cast to the run-end-encoded target type for column-type uniformity across the
+        // constant/null/coalesce paths (not for compression -- a per-row-varying column
+        // gains nothing from REE).
+        Ok(cast(&coalesced, target_type)?)
     }
 
     fn create_column(
@@ -2291,6 +2393,80 @@ mod test {
         let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
         assert_eq!(seq_col.len(), 3);
         assert!((0..3).all(|i| seq_col.is_null(i)));
+    }
+
+    /// Builds a transformer + a file batch for the coalesce case: `id` plus a physical
+    /// `_last_updated_sequence_number` column carrying `seq_values`.
+    fn coalesce_transformer_and_batch(
+        seq_values: Vec<Option<i64>>,
+        id_values: Vec<i32>,
+        fallback: i64,
+    ) -> (RecordBatchTransformer, RecordBatch) {
+        use crate::metadata_columns::{
+            RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+        };
+        use crate::spec::Datum;
+
+        let snapshot_schema = Arc::new(
+            Schema::builder()
+                .with_schema_id(0)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        let parquet_schema = Arc::new(ArrowSchema::new(vec![
+            field_with_id("id", DataType::Int32, false, 1),
+            field_with_id(
+                RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+                DataType::Int64,
+                true,
+                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+            ),
+        ]));
+        let projected_field_ids = [1, RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER];
+        let transformer = RecordBatchTransformerBuilder::new(snapshot_schema, &projected_field_ids)
+            .with_coalesced_metadata_column(
+                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                Datum::long(fallback),
+            )
+            .build();
+        let batch = RecordBatch::try_new(parquet_schema, vec![
+            Arc::new(Int32Array::from(id_values)),
+            Arc::new(Int64Array::from(seq_values)),
+        ])
+        .unwrap();
+        (transformer, batch)
+    }
+
+    #[test]
+    fn last_updated_sequence_number_coalesce_column() {
+        let (mut transformer, batch) =
+            coalesce_transformer_and_batch(vec![Some(5), None, Some(8)], vec![10, 20, 30], 9);
+        let result = transformer.process_record_batch(batch).unwrap();
+
+        // Per-row value where non-null; the fallback (9) where null.
+        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
+        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(seq_col.len(), 3);
+        assert_eq!(seq_col.value(0), 5);
+        assert_eq!(seq_col.value(1), 9);
+        assert_eq!(seq_col.value(2), 8);
+    }
+
+    #[test]
+    fn last_updated_sequence_number_coalesce_empty_batch() {
+        // A 0-row batch (reachable when a predicate or positional deletes clear a row
+        // group) must still produce a well-formed, empty column of the shared type.
+        let (mut transformer, batch) = coalesce_transformer_and_batch(vec![], vec![], 9);
+        let result = transformer.process_record_batch(batch).unwrap();
+
+        assert_eq!(result.num_rows(), 0);
+        let seq_col = cast(result.column(1), &DataType::Int64).unwrap();
+        let seq_col = seq_col.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(seq_col.len(), 0);
     }
 
     /// field 1 and RESERVED_FIELD_ID_POS are of identical type


### PR DESCRIPTION
## Which issue does this PR close?

Refs https://github.com/apache/iceberg-rust/issues/2879

## What changes are included in this PR?

The prior change rejected files that physically carry a per-row _last_updated_sequence_number column.

Read such columns instead and coalesce per the spec. i.e. use the per-row value where non-null, fall back to the file's data sequence number only where null.

`_row_id` is a later PR.

## Are these changes tested?

Added tests. 