### PR TITLE
feature(encryption): [17/N] Enable encrypted writes

### DIFF
--- a/crates/catalog/loader/tests/common/mod.rs
+++ b/crates/catalog/loader/tests/common/mod.rs
@@ -352,6 +352,28 @@ pub fn encrypted_table_creation(name: impl ToString) -> TableCreation {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum TableMode {
+    Plain,
+    Encrypted,
+}
+
+impl TableMode {
+    pub fn table_creation(self, name: impl ToString) -> TableCreation {
+        match self {
+            Self::Plain => table_creation(name),
+            Self::Encrypted => encrypted_table_creation(name),
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Plain => "plain",
+            Self::Encrypted => "encrypted",
+        }
+    }
+}
+
 pub fn assert_map_contains(expected: &HashMap<String, String>, actual: &HashMap<String, String>) {
     for (key, value) in expected {
         assert_eq!(actual.get(key), Some(value));

--- a/crates/catalog/loader/tests/common/mod.rs
+++ b/crates/catalog/loader/tests/common/mod.rs
@@ -23,12 +23,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
+use iceberg::encryption::kms::{KmsClientFactory, MemoryKmsClientFactory};
 use iceberg::io::{
     FileIOBuilder, LocalFsStorageFactory, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_PATH_STYLE_ACCESS,
     S3_REGION, S3_SECRET_ACCESS_KEY,
 };
 use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
-use iceberg::spec::{NestedField, PrimitiveType, Schema, Type};
+use iceberg::spec::{FormatVersion, NestedField, PrimitiveType, Schema, TableProperties, Type};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation};
 use iceberg_catalog_glue::{
     AWS_ACCESS_KEY_ID, AWS_REGION_NAME, AWS_SECRET_ACCESS_KEY, GLUE_CATALOG_PROP_URI,
@@ -89,19 +90,26 @@ pub struct CatalogHarness {
 // the same behavior against all backends.
 pub async fn load_catalog(kind: CatalogKind) -> Option<CatalogHarness> {
     set_up();
+    let factory = MemoryKmsClientFactory::new();
+    factory.add_master_key(TEST_MASTER_KEY_ID).unwrap();
+    let kms_client_factory = Arc::new(factory) as Arc<dyn KmsClientFactory>;
+
     match kind {
         CatalogKind::Rest => Some(CatalogHarness {
-            catalog: Arc::new(rest_catalog().await) as Arc<dyn Catalog>,
+            catalog: Arc::new(rest_catalog(Arc::clone(&kms_client_factory)).await)
+                as Arc<dyn Catalog>,
             label: "rest",
             _tempdirs: Vec::new(),
         }),
         CatalogKind::Glue => Some(CatalogHarness {
-            catalog: Arc::new(glue_catalog().await) as Arc<dyn Catalog>,
+            catalog: Arc::new(glue_catalog(Arc::clone(&kms_client_factory)).await)
+                as Arc<dyn Catalog>,
             label: "glue",
             _tempdirs: Vec::new(),
         }),
         CatalogKind::Hms => Some(CatalogHarness {
-            catalog: Arc::new(hms_catalog().await) as Arc<dyn Catalog>,
+            catalog: Arc::new(hms_catalog(Arc::clone(&kms_client_factory)).await)
+                as Arc<dyn Catalog>,
             label: "hms",
             _tempdirs: Vec::new(),
         }),
@@ -114,6 +122,7 @@ pub async fn load_catalog(kind: CatalogKind) -> Option<CatalogHarness> {
 
             let catalog = SqlCatalogBuilder::default()
                 .with_storage_factory(Arc::new(LocalFsStorageFactory))
+                .with_kms_client_factory(Arc::clone(&kms_client_factory))
                 .load(
                     "sql",
                     HashMap::from([
@@ -153,6 +162,7 @@ pub async fn load_catalog(kind: CatalogKind) -> Option<CatalogHarness> {
             }
 
             let catalog = S3TablesCatalogBuilder::default()
+                .with_kms_client_factory(Arc::clone(&kms_client_factory))
                 .load("s3tables", props)
                 .await
                 .unwrap();
@@ -170,6 +180,7 @@ pub async fn load_catalog(kind: CatalogKind) -> Option<CatalogHarness> {
                 warehouse_dir.path().to_str().unwrap().to_string(),
             )]);
             let catalog = MemoryCatalogBuilder::default()
+                .with_kms_client_factory(Arc::clone(&kms_client_factory))
                 .load("memory", props)
                 .await
                 .unwrap();
@@ -183,9 +194,11 @@ pub async fn load_catalog(kind: CatalogKind) -> Option<CatalogHarness> {
     }
 }
 
+pub const TEST_MASTER_KEY_ID: &str = "test-master-key";
+
 // Catalog-specific setup is intentionally isolated here so the suites
 // remain implementation-agnostic.
-async fn rest_catalog() -> RestCatalog {
+async fn rest_catalog(kms_client_factory: Arc<dyn KmsClientFactory>) -> RestCatalog {
     let rest_endpoint = get_rest_catalog_endpoint();
 
     let client = reqwest::Client::new();
@@ -206,6 +219,7 @@ async fn rest_catalog() -> RestCatalog {
 
     RestCatalogBuilder::default()
         .with_storage_factory(Arc::new(LocalFsStorageFactory))
+        .with_kms_client_factory(kms_client_factory)
         .load(
             "rest",
             HashMap::from([(REST_CATALOG_PROP_URI.to_string(), rest_endpoint)]),
@@ -214,7 +228,7 @@ async fn rest_catalog() -> RestCatalog {
         .unwrap()
 }
 
-async fn glue_catalog() -> GlueCatalog {
+async fn glue_catalog(kms_client_factory: Arc<dyn KmsClientFactory>) -> GlueCatalog {
     let glue_endpoint = get_glue_endpoint();
     let minio_endpoint = get_minio_endpoint();
 
@@ -257,12 +271,13 @@ async fn glue_catalog() -> GlueCatalog {
     glue_props.extend(props);
 
     GlueCatalogBuilder::default()
+        .with_kms_client_factory(kms_client_factory)
         .load("glue", glue_props)
         .await
         .unwrap()
 }
 
-async fn hms_catalog() -> HmsCatalog {
+async fn hms_catalog(kms_client_factory: Arc<dyn KmsClientFactory>) -> HmsCatalog {
     let hms_endpoint = get_hms_endpoint();
     let minio_endpoint = get_minio_endpoint();
 
@@ -302,6 +317,7 @@ async fn hms_catalog() -> HmsCatalog {
         .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
             customized_credential_load: None,
         }))
+        .with_kms_client_factory(kms_client_factory)
         .load("hms", props)
         .await
         .unwrap()
@@ -323,6 +339,17 @@ pub fn table_creation(name: impl ToString) -> TableCreation {
         .properties(HashMap::new())
         .schema(schema)
         .build()
+}
+
+pub fn encrypted_table_creation(name: impl ToString) -> TableCreation {
+    TableCreation {
+        format_version: FormatVersion::V3,
+        properties: HashMap::from([(
+            TableProperties::PROPERTY_ENCRYPTION_KEY_ID.to_string(),
+            TEST_MASTER_KEY_ID.to_string(),
+        )]),
+        ..table_creation(name)
+    }
 }
 
 pub fn assert_map_contains(expected: &HashMap<String, String>, actual: &HashMap<String, String>) {

--- a/crates/catalog/loader/tests/table_suite.rs
+++ b/crates/catalog/loader/tests/table_suite.rs
@@ -23,9 +23,7 @@ mod common;
 
 use std::collections::HashMap;
 
-use common::{
-    CatalogKind, cleanup_namespace_dyn, encrypted_table_creation, load_catalog, table_creation,
-};
+use common::{CatalogKind, TableMode, cleanup_namespace_dyn, load_catalog, table_creation};
 use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Struct};
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{ErrorKind, NamespaceIdent, Result, TableIdent};
@@ -329,27 +327,38 @@ async fn test_catalog_purge_table(#[case] kind: CatalogKind) -> Result<()> {
 }
 
 #[rstest]
-#[case::glue_catalog(CatalogKind::Glue)]
-#[case::sql_catalog(CatalogKind::Sql)]
-#[case::memory_catalog(CatalogKind::Memory)]
+#[case::glue_plain(CatalogKind::Glue, TableMode::Plain)]
+#[case::glue_encrypted(CatalogKind::Glue, TableMode::Encrypted)]
+#[case::sql_plain(CatalogKind::Sql, TableMode::Plain)]
+#[case::sql_encrypted(CatalogKind::Sql, TableMode::Encrypted)]
+#[case::memory_plain(CatalogKind::Memory, TableMode::Plain)]
+#[case::memory_encrypted(CatalogKind::Memory, TableMode::Encrypted)]
 #[tokio::test]
-async fn test_catalog_purge_encrypted_table(#[case] kind: CatalogKind) -> Result<()> {
+async fn test_catalog_purge_table_with_data(
+    #[case] kind: CatalogKind,
+    #[case] mode: TableMode,
+) -> Result<()> {
     let Some(harness) = load_catalog(kind).await else {
         return Ok(());
     };
     let catalog = harness.catalog;
     let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
-        "catalog_purge_encrypted_table",
-        harness.label
+        "catalog_purge_table_with_data",
+        harness.label,
+        mode.label()
     ));
 
     cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
     catalog.create_namespace(&namespace, HashMap::new()).await?;
 
-    let table_name =
-        normalize_test_name_with_parts!("catalog_purge_encrypted_table", harness.label, "table");
+    let table_name = normalize_test_name_with_parts!(
+        "catalog_purge_table_with_data",
+        harness.label,
+        mode.label(),
+        "table"
+    );
     let table = catalog
-        .create_table(&namespace, encrypted_table_creation(table_name))
+        .create_table(&namespace, mode.table_creation(table_name))
         .await?;
     let ident = table.identifier().clone();
     let file_io = table.file_io().clone();

--- a/crates/catalog/loader/tests/table_suite.rs
+++ b/crates/catalog/loader/tests/table_suite.rs
@@ -23,7 +23,10 @@ mod common;
 
 use std::collections::HashMap;
 
-use common::{CatalogKind, cleanup_namespace_dyn, load_catalog, table_creation};
+use common::{
+    CatalogKind, cleanup_namespace_dyn, encrypted_table_creation, load_catalog, table_creation,
+};
+use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Struct};
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{ErrorKind, NamespaceIdent, Result, TableIdent};
 use iceberg_test_utils::normalize_test_name_with_parts;
@@ -318,6 +321,82 @@ async fn test_catalog_purge_table(#[case] kind: CatalogKind) -> Result<()> {
             !file_io.exists(location).await?,
             "Metadata file should have been deleted after purge"
         );
+    }
+
+    catalog.drop_namespace(&namespace).await?;
+
+    Ok(())
+}
+
+#[rstest]
+#[case::glue_catalog(CatalogKind::Glue)]
+#[case::sql_catalog(CatalogKind::Sql)]
+#[case::memory_catalog(CatalogKind::Memory)]
+#[tokio::test]
+async fn test_catalog_purge_encrypted_table(#[case] kind: CatalogKind) -> Result<()> {
+    let Some(harness) = load_catalog(kind).await else {
+        return Ok(());
+    };
+    let catalog = harness.catalog;
+    let namespace = NamespaceIdent::new(normalize_test_name_with_parts!(
+        "catalog_purge_encrypted_table",
+        harness.label
+    ));
+
+    cleanup_namespace_dyn(catalog.as_ref(), &namespace).await;
+    catalog.create_namespace(&namespace, HashMap::new()).await?;
+
+    let table_name =
+        normalize_test_name_with_parts!("catalog_purge_encrypted_table", harness.label, "table");
+    let table = catalog
+        .create_table(&namespace, encrypted_table_creation(table_name))
+        .await?;
+    let ident = table.identifier().clone();
+    let file_io = table.file_io().clone();
+    let data_file_path = format!("{}/data/00000.parquet", table.metadata().location());
+
+    file_io
+        .new_output(&data_file_path)?
+        .write(vec![0; 16].into())
+        .await?;
+
+    let data_file = DataFileBuilder::default()
+        .content(DataContentType::Data)
+        .file_path(data_file_path.clone())
+        .file_format(DataFileFormat::Parquet)
+        .partition(Struct::empty())
+        .record_count(1)
+        .file_size_in_bytes(16)
+        .partition_spec_id(table.metadata().default_partition_spec_id())
+        .build()
+        .unwrap();
+
+    let tx = Transaction::new(&table);
+    tx.fast_append()
+        .add_data_files(vec![data_file])
+        .apply(tx)?
+        .commit(catalog.as_ref())
+        .await?;
+    let table = catalog.load_table(&ident).await?;
+
+    let metadata_location = table.metadata_location().map(str::to_string);
+    let snapshot = table.metadata().current_snapshot().unwrap();
+    let manifest_list_location = snapshot.manifest_list().to_string();
+    let manifest_list = table.manifest_list_reader(snapshot).load().await?;
+    let manifest_location = manifest_list.entries()[0].manifest_path.clone();
+
+    assert!(file_io.exists(&data_file_path).await?);
+    assert!(file_io.exists(&manifest_location).await?);
+    assert!(file_io.exists(&manifest_list_location).await?);
+
+    catalog.purge_table(&ident).await?;
+
+    assert!(!catalog.table_exists(&ident).await?);
+    assert!(!file_io.exists(&data_file_path).await?);
+    assert!(!file_io.exists(&manifest_location).await?);
+    assert!(!file_io.exists(&manifest_list_location).await?);
+    if let Some(location) = &metadata_location {
+        assert!(!file_io.exists(location).await?);
     }
 
     catalog.drop_namespace(&namespace).await?;

--- a/crates/catalog/loader/tests/table_suite.rs
+++ b/crates/catalog/loader/tests/table_suite.rs
@@ -327,10 +327,15 @@ async fn test_catalog_purge_table(#[case] kind: CatalogKind) -> Result<()> {
 }
 
 #[rstest]
+// The REST fixture cannot purge externally written manifest files.
 #[case::glue_plain(CatalogKind::Glue, TableMode::Plain)]
 #[case::glue_encrypted(CatalogKind::Glue, TableMode::Encrypted)]
+#[case::hms_plain(CatalogKind::Hms, TableMode::Plain)]
+#[case::hms_encrypted(CatalogKind::Hms, TableMode::Encrypted)]
 #[case::sql_plain(CatalogKind::Sql, TableMode::Plain)]
 #[case::sql_encrypted(CatalogKind::Sql, TableMode::Encrypted)]
+#[case::s3tables_plain(CatalogKind::S3Tables, TableMode::Plain)]
+#[case::s3tables_encrypted(CatalogKind::S3Tables, TableMode::Encrypted)]
 #[case::memory_plain(CatalogKind::Memory, TableMode::Plain)]
 #[case::memory_encrypted(CatalogKind::Memory, TableMode::Encrypted)]
 #[tokio::test]

--- a/crates/catalog/loader/tests/table_suite.rs
+++ b/crates/catalog/loader/tests/table_suite.rs
@@ -327,11 +327,9 @@ async fn test_catalog_purge_table(#[case] kind: CatalogKind) -> Result<()> {
 }
 
 #[rstest]
-// The REST fixture cannot purge externally written manifest files.
+// REST cannot purge external manifests, and HMS cannot update tables.
 #[case::glue_plain(CatalogKind::Glue, TableMode::Plain)]
 #[case::glue_encrypted(CatalogKind::Glue, TableMode::Encrypted)]
-#[case::hms_plain(CatalogKind::Hms, TableMode::Plain)]
-#[case::hms_encrypted(CatalogKind::Hms, TableMode::Encrypted)]
 #[case::sql_plain(CatalogKind::Sql, TableMode::Plain)]
 #[case::sql_encrypted(CatalogKind::Sql, TableMode::Encrypted)]
 #[case::s3tables_plain(CatalogKind::S3Tables, TableMode::Plain)]

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -81,7 +81,7 @@ use crate::transaction::update_properties::UpdatePropertiesAction;
 use crate::transaction::update_schema::UpdateSchemaAction;
 use crate::transaction::update_statistics::UpdateStatisticsAction;
 use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
-use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
+use crate::{Catalog, TableCommit, TableRequirement, TableUpdate};
 
 /// Table transaction.
 #[derive(Clone)]
@@ -180,14 +180,6 @@ impl Transaction {
 
         let table_props = self.table.metadata().table_properties()?;
 
-        // TODO(https://github.com/apache/iceberg-rust/issues/2034): remove once encrypted writes are supported
-        if table_props.encryption_key_id.is_some() {
-            return Err(Error::new(
-                ErrorKind::FeatureUnsupported,
-                "Cannot commit to an encrypted table: encrypted writes are not yet supported",
-            ));
-        }
-
         let backoff = Self::build_backoff(table_props)?;
         let tx = self;
 
@@ -263,6 +255,7 @@ mod tests {
     use crate::memory::tests::new_memory_catalog;
     use crate::spec::{
         DataContentType, DataFileBuilder, DataFileFormat, Literal, Struct, TableMetadata,
+        TableProperties,
     };
     use crate::table::Table;
     use crate::test_utils::{make_encrypted_table, test_runtime};
@@ -576,8 +569,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_rejects_encrypted_table() {
-        let table = make_encrypted_table().await;
+    async fn test_commit_to_encrypted_table() {
+        let table = make_encrypted_table().await.with_metadata_location(
+            "memory:///table/metadata/00000-9c12d441-03fe-4693-9a96-a0705ddf69c1.metadata.json"
+                .to_string(),
+        );
+        let refreshed_table = table.clone();
+        let update_table = table.clone();
+        let mut mock_catalog = MockCatalog::new();
+        mock_catalog
+            .expect_load_table()
+            .times(1)
+            .returning_st(move |_| {
+                let refreshed_table = refreshed_table.clone();
+                Box::pin(async move { Ok(refreshed_table) })
+            });
+        mock_catalog
+            .expect_update_table()
+            .times(1)
+            .returning_st(move |commit| {
+                let update_table = update_table.clone();
+                Box::pin(async move { commit.apply(update_table) })
+            });
 
         let tx = Transaction::new(&table);
         let tx = tx
@@ -586,18 +599,25 @@ mod tests {
             .apply(tx)
             .unwrap();
 
-        let mock_catalog = MockCatalog::new();
-        let result = tx.commit(&mock_catalog).await;
+        let updated_table = tx.commit(&mock_catalog).await.unwrap();
 
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::FeatureUnsupported);
-        assert!(
-            err.message()
-                .contains("encrypted writes are not yet supported"),
-            "unexpected error message: {}",
-            err.message()
+        assert_eq!(
+            updated_table
+                .metadata()
+                .properties()
+                .get(TableProperties::PROPERTY_ENCRYPTION_KEY_ID)
+                .map(String::as_str),
+            Some("master-1")
         );
+        assert_eq!(
+            updated_table
+                .metadata()
+                .properties()
+                .get("test.key")
+                .map(String::as_str),
+            Some("test.value")
+        );
+        assert!(updated_table.encryption_manager().is_some());
     }
 }
 

--- a/crates/sqllogictest/src/engine/datafusion.rs
+++ b/crates/sqllogictest/src/engine/datafusion.rs
@@ -22,14 +22,19 @@ use std::sync::Arc;
 use datafusion::catalog::CatalogProvider;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_sqllogictest::DataFusion;
+use iceberg::encryption::kms::MemoryKmsClientFactory;
 use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
-use iceberg::spec::{NestedField, PrimitiveType, Schema, Transform, Type, UnboundPartitionSpec};
+use iceberg::spec::{
+    NestedField, PrimitiveType, Schema, TableProperties, Transform, Type, UnboundPartitionSpec,
+};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation};
 use iceberg_datafusion::IcebergCatalogProvider;
 use indicatif::ProgressBar;
 
 use crate::engine::{DatafusionCatalogConfig, EngineRunner, run_slt_with_runner};
 use crate::error::Result;
+
+const TEST_MASTER_KEY_ID: &str = "test-master-key";
 
 pub struct DataFusionEngine {
     test_data_path: PathBuf,
@@ -79,7 +84,11 @@ impl DataFusionEngine {
     ) -> anyhow::Result<Arc<dyn CatalogProvider>> {
         // TODO: Use catalog_config to load different catalog types via iceberg-catalog-loader
         // See: https://github.com/apache/iceberg-rust/issues/1780
+        let kms_factory = MemoryKmsClientFactory::new();
+        kms_factory.add_master_key(TEST_MASTER_KEY_ID)?;
+
         let catalog = MemoryCatalogBuilder::default()
+            .with_kms_client_factory(Arc::new(kms_factory))
             .load(
                 "memory",
                 HashMap::from([(
@@ -96,6 +105,7 @@ impl DataFusionEngine {
         // Create partitioned test table (unpartitioned tables are now created via SQL)
         Self::create_partitioned_table(&catalog, &namespace).await?;
         Self::create_binary_table(&catalog, &namespace).await?;
+        Self::create_encrypted_table(&catalog, &namespace).await?;
 
         Ok(Arc::new(
             IcebergCatalogProvider::try_new(Arc::new(catalog)).await?,
@@ -156,6 +166,35 @@ impl DataFusionEngine {
                 TableCreation::builder()
                     .name("test_binary_table".to_string())
                     .schema(schema)
+                    .build(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn create_encrypted_table(
+        catalog: &impl Catalog,
+        namespace: &NamespaceIdent,
+    ) -> anyhow::Result<()> {
+        let schema = Schema::builder()
+            .with_fields(vec![
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+            ])
+            .build()?;
+
+        catalog
+            .create_table(
+                namespace,
+                TableCreation::builder()
+                    .name("test_encrypted_round_trip".to_string())
+                    .schema(schema)
+                    .format_version(iceberg::spec::FormatVersion::V3)
+                    .properties([(
+                        TableProperties::PROPERTY_ENCRYPTION_KEY_ID.to_string(),
+                        TEST_MASTER_KEY_ID.to_string(),
+                    )])
                     .build(),
             )
             .await?;

--- a/crates/sqllogictest/testdata/schedules/df_encrypted_insert_round_trip.toml
+++ b/crates/sqllogictest/testdata/schedules/df_encrypted_insert_round_trip.toml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[engines]
+df = { type = "datafusion" }
+
+[[steps]]
+engine = "df"
+slt = "df_test/encrypted_insert_round_trip.slt"

--- a/crates/sqllogictest/testdata/slts/df_test/encrypted_insert_round_trip.slt
+++ b/crates/sqllogictest/testdata/slts/df_test/encrypted_insert_round_trip.slt
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+query II rowsort
+SELECT * FROM default.default.test_encrypted_round_trip
+----
+
+query I
+INSERT INTO default.default.test_encrypted_round_trip VALUES (1, 'Alice'), (2, 'Bob')
+----
+2
+
+query II rowsort
+SELECT * FROM default.default.test_encrypted_round_trip
+----
+1 Alice
+2 Bob

--- a/crates/sqllogictest/testdata/slts/df_test/show_tables.slt
+++ b/crates/sqllogictest/testdata/slts/df_test/show_tables.slt
@@ -29,6 +29,10 @@ default default test_binary_table BASE TABLE
 default default test_binary_table$history BASE TABLE
 default default test_binary_table$manifests BASE TABLE
 default default test_binary_table$snapshots BASE TABLE
+default default test_encrypted_round_trip BASE TABLE
+default default test_encrypted_round_trip$history BASE TABLE
+default default test_encrypted_round_trip$manifests BASE TABLE
+default default test_encrypted_round_trip$snapshots BASE TABLE
 default default test_partitioned_table BASE TABLE
 default default test_partitioned_table$history BASE TABLE
 default default test_partitioned_table$manifests BASE TABLE


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/iceberg-rust/issues/2919
- Working towards: https://github.com/apache/iceberg-rust/issues/2034

## What changes are included in this PR?
Since merging https://github.com/apache/iceberg-rust/pull/2701 we can now write encrypted parquet files which means we now fully support read and write paths. The last step is to remove the error on the commit path to allow users to actually write encrypted tables.


<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

I've added roundtrip tests for datafusion in a new slt test and purge table catalog tests can now be added since we can commit to an encrypted table.

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## AI Disclosure

<!--
https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions
-->
