### PR TITLE
feat: expose TableCommit::from_parts

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3761,6 +3761,7 @@ pub fn iceberg::SessionContext::builder() -> SessionContextBuilder<((), (), (), 
 pub struct iceberg::TableCommit
 impl iceberg::TableCommit
 pub fn iceberg::TableCommit::apply(self, table: iceberg::table::Table) -> iceberg::Result<iceberg::table::Table>
+pub fn iceberg::TableCommit::from_parts(ident: iceberg::TableIdent, requirements: alloc::vec::Vec<iceberg::TableRequirement>, updates: alloc::vec::Vec<iceberg::TableUpdate>) -> Self
 pub fn iceberg::TableCommit::identifier(&self) -> &iceberg::TableIdent
 pub fn iceberg::TableCommit::take_requirements(&mut self) -> alloc::vec::Vec<iceberg::TableRequirement>
 pub fn iceberg::TableCommit::take_updates(&mut self) -> alloc::vec::Vec<iceberg::TableUpdate>

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -385,6 +385,27 @@ pub struct TableCommit {
 }
 
 impl TableCommit {
+    /// Builds a [`TableCommit`] from a table identifier, requirements, and
+    /// updates.
+    ///
+    /// The transaction API covers the common commit shapes, but engines that
+    /// build snapshots at the manifest/metadata layer (for example a REPLACE
+    /// commit produced by external compaction) need to hand a commit directly
+    /// to [`Catalog::update_table`]. The caller is responsible for supplying
+    /// requirements that make the commit safe to retry (compare-and-swap on
+    /// the branch head) and updates that keep the table metadata consistent.
+    pub fn from_parts(
+        ident: TableIdent,
+        requirements: Vec<TableRequirement>,
+        updates: Vec<TableUpdate>,
+    ) -> Self {
+        Self {
+            ident,
+            requirements,
+            updates,
+        }
+    }
+
     /// Return the table identifier.
     pub fn identifier(&self) -> &TableIdent {
         &self.ident


### PR DESCRIPTION
## Which issue does this PR close?

None filed — happy to open one if preferred.

## What changes are included in this PR?

Adds a public constructor `TableCommit::from_parts(ident, requirements, updates)`.

Today `TableCommit` can only be produced by the transaction action set, which covers the common commit shapes (fast-append, schema/property updates, and since 0.10 snapshot expiry) but not commits built at the manifest/metadata layer. The concrete case: an engine running external compaction writes rewritten data files and new manifests itself, and needs to submit a REPLACE snapshot through `Catalog::update_table` with compare-and-swap requirements on the branch head. There is currently no public way to construct that `TableCommit`, so engines that need it end up forking the crate.

This exposes the same construction the transaction layer uses internally. The doc comment states the caller's obligations: requirements that make the commit safe to retry, and updates that keep the metadata consistent. No behavior change for existing APIs; `public-api.txt` updated.

## Are these changes tested?

Covered by existing construction/`apply` tests via the transaction path; the constructor itself is a plain field assembly. We carry this exact patch in a fork (against 0.9.1 and now 0.10.1) for external compaction commits, and exercise it through our compaction integration tests.
