### PR TITLE
refactor(auth) Emphasize AuthManagers aren't shared between catalogs

### DIFF
--- a/crates/catalog/rest/public-api.txt
+++ b/crates/catalog/rest/public-api.txt
@@ -287,7 +287,7 @@ pub fn iceberg_catalog_rest::RestCatalog::update_namespace<'life0, 'life1, 'asyn
 pub fn iceberg_catalog_rest::RestCatalog::update_table<'life0, 'async_trait>(&'life0 self, commit: iceberg::catalog::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::error::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg_catalog_rest::RestCatalogBuilder
 impl iceberg_catalog_rest::RestCatalogBuilder
-pub fn iceberg_catalog_rest::RestCatalogBuilder::with_auth_manager(self, auth_manager: alloc::sync::Arc<dyn iceberg_catalog_rest::AuthManager>) -> Self
+pub fn iceberg_catalog_rest::RestCatalogBuilder::with_auth_manager<M>(self, auth_manager: M) -> Self where M: iceberg_catalog_rest::AuthManager + 'static
 pub fn iceberg_catalog_rest::RestCatalogBuilder::with_client(self, client: reqwest::async_impl::client::Client) -> Self
 pub fn iceberg_catalog_rest::RestCatalogBuilder::with_session_context(self, context: iceberg::catalog::session::SessionContext) -> Self
 impl core::default::Default for iceberg_catalog_rest::RestCatalogBuilder
@@ -322,7 +322,7 @@ pub fn iceberg_catalog_rest::RestSessionCatalog::update_table<'life0, 'life1, 'a
 pub struct iceberg_catalog_rest::RestSessionCatalogBuilder
 impl iceberg_catalog_rest::RestSessionCatalogBuilder
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::load(self, name: impl core::convert::Into<alloc::string::String>, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> impl core::future::future::Future<Output = iceberg::error::Result<iceberg_catalog_rest::RestSessionCatalog>> + core::marker::Send
-pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::with_auth_manager(self, auth_manager: alloc::sync::Arc<dyn iceberg_catalog_rest::AuthManager>) -> Self
+pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::with_auth_manager<M>(self, auth_manager: M) -> Self where M: iceberg_catalog_rest::AuthManager + 'static
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::with_client(self, client: reqwest::async_impl::client::Client) -> Self
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::with_kms_client_factory(self, kms_client_factory: alloc::sync::Arc<dyn iceberg::encryption::kms::factory::KmsClientFactory>) -> Self
 pub fn iceberg_catalog_rest::RestSessionCatalogBuilder::with_runtime(self, runtime: iceberg::runtime::Runtime) -> Self

--- a/crates/catalog/rest/src/auth/mod.rs
+++ b/crates/catalog/rest/src/auth/mod.rs
@@ -38,11 +38,13 @@ pub const AUTH_TYPE_OAUTH2: &str = "oauth2";
 
 /// Creates the [`AuthSession`]s used to authenticate REST catalog requests.
 ///
-/// A manager is created once per catalog, either from the `rest.auth.type`
-/// property or injected through
+/// A manager is exclusively scoped to one catalog and must not be reused by
+/// other catalogs. It is either created from the `rest.auth.type` property or
+/// injected through
 /// [`RestCatalogBuilder::with_auth_manager`](crate::RestCatalogBuilder::with_auth_manager) or
 /// [`RestSessionCatalogBuilder::with_auth_manager`](crate::RestSessionCatalogBuilder::with_auth_manager).
-/// It builds the sessions the catalog then keeps.
+/// Catalog initialization calls [`AuthManager::catalog_session`] exactly once;
+/// later sessions may rely on the state established by that call.
 ///
 /// Both methods are handed the catalog's [`HttpClient`], which an
 /// implementation may reuse for its own requests (e.g. a token exchange) so

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -128,8 +128,12 @@ impl RestCatalogBuilder {
         self
     }
 
-    /// Injects a custom auth manager, overriding the `rest.auth.type` configuration.
-    pub fn with_auth_manager(mut self, auth_manager: Arc<dyn AuthManager>) -> Self {
+    /// Sets a custom auth manager, overriding the `rest.auth.type` configuration.
+    ///
+    /// The builder takes ownership of the manager. The loaded catalog shares it
+    /// across authentication sessions and requests.
+    pub fn with_auth_manager<M>(mut self, auth_manager: M) -> Self
+    where M: AuthManager + 'static {
         self.inner = self.inner.with_auth_manager(auth_manager);
         self
     }
@@ -547,7 +551,7 @@ impl RestCatalog {
     fn new(
         context: SessionContext,
         config: RestCatalogConfig,
-        auth_manager: Option<Arc<dyn AuthManager>>,
+        auth_manager: Option<Box<dyn AuthManager>>,
         storage_factory: Option<Arc<dyn StorageFactory>>,
         runtime: Runtime,
         kms_client: Option<Arc<dyn KeyManagementClient>>,
@@ -706,13 +710,13 @@ impl RestSessionCatalog {
     /// Creates a `RestSessionCatalog` from a [`RestCatalogConfig`].
     fn new(
         config: RestCatalogConfig,
-        auth_manager: Option<Arc<dyn AuthManager>>,
+        auth_manager: Option<Box<dyn AuthManager>>,
         storage_factory: Option<Arc<dyn StorageFactory>>,
         runtime: Runtime,
         kms_client: Option<Arc<dyn KeyManagementClient>>,
     ) -> Self {
         Self {
-            auth_manager,
+            auth_manager: auth_manager.map(Arc::from),
             user_config: config,
             client: OnceCell::new(),
             storage_factory,
@@ -1489,7 +1493,7 @@ impl SessionCatalog for RestSessionCatalog {
 #[derive(Debug)]
 pub struct RestSessionCatalogBuilder {
     config: RestCatalogConfig,
-    auth_manager: Option<Arc<dyn AuthManager>>,
+    auth_manager: Option<Box<dyn AuthManager>>,
     storage_factory: Option<Arc<dyn StorageFactory>>,
     kms_client_factory: Option<Arc<dyn KmsClientFactory>>,
     runtime: Option<Runtime>,
@@ -1521,9 +1525,13 @@ impl RestSessionCatalogBuilder {
         self
     }
 
-    /// Injects a custom auth manager, overriding the `rest.auth.type` configuration.
-    pub fn with_auth_manager(mut self, auth_manager: Arc<dyn AuthManager>) -> Self {
-        self.auth_manager = Some(auth_manager);
+    /// Sets a custom auth manager, overriding the `rest.auth.type` configuration.
+    ///
+    /// The builder takes ownership of the manager. The loaded catalog shares it
+    /// across authentication sessions and requests.
+    pub fn with_auth_manager<M>(mut self, auth_manager: M) -> Self
+    where M: AuthManager + 'static {
+        self.auth_manager = Some(Box::new(auth_manager));
         self
     }
 
@@ -1676,14 +1684,18 @@ mod tests {
     use crate::request::HttpRequest;
 
     fn test_catalog(config: RestCatalogConfig) -> RestSessionCatalog {
-        test_catalog_with(config, None)
+        RestSessionCatalog::new(config, None, None, Runtime::current(), None)
     }
 
-    fn test_catalog_with(
-        config: RestCatalogConfig,
-        auth_manager: Option<Arc<dyn AuthManager>>,
-    ) -> RestSessionCatalog {
-        RestSessionCatalog::new(config, auth_manager, None, Runtime::current(), None)
+    fn test_catalog_with<M>(config: RestCatalogConfig, auth_manager: M) -> RestSessionCatalog
+    where M: AuthManager + 'static {
+        RestSessionCatalog::new(
+            config,
+            Some(Box::new(auth_manager)),
+            None,
+            Runtime::current(),
+            None,
+        )
     }
 
     fn test_client() -> HttpClient {
@@ -2410,7 +2422,7 @@ mod tests {
         let catalog = RestCatalog::new(
             SessionContext::empty(),
             RestCatalogConfig::builder().uri(server.url()).build(),
-            Some(Arc::new(manager)),
+            Some(Box::new(manager)),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,
@@ -2587,7 +2599,7 @@ mod tests {
                     "tok-user".to_string(),
                 )]))
                 .build(),
-            Some(Arc::new(CapturingManager(captured.clone()))),
+            Some(Box::new(CapturingManager(captured.clone()))),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,
@@ -2659,7 +2671,7 @@ mod tests {
                 .uri(server.url())
                 .warehouse("client-wh".to_string())
                 .build(),
-            Some(Arc::new(CapturingManager(captured.clone()))),
+            Some(Box::new(CapturingManager(captured.clone()))),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,
@@ -2691,7 +2703,7 @@ mod tests {
                 .uri(server.url())
                 .warehouse("client-wh".to_string())
                 .build(),
-            Some(Arc::new(CapturingManager(captured.clone()))),
+            Some(Box::new(CapturingManager(captured.clone()))),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,
@@ -2767,7 +2779,7 @@ mod tests {
         let catalog = RestCatalog::new(
             SessionContext::empty(),
             RestCatalogConfig::builder().uri(server.url()).build(),
-            Some(Arc::new(GuardManager(dropped.clone()))),
+            Some(Box::new(GuardManager(dropped.clone()))),
             Some(Arc::new(LocalFsStorageFactory)),
             Runtime::current(),
             None,
@@ -2912,7 +2924,7 @@ mod tests {
             .build();
 
         // The unknown auth type is never consulted.
-        let catalog = test_catalog_with(config, Some(Arc::new(StubAuthManager)));
+        let catalog = test_catalog_with(config, StubAuthManager);
         assert!(catalog.resolve_auth_manager().is_ok());
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

While working on the `OAuth2Manager::contextual_session` implementation, following https://github.com/apache/iceberg-rust/pull/3081, I noticed that some auth manager state that gets set during `AuthManager::catalog_session` (at catalog initialization) could get overwritten by later repeated calls to the same function.
Because later sessions are derived from that state (e.g. contextual sessions depend on the shared catalog session), calling `AuthManager::catalog_session` again, would reset that state (and should likely reset any cached contextual sessions). Well-behaved catalog implementations would not call that method multiple times, but an auth manager shared between multiple catalogs would result in the same behavior.

The expected contract is that auth manager is only used per catalog. This PR tries to make the API a little bit harder to misuse.

## What changes are included in this PR?

This PR makes REST catalog builders take ownership of custom `AuthManager` implementations instead of accepting a shared `Arc`. This emphasizes that each manager is scoped to one catalog and prevents accidental reuse across catalogs from resetting authentication state that later sessions may rely on.

The manager remains shared internally across the catalog's authentication sessions and requests. The public API snapshot and `AuthManager` documentation are updated accordingly.

## Are these changes tested?

No new tests are included because this only touches the ownership API. My coming PR to implement the `OAuth2Manager::contextual_session` shows how it changes a `Mutex<ContextualAuthState>` to a `OnceCell<ContextualAuthState>` by forcing the contract of a single `catalog_session` call per manager, repeated calls may error in that case.

## AI Disclosure

AI was used during implementation and documentation.
