### PR TITLE
chore: Enable automatic review by GitHub Copilot on PRs on behalf of author

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -59,6 +59,10 @@ github:
     - CTTY
   ghp_branch: gh-pages
   ghp_path: /
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: true
 
 notifications:
   commits: commits@iceberg.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,7 +62,7 @@ github:
   copilot_code_review:
     enabled: true
     review_drafts: false
-    review_on_push: true
+    review_on_push: false
 
 notifications:
   commits: commits@iceberg.apache.org

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Instructions
+
+## Code review
+
+You are a pragmatic senior Rust developer.
+When reviewing pull requests, follow these rules to avoid noise and redundancy:
+
+- Be concise: Keep comments brief and to the point. Avoid
+  conversational filler or praising the code unless it's exceptional.
+- High-impact only: Focus on logic errors, security vulnerabilities,
+  performance bottlenecks, and breaking changes.
+- Skip the Obvious: Do not describe what the code is doing. Assume the
+  reader understands the code.
+- Ignore trivialities: Do not comment on minor style issues or things
+  that an automated linter should catch.
+- Single comment per issue: If the same pattern occurs multiple times,
+  mention it once and suggest a global fix instead of commenting on
+  every line.
+- First-time contributors: For users new to this repository,
+  explicitly instruct them to "Please check and address all review
+  comments in this PR."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,22 +1,3 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
-
 # Instructions
 
 ## Code review

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -38,7 +38,9 @@ header:
     - "target"
     - "Cargo.lock"
     - "bindings/python/uv.lock"
+    # GitHub configuration
     - ".github/PULL_REQUEST_TEMPLATE.md"
+    - ".github/copilot-instructions.md"
     # Python environment
     - "bindings/python/.venv/"
     - "bindings/python/.pytest_cache/"


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/iceberg-rust/issues/2940.

## What changes are included in this PR?

Enables GitHub Copilot review to be automatically requested where PR author has it available.

This is based on https://github.com/apache/iceberg-cpp/pull/833.

## Are these changes tested?

Not applicable.

## AI Disclosure

No AI used to author this PR. Content is broadly copied from iceberg-cpp's equivalent PR: https://github.com/apache/iceberg-cpp/pull/833
