### PR TITLE
refactor: change from serialising a u64 to i64

### DIFF
--- a/crates/iceberg/src/spec/manifest_list/_serde.rs
+++ b/crates/iceberg/src/spec/manifest_list/_serde.rs
@@ -193,7 +193,7 @@ pub(super) struct ManifestFileV3 {
     pub deleted_rows_count: i64,
     pub partitions: Option<Vec<FieldSummary>>,
     pub key_metadata: Option<ByteBuf>,
-    pub first_row_id: Option<u64>,
+    pub first_row_id: Option<i64>,
 }
 
 impl ManifestFileV3 {
@@ -215,7 +215,7 @@ impl ManifestFileV3 {
             deleted_rows_count: Some(self.deleted_rows_count.try_into()?),
             partitions: self.partitions,
             key_metadata: self.key_metadata.map(|b| b.into_vec()),
-            first_row_id: self.first_row_id,
+            first_row_id: self.first_row_id.map(|n| n.try_into()).transpose()?,
         };
 
         Ok(manifest_file)
@@ -372,7 +372,7 @@ impl TryFrom<ManifestFile> for ManifestFileV3 {
                 .try_into()?,
             partitions: value.partitions,
             key_metadata,
-            first_row_id: value.first_row_id,
+            first_row_id: value.first_row_id.map(|n| n.try_into()).transpose()?,
         })
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This is a part of the upgrade to Avro 0.22. We currently serialise the manifest `first_row_id` as a `u64`, and this is incorrect and out of spec.

From the Iceberg spec:
 * `first_row_id` is defined as a `long` - see: https://iceberg.apache.org/spec/#manifest-lists
 * a long is defined as a `64-bit signed integer` - see: https://iceberg.apache.org/spec/#primitive-types

This is relevant to the Avro 0.22 upgrade because:
 - in version 0.21, serialising a `u64` as a long is allowed. It is silently coerced.
 - in version 0.22, this fails and is rejected.

- Closes some of #3063 

I am making this change on it's own to help isolate changes (and to isolate discussion in case this is the wrong place, or changes elsewhere are needed).

## What changes are included in this PR?

 - Change from serialising `first_row_id` as a `u64` to an `i64`.

## Are these changes tested?

 - Tests from main pass.
 - I've also made this change on the Avro 0.22 branch I have, and the latest version works with this change.

## AI Disclosure

The code changes and this PR comment is all made by a human.

Claude was used to debug the issue, and as a search. This included in code, and in spec.
