### PR TITLE
fix: Address property macro review follow-ups

### DIFF
--- a/crates/iceberg/src/lib.rs
+++ b/crates/iceberg/src/lib.rs
@@ -65,6 +65,7 @@
 #[macro_use]
 extern crate derive_builder;
 extern crate core;
+// Required so `#[derive(Properties)]` output can name `::iceberg::Error`.
 extern crate self as iceberg;
 
 mod error;

--- a/crates/property-macro/README.md
+++ b/crates/property-macro/README.md
@@ -145,16 +145,13 @@ struct TableLikeProperties {
     #[property(prefix = COLUMN_FPP_PREFIX, getter)]
     column_fpp: HashMap<String, f64>,
 
-    /// A single-key parser can validate and normalize a property value.
+    /// A single-key parser can validate and normalize an explicitly configured path.
     #[property(
         key = LOCATION,
-        // Iceberg computes the real absent case as `<table-location>/data`.
-        // This literal is only an illustrative default for the macro example.
-        default = "<table-location>/data",
-        parse_with = parse_location,
-        getter
+        default = None,
+        parse_with = parse_location
     )]
-    location: String,
+    location: Option<String>,
 
     /// A full-map parser can model one field with multiple property keys.
     #[property(
@@ -165,6 +162,14 @@ struct TableLikeProperties {
         getter
     )]
     dimensions: (u64, u64, u64),
+}
+
+impl TableLikeProperties {
+    fn location(&self) -> &str {
+        self.location
+            .as_deref()
+            .unwrap_or("<table-location>/data")
+    }
 }
 
 fn main() -> iceberg::Result<()> {

--- a/crates/property-macro/README.md
+++ b/crates/property-macro/README.md
@@ -145,11 +145,14 @@ struct TableLikeProperties {
     #[property(prefix = COLUMN_FPP_PREFIX, getter)]
     column_fpp: HashMap<String, f64>,
 
-    /// A single-key parser can validate and normalize an explicitly configured path.
+    /// An explicitly configured data path override.
+    /// `None` means callers should use `<table-location>/data`.
+    /// A single-key parser validates and normalizes configured values.
     #[property(
         key = LOCATION,
         default = None,
-        parse_with = parse_location
+        parse_with = parse_location,
+        getter
     )]
     location: Option<String>,
 
@@ -164,21 +167,13 @@ struct TableLikeProperties {
     dimensions: (u64, u64, u64),
 }
 
-impl TableLikeProperties {
-    fn location(&self) -> &str {
-        self.location
-            .as_deref()
-            .unwrap_or("<table-location>/data")
-    }
-}
-
 fn main() -> iceberg::Result<()> {
     let defaults = TableLikeProperties::from_properties(&HashMap::new())?;
     assert_eq!(defaults.commit().retries(), 4);
     assert_eq!(defaults.owner(), &None);
     assert!(defaults.fanout_enabled());
     assert!(defaults.column_fpp().is_empty());
-    assert_eq!(defaults.location(), "<table-location>/data");
+    assert_eq!(defaults.location(), &None);
     assert_eq!(defaults.dimensions(), (640, 480, 320));
 
     let raw = HashMap::from([
@@ -198,7 +193,10 @@ fn main() -> iceberg::Result<()> {
     assert_eq!(properties.owner().as_deref(), Some("iceberg"));
     assert!(!properties.fanout_enabled());
     assert_eq!(properties.column_fpp()["id"], 0.01);
-    assert_eq!(properties.location(), "s3://bucket/table");
+    assert_eq!(
+        properties.location().as_deref(),
+        Some("s3://bucket/table")
+    );
     assert_eq!(properties.dimensions(), (1920, 1080, 720));
 
     let error = TableLikeProperties::from_properties(&HashMap::from([(

--- a/crates/property-macro/README.md
+++ b/crates/property-macro/README.md
@@ -50,6 +50,10 @@ Documentation attributes on the field are copied to the generated getter. The
 macro generates no setters, backing fields, or conversion back to a property
 map.
 
+`Option<T>` key fields and `HashMap<String, T>` prefix fields must use the
+corresponding types from `std`. The macro recognizes those field shapes
+syntactically and generates code using the standard-library variants.
+
 ## Complete example
 
 This example covers exact keys and defaults, optional values, case-insensitive
@@ -144,7 +148,9 @@ struct TableLikeProperties {
     /// A single-key parser can validate and normalize a property value.
     #[property(
         key = LOCATION,
-        default = "warehouse",
+        // Iceberg computes the real absent case as `<table-location>/data`.
+        // This literal is only an illustrative default for the macro example.
+        default = "<table-location>/data",
         parse_with = parse_location,
         getter
     )]
@@ -167,7 +173,7 @@ fn main() -> iceberg::Result<()> {
     assert_eq!(defaults.owner(), &None);
     assert!(defaults.fanout_enabled());
     assert!(defaults.column_fpp().is_empty());
-    assert_eq!(defaults.location(), "warehouse");
+    assert_eq!(defaults.location(), "<table-location>/data");
     assert_eq!(defaults.dimensions(), (640, 480, 320));
 
     let raw = HashMap::from([

--- a/crates/property-macro/tests/properties.rs
+++ b/crates/property-macro/tests/properties.rs
@@ -249,6 +249,15 @@ fn custom_single_value_parser_wraps_present_optional_values() {
     )]))
     .unwrap();
     assert_eq!(parsed.location().as_deref(), Some("path"));
+
+    let error = OptionalValidatedProperties::from_properties(&HashMap::from([(
+        "optional-location".to_string(),
+        "  ".to_string(),
+    )]))
+    .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::DataInvalid);
+    assert_eq!(error.message(), "value must not be empty");
+    assert!(format!("{error}").contains("property: optional-location"));
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Which issue does this PR close?

- Follow-up to #2970 and part of #2877.

## What changes are included in this PR?

- Address the final four inline review comments from @laskoviymishka on #2970.
- Document why the `extern crate self as iceberg` alias is required by generated code.
- Clarify the macro's `std::Option` / `std::collections::HashMap` requirement.
- Replace the misleading `write.data.path = "warehouse"` example default.
- Exercise the error path for `Option<T>` with `parse_with`.

This is the bottom PR in stack #2990; #2988 follows it.

## Are these changes tested?

- `cargo test -p iceberg-property-macro`
- `cargo fmt --all -- --check`

## AI Disclosure

This change was implemented and validated with OpenAI Codex assistance.
