### PR TITLE
fix: update h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Which issue does this PR close?

The security audit on #3000 detected [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258.html) / [GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h). `h2` 0.4.15 can queue empty HTTP/2 DATA frames without a bound when streams are not actively drained, potentially causing unbounded memory use or a panic. The advisory marks 0.4.16 as patched.

## What changes are included in this PR?

- update the transitive `h2` dependency from 0.4.15 to 0.4.16 in `Cargo.lock`
- leave all other dependency versions unchanged

## Are these changes tested?

- `cargo audit --file Cargo.lock` with the security workflow's existing ignore list
- `cargo tree -i h2@0.4.16 --locked --offline`
- `cargo check -p iceberg --all-features --locked`
- `git diff --check`

## AI Disclosure

This was fully generated with Codex following the CI failure.
