### PR TITLE
refactor: a first pass at changing to use i64 over u64

### DIFF
--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -880,9 +880,9 @@ pub(super) mod _serde {
         #[serde(skip_serializing_if = "Option::is_none")]
         schema_id: Option<SchemaId>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        first_row_id: Option<u64>,
+        first_row_id: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        added_rows: Option<u64>,
+        added_rows: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         key_id: Option<String>,
     }
@@ -2360,7 +2360,7 @@ mod tests {
                 {
                     "action": "remove-schemas",
                     "schema-ids": [1, 2]
-                }        
+                }
             "#,
             TableUpdate::RemoveSchemas {
                 schema_ids: vec![1, 2],
@@ -2382,7 +2382,7 @@ mod tests {
                         "encrypted-key-metadata": "{encoded_key}",
                         "encrypted-by-id": "b"
                     }}
-                }}        
+                }}
             "#
             ),
             TableUpdate::AddEncryptionKey {
@@ -2402,7 +2402,7 @@ mod tests {
                 {
                     "action": "remove-encryption-key",
                     "key-id": "a"
-                }        
+                }
             "#,
             TableUpdate::RemoveEncryptionKey {
                 key_id: "a".to_string(),

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -41,7 +41,7 @@ pub(crate) enum CachedObjectKey {
     // manifest inherits it onto its entries: the same physical manifest can be
     // referenced with different offsets across snapshots and branches, so it
     // cannot be shared under the path alone.
-    Manifest((String, Option<u64>)),
+    Manifest((String, Option<i64>)),
 }
 
 /// Caches metadata objects deserialized from immutable files

--- a/crates/iceberg/src/spec/manifest/reader.rs
+++ b/crates/iceberg/src/spec/manifest/reader.rs
@@ -314,7 +314,7 @@ mod tests {
 
     /// Builds a manifest file with the given content type and manifest-level
     /// `first_row_id`. Other fields are irrelevant to row-id assignment.
-    fn manifest_file(content: ManifestContentType, first_row_id: Option<u64>) -> ManifestFile {
+    fn manifest_file(content: ManifestContentType, first_row_id: Option<i64>) -> ManifestFile {
         ManifestFile {
             manifest_path: "memory:///m.avro".to_string(),
             manifest_length: 0,
@@ -398,7 +398,7 @@ mod tests {
     fn test_assign_first_row_ids_rejects_oversized_manifest_first_row_id() {
         // A manifest-level first_row_id above i64::MAX cannot be represented as the
         // signed running counter and must be rejected.
-        let manifest = manifest_file(ManifestContentType::Data, Some(i64::MAX as u64 + 1));
+        let manifest = manifest_file(ManifestContentType::Data, Some((i64::MAX as u64 + 1) as i64));
         let mut entries = vec![data_entry(ManifestStatus::Added, 3, None)];
 
         let err = test_reader()
@@ -412,7 +412,7 @@ mod tests {
     fn test_assign_first_row_ids_rejects_counter_overflow() {
         // Advancing the running counter past i64::MAX must be rejected rather than
         // wrapping to a negative value that would corrupt subsequent assignments.
-        let manifest = manifest_file(ManifestContentType::Data, Some(i64::MAX as u64));
+        let manifest = manifest_file(ManifestContentType::Data, Some(i64::MAX));
         let mut entries = vec![data_entry(ManifestStatus::Added, 1, None)];
 
         let err = test_reader()

--- a/crates/iceberg/src/spec/manifest/reader.rs
+++ b/crates/iceberg/src/spec/manifest/reader.rs
@@ -395,20 +395,6 @@ mod tests {
     }
 
     #[test]
-    fn test_assign_first_row_ids_rejects_oversized_manifest_first_row_id() {
-        // A manifest-level first_row_id above i64::MAX cannot be represented as the
-        // signed running counter and must be rejected.
-        let manifest = manifest_file(ManifestContentType::Data, Some((i64::MAX as u64 + 1) as i64));
-        let mut entries = vec![data_entry(ManifestStatus::Added, 3, None)];
-
-        let err = test_reader()
-            .assign_first_row_ids(&manifest, &mut entries)
-            .expect_err("an oversized manifest first_row_id must be rejected");
-        assert_eq!(err.kind(), ErrorKind::DataInvalid);
-        assert!(err.message().contains("Invalid first_row_id"));
-    }
-
-    #[test]
     fn test_assign_first_row_ids_rejects_counter_overflow() {
         // Advancing the running counter past i64::MAX must be rejected rather than
         // wrapping to a negative value that would corrupt subsequent assignments.

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -207,7 +207,7 @@ pub struct ManifestWriter {
     existing_rows: u64,
     deleted_files: u32,
     deleted_rows: u64,
-    first_row_id: Option<u64>,
+    first_row_id: Option<i64>,
 
     min_seq_num: Option<i64>,
 
@@ -226,7 +226,7 @@ impl ManifestWriter {
         snapshot_id: Option<i64>,
         key_metadata: Option<Vec<u8>>,
         metadata: ManifestMetadata,
-        first_row_id: Option<u64>,
+        first_row_id: Option<i64>,
     ) -> Self {
         Self {
             writer_future,

--- a/crates/iceberg/src/spec/manifest_list/_serde.rs
+++ b/crates/iceberg/src/spec/manifest_list/_serde.rs
@@ -193,7 +193,7 @@ pub(super) struct ManifestFileV3 {
     pub deleted_rows_count: i64,
     pub partitions: Option<Vec<FieldSummary>>,
     pub key_metadata: Option<ByteBuf>,
-    pub first_row_id: Option<u64>,
+    pub first_row_id: Option<i64>,
 }
 
 impl ManifestFileV3 {

--- a/crates/iceberg/src/spec/manifest_list/manifest_file.rs
+++ b/crates/iceberg/src/spec/manifest_list/manifest_file.rs
@@ -102,7 +102,7 @@ pub struct ManifestFile {
     /// field 520
     ///
     /// The starting _row_id to assign to rows added by ADDED data files
-    pub first_row_id: Option<u64>,
+    pub first_row_id: Option<i64>,
 }
 
 impl ManifestFile {

--- a/crates/iceberg/src/spec/manifest_list/writer.rs
+++ b/crates/iceberg/src/spec/manifest_list/writer.rs
@@ -36,7 +36,7 @@ pub struct ManifestListWriter {
     avro_writer: Writer<'static, Vec<u8>>,
     sequence_number: i64,
     snapshot_id: i64,
-    next_row_id: Option<u64>,
+    next_row_id: Option<i64>,
 }
 
 impl std::fmt::Debug for ManifestListWriter {
@@ -50,7 +50,7 @@ impl std::fmt::Debug for ManifestListWriter {
 
 impl ManifestListWriter {
     /// Get the next row ID that will be assigned to the next data manifest added.
-    pub fn next_row_id(&self) -> Option<u64> {
+    pub fn next_row_id(&self) -> Option<i64> {
         self.next_row_id
     }
 
@@ -107,7 +107,7 @@ impl ManifestListWriter {
         snapshot_id: i64,
         parent_snapshot_id: Option<i64>,
         sequence_number: i64,
-        first_row_id: Option<u64>, // Always None for delete manifests
+        first_row_id: Option<i64>, // Always None for delete manifests
     ) -> Self {
         let mut metadata = HashMap::from_iter([
             ("snapshot-id".to_string(), snapshot_id.to_string()),
@@ -142,7 +142,7 @@ impl ManifestListWriter {
         metadata: HashMap<String, String>,
         sequence_number: i64,
         snapshot_id: i64,
-        first_row_id: Option<u64>,
+        first_row_id: Option<i64>, // Always None for delete manifests
     ) -> Self {
         let avro_schema = match format_version {
             FormatVersion::V1 => &MANIFEST_LIST_AVRO_SCHEMA_V1,
@@ -289,7 +289,7 @@ impl ManifestListWriter {
     }
 }
 
-fn require_row_counts_in_manifest(manifest: &ManifestFile) -> Result<(u64, u64)> {
+fn require_row_counts_in_manifest(manifest: &ManifestFile) -> Result<(i64, i64)> {
     let existing_rows_count = manifest.existing_rows_count.ok_or_else(|| {
         Error::new(
             ErrorKind::DataInvalid,
@@ -308,7 +308,7 @@ fn require_row_counts_in_manifest(manifest: &ManifestFile) -> Result<(u64, u64)>
             ),
         )
     })?;
-    Ok((existing_rows_count, added_rows_count))
+    Ok((existing_rows_count as i64, added_rows_count as i64))
 }
 
 #[cfg(test)]

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -76,9 +76,9 @@ pub struct Summary {
 /// Row range of a snapshot, contains first_row_id and added_rows_count.
 pub struct SnapshotRowRange {
     /// The first _row_id assigned to the first row in the first data file in the first manifest.
-    pub first_row_id: u64,
+    pub first_row_id: i64,
     /// The upper bound of the number of rows with assigned row IDs
-    pub added_rows: u64,
+    pub added_rows: i64,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, TypedBuilder)]
@@ -112,7 +112,7 @@ pub struct Snapshot {
     pub(crate) encryption_key_id: Option<String>,
     /// Row range of this snapshot, required when the table version supports row lineage.
     /// Specify as a tuple of (first_row_id, added_rows_count)
-    #[builder(default, setter(!strip_option, transform = |first_row_id: u64, added_rows: u64| Some(SnapshotRowRange { first_row_id, added_rows })))]
+    #[builder(default, setter(!strip_option, transform = |first_row_id: i64, added_rows: i64| Some(SnapshotRowRange { first_row_id, added_rows })))]
     // This is specified as a struct instead of two separate fields to ensure that both fields are either set or not set.
     // The java implementations uses two separate fields, then sets `added_row_counts` to Null if `first_row_id` is set to Null.
     // It throws an error if `added_row_counts` is set but `first_row_id` is not set, or if either of the two is negative.
@@ -198,7 +198,7 @@ impl Snapshot {
     /// this branch) in the past.
     ///
     /// This field is optional but is required when the table version supports row lineage.
-    pub fn first_row_id(&self) -> Option<u64> {
+    pub fn first_row_id(&self) -> Option<i64> {
         self.row_range.as_ref().map(|r| r.first_row_id)
     }
 
@@ -206,13 +206,13 @@ impl Snapshot {
     /// ManifestFile#ADDED_ROWS_COUNT} for every manifest added in this snapshot.
     ///
     /// This field is optional but is required when the table version supports row lineage.
-    pub fn added_rows_count(&self) -> Option<u64> {
+    pub fn added_rows_count(&self) -> Option<i64> {
         self.row_range.as_ref().map(|r| r.added_rows)
     }
 
     /// Returns the row range of this snapshot, if available.
     /// This is a tuple containing (first_row_id, added_rows_count).
-    pub fn row_range(&self) -> Option<(u64, u64)> {
+    pub fn row_range(&self) -> Option<(i64, i64)> {
         self.row_range
             .as_ref()
             .map(|r| (r.first_row_id, r.added_rows))
@@ -252,9 +252,9 @@ pub(super) mod _serde {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub schema_id: Option<SchemaId>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub first_row_id: Option<u64>,
+        pub first_row_id: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub added_rows: Option<u64>,
+        pub added_rows: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub key_id: Option<String>,
     }

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -54,7 +54,7 @@ pub(crate) static EMPTY_SNAPSHOT_ID: i64 = -1;
 pub(crate) static INITIAL_SEQUENCE_NUMBER: i64 = 0;
 
 /// Initial row id for row lineage for new v3 tables and older tables upgrading to v3.
-pub const INITIAL_ROW_ID: u64 = 0;
+pub const INITIAL_ROW_ID: i64 = 0;
 /// Minimum format version that supports row lineage (v3).
 pub const MIN_FORMAT_VERSION_ROW_LINEAGE: FormatVersion = FormatVersion::V3;
 /// Reference to [`TableMetadata`].
@@ -137,7 +137,7 @@ pub struct TableMetadata {
     /// Encryption Keys - map of key id to the actual key
     pub(crate) encryption_keys: HashMap<String, EncryptedKey>,
     /// Next row id to be assigned for Row Lineage (v3)
-    pub(crate) next_row_id: u64,
+    pub(crate) next_row_id: i64,
 }
 
 impl TableMetadata {
@@ -454,7 +454,7 @@ impl TableMetadata {
 
     /// Get the next row id to be assigned
     #[inline]
-    pub fn next_row_id(&self) -> u64 {
+    pub fn next_row_id(&self) -> i64 {
         self.next_row_id
     }
 
@@ -815,7 +815,7 @@ pub(super) mod _serde {
         pub format_version: VersionNumber<3>,
         #[serde(flatten)]
         pub shared: TableMetadataV2V3Shared,
-        pub next_row_id: u64,
+        pub next_row_id: i64,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub encryption_keys: Option<Vec<EncryptedKey>>,
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
An example of moving all of the `u64` items to `i64`.