### PR TITLE
feat(transaction): add Transaction::stage to get the TableCommit without a Catalog

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3235,6 +3235,7 @@ pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::tr
 pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
+pub async fn iceberg::transaction::Transaction::stage(&self) -> iceberg::Result<iceberg::TableCommit>
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
 pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -164,6 +164,7 @@ mod tests {
     use crate::encryption::kms::MemoryKeyManagementClient;
     use crate::encryption::{SensitiveBytes, StandardKeyMetadata};
     use crate::io::FileIO;
+    use crate::memory::tests::new_memory_catalog;
     use crate::spec::{
         DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
         ManifestEntry, ManifestListWriter, ManifestStatus, ManifestWriterBuilder, SnapshotRef,
@@ -171,9 +172,9 @@ mod tests {
     };
     use crate::table::Table;
     use crate::test_utils::{make_encrypted_table, test_runtime};
-    use crate::transaction::tests::make_v2_minimal_table;
-    use crate::transaction::{Transaction, TransactionAction};
-    use crate::{TableIdent, TableRequirement, TableUpdate};
+    use crate::transaction::tests::{make_v2_minimal_table, make_v3_minimal_table_in_catalog};
+    use crate::transaction::{ApplyTransactionAction, Transaction, TransactionAction};
+    use crate::{Catalog, TableIdent, TableRequirement, TableUpdate};
 
     fn render_template(template: &str, ctx: Value) -> String {
         let mut env = Environment::new();
@@ -921,5 +922,154 @@ mod tests {
             manifest.entries()[0].snapshot_id().unwrap()
         );
         assert_eq!(data_file, *manifest.entries()[0].data_file());
+    }
+
+    /// `Transaction::stage` on a fast-append must produce exactly what a committed
+    /// fast-append produces: the same update/requirement shape, and a real
+    /// manifest on storage carrying the staged file.
+    #[tokio::test]
+    async fn test_stage_fast_append_matches_committed_fast_append() {
+        let table = make_v2_minimal_table();
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/3.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(300))]))
+            .build()
+            .unwrap();
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .fast_append()
+            .add_data_files(vec![data_file.clone()])
+            .apply(tx)
+            .unwrap();
+        let mut commit = tx.stage().await.unwrap();
+        assert_eq!(table.identifier(), commit.identifier());
+        let updates = commit.take_updates();
+        let requirements = commit.take_requirements();
+
+        assert!(
+            matches!((&updates[0],&updates[1]), (TableUpdate::AddSnapshot { snapshot },TableUpdate::SetSnapshotRef { reference,ref_name }) if snapshot.snapshot_id() == reference.snapshot_id && ref_name == MAIN_BRANCH)
+        );
+        assert_eq!(
+            vec![
+                TableRequirement::UuidMatch {
+                    uuid: table.metadata().uuid()
+                },
+                TableRequirement::RefSnapshotIdMatch {
+                    r#ref: MAIN_BRANCH.to_string(),
+                    snapshot_id: table.metadata().current_snapshot_id
+                }
+            ],
+            requirements
+        );
+
+        assert_eq!(
+            vec![data_file],
+            committed_data_files(&table, &updates).await
+        );
+    }
+
+    /// Staging must not advance any catalog pointer; the staged commit must then
+    /// be committable through the caller's own catalog round-trip.
+    #[tokio::test]
+    async fn test_stage_fast_append_leaves_commit_to_the_caller() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("test/1.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(10)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::from_iter([Some(Literal::long(0))]))
+            .build()
+            .unwrap();
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .fast_append()
+            .add_data_files(vec![data_file.clone()])
+            .apply(tx)
+            .unwrap();
+        let commit = tx.stage().await.unwrap();
+
+        // Nothing committed yet: the catalog still serves the pre-stage metadata.
+        let reloaded = catalog.load_table(table.identifier()).await.unwrap();
+        assert_eq!(table.metadata(), reloaded.metadata());
+        assert!(reloaded.metadata().current_snapshot().is_none());
+
+        // The caller's own commit path: the staged TableCommit goes to the catalog as-is.
+        let committed = catalog.update_table(commit).await.unwrap();
+
+        let snapshot = committed.metadata().current_snapshot().unwrap();
+        let manifest_list = committed
+            .manifest_list_reader(snapshot)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(1, manifest_list.entries().len());
+        let manifest = committed
+            .manifest_reader()
+            .read(&manifest_list.entries()[0])
+            .await
+            .unwrap();
+        assert_eq!(1, manifest.entries().len());
+        assert_eq!(
+            data_file.file_path(),
+            manifest.entries()[0].data_file().file_path()
+        );
+    }
+
+    /// `with_check_duplicate` is a read-only precondition: the staged manifest
+    /// content and requirements are identical whether it runs or not.
+    #[tokio::test]
+    async fn test_stage_fast_append_check_duplicate_stages_identical_content() {
+        let table = make_v2_minimal_table();
+
+        let make_file = || {
+            DataFileBuilder::default()
+                .content(DataContentType::Data)
+                .file_path("test/3.parquet".to_string())
+                .file_format(DataFileFormat::Parquet)
+                .file_size_in_bytes(100)
+                .record_count(1)
+                .partition_spec_id(table.metadata().default_partition_spec_id())
+                .partition(Struct::from_iter([Some(Literal::long(300))]))
+                .build()
+                .unwrap()
+        };
+
+        async fn stage(
+            table: &Table,
+            data_file: DataFile,
+            check_duplicate: bool,
+        ) -> (Vec<TableUpdate>, Vec<TableRequirement>) {
+            let tx = Transaction::new(table);
+            let tx = tx
+                .fast_append()
+                .with_check_duplicate(check_duplicate)
+                .add_data_files(vec![data_file])
+                .apply(tx)
+                .unwrap();
+            let mut commit = tx.stage().await.unwrap();
+            (commit.take_updates(), commit.take_requirements())
+        }
+
+        let (updates_on, reqs_on) = stage(&table, make_file(), true).await;
+        let (updates_off, reqs_off) = stage(&table, make_file(), false).await;
+
+        assert_eq!(reqs_on, reqs_off);
+        let files_on = committed_data_files(&table, &updates_on).await;
+        let files_off = committed_data_files(&table, &updates_off).await;
+        assert_eq!(files_on, files_off);
+        assert_eq!(vec![make_file()], files_off);
     }
 }

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -171,6 +171,37 @@ impl Transaction {
         ExpireSnapshotsAction::new()
     }
 
+    /// Stage this transaction: run every action against the transaction's
+    /// base table and return the resulting [`TableCommit`] **without** sending
+    /// it to a catalog.
+    ///
+    /// This is the first half of [`commit`](Self::commit). It produces the
+    /// exact same updates and requirements that `commit` would pass to
+    /// [`Catalog::update_table`] on its first attempt — including any files an
+    /// action writes to the table's storage, such as a fast-append's manifest
+    /// and manifest list. The second half (refresh-and-retry against the
+    /// catalog) is left to the caller.
+    ///
+    /// Use this when you own the commit path: an embedded writer that swaps
+    /// the metadata pointer itself, or a caller that folds several tables'
+    /// staged commits into one atomic multi-table commit. The staged
+    /// [`TableCommit`] can be applied locally with [`TableCommit::apply`],
+    /// taken apart with [`TableCommit::take_updates`] /
+    /// [`TableCommit::take_requirements`], or handed to
+    /// [`Catalog::update_table`] as-is.
+    ///
+    /// Staging is against the transaction's base table snapshot as it was when
+    /// the transaction was created; it does not refresh from a catalog.
+    pub async fn stage(&self) -> Result<TableCommit> {
+        let (_, updates, requirements) = self.apply_actions(self.table.clone()).await?;
+
+        Ok(TableCommit::builder()
+            .ident(self.table.identifier().to_owned())
+            .updates(updates)
+            .requirements(requirements)
+            .build())
+    }
+
     /// Commit transaction.
     pub async fn commit(self, catalog: &dyn Catalog) -> Result<Table> {
         if self.actions.is_empty() {
@@ -195,6 +226,31 @@ impl Transaction {
         .1
     }
 
+    /// Run every action in order against `base`, threading each action's
+    /// result into the next. Returns the final table plus the accumulated
+    /// updates and requirements.
+    async fn apply_actions(
+        &self,
+        base: Table,
+    ) -> Result<(Table, Vec<TableUpdate>, Vec<TableRequirement>)> {
+        let mut current_table = base;
+        let mut existing_updates: Vec<TableUpdate> = vec![];
+        let mut existing_requirements: Vec<TableRequirement> = vec![];
+
+        for action in &self.actions {
+            let action_commit = Arc::clone(action).commit(&current_table).await?;
+            // apply action commit to current_table
+            current_table = Self::apply(
+                current_table,
+                action_commit,
+                &mut existing_updates,
+                &mut existing_requirements,
+            )?;
+        }
+
+        Ok((current_table, existing_updates, existing_requirements))
+    }
+
     fn build_backoff(props: TableProperties) -> Result<ExponentialBackoff> {
         Ok(ExponentialBuilder::new()
             .with_min_delay(Duration::from_millis(props.commit_min_retry_wait_ms()))
@@ -217,20 +273,8 @@ impl Transaction {
             self.table = refreshed.clone();
         }
 
-        let mut current_table = self.table.clone();
-        let mut existing_updates: Vec<TableUpdate> = vec![];
-        let mut existing_requirements: Vec<TableRequirement> = vec![];
-
-        for action in &self.actions {
-            let action_commit = Arc::clone(action).commit(&current_table).await?;
-            // apply action commit to current_table
-            current_table = Self::apply(
-                current_table,
-                action_commit,
-                &mut existing_updates,
-                &mut existing_requirements,
-            )?;
-        }
+        let (_, existing_updates, existing_requirements) =
+            self.apply_actions(self.table.clone()).await?;
 
         let table_commit = TableCommit::builder()
             .ident(self.table.identifier().to_owned())
@@ -260,7 +304,7 @@ mod tests {
     use crate::table::Table;
     use crate::test_utils::{make_encrypted_table, test_runtime};
     use crate::transaction::{ApplyTransactionAction, Transaction};
-    use crate::{Catalog, Error, ErrorKind, TableCreation, TableIdent};
+    use crate::{Catalog, Error, ErrorKind, TableCreation, TableIdent, TableUpdate};
 
     pub fn make_v1_table() -> Table {
         let file = File::open(format!(
@@ -384,6 +428,67 @@ mod tests {
             .metadata;
 
         table.with_metadata(Arc::new(metadata))
+    }
+
+    /// `stage` runs every action in order and returns the combined TableCommit
+    /// without touching the catalog; the staged commit then round-trips through
+    /// `Catalog::update_table` as-is.
+    #[tokio::test]
+    async fn test_stage_returns_commit_without_touching_catalog() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("a".to_string(), "1".to_string())
+            .apply(tx)
+            .unwrap();
+        let tx = tx
+            .update_location()
+            .set_location(format!("{}/moved", table.metadata().location()))
+            .apply(tx)
+            .unwrap();
+
+        let mut commit = tx.stage().await.unwrap();
+        assert_eq!(table.identifier(), commit.identifier());
+        let updates = commit.take_updates();
+        let requirements = commit.take_requirements();
+        // UpdatePropertiesAction emits SetProperties + RemoveProperties, UpdateLocationAction
+        // emits SetLocation; neither carries a requirement.
+        assert_eq!(3, updates.len());
+        assert!(matches!(updates[0], TableUpdate::SetProperties { .. }));
+        assert!(matches!(updates[1], TableUpdate::RemoveProperties { .. }));
+        assert!(matches!(updates[2], TableUpdate::SetLocation { .. }));
+        assert!(requirements.is_empty());
+
+        // The catalog has not seen anything.
+        let reloaded = catalog.load_table(table.identifier()).await.unwrap();
+        assert_eq!(table.metadata(), reloaded.metadata());
+
+        // Re-stage and hand the untouched TableCommit to the catalog ourselves.
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("a".to_string(), "1".to_string())
+            .apply(tx)
+            .unwrap();
+        let committed = catalog
+            .update_table(tx.stage().await.unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            Some(&"1".to_string()),
+            committed.metadata().properties().get("a")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stage_empty_transaction_is_empty_commit() {
+        let table = make_v2_table();
+        let mut commit = Transaction::new(&table).stage().await.unwrap();
+        assert!(commit.take_updates().is_empty());
+        assert!(commit.take_requirements().is_empty());
     }
 
     /// Helper function to create a transaction with a simple update action


### PR DESCRIPTION
## What

`Transaction::stage(&self) -> Result<TableCommit>`: run the transaction's actions and return the resulting `TableCommit` instead of sending it to a `Catalog`.

It is the first half of `Transaction::commit`. Same action loop, same updates and requirements `commit` would pass to `Catalog::update_table` on its first attempt, same files written to storage (a fast-append's manifest and manifest list). The refresh-and-retry half against the catalog is left to the caller. `do_commit` now shares the loop (`apply_actions`), so there is one code path.

`Catalog::update_table` already consumes a `TableCommit`, so the staged commit can be applied locally (`TableCommit::apply`), taken apart (`take_updates` / `take_requirements`), or handed to any catalog as-is.

## Why

A caller that owns its commit path cannot get a `TableCommit` out of a `Transaction` today: `commit` is the only exit, and it requires a `&dyn Catalog`. That is the case for an embedded writer that swaps the metadata pointer itself, and for a writer that folds several tables' appends into one atomic multi-table commit.

Found building skade, an embedded Iceberg engine that commits from inside the writing process: https://codeberg.org/nordisk/skade

The workaround on `main` is a fake `Catalog`: 15 trait methods, 13 of them `unimplemented!()`, `load_table` returning the table and `update_table` capturing the commit, plus rebuilding a `Table` via `Table::builder().runtime(Runtime::current())` because `Table::with_metadata` is `pub(crate)`. It works; it is not an API.

This supersedes the first version of this PR (`stage_fast_append`), which was fast-append-specific and sold the speedup of `FastAppendAction::with_check_duplicate(false)` as its own. @blackmwk was right that the flag already exists; what was missing is reaching the staged commit without a catalog. `stage` is action-agnostic.

## Tests

- staged fast-append has the same update/requirement shape as a committed one, and the staged manifest carries exactly the staged file
- staging leaves a memory catalog untouched; the staged `TableCommit` then commits through `Catalog::update_table` unchanged
- a multi-action transaction (properties + location) stages every update in order
- `with_check_duplicate` on/off stages identical requirements and manifest content
- empty transaction stages an empty commit
- `public-api.txt` regenerated (one added line)
