### PR TITLE
fix: allow name mappings without names

### DIFF
--- a/crates/iceberg/src/spec/name_mapping/mod.rs
+++ b/crates/iceberg/src/spec/name_mapping/mod.rs
@@ -51,6 +51,7 @@ impl NameMapping {
 pub struct MappedField {
     #[serde(skip_serializing_if = "Option::is_none")]
     field_id: Option<i32>,
+    #[serde(default)]
     names: Vec<String>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -146,6 +147,46 @@ mod tests {
         let mapped_field_with_null_fields: MappedField =
             serde_json::from_str(mapped_field_with_null_fields).unwrap();
         assert_eq!(mapped_field_with_null_fields, expected);
+    }
+
+    #[test]
+    fn test_json_mapped_field_omitted_names_deserialization() {
+        let mapped_field: MappedField = serde_json::from_str(
+            r#"
+            {
+                "field-id": 1
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(mapped_field, MappedField {
+            field_id: Some(1),
+            names: vec![],
+            fields: vec![],
+        });
+    }
+
+    #[test]
+    fn test_json_name_mapping_with_omitted_names_round_trip() {
+        let json = r#"[{"field-id":1},{"field-id":2,"names":["data"]}]"#;
+        let expected = NameMapping::new(vec![
+            MappedField::new(Some(1), vec![], vec![]),
+            MappedField::new(Some(2), vec!["data".to_string()], vec![]),
+        ]);
+
+        let name_mapping: NameMapping = serde_json::from_str(json).unwrap();
+        assert_eq!(name_mapping, expected);
+
+        let serialized = serde_json::to_string(&name_mapping).unwrap();
+        assert_eq!(
+            serialized,
+            r#"[{"field-id":1,"names":[]},{"field-id":2,"names":["data"]}]"#
+        );
+        assert_eq!(
+            serde_json::from_str::<NameMapping>(&serialized).unwrap(),
+            expected
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept Java-compatible name mapping entries that omit names by defaulting to an empty list
- add direct deserialization and round-trip coverage while retaining explicit names

## Testing

- cargo fmt --all -- --check
- cargo test -p iceberg spec::name_mapping --lib
- cargo clippy -p iceberg --lib --tests -- -D warnings
- cargo test -p iceberg --lib