### PR TITLE
fix: Correct exempt list for issue staleness

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,8 +35,8 @@ jobs:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           # stale issues
-          stale-issue-label: 'stale,security'
-          exempt-issue-labels: 'not-stale'
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'not-stale,security'
           days-before-issue-stale: 180
           days-before-issue-close: 14
           stale-issue-message: >


### PR DESCRIPTION
## Which issue does this PR close?

No issue is open for this PR.

## What changes are included in this PR?

This fixes the exempt list - it should not include security issues when marking issues stale.

## Are these changes tested?

N/A

## AI Disclosure

No AI was used.