### PR TITLE
feat(datafusion): carry catalog identity on StaticTableProvider

### DIFF
--- a/crates/integrations/datafusion/public-api.txt
+++ b/crates/integrations/datafusion/public-api.txt
@@ -14,6 +14,7 @@ pub fn iceberg_datafusion::metadata_table::IcebergMetadataTableProvider::table_t
 pub mod iceberg_datafusion::physical_plan
 pub struct iceberg_datafusion::physical_plan::IcebergTableScan
 impl iceberg_datafusion::physical_plan::IcebergTableScan
+pub fn iceberg_datafusion::physical_plan::IcebergTableScan::catalog_config(&self) -> core::option::Option<&iceberg_datafusion::IcebergCatalogConfig>
 pub fn iceberg_datafusion::physical_plan::IcebergTableScan::limit(&self) -> core::option::Option<usize>
 pub fn iceberg_datafusion::physical_plan::IcebergTableScan::predicates(&self) -> core::option::Option<&iceberg::expr::predicate::Predicate>
 pub fn iceberg_datafusion::physical_plan::IcebergTableScan::projection(&self) -> core::option::Option<&[alloc::string::String]>
@@ -57,8 +58,12 @@ impl datafusion_catalog::table::TableProviderFactory for iceberg_datafusion::tab
 pub fn iceberg_datafusion::table_provider_factory::IcebergTableProviderFactory::create<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, _state: &'life1 dyn datafusion_session::session::Session, cmd: &'life2 datafusion_expr::logical_plan::ddl::CreateExternalTable) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = datafusion_common::error::Result<alloc::sync::Arc<dyn datafusion_catalog::table::TableProvider>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub struct iceberg_datafusion::table::IcebergStaticTableProvider
 impl iceberg_datafusion::IcebergStaticTableProvider
+pub fn iceberg_datafusion::IcebergStaticTableProvider::config(&self) -> core::option::Option<&iceberg_datafusion::IcebergCatalogConfig>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::snapshot_id(&self) -> core::option::Option<i64>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::table_ident(&self) -> &iceberg::catalog::TableIdent
 pub async fn iceberg_datafusion::IcebergStaticTableProvider::try_new_from_table(table: iceberg::table::Table) -> iceberg::error::Result<Self>
 pub async fn iceberg_datafusion::IcebergStaticTableProvider::try_new_from_table_snapshot(table: iceberg::table::Table, snapshot_id: i64) -> iceberg::error::Result<Self>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::with_catalog_config(self, config: iceberg_datafusion::IcebergCatalogConfig) -> Self
 impl core::clone::Clone for iceberg_datafusion::IcebergStaticTableProvider
 pub fn iceberg_datafusion::IcebergStaticTableProvider::clone(&self) -> iceberg_datafusion::IcebergStaticTableProvider
 impl core::fmt::Debug for iceberg_datafusion::IcebergStaticTableProvider
@@ -91,6 +96,20 @@ impl core::fmt::Debug for iceberg_datafusion::table_provider_factory::IcebergTab
 pub fn iceberg_datafusion::table_provider_factory::IcebergTableProviderFactory::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl datafusion_catalog::table::TableProviderFactory for iceberg_datafusion::table_provider_factory::IcebergTableProviderFactory
 pub fn iceberg_datafusion::table_provider_factory::IcebergTableProviderFactory::create<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, _state: &'life1 dyn datafusion_session::session::Session, cmd: &'life2 datafusion_expr::logical_plan::ddl::CreateExternalTable) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = datafusion_common::error::Result<alloc::sync::Arc<dyn datafusion_catalog::table::TableProvider>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub struct iceberg_datafusion::IcebergCatalogConfig
+pub iceberg_datafusion::IcebergCatalogConfig::name: alloc::string::String
+pub iceberg_datafusion::IcebergCatalogConfig::props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub iceberg_datafusion::IcebergCatalogConfig::type: alloc::string::String
+impl iceberg_datafusion::IcebergCatalogConfig
+pub fn iceberg_datafusion::IcebergCatalogConfig::new(type: impl core::convert::Into<alloc::string::String>, name: impl core::convert::Into<alloc::string::String>, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> Self
+impl core::clone::Clone for iceberg_datafusion::IcebergCatalogConfig
+pub fn iceberg_datafusion::IcebergCatalogConfig::clone(&self) -> iceberg_datafusion::IcebergCatalogConfig
+impl core::cmp::Eq for iceberg_datafusion::IcebergCatalogConfig
+impl core::cmp::PartialEq for iceberg_datafusion::IcebergCatalogConfig
+pub fn iceberg_datafusion::IcebergCatalogConfig::eq(&self, other: &iceberg_datafusion::IcebergCatalogConfig) -> bool
+impl core::fmt::Debug for iceberg_datafusion::IcebergCatalogConfig
+pub fn iceberg_datafusion::IcebergCatalogConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for iceberg_datafusion::IcebergCatalogConfig
 pub struct iceberg_datafusion::IcebergCatalogProvider
 impl iceberg_datafusion::IcebergCatalogProvider
 pub async fn iceberg_datafusion::IcebergCatalogProvider::try_new(client: alloc::sync::Arc<dyn iceberg::catalog::Catalog>) -> iceberg::error::Result<Self>
@@ -101,8 +120,12 @@ pub fn iceberg_datafusion::IcebergCatalogProvider::schema(&self, name: &str) -> 
 pub fn iceberg_datafusion::IcebergCatalogProvider::schema_names(&self) -> alloc::vec::Vec<alloc::string::String>
 pub struct iceberg_datafusion::IcebergStaticTableProvider
 impl iceberg_datafusion::IcebergStaticTableProvider
+pub fn iceberg_datafusion::IcebergStaticTableProvider::config(&self) -> core::option::Option<&iceberg_datafusion::IcebergCatalogConfig>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::snapshot_id(&self) -> core::option::Option<i64>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::table_ident(&self) -> &iceberg::catalog::TableIdent
 pub async fn iceberg_datafusion::IcebergStaticTableProvider::try_new_from_table(table: iceberg::table::Table) -> iceberg::error::Result<Self>
 pub async fn iceberg_datafusion::IcebergStaticTableProvider::try_new_from_table_snapshot(table: iceberg::table::Table, snapshot_id: i64) -> iceberg::error::Result<Self>
+pub fn iceberg_datafusion::IcebergStaticTableProvider::with_catalog_config(self, config: iceberg_datafusion::IcebergCatalogConfig) -> Self
 impl core::clone::Clone for iceberg_datafusion::IcebergStaticTableProvider
 pub fn iceberg_datafusion::IcebergStaticTableProvider::clone(&self) -> iceberg_datafusion::IcebergStaticTableProvider
 impl core::fmt::Debug for iceberg_datafusion::IcebergStaticTableProvider

--- a/crates/integrations/datafusion/src/catalog_config.rs
+++ b/crates/integrations/datafusion/src/catalog_config.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+
+/// A plain-data description of the catalog and storage that backs a table.
+///
+/// Holds the inputs a catalog loader takes — `type` selects the builder, `name`
+/// and `props` are what [`CatalogBuilder::load`](iceberg::CatalogBuilder::load)
+/// receives — and no live connections, so it can be serialized and shipped to a
+/// remote worker that rebuilds the catalog and its `FileIO`. Nothing in this
+/// crate connects using these values. See
+/// [`IcebergStaticTableProvider::with_catalog_config`](crate::IcebergStaticTableProvider::with_catalog_config).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IcebergCatalogConfig {
+    /// Catalog type, e.g. `"rest"`, `"sql"`, `"glue"`.
+    pub r#type: String,
+    /// Catalog name, as it would be passed to a catalog loader.
+    pub name: String,
+    /// Catalog connection properties and storage/`FileIO` properties, which in
+    /// practice live together in a single map.
+    pub props: HashMap<String, String>,
+}
+
+impl IcebergCatalogConfig {
+    pub fn new(
+        r#type: impl Into<String>,
+        name: impl Into<String>,
+        props: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            r#type: r#type.into(),
+            name: name.into(),
+            props,
+        }
+    }
+}

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -18,6 +18,9 @@
 mod catalog;
 pub use catalog::*;
 
+mod catalog_config;
+pub use catalog_config::*;
+
 mod error;
 pub use error::*;
 

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -33,7 +33,7 @@ use iceberg::expr::Predicate;
 use iceberg::table::Table;
 
 use super::expr_to_predicate::convert_filters_to_predicate;
-use crate::to_datafusion_error;
+use crate::{IcebergCatalogConfig, to_datafusion_error};
 
 /// Manages the scanning process of an Iceberg [`Table`], encapsulating the
 /// necessary details and computed properties required for execution planning.
@@ -52,6 +52,8 @@ pub struct IcebergTableScan {
     predicates: Option<Predicate>,
     /// Optional limit on the number of rows to return
     limit: Option<usize>,
+    /// Catalog and storage the scanned table came from, if recorded
+    catalog_config: Option<IcebergCatalogConfig>,
 }
 
 impl IcebergTableScan {
@@ -79,7 +81,20 @@ impl IcebergTableScan {
             projection,
             predicates,
             limit,
+            catalog_config: None,
         }
+    }
+
+    pub(crate) fn with_catalog_config(
+        mut self,
+        catalog_config: Option<IcebergCatalogConfig>,
+    ) -> Self {
+        self.catalog_config = catalog_config;
+        self
+    }
+
+    pub fn catalog_config(&self) -> Option<&IcebergCatalogConfig> {
+        self.catalog_config.as_ref()
     }
 
     pub fn table(&self) -> &Table {

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -48,6 +48,7 @@ use iceberg::table::Table;
 use iceberg::{Catalog, Error, ErrorKind, NamespaceIdent, Result, TableIdent};
 use metadata_table::IcebergMetadataTableProvider;
 
+use crate::IcebergCatalogConfig;
 use crate::error::to_datafusion_error;
 use crate::physical_plan::commit::IcebergCommitExec;
 use crate::physical_plan::project::project_with_partition;
@@ -248,6 +249,8 @@ pub struct IcebergStaticTableProvider {
     snapshot_id: Option<i64>,
     /// A reference-counted arrow `Schema`
     schema: ArrowSchemaRef,
+    /// Catalog and storage `table` was loaded from, if recorded
+    config: Option<IcebergCatalogConfig>,
 }
 
 impl IcebergStaticTableProvider {
@@ -260,6 +263,7 @@ impl IcebergStaticTableProvider {
             table,
             snapshot_id: None,
             schema,
+            config: None,
         })
     }
 
@@ -286,7 +290,32 @@ impl IcebergStaticTableProvider {
             table,
             snapshot_id: Some(snapshot_id),
             schema,
+            config: None,
         })
+    }
+
+    /// Records the catalog and storage the table was loaded from.
+    ///
+    /// The provider still never contacts the catalog. The config is carried so
+    /// the scan nodes it produces can rebuild storage on a remote worker, and so
+    /// a caller can load the same table from a rebuilt catalog: the config
+    /// identifies the catalog, [`Self::table_ident`] the table within it, and
+    /// [`Self::snapshot_id`] the snapshot to pin.
+    pub fn with_catalog_config(mut self, config: IcebergCatalogConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    pub fn config(&self) -> Option<&IcebergCatalogConfig> {
+        self.config.as_ref()
+    }
+
+    pub fn table_ident(&self) -> &TableIdent {
+        self.table.identifier()
+    }
+
+    pub fn snapshot_id(&self) -> Option<i64> {
+        self.snapshot_id
     }
 }
 
@@ -308,14 +337,17 @@ impl TableProvider for IcebergStaticTableProvider {
         limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         // Use cached table (no refresh)
-        Ok(Arc::new(IcebergTableScan::new(
-            self.table.clone(),
-            self.snapshot_id,
-            self.schema.clone(),
-            projection,
-            filters,
-            limit,
-        )))
+        Ok(Arc::new(
+            IcebergTableScan::new(
+                self.table.clone(),
+                self.snapshot_id,
+                self.schema.clone(),
+                projection,
+                filters,
+                limit,
+            )
+            .with_catalog_config(self.config.clone()),
+        ))
     }
 
     fn supports_filters_pushdown(
@@ -510,6 +542,62 @@ mod tests {
         let df = ctx.sql("SELECT count(*) FROM mytable").await.unwrap();
         let physical_plan = df.create_physical_plan().await;
         assert!(physical_plan.is_ok());
+    }
+
+    fn test_catalog_config() -> IcebergCatalogConfig {
+        IcebergCatalogConfig::new(
+            "rest",
+            "test_catalog",
+            HashMap::from([("uri".to_string(), "http://localhost:8181".to_string())]),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_static_provider_exposes_catalog_identity() {
+        let table = get_test_table_from_metadata_file().await;
+        let ident = table.identifier().clone();
+        let snapshot_id = table.metadata().snapshots().next().unwrap().snapshot_id();
+        let config = test_catalog_config();
+
+        let provider = IcebergStaticTableProvider::try_new_from_table(table.clone())
+            .await
+            .unwrap();
+        assert!(provider.config().is_none());
+
+        let provider = IcebergStaticTableProvider::try_new_from_table_snapshot(table, snapshot_id)
+            .await
+            .unwrap();
+        assert!(provider.config().is_none());
+
+        // Exactly the inputs needed to rebuild an equivalent provider elsewhere.
+        let provider = provider.with_catalog_config(config.clone());
+        assert_eq!(provider.config(), Some(&config));
+        assert_eq!(provider.table_ident(), &ident);
+        assert_eq!(provider.snapshot_id(), Some(snapshot_id));
+    }
+
+    #[tokio::test]
+    async fn test_static_provider_propagates_catalog_config_into_scan() {
+        let table = get_test_table_from_metadata_file().await;
+        let config = test_catalog_config();
+        let ctx = SessionContext::new();
+
+        let provider = IcebergStaticTableProvider::try_new_from_table(table.clone())
+            .await
+            .unwrap();
+        let plan = provider.scan(&ctx.state(), None, &[], None).await.unwrap();
+        let scan = plan
+            .downcast_ref::<IcebergTableScan>()
+            .expect("static provider should produce an IcebergTableScan");
+        assert!(scan.catalog_config().is_none());
+
+        let provider = IcebergStaticTableProvider::try_new_from_table(table)
+            .await
+            .unwrap()
+            .with_catalog_config(config.clone());
+        let plan = provider.scan(&ctx.state(), None, &[], None).await.unwrap();
+        let scan = plan.downcast_ref::<IcebergTableScan>().unwrap();
+        assert_eq!(scan.catalog_config(), Some(&config));
     }
 
     // Tests for IcebergTableProvider


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #3017

## What changes are included in this PR?

related to discussion in github.com/apache/iceberg-rust/pull/2862

- Adds the struct: `IcebergCatalogConfig { type, name, props }`, which mirrors inputs to `CatalogBuilder::load`, as an optional field to StaticTableProvider and `IcebergTableScan`.
- `IcebergStaticTableProvider::with_catalog_config` records it; `config()`, `table_ident()`, and `snapshot_id()` read it back (to recreate the Table struct with new live FileIO).
- `IcebergTableScan` carries it into the physical plan, so a scan shipped to a remote worker can rebuild its own storage.

Nothing connects using these values. The field is an `Option` defaulting to `None`,
so existing constructors are unaffected and the public API change is purely additive.

It lives in `iceberg-datafusion` rather than `iceberg-catalog-loader` to avoid
pulling the glue/hms/rest/s3tables/sql catalogs in for a three-field struct.

## Are these changes tested?

- test_static_provider_propagates_catalog_config_into_scan
- test_static_provider_exposes_catalog_identity

## AI Disclosure

- Helped identify the shape of IcebergCatalogConfig based off `CatalogBuilder::load`
- PR validation.

