### PR TITLE
docs: Update release guide based on retrospective of 0.10 releases

### DIFF
--- a/website/src/release.md
+++ b/website/src/release.md
@@ -36,6 +36,7 @@ This guide complements the foundation-wide policies and guides:
 In this guide:
 
 - `iceberg_version`: the final Iceberg Rust version, like `0.9.1`.
+- `iceberg_minor_release_branch`: the release branch for the minor version, like `0.9.x`.
 - `rc`: the numeric release candidate voting round, like `2`.
 - `rc_tag`: the git tag for a release candidate, like `v0.9.1-rc.2`.
 - `rc_dist_dir`: the ASF dev distribution directory, like `apache-iceberg-rust-0.9.1-rc2`.
@@ -54,7 +55,7 @@ Where this can be supported by a non-committer, this will be mentioned in the gu
 
 <div class="warning">
 
-This section is the requirements for individuals who are new to the role of release manager.
+This section is the requirements for committers or PMC members who are new to the role of release manager.
 
 </div>
 
@@ -70,11 +71,22 @@ Install the release tooling used by the local scripts:
 
 The local release helpers are under `dev/release/`. They log every step before it runs and after it succeeds. If a step fails, the script prints the failed step and stops.
 
+## How to propose a new release
+
+Ultimately, it is up to the community on when to cut a new release.
+You can propose this via the [Apache Iceberg dev mailing list](https://lists.apache.org/list.html?dev@iceberg.apache.org)
+or simply open a tracking issue, mentioned later in this guide.
+
 ## Start a tracking issue about the next release
 
-Start a tracking issue on GitHub for the upcoming release to track all tasks that need to be completed.
-You should own this tracking issue and coordinate with the community when to target a new release and what changes need to be included.
+Start a tracking issue on GitHub for the upcoming release to track all the changes needed to be merged/addressed for the release.
+
+If you are acting as release manager, you should own this issue and coordinate with the community when to target a new release and what changes need to be included.
 You do not need to be a committer to create and own the tracking issue.
+
+### Template
+
+You may use the template below to create the issue.
 
 Title:
 
@@ -87,55 +99,51 @@ Content:
 ```markdown
 This issue is used to track tasks of the iceberg rust ${iceberg_version} release.
 
-## Tasks
-
 ### Blockers
 
-> Blockers are the tasks that must be completed before the release.
+> Blockers are the tasks, such as bugs, that should be completed before the release.
 
-### Build Release
+- TBD
 
-#### GitHub Side
+### Community-desired features / changes
 
-- [ ] Draft GitHub release
-- [ ] Bump version in project, update dependencies list, and update changelog
-- [ ] Create and push release candidate tag
+> These are features or other changes that the community would prefer to go into the next release,
+> but should not block it.
 
-#### ASF Side
+- TBD
 
-- [ ] Create ASF source release artifacts
-- [ ] Upload artifacts to the SVN dist repo
+### Release Guide
 
-### Voting
-
-- [ ] Start VOTE at iceberg community
-
-### Official Release
-
-- [ ] Publish artifacts to SVN RELEASE branch
-- [ ] Change Iceberg Rust Website download link
-- [ ] Publish GitHub release, automatically pushing the Git tag
-- [ ] Send the announcement
-
-For details of each step, please refer to: https://rust.iceberg.apache.org/release
+For details on how to run a release, please refer to: https://rust.iceberg.apache.org/release
 ```
 
 ## GitHub Side
 
 The following steps should be followed once the release is ready to begin.
 
+### Create a minor version release branch, if it doesn't already exist
+
+A committer must ensure that a release branch exists for each minor version.
+
+If the release is for an existing minor version (such as the `.1` patch release in `v0.10.1`), the release branch should already exist with the name `v0.10.x`.
+
+If the release is for a new minor version (such as the `.10` release in `v0.10.0`), you should create the release branch now.
+
+```
+git switch -c ${iceberg_minor_release_branch} && git push upstream ${iceberg_minor_release_branch}
+```
+
 ### Draft GitHub release
 
 - [Draft a new GitHub Release using the GitHub web UI](https://github.com/apache/iceberg-rust/releases/new).
 - Enter the git tag of this release version, of the form `v0.y.z`. For example, `v0.9.0`.
-  The tag should not exist at this stage and GitHub will offer to create it when the release is published.
-- Make sure the branch target is `main` for minor release (such as `0.9.0`), or the minor version branch for a patch release (such as `0.9.1`).
-- Generate the release note by clicking the `Generate release notes` button.
+  It is correct that the tag does not exist at this stage, as it will be created later in the release process.
+- Use the minor version branch created earlier as the branch target. For example, `v0.9.x`.
 - Save the draft.
 
 ### Update crate versions, dependencies list, and changelog
 
-The following changes can be made in one pull request.
+The following changes can be made in one pull request against the minor version branch (e.g. `v0.9.x`).
 
 #### Bump crate versions
 
@@ -144,10 +152,13 @@ This version is the final version, not the release candidate version.
 
 - Rust core and Python binding: bump version in root `Cargo.toml` under `[workspace.package]`.
 
+If you are preparing changes for later release candidates (2+), bumping crate versions should not be necessary.
+
 #### Update CHANGELOG.md
 
-Use the content of the draft GitHub release to update `CHANGELOG.md`.
-Since drafting a GitHub release requires `content: write` GitHub permissions, this step must be owned by a committer.
+Update `CHANGELOG.md` based on the changes since the previous version.
+You may use generative AI to assist making this update, but please review the proposed changes for correctness.
+The changelog should reflect a summary of each commit in the new release.
 
 #### Update dependency lists
 
@@ -165,9 +176,12 @@ dev/release/dependencies.sh check
 
 #### Open pull request
 
-Open a pull request with all three changes.
+Open a pull request with all the changes.
+The release branch should be used as the base for the pull request.
 
 ### Create release candidate tag and artifacts
+
+This step must be completed by a committer.
 
 After the version bump PR gets merged, check out the exact commit to release and run:
 
@@ -216,9 +230,29 @@ git push origin "v${iceberg_version}-rc.${rc}"
 
 If an RC has a problem, abandon that RC and increment the RC number.
 
+### Draft an Apache Iceberg blog post
+
+The [Apache Iceberg blog](https://iceberg.apache.org/blog/) is one mechanism to share news about the project,
+however it is not a strict requirement for any release.
+Blog posts are published on the website, and shared via the project's social media.
+
+A blog post is typically published covering the whole minor release (i.e. `v0.9`), and communicates the changes since the last minor version.
+It may be updated for patch versions if deemed appropriate.
+For example, the [0.10 blog post was updated](https://iceberg.apache.org/blog/apache-iceberg-rust-0.10.0-release/#patch-releases) to communicate why `0.10.1` was released.
+
+If someone would like to volunteer to author this blog post, now is a good time to draft it based on the proposed changes to be released.
+The blog post should be a curated summary of the biggest changes to go in.
+Drafting the initial body of the post by hand is recommended, as this allows for a more authentic contribution and avoids mistakes where generative AI may summarize changes incorrectly.
+
+Blog posts are created by opening a PR to the main Apache Iceberg repository in the [`site/docs/blog/posts` directory](https://github.com/apache/iceberg/tree/main/site/docs/blog/posts).
+It should not be merged until the release has completed.
+
 ## ASF Side
 
-If any step in the ASF release process fails and requires code changes, abandon that RC and prepare a new RC number.
+All ASF-side steps must be performed by a project committer.
+
+**If any step in the ASF release process fails and requires code changes, abandon that RC and prepare a new RC number.**
+
 Our release page displays ASF releases instead of GitHub Releases.
 
 ### Verify the release candidate locally
@@ -316,7 +350,7 @@ Please vote accordingly:
 [ ] +0 No opinion
 [ ] -1 Disapprove (please provide a reason)
 
-To learn more about Apache Iceberg, please visit:
+To learn more about Apache Iceberg Rust, please visit:
 https://rust.iceberg.apache.org/
 
 Checklist for reference:
@@ -337,7 +371,7 @@ ${name}
 
 Example: <https://lists.apache.org/thread/c211gqq2yl15jbxqk4rcnq1bdqltjm5l>
 
-After at least 3 `+1` binding votes from Iceberg PMC members, claim the vote result.
+After at least 72 hours and 3 `+1` binding votes from Iceberg PMC members, claim the vote result.
 
 Title:
 
@@ -451,6 +485,9 @@ After downloading them, here are the instructions on how to verify them.
 
 ## Official Release
 
+All steps in this section must be performed by a project committer,
+except the announcement e-mail which must be performed by a PMC member.
+
 ### Promote the RC
 
 After the VOTE passes, create the final release tag and move the ASF artifacts from dev dist to release dist:
@@ -467,23 +504,50 @@ Useful options include:
 - `--dev_dist_url https://dist.apache.org/repos/dist/dev/iceberg`: SVN directory URL containing RC artifact directories.
 - `--release_dist_url https://dist.apache.org/repos/dist/release/iceberg`: SVN directory URL where final release artifact directories are published.
 
-The release script does not push the final release tag.
-Review the output and then move on to the next step to publish the GitHub release and tag.
+The release script does not push the final signed release tag.
+Review the output and then manually publish the release tag.
+
+```shell
+git push origin "v${iceberg_version}"
+```
+
+The creation of the final release tag triggers the publish workflow for crates.
+Python packages are manually triggered later.
+Please verify that the triggered workflows for the crates succeeded.
+
+Note, this workflow for crates is expected to fail if new crates are being published for the first time.
+In this instance, a committer must manually publish the crate in order to continue.
+See [publishing a crate for the first time](#publishing-a-crate-for-the-first-time) for what steps to take.
+Once all the crates are published, Python publishing should start.
+
+Python publishing is performed by a GitHub workflow, however the trigger is manual.
+Trigger this now using the following GitHub CLI command, or the equivalent on the GitHub website.
+It must use the published release tag as the reference for the workflow run.
+
+```shell
+gh workflow run --repo apache/iceberg-rust release_python.yml -f release_tag=v${iceberg_version} --ref refs/tags/v{iceberg_version}
+```
+
+Verify that the workflow succeeds, indicating that the Python packages are released.
+If there is any issue, you may continue with the release however please note in any relevant steps that the Python package publish failed and open a patch release tracking issue to plan addressing the problem.
+Note, this should be an exceptional case.
 
 ### Publish the GitHub Release
 
 A GitHub release should have been drafted earlier in the release process.
-Open the release and publish it now.
 
-On publish, the Git tag will be created for the release.
-
-The creation of the final release tag triggers the publish workflow for crates and pyiceberg-core.
+Open the GitHub release and update the body with the contents of the changelog.
+Then, publish the GitHub release.
 
 ### Send the announcement
 
 Send the release announcement to `dev@iceberg.apache.org` and CC `announce@apache.org`.
 
-Instead of adding breaking changes, include the new features as "notable changes" in the announcement.
+You must be a PMC member to send e-mails to `announce@apache.org`.
+The e-mail must be plain text.
+Disable HTML formatting if your e-mail client enables it by default.
+
+Instead of adding breaking changes, we include the new features as "notable changes" in the announcement.
 
 Title:
 
@@ -525,3 +589,54 @@ On behalf of Apache Iceberg Community
 ```
 
 Example: <https://lists.apache.org/thread/oy77n55brvk72tnlb2bjzfs9nz3cfd0s>
+
+### Publish the release blog post
+
+If a release blog post has been drafted (introduced earlier in this guide), now is the time to ensure it is ready to merge and publish.
+It does not need to be published immediately for the release to be considered complete,
+however it is in the community's best interest to publish it soon after.
+
+## Appendix
+
+### Publishing a crate for the first time
+
+Publishing the Iceberg crates is automated using GitHub Actions,
+which authenticates with crates.io using trusted publishing.
+
+Trusted publishing must first be configured for each crate.
+If the crate has never been published, crates.io rejects attempts to publish.
+
+When a release workflow fails due to the presence of a new crate, a committer must perform steps enumerated below.
+Once complete, future versions can be published automatically using GitHub Actions.
+
+#### Initial crate publish
+
+Manually publish the crate using the following command.
+You **must** have the source code checked out matching the pushed Git tag for the release.
+
+```shell
+cargo publish --package <package-name>
+```
+
+#### Configure crate permissions
+
+After publishing succeeds, the crate must be configured to allow other committers to publish.
+
+Add the GitHub team that Apache Iceberg committers are a member of.
+
+```shell
+cargo owner --add github:<github-team-org>:<github-team-name>
+```
+
+Additionally, add two PMC members (excluding yourself) as owners of the crate.
+A GitHub team cannot manage permissions for the crate, so it is important that individuals have ownership to continue being able to manage the crate should a PMC member become inactive.
+See the [Cargo documentation for `cargo owner`](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner) for reference.
+
+```shell
+cargo owner --add <github-handle>
+```
+
+#### Configure trusted publishing
+
+Review the [crates.io trusted publishing documentation](https://crates.io/docs/trusted-publishing) for the latest instructions on how to configure it.
+You should also review another already-existing crate for reference.


### PR DESCRIPTION
## Which issue does this PR close?

Addresses some issues raised in https://github.com/apache/iceberg-rust/issues/2864.

## What changes are included in this PR?

Focus is only on the release guide.
It includes changes addressing failures that came up during the release process, fixes or removes ambiguity.
It also simplifies some parts, such as simplifying the tracking issue template.

## Are these changes tested?

N/A

## AI Disclosure

No AI was used in contributing these changes.