### PR TITLE
fix(transform): support hour transform for nanosecond arrays

### DIFF
--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -348,6 +348,11 @@ impl TransformFunction for Hour {
                 .downcast_ref::<TimestampMicrosecondArray>()
                 .unwrap()
                 .unary(|v| -> i32 { Self::hour_timestamp_micro(v) }),
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => input
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .unwrap()
+                .unary(|v| -> i32 { Self::hour_timestamp_nano(v) }),
             _ => {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
@@ -391,7 +396,9 @@ impl TransformFunction for Hour {
 mod test {
     use std::sync::Arc;
 
-    use arrow_array::{ArrayRef, Date32Array, Int32Array, TimestampMicrosecondArray};
+    use arrow_array::{
+        ArrayRef, Date32Array, Int32Array, TimestampMicrosecondArray, TimestampNanosecondArray,
+    };
     use chrono::{NaiveDate, NaiveDateTime};
 
     use crate::Result;
@@ -2714,6 +2721,19 @@ mod test {
         assert_eq!(res.value(2), expect_hour[2]);
         assert_eq!(res.value(3), expect_hour[3]);
         assert_eq!(res.value(4), -1);
+
+        // Test TimestampNanosecond with and without timezone
+        let timestamp_nanos = vec![0, super::NANOSECONDS_PER_HOUR, -1];
+        let date_arrays = [
+            Arc::new(TimestampNanosecondArray::from(timestamp_nanos.clone())) as ArrayRef,
+            Arc::new(TimestampNanosecondArray::from(timestamp_nanos).with_timezone_utc())
+                as ArrayRef,
+        ];
+        for date_array in date_arrays {
+            let res = hour.transform(date_array).unwrap();
+            let res = res.as_any().downcast_ref::<Int32Array>().unwrap();
+            assert_eq!(res.values(), &[0, 1, -1]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3025.

## What changes are included in this PR?

- Accept Arrow nanosecond timestamp arrays in the `hour` transform using the existing nanosecond conversion helper.
- Add regression coverage for `timestamp_ns` and `timestamptz_ns` arrays, including a pre-epoch value.

## Are these changes tested?

- `cargo test -p iceberg transform::temporal::test::test_transform_hours --lib`
- `make check`
- `make unit-test`
- `ICEBERG_TEST_HMS_ENDPOINT=127.0.0.1:9083 cargo nextest run --all-targets --all-features --workspace --no-fail-fast --test-threads 1` (2,067 passed, 0 skipped)

## AI Disclosure

Codex assisted with repository inspection, duplicate issue/PR searches, test scaffolding, implementation, validation, and drafting this PR. I reviewed the complete diff and verified the behavior and tests end to end.
