### PR TITLE
docs: Add instruction to merge release branch back to main in release guide

### DIFF
--- a/website/src/release.md
+++ b/website/src/release.md
@@ -602,6 +602,19 @@ On behalf of Apache Iceberg Community
 
 Example: <https://lists.apache.org/thread/oy77n55brvk72tnlb2bjzfs9nz3cfd0s>
 
+### Merge changes from the release branch into main
+
+As the release branch evolves, changes will be added there that should be introduced to `main` branch too.
+This is the case even for the first release on a branch, since every release includes `CHANGELOG.md` entry updates.
+
+Create a pull request that pulls back the changes from the release branch.
+To prepare the pull request,
+create a merge commit from the release branch into main,
+run `make generate-public-api` and `./dev/release/dependencies.sh generate`,
+and open the pull request with both changes.
+
+Once merged into `main`, `main` is then ready for future release branches being cut from it.
+
 ### Publish the release blog post
 
 If a release blog post has been drafted (introduced earlier in this guide), now is the time to ensure it is ready to merge and publish.


### PR DESCRIPTION
## Which issue does this PR close?

Addresses action item in #2864.

## What changes are included in this PR?

Add note to release guide to instruct release manager to merge release branch back into `main` following each release.

## Are these changes tested?

N/A

## AI Disclosure

No AI was used in this change.