### PR TITLE
chore(ci): Remove workflow trigger from publish.yml for PyPI publish, add note to release.md

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,15 +60,3 @@ jobs:
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-  # Trigger Python release after crate publishing completes.
-  # Only runs for tag pushes; for manual Python releases, use workflow_dispatch on release_python.yml directly.
-  release-python:
-    needs: [publish]
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    permissions:
-      contents: read
-      id-token: write # Required for PyPI trusted publishing in the called workflow
-    uses: ./.github/workflows/release_python.yml
-    with:
-      release_tag: ${{ github.ref_name }}

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -18,12 +18,6 @@
 name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
-  workflow_call:
-    inputs:
-      release_tag:
-        description: 'Release tag (e.g., v0.4.0 or v0.4.0-rc.1)'
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       release_tag:

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -230,6 +230,18 @@ git push origin "v${iceberg_version}-rc.${rc}"
 
 If an RC has a problem, abandon that RC and increment the RC number.
 
+### Trigger release candidate PyPI publish
+
+Python packages based on the release candidate are published to PyPI.
+These are published by a workflow that must be triggered manually.
+
+Trigger this now using the following GitHub CLI command, or the equivalent on the GitHub website.
+It must use the published release tag as the reference for the workflow run.
+
+```shell
+gh workflow run --repo apache/iceberg-rust release_python.yml -f release_tag=${rc_tag} --ref refs/tags/${rc_tag}
+```
+
 ### Draft an Apache Iceberg blog post
 
 The [Apache Iceberg blog](https://iceberg.apache.org/blog/) is one mechanism to share news about the project,
@@ -525,7 +537,7 @@ Trigger this now using the following GitHub CLI command, or the equivalent on th
 It must use the published release tag as the reference for the workflow run.
 
 ```shell
-gh workflow run --repo apache/iceberg-rust release_python.yml -f release_tag=v${iceberg_version} --ref refs/tags/v{iceberg_version}
+gh workflow run --repo apache/iceberg-rust release_python.yml -f release_tag=v${iceberg_version} --ref refs/tags/v${iceberg_version}
 ```
 
 Verify that the workflow succeeds, indicating that the Python packages are released.


### PR DESCRIPTION
## Which issue does this PR close?

Related to #2864.

## What changes are included in this PR?

Disables the automated trigger of the workflow as it is expected to fail at the moment. Workflow calls are not supported for PyPI trusted publishing.

Additionally, a minor fix was made to the full release step in `release.md`.

## Are these changes tested?

N/A

## AI Disclosure

No AI was used for this change.
