### PR TITLE
perf(manifest): reuse the partition type across entries instead of rebuilding

### DIFF
--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -21,7 +21,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use super::{Datum, ManifestEntry, Schema, Struct};
-use crate::spec::{FormatVersion, Literal, RawLiteral, StructType, Type};
+use crate::spec::{FormatVersion, Literal, RawLiteral, Type};
 use crate::{Error, ErrorKind, metadata_columns};
 
 #[derive(Serialize, Deserialize)]
@@ -34,7 +34,7 @@ pub(super) struct ManifestEntryV2 {
 }
 
 impl ManifestEntryV2 {
-    pub fn try_from(value: ManifestEntry, partition_type: &StructType) -> Result<Self, Error> {
+    pub fn try_from(value: ManifestEntry, partition_type: &Type) -> Result<Self, Error> {
         Ok(Self {
             status: value.status as i32,
             snapshot_id: value.snapshot_id,
@@ -47,7 +47,7 @@ impl ManifestEntryV2 {
     pub fn try_into(
         self,
         partition_spec_id: i32,
-        partition_type: &StructType,
+        partition_type: &Type,
         schema: &Schema,
     ) -> Result<ManifestEntry, Error> {
         Ok(ManifestEntry {
@@ -70,7 +70,7 @@ pub(super) struct ManifestEntryV1 {
 }
 
 impl ManifestEntryV1 {
-    pub fn try_from(value: ManifestEntry, partition_type: &StructType) -> Result<Self, Error> {
+    pub fn try_from(value: ManifestEntry, partition_type: &Type) -> Result<Self, Error> {
         Ok(Self {
             status: value.status as i32,
             snapshot_id: value.snapshot_id.unwrap_or_default(),
@@ -81,7 +81,7 @@ impl ManifestEntryV1 {
     pub fn try_into(
         self,
         partition_spec_id: i32,
-        partition_type: &StructType,
+        partition_type: &Type,
         schema: &Schema,
     ) -> Result<ManifestEntry, Error> {
         Ok(ManifestEntry {
@@ -127,7 +127,7 @@ pub(super) struct DataFileSerde {
 impl DataFileSerde {
     pub fn try_from(
         value: super::DataFile,
-        partition_type: &StructType,
+        partition_type: &Type,
         format_version: FormatVersion,
     ) -> Result<Self, Error> {
         let block_size_in_bytes = if format_version == FormatVersion::V1 {
@@ -139,10 +139,7 @@ impl DataFileSerde {
             content: value.content as i32,
             file_path: value.file_path,
             file_format: value.file_format.to_string().to_ascii_uppercase(),
-            partition: RawLiteral::try_from(
-                Literal::Struct(value.partition),
-                &Type::Struct(partition_type.clone()),
-            )?,
+            partition: RawLiteral::try_from(Literal::Struct(value.partition), partition_type)?,
             record_count: value.record_count.try_into()?,
             file_size_in_bytes: value.file_size_in_bytes.try_into()?,
             block_size_in_bytes,
@@ -166,12 +163,12 @@ impl DataFileSerde {
     pub fn try_into(
         self,
         partition_spec_id: i32,
-        partition_type: &StructType,
+        partition_type: &Type,
         schema: &Schema,
     ) -> Result<super::DataFile, Error> {
         let partition = self
             .partition
-            .try_into(&Type::Struct(partition_type.clone()))?
+            .try_into(partition_type)?
             .map(|v| {
                 if let Literal::Struct(v) = v {
                     Ok(v)
@@ -492,7 +489,7 @@ mod tests {
         let v2_entry = v1_entry
             .try_into(
                 0, // partition_spec_id
-                &StructType::new(vec![]),
+                &Type::Struct(StructType::new(vec![])),
                 &schema(),
             )
             .unwrap();
@@ -572,7 +569,7 @@ mod tests {
         let data_file = v1_style_data_file
             .try_into(
                 0, // partition_spec_id
-                &StructType::new(vec![]),
+                &Type::Struct(StructType::new(vec![])),
                 &schema(),
             )
             .unwrap();

--- a/crates/iceberg/src/spec/manifest/data_file.rs
+++ b/crates/iceberg/src/spec/manifest/data_file.rs
@@ -28,7 +28,7 @@ use super::{
     Datum, FormatVersion, Schema, data_file_schema_v1, data_file_schema_v2, data_file_schema_v3,
 };
 use crate::error::Result;
-use crate::spec::{DEFAULT_PARTITION_SPEC_ID, Struct, StructType};
+use crate::spec::{DEFAULT_PARTITION_SPEC_ID, Struct, StructType, Type};
 use crate::{Error, ErrorKind};
 
 /// Data file carries data file path, partition tuple, metrics, …
@@ -303,10 +303,13 @@ pub fn write_data_files_to_avro<W: Write>(
     };
     let mut writer = AvroWriter::new(&avro_schema, writer);
 
+    // Wrap once and reuse across files so the field-name lookup is not rebuilt
+    // for each data file.
+    let partition_struct_type = Type::Struct(partition_type.clone());
     for data_file in data_files {
         let value = to_value(DataFileSerde::try_from(
             data_file,
-            partition_type,
+            &partition_struct_type,
             FormatVersion::V1,
         )?)?
         .resolve(&avro_schema)?;
@@ -331,12 +334,15 @@ pub fn read_data_files_from_avro<R: Read>(
     };
 
     let reader = AvroReader::with_schema(&avro_schema, reader)?;
+    // Wrap once and reuse across files so the field-name lookup is not rebuilt
+    // for each data file.
+    let partition_struct_type = Type::Struct(partition_type.clone());
     reader
         .into_iter()
         .map(|value| {
             from_value::<DataFileSerde>(&value?)?.try_into(
                 partition_spec_id,
-                partition_type,
+                &partition_struct_type,
                 schema,
             )
         })

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -30,7 +30,7 @@ use apache_avro::{Reader as AvroReader, from_value};
 pub use writer::*;
 
 use super::{
-    Datum, FormatVersion, ManifestContentType, PartitionSpec, PrimitiveType, Schema, Struct,
+    Datum, FormatVersion, ManifestContentType, PartitionSpec, PrimitiveType, Schema, Struct, Type,
     UNASSIGNED_SEQUENCE_NUMBER,
 };
 use crate::error::Result;
@@ -54,6 +54,10 @@ impl Manifest {
 
         // Parse manifest entries
         let partition_type = metadata.partition_spec.partition_type(&metadata.schema)?;
+        // Wrap the partition type once and share it across all entries: the
+        // per-entry conversion needs a `&Type`, and building it here keeps the
+        // lazily-populated field-name lookup from being rebuilt for every entry.
+        let partition_struct_type = Type::Struct(partition_type.clone());
 
         let entries = match metadata.format_version {
             FormatVersion::V1 => {
@@ -64,7 +68,7 @@ impl Manifest {
                     .map(|value| {
                         from_value::<_serde::ManifestEntryV1>(&value?)?.try_into(
                             metadata.partition_spec.spec_id(),
-                            &partition_type,
+                            &partition_struct_type,
                             &metadata.schema,
                         )
                     })
@@ -79,7 +83,7 @@ impl Manifest {
                     .map(|value| {
                         from_value::<_serde::ManifestEntryV2>(&value?)?.try_into(
                             metadata.partition_spec.spec_id(),
-                            &partition_type,
+                            &partition_struct_type,
                             &metadata.schema,
                         )
                     })
@@ -127,7 +131,8 @@ pub fn serialize_data_file_to_json(
     partition_type: &super::StructType,
     format_version: FormatVersion,
 ) -> Result<String> {
-    let serde = _serde::DataFileSerde::try_from(data_file, partition_type, format_version)?;
+    let partition_struct_type = Type::Struct(partition_type.clone());
+    let serde = _serde::DataFileSerde::try_from(data_file, &partition_struct_type, format_version)?;
     serde_json::to_string(&serde).map_err(|e| {
         Error::new(
             ErrorKind::DataInvalid,
@@ -152,7 +157,8 @@ pub fn deserialize_data_file_from_json(
         .with_source(e)
     })?;
 
-    serde.try_into(partition_spec_id, partition_type, schema)
+    let partition_struct_type = Type::Struct(partition_type.clone());
+    serde.try_into(partition_spec_id, &partition_struct_type, schema)
 }
 
 #[cfg(test)]
@@ -391,7 +397,11 @@ mod tests {
                 .add_user_metadata("content".to_string(), metadata.content.to_string())
                 .unwrap();
             let value = to_value(
-                _serde::ManifestEntryV2::try_from(entry.clone(), &partition_type).unwrap(),
+                _serde::ManifestEntryV2::try_from(
+                    entry.clone(),
+                    &Type::Struct(partition_type.clone()),
+                )
+                .unwrap(),
             )
             .unwrap()
             .resolve(&avro_schema)

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -35,7 +35,7 @@ use crate::spec::manifest::_serde::{ManifestEntryV1, ManifestEntryV2};
 use crate::spec::manifest::{manifest_schema_v1, manifest_schema_v2};
 use crate::spec::{
     DataContentType, DataFile, FieldSummary, ManifestEntry, ManifestFile, ManifestMetadata,
-    ManifestStatus, PrimitiveLiteral, SchemaRef, StructType,
+    ManifestStatus, PrimitiveLiteral, SchemaRef, StructType, Type,
 };
 use crate::{Error, ErrorKind};
 
@@ -445,6 +445,9 @@ impl ManifestWriter {
             .metadata
             .partition_spec
             .partition_type(&self.metadata.schema)?;
+        // Wrap once and reuse for every entry so the per-entry conversion does
+        // not rebuild the partition type's field-name lookup on each call.
+        let partition_struct_type = Type::Struct(partition_type.clone());
         let table_schema = &self.metadata.schema;
         let avro_schema = match self.metadata.format_version {
             FormatVersion::V1 => manifest_schema_v1(&partition_type)?,
@@ -490,11 +493,13 @@ impl ManifestWriter {
         // Write manifest entries
         for entry in std::mem::take(&mut self.manifest_entries) {
             let value = match self.metadata.format_version {
-                FormatVersion::V1 => to_value(ManifestEntryV1::try_from(entry, &partition_type)?)?
-                    .resolve(&avro_schema)?,
+                FormatVersion::V1 => {
+                    to_value(ManifestEntryV1::try_from(entry, &partition_struct_type)?)?
+                        .resolve(&avro_schema)?
+                }
                 // Manifest entry format did not change between V2 and V3
                 FormatVersion::V2 | FormatVersion::V3 => {
-                    to_value(ManifestEntryV2::try_from(entry, &partition_type)?)?
+                    to_value(ManifestEntryV2::try_from(entry, &partition_struct_type)?)?
                         .resolve(&avro_schema)?
                 }
             };


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3027

## What changes are included in this PR?

Reading or writing a manifest wrapped the partition type as Type::Struct(partition_type.clone()) once per entry. Because StructType's field-name lookup is a lazily built OnceLock that the clone leaves empty, every entry re-cloned the field vector and rebuilt the whole name lookup (cloning each partition field name) only to discard it.

## Are these changes tested?

Yes, updated tests. 

I benchmarked the read path (`Manifest::parse_avro`):

- Workload: one V2 manifest, 20K entries, 5-field partition, ~2.7 MB on disk
- Method: write once, then time 50 reads, report best + mean; 3 trials each on HEAD (fixed) vs the parent commit e50a094c (no fix)

```
┌─────────────────┬───────────────────────┬───────────┐
│                 │       best (ms)       │ mean (ms) │
├─────────────────┼───────────────────────┼───────────┤
│ Before (no fix) │ 54.07 / 54.99 / 55.14 │ ~56.5     │
├─────────────────┼───────────────────────┼───────────┤
│ After (fix)     │ 51.36 / 51.93 / 52.29 │ ~53.7     │
└─────────────────┴───────────────────────┴───────────┘
```

So it speeds up reads by about ~5%. The gains are modest because the Avro parsing still dominates. But this is a safe change and a useful improvement. 
