### PR TITLE
feat: add staged create transactions

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1110,6 +1110,8 @@ pub fn iceberg::memory::MemoryCatalog::rename_table<'life0, 'life1, 'life2, 'asy
 pub fn iceberg::memory::MemoryCatalog::table_exists<'life0, 'life1, 'async_trait>(&'life0 self, table_ident: &'life1 iceberg::TableIdent) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub fn iceberg::memory::MemoryCatalog::update_namespace<'life0, 'life1, 'async_trait>(&'life0 self, namespace_ident: &'life1 iceberg::NamespaceIdent, properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub fn iceberg::memory::MemoryCatalog::update_table<'life0, 'async_trait>(&'life0 self, commit: iceberg::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::TransactionalCatalog for iceberg::memory::MemoryCatalog
+pub fn iceberg::memory::MemoryCatalog::create_table_transaction<'life0, 'life1, 'async_trait>(&'life0 self, namespace: &'life1 iceberg::NamespaceIdent, creation: iceberg::TableCreation) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::Transaction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub struct iceberg::memory::MemoryCatalogBuilder
 impl core::default::Default for iceberg::memory::MemoryCatalogBuilder
 pub fn iceberg::memory::MemoryCatalogBuilder::default() -> Self
@@ -3262,7 +3264,9 @@ pub async fn iceberg::transaction::Transaction::commit(self, catalog: &dyn icebe
 pub fn iceberg::transaction::Transaction::expire_snapshots(&self) -> iceberg::transaction::expire_snapshots::ExpireSnapshotsAction
 pub fn iceberg::transaction::Transaction::fast_append(&self) -> iceberg::transaction::append::FastAppendAction
 pub fn iceberg::transaction::Transaction::new(table: &iceberg::table::Table) -> Self
+pub fn iceberg::transaction::Transaction::new_create(table: iceberg::table::Table) -> Self
 pub fn iceberg::transaction::Transaction::replace_sort_order(&self) -> iceberg::transaction::sort_order::ReplaceSortOrderAction
+pub fn iceberg::transaction::Transaction::table(&self) -> &iceberg::table::Table
 pub fn iceberg::transaction::Transaction::update_location(&self) -> iceberg::transaction::update_location::UpdateLocationAction
 pub fn iceberg::transaction::Transaction::update_schema(&self) -> iceberg::transaction::update_schema::UpdateSchemaAction
 pub fn iceberg::transaction::Transaction::update_statistics(&self) -> iceberg::transaction::update_statistics::UpdateStatisticsAction
@@ -3695,6 +3699,8 @@ pub fn iceberg::memory::MemoryCatalog::rename_table<'life0, 'life1, 'life2, 'asy
 pub fn iceberg::memory::MemoryCatalog::table_exists<'life0, 'life1, 'async_trait>(&'life0 self, table_ident: &'life1 iceberg::TableIdent) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub fn iceberg::memory::MemoryCatalog::update_namespace<'life0, 'life1, 'async_trait>(&'life0 self, namespace_ident: &'life1 iceberg::NamespaceIdent, properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub fn iceberg::memory::MemoryCatalog::update_table<'life0, 'async_trait>(&'life0 self, commit: iceberg::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl iceberg::TransactionalCatalog for iceberg::memory::MemoryCatalog
+pub fn iceberg::memory::MemoryCatalog::create_table_transaction<'life0, 'life1, 'async_trait>(&'life0 self, namespace: &'life1 iceberg::NamespaceIdent, creation: iceberg::TableCreation) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::Transaction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub struct iceberg::MetadataLocation
 impl iceberg::MetadataLocation
 pub fn iceberg::MetadataLocation::compression_codec(&self) -> iceberg::compression::CompressionCodec
@@ -3796,7 +3802,9 @@ pub fn iceberg::SessionContext::builder() -> SessionContextBuilder<((), (), (), 
 pub struct iceberg::TableCommit
 impl iceberg::TableCommit
 pub fn iceberg::TableCommit::apply(self, table: iceberg::table::Table) -> iceberg::Result<iceberg::table::Table>
+pub fn iceberg::TableCommit::apply_new(self) -> iceberg::Result<iceberg::table::Table>
 pub fn iceberg::TableCommit::identifier(&self) -> &iceberg::TableIdent
+pub fn iceberg::TableCommit::is_create(&self) -> bool
 pub fn iceberg::TableCommit::take_requirements(&mut self) -> alloc::vec::Vec<iceberg::TableRequirement>
 pub fn iceberg::TableCommit::take_updates(&mut self) -> alloc::vec::Vec<iceberg::TableUpdate>
 impl core::fmt::Debug for iceberg::TableCommit
@@ -3916,5 +3924,9 @@ pub fn iceberg::SessionCatalog::rename_table<'life0, 'life1, 'life2, 'life3, 'as
 pub fn iceberg::SessionCatalog::table_exists<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, context: &'life1 iceberg::SessionContext, table: &'life2 iceberg::TableIdent) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub fn iceberg::SessionCatalog::update_namespace<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, context: &'life1 iceberg::SessionContext, namespace: &'life2 iceberg::NamespaceIdent, properties: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
 pub fn iceberg::SessionCatalog::update_table<'life0, 'life1, 'async_trait>(&'life0 self, context: &'life1 iceberg::SessionContext, commit: iceberg::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait iceberg::TransactionalCatalog: iceberg::Catalog
+pub fn iceberg::TransactionalCatalog::create_table_transaction<'life0, 'life1, 'async_trait>(&'life0 self, namespace: &'life1 iceberg::NamespaceIdent, creation: iceberg::TableCreation) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::Transaction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl iceberg::TransactionalCatalog for iceberg::memory::MemoryCatalog
+pub fn iceberg::memory::MemoryCatalog::create_table_transaction<'life0, 'life1, 'async_trait>(&'life0 self, namespace: &'life1 iceberg::NamespaceIdent, creation: iceberg::TableCreation) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::transaction::Transaction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 pub async fn iceberg::drop_table_data(table_info: &iceberg::table::Table) -> iceberg::Result<()>
 pub type iceberg::Result<T> = core::result::Result<T, iceberg::Error>

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -3810,7 +3810,7 @@ pub fn iceberg::TableCommit::take_updates(&mut self) -> alloc::vec::Vec<iceberg:
 impl core::fmt::Debug for iceberg::TableCommit
 pub fn iceberg::TableCommit::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl iceberg::TableCommit
-pub fn iceberg::TableCommit::builder() -> TableCommitBuilder<((), (), ())>
+pub fn iceberg::TableCommit::builder() -> TableCommitBuilder<((), (), (), ())>
 pub struct iceberg::TableCreation
 pub iceberg::TableCreation::format_version: iceberg::spec::FormatVersion
 pub iceberg::TableCreation::location: core::option::Option<alloc::string::String>

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -31,9 +31,10 @@ use crate::io::{FileIO, FileIOBuilder, MemoryStorageFactory, StorageFactory};
 use crate::runtime::Runtime;
 use crate::spec::{TableMetadata, TableMetadataBuilder};
 use crate::table::Table;
+use crate::transaction::Transaction;
 use crate::{
     Catalog, CatalogBuilder, Error, ErrorKind, MetadataLocation, Namespace, NamespaceIdent, Result,
-    TableCommit, TableCreation, TableIdent,
+    TableCommit, TableCreation, TableIdent, TransactionalCatalog,
 };
 
 /// Memory catalog warehouse location
@@ -413,13 +414,16 @@ impl Catalog for MemoryCatalog {
     /// Update a table in the catalog.
     async fn update_table(&self, commit: TableCommit) -> Result<Table> {
         let mut root_namespace_state = self.root_namespace_state.lock().await;
-
-        let current_table = self
-            .load_table_from_locked_state(commit.identifier(), &root_namespace_state)
-            .await?;
-
-        // Apply TableCommit to get staged table
-        let staged_table = commit.apply(current_table)?;
+        let creating =
+            commit.is_create() && !root_namespace_state.table_exists(commit.identifier())?;
+        let staged_table = if creating {
+            commit.apply_new()?
+        } else {
+            let current_table = self
+                .load_table_from_locked_state(commit.identifier(), &root_namespace_state)
+                .await?;
+            commit.apply(current_table)?
+        };
 
         // Write table metadata to the new location
         let metadata_location =
@@ -429,10 +433,55 @@ impl Catalog for MemoryCatalog {
             .write_to(staged_table.file_io(), &metadata_location)
             .await?;
 
-        // Flip the pointer to reference the new metadata file.
-        let updated_table = root_namespace_state.commit_table_update(staged_table)?;
+        if creating {
+            root_namespace_state
+                .insert_new_table(staged_table.identifier(), metadata_location.to_string())?;
+            Ok(staged_table)
+        } else {
+            root_namespace_state.commit_table_update(staged_table)
+        }
+    }
+}
 
-        Ok(updated_table)
+#[async_trait]
+impl TransactionalCatalog for MemoryCatalog {
+    async fn create_table_transaction(
+        &self,
+        namespace: &NamespaceIdent,
+        mut creation: TableCreation,
+    ) -> Result<Transaction> {
+        let root_namespace_state = self.root_namespace_state.lock().await;
+        let table_ident = TableIdent::new(namespace.clone(), creation.name.clone());
+        if root_namespace_state.table_exists(&table_ident)? {
+            return Err(Error::new(
+                ErrorKind::TableAlreadyExists,
+                format!("Cannot create table {table_ident:?}. Table already exists."),
+            ));
+        }
+        if creation.location.is_none() {
+            let namespace_properties = root_namespace_state.get_properties(namespace)?;
+            let location_prefix = namespace_properties
+                .get(LOCATION)
+                .cloned()
+                .unwrap_or_else(|| format!("{}/{}", self.warehouse_location, namespace.join("/")));
+            creation.location = Some(format!("{location_prefix}/{}", table_ident.name()));
+        }
+        drop(root_namespace_state);
+
+        let metadata = TableMetadataBuilder::from_table_creation(creation)?
+            .build()?
+            .metadata;
+        let metadata_location = MetadataLocation::try_new_with_metadata(&metadata)?;
+        let mut builder = Table::builder()
+            .file_io(self.file_io.clone())
+            .metadata_location(metadata_location.to_string())
+            .metadata(metadata)
+            .identifier(table_ident)
+            .runtime(self.runtime.clone());
+        if let Some(kms_client) = self.kms_client.clone() {
+            builder = builder.kms_client(kms_client);
+        }
+        Ok(Transaction::new_create(builder.build()?))
     }
 }
 
@@ -449,7 +498,10 @@ pub(crate) mod tests {
     use super::*;
     use crate::encryption::kms::MemoryKmsClientFactory;
     use crate::io::{FileIO, LocalFsStorageFactory};
-    use crate::spec::{NestedField, PartitionSpec, PrimitiveType, Schema, SortOrder, Type};
+    use crate::spec::{
+        DataContentType, DataFile, DataFileBuilder, DataFileFormat, NestedField, PartitionSpec,
+        PrimitiveType, Schema, SortOrder, Struct, Type,
+    };
     use crate::test_utils::test_runtime;
     use crate::transaction::{ApplyTransactionAction, Transaction};
 
@@ -458,7 +510,7 @@ pub(crate) mod tests {
         temp_dir.path().to_str().unwrap().to_string()
     }
 
-    pub(crate) async fn new_memory_catalog() -> impl Catalog {
+    pub(crate) async fn new_memory_catalog() -> impl TransactionalCatalog {
         let warehouse_location = temp_path();
         MemoryCatalogBuilder::default()
             .load(
@@ -491,6 +543,22 @@ pub(crate) mod tests {
             .with_fields(vec![
                 NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
             ])
+            .build()
+            .unwrap()
+    }
+
+    fn data_file(table: &Table, name: &str) -> DataFile {
+        DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path(format!(
+                "{}/data/{name}.parquet",
+                table.metadata().location()
+            ))
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .partition_spec_id(table.metadata().default_partition_spec_id())
+            .partition(Struct::empty())
             .build()
             .unwrap()
     }
@@ -1952,6 +2020,64 @@ pub(crate) mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::TableNotFound);
+    }
+
+    #[tokio::test]
+    async fn test_create_transaction_creates_atomically() {
+        let catalog = new_memory_catalog().await;
+        let namespace = NamespaceIdent::new("create_tx".to_string());
+        create_namespace(&catalog, &namespace).await;
+        let ident = TableIdent::new(namespace.clone(), "table".to_string());
+        let creation = TableCreation::builder()
+            .name(ident.name().to_string())
+            .schema(simple_table_schema())
+            .build();
+
+        let transaction = catalog
+            .create_table_transaction(&namespace, creation)
+            .await
+            .unwrap();
+        let file = data_file(transaction.table(), "created");
+        let action = transaction.fast_append().add_data_files([file]);
+        let transaction = action.apply(transaction).unwrap();
+
+        assert!(!catalog.table_exists(&ident).await.unwrap());
+
+        let table = transaction.commit(&catalog).await.unwrap();
+
+        assert!(catalog.table_exists(&ident).await.unwrap());
+        assert!(table.metadata().current_snapshot().is_some());
+        assert_eq!(1, table.metadata().snapshots().len());
+    }
+
+    #[tokio::test]
+    async fn test_create_transaction_rejects_concurrent_create() {
+        let catalog = new_memory_catalog().await;
+        let namespace = NamespaceIdent::new("concurrent_create_tx".to_string());
+        create_namespace(&catalog, &namespace).await;
+        let ident = TableIdent::new(namespace.clone(), "table".to_string());
+        let creation = TableCreation::builder()
+            .name(ident.name().to_string())
+            .schema(simple_table_schema())
+            .build();
+        let transaction = catalog
+            .create_table_transaction(&namespace, creation)
+            .await
+            .unwrap();
+
+        create_table(&catalog, &ident).await;
+        let error = transaction.commit(&catalog).await.unwrap_err();
+
+        assert_eq!(ErrorKind::CatalogCommitConflicts, error.kind());
+        assert!(
+            catalog
+                .load_table(&ident)
+                .await
+                .unwrap()
+                .metadata()
+                .current_snapshot()
+                .is_none()
+        );
     }
 
     /// Master key bytes used to generate the encrypted testdata fixtures.

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -50,6 +50,7 @@ use crate::spec::{
     UnboundPartitionSpec, ViewFormatVersion, ViewRepresentations, ViewVersion,
 };
 use crate::table::Table;
+use crate::transaction::Transaction;
 use crate::{Error, ErrorKind, Result};
 
 /// The catalog API for Iceberg Rust.
@@ -122,6 +123,17 @@ pub trait Catalog: Debug + Sync + Send {
 
     /// Update a table to the catalog.
     async fn update_table(&self, commit: TableCommit) -> Result<Table>;
+}
+
+/// Catalog operations that stage table creation in a transaction.
+#[async_trait]
+pub trait TransactionalCatalog: Catalog {
+    /// Start a transaction that creates a table when committed.
+    async fn create_table_transaction(
+        &self,
+        namespace: &NamespaceIdent,
+        creation: TableCreation,
+    ) -> Result<Transaction>;
 }
 
 /// Common interface for all catalog builders.
@@ -382,6 +394,8 @@ pub struct TableCommit {
     requirements: Vec<TableRequirement>,
     /// The updates of the table.
     updates: Vec<TableUpdate>,
+    #[builder(default, setter(skip))]
+    staged_table: Option<Table>,
 }
 
 impl TableCommit {
@@ -398,6 +412,30 @@ impl TableCommit {
     /// Take all updates.
     pub fn take_updates(&mut self) -> Vec<TableUpdate> {
         take(&mut self.updates)
+    }
+
+    /// Return whether this commit creates a table.
+    pub fn is_create(&self) -> bool {
+        self.staged_table.is_some()
+    }
+
+    pub(crate) fn with_staged_table(mut self, staged_table: Table) -> Self {
+        self.staged_table = Some(staged_table);
+        self
+    }
+
+    /// Apply a create commit when no table currently exists.
+    pub fn apply_new(self) -> Result<Table> {
+        for requirement in self.requirements {
+            requirement.check(None)?;
+        }
+
+        self.staged_table.ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "Cannot apply an update commit without an existing table",
+            )
+        })
     }
 
     /// Applies this [`TableCommit`] to the given [`Table`] as part of a catalog update.

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -394,7 +394,7 @@ pub struct TableCommit {
     requirements: Vec<TableRequirement>,
     /// The updates of the table.
     updates: Vec<TableUpdate>,
-    #[builder(default, setter(skip))]
+    #[builder(default, setter(strip_option))]
     staged_table: Option<Table>,
 }
 
@@ -417,11 +417,6 @@ impl TableCommit {
     /// Return whether this commit creates a table.
     pub fn is_create(&self) -> bool {
         self.staged_table.is_some()
-    }
-
-    pub(crate) fn with_staged_table(mut self, staged_table: Table) -> Self {
-        self.staged_table = Some(staged_table);
-        self
     }
 
     /// Apply a create commit when no table currently exists.

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -83,11 +83,19 @@ use crate::transaction::update_statistics::UpdateStatisticsAction;
 use crate::transaction::upgrade_format_version::UpgradeFormatVersionAction;
 use crate::{Catalog, Error, ErrorKind, TableCommit, TableRequirement, TableUpdate};
 
+#[derive(Clone)]
+enum TransactionType {
+    Update,
+    Create,
+}
+
 /// Table transaction.
 #[derive(Clone)]
 pub struct Transaction {
     table: Table,
     actions: Vec<BoxedTransactionAction>,
+    transaction_type: TransactionType,
+    initial_updates: Vec<TableUpdate>,
 }
 
 impl Transaction {
@@ -96,7 +104,25 @@ impl Transaction {
         Self {
             table: table.clone(),
             actions: vec![],
+            transaction_type: TransactionType::Update,
+            initial_updates: vec![],
         }
+    }
+
+    /// Creates a transaction from table metadata staged by a catalog.
+    pub fn new_create(table: Table) -> Self {
+        let initial_updates = create_updates(table.metadata());
+        Self {
+            table,
+            actions: vec![],
+            transaction_type: TransactionType::Create,
+            initial_updates,
+        }
+    }
+
+    /// Returns the table state visible inside this transaction.
+    pub fn table(&self) -> &Table {
+        &self.table
     }
 
     fn update_table_metadata(table: Table, updates: &[TableUpdate]) -> Result<Table> {
@@ -173,8 +199,7 @@ impl Transaction {
 
     /// Commit transaction.
     pub async fn commit(self, catalog: &dyn Catalog) -> Result<Table> {
-        if self.actions.is_empty() {
-            // nothing to commit
+        if self.actions.is_empty() && matches!(self.transaction_type, TransactionType::Update) {
             return Ok(self.table);
         }
 
@@ -186,6 +211,11 @@ impl Transaction {
                 ErrorKind::FeatureUnsupported,
                 "Cannot commit to an encrypted table: encrypted writes are not yet supported",
             ));
+        }
+
+        if matches!(self.transaction_type, TransactionType::Create) {
+            let mut tx = self;
+            return tx.do_commit(catalog).await;
         }
 
         let backoff = Self::build_backoff(table_props)?;
@@ -216,17 +246,18 @@ impl Transaction {
     }
 
     async fn do_commit(&mut self, catalog: &dyn Catalog) -> Result<Table> {
-        let refreshed = catalog.load_table(self.table.identifier()).await?;
+        if matches!(self.transaction_type, TransactionType::Update) {
+            let refreshed = catalog.load_table(self.table.identifier()).await?;
 
-        if self.table.metadata() != refreshed.metadata()
-            || self.table.metadata_location() != refreshed.metadata_location()
-        {
-            // current base is stale, use refreshed as base and re-apply transaction actions
-            self.table = refreshed.clone();
+            if self.table.metadata() != refreshed.metadata()
+                || self.table.metadata_location() != refreshed.metadata_location()
+            {
+                self.table = refreshed;
+            }
         }
 
         let mut current_table = self.table.clone();
-        let mut existing_updates: Vec<TableUpdate> = vec![];
+        let mut existing_updates = self.initial_updates.clone();
         let mut existing_requirements: Vec<TableRequirement> = vec![];
 
         for action in &self.actions {
@@ -240,14 +271,72 @@ impl Transaction {
             )?;
         }
 
+        existing_requirements = match &self.transaction_type {
+            TransactionType::Update => existing_requirements,
+            TransactionType::Create => vec![TableRequirement::NotExist],
+        };
+
         let table_commit = TableCommit::builder()
             .ident(self.table.identifier().to_owned())
             .updates(existing_updates)
             .requirements(existing_requirements)
             .build();
-
-        catalog.update_table(table_commit).await
+        if matches!(self.transaction_type, TransactionType::Create) {
+            catalog
+                .update_table(table_commit.with_staged_table(current_table))
+                .await
+        } else {
+            catalog.update_table(table_commit).await
+        }
     }
+}
+
+fn create_updates(metadata: &crate::spec::TableMetadata) -> Vec<TableUpdate> {
+    let mut updates = vec![
+        TableUpdate::AssignUuid {
+            uuid: metadata.uuid(),
+        },
+        TableUpdate::UpgradeFormatVersion {
+            format_version: metadata.format_version(),
+        },
+        TableUpdate::AddSchema {
+            schema: metadata.current_schema().as_ref().clone(),
+        },
+        TableUpdate::SetCurrentSchema {
+            schema_id: crate::spec::TableMetadataBuilder::LAST_ADDED,
+        },
+        TableUpdate::AddSpec {
+            spec: metadata
+                .default_partition_spec()
+                .as_ref()
+                .clone()
+                .into_unbound(),
+        },
+        TableUpdate::SetDefaultSpec {
+            spec_id: crate::spec::TableMetadataBuilder::LAST_ADDED,
+        },
+        TableUpdate::AddSortOrder {
+            sort_order: metadata.default_sort_order().as_ref().clone(),
+        },
+        TableUpdate::SetDefaultSortOrder {
+            sort_order_id: i64::from(crate::spec::TableMetadataBuilder::LAST_ADDED),
+        },
+        TableUpdate::SetLocation {
+            location: metadata.location().to_string(),
+        },
+    ];
+    if !metadata.properties().is_empty() {
+        updates.push(TableUpdate::SetProperties {
+            updates: metadata.properties().clone(),
+        });
+    }
+    updates.extend(
+        metadata
+            .encryption_keys_iter()
+            .cloned()
+            .map(|encryption_key| TableUpdate::AddEncryptionKey { encryption_key }),
+    );
+    updates
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -279,14 +279,13 @@ impl Transaction {
         let table_commit = TableCommit::builder()
             .ident(self.table.identifier().to_owned())
             .updates(existing_updates)
-            .requirements(existing_requirements)
-            .build();
+            .requirements(existing_requirements);
         if matches!(self.transaction_type, TransactionType::Create) {
             catalog
-                .update_table(table_commit.with_staged_table(current_table))
+                .update_table(table_commit.staged_table(current_table).build())
                 .await
         } else {
-            catalog.update_table(table_commit).await
+            catalog.update_table(table_commit.build()).await
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3040.

## What changes are included in this PR?

This PR adds staged table creation alongside the existing eager Catalog::create_table path. Implemented for MemoryCatalog and RestCatalog

## Are these changes tested?

Yes.

## AI Disclosure

Developed with the help of Codex.