### PR TITLE
refactor(memory): derive catalog configuration from properties

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1121,6 +1121,11 @@ pub fn iceberg::memory::MemoryCatalogBuilder::load(self, name: impl core::conver
 pub fn iceberg::memory::MemoryCatalogBuilder::with_kms_client_factory(self, kms_client_factory: alloc::sync::Arc<dyn iceberg::encryption::kms::KmsClientFactory>) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_runtime(self, runtime: iceberg::Runtime) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_storage_factory(self, storage_factory: alloc::sync::Arc<dyn iceberg::io::StorageFactory>) -> Self
+pub struct iceberg::memory::MemoryCatalogProperties
+impl iceberg::memory::MemoryCatalogProperties
+pub fn iceberg::memory::MemoryCatalogProperties::from_properties(properties: &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> iceberg::Result<Self>
+impl core::fmt::Debug for iceberg::memory::MemoryCatalogProperties
+pub fn iceberg::memory::MemoryCatalogProperties::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub const iceberg::memory::MEMORY_CATALOG_WAREHOUSE: &str
 pub mod iceberg::metadata_columns
 pub const iceberg::metadata_columns::RESERVED_COL_NAME_CHANGE_ORDINAL: &str

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1121,11 +1121,6 @@ pub fn iceberg::memory::MemoryCatalogBuilder::load(self, name: impl core::conver
 pub fn iceberg::memory::MemoryCatalogBuilder::with_kms_client_factory(self, kms_client_factory: alloc::sync::Arc<dyn iceberg::encryption::kms::KmsClientFactory>) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_runtime(self, runtime: iceberg::Runtime) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_storage_factory(self, storage_factory: alloc::sync::Arc<dyn iceberg::io::StorageFactory>) -> Self
-pub struct iceberg::memory::MemoryCatalogProperties
-impl iceberg::memory::MemoryCatalogProperties
-pub fn iceberg::memory::MemoryCatalogProperties::from_properties(properties: &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> iceberg::Result<Self>
-impl core::fmt::Debug for iceberg::memory::MemoryCatalogProperties
-pub fn iceberg::memory::MemoryCatalogProperties::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub const iceberg::memory::MEMORY_CATALOG_WAREHOUSE: &str
 pub mod iceberg::metadata_columns
 pub const iceberg::metadata_columns::RESERVED_COL_NAME_CHANGE_ORDINAL: &str

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1112,7 +1112,7 @@ pub fn iceberg::memory::MemoryCatalog::update_namespace<'life0, 'life1, 'async_t
 pub fn iceberg::memory::MemoryCatalog::update_table<'life0, 'async_trait>(&'life0 self, commit: iceberg::TableCommit) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = iceberg::Result<iceberg::table::Table>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 pub struct iceberg::memory::MemoryCatalogBuilder
 impl core::default::Default for iceberg::memory::MemoryCatalogBuilder
-pub fn iceberg::memory::MemoryCatalogBuilder::default() -> Self
+pub fn iceberg::memory::MemoryCatalogBuilder::default() -> iceberg::memory::MemoryCatalogBuilder
 impl core::fmt::Debug for iceberg::memory::MemoryCatalogBuilder
 pub fn iceberg::memory::MemoryCatalogBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl iceberg::CatalogBuilder for iceberg::memory::MemoryCatalogBuilder
@@ -1121,6 +1121,11 @@ pub fn iceberg::memory::MemoryCatalogBuilder::load(self, name: impl core::conver
 pub fn iceberg::memory::MemoryCatalogBuilder::with_kms_client_factory(self, kms_client_factory: alloc::sync::Arc<dyn iceberg::encryption::kms::KmsClientFactory>) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_runtime(self, runtime: iceberg::Runtime) -> Self
 pub fn iceberg::memory::MemoryCatalogBuilder::with_storage_factory(self, storage_factory: alloc::sync::Arc<dyn iceberg::io::StorageFactory>) -> Self
+pub struct iceberg::memory::MemoryCatalogProperties
+impl iceberg::memory::MemoryCatalogProperties
+pub fn iceberg::memory::MemoryCatalogProperties::from_properties(properties: &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> iceberg::Result<Self>
+impl core::fmt::Debug for iceberg::memory::MemoryCatalogProperties
+pub fn iceberg::memory::MemoryCatalogProperties::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub const iceberg::memory::MEMORY_CATALOG_WAREHOUSE: &str
 pub mod iceberg::metadata_columns
 pub const iceberg::metadata_columns::RESERVED_COL_NAME_CHANGE_ORDINAL: &str

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -78,6 +78,15 @@ impl CatalogBuilder for MemoryCatalogBuilder {
 
         async move {
             let catalog_properties = MemoryCatalogProperties::from_properties(&props)?;
+            if catalog_properties.warehouse.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Catalog warehouse is required",
+                ));
+            }
+
+            let mut props = props;
+            props.remove(MEMORY_CATALOG_WAREHOUSE);
             let runtime = self.runtime.unwrap_or_else(Runtime::current);
             let kms_client = match self.kms_client_factory {
                 Some(factory) => Some(factory.create_kms_client(&props).await?),
@@ -95,25 +104,10 @@ impl CatalogBuilder for MemoryCatalogBuilder {
     }
 }
 
-fn parse_warehouse(warehouse: &str) -> Result<String> {
-    if warehouse.is_empty() {
-        Err(Error::new(
-            ErrorKind::DataInvalid,
-            "Catalog warehouse is required",
-        ))
-    } else {
-        Ok(warehouse.to_string())
-    }
-}
-
 /// Memory catalog properties parsed from a catalog property map.
 #[derive(Debug, Properties)]
-pub struct MemoryCatalogProperties {
-    #[property(
-        key = MEMORY_CATALOG_WAREHOUSE,
-        default = "",
-        parse_with = parse_warehouse
-    )]
+pub(crate) struct MemoryCatalogProperties {
+    #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
     warehouse: String,
 }
 
@@ -303,12 +297,6 @@ impl Catalog for MemoryCatalog {
             let namespace_properties = root_namespace_state.get_properties(namespace_ident)?;
             let location_prefix = match namespace_properties.get(LOCATION) {
                 Some(namespace_location) => namespace_location.clone(),
-                None if self.properties.warehouse.is_empty() => {
-                    return Err(Error::new(
-                        ErrorKind::DataInvalid,
-                        "Catalog warehouse is required",
-                    ));
-                }
                 None => format!(
                     "{}/{}",
                     self.properties.warehouse,
@@ -465,31 +453,50 @@ pub(crate) mod tests {
 
     #[test]
     fn test_catalog_properties() {
-        let properties = MemoryCatalogProperties::from_properties(&HashMap::from([
-            (
-                MEMORY_CATALOG_WAREHOUSE.to_string(),
-                "memory:///warehouse".to_string(),
-            ),
-            ("custom.property".to_string(), "value".to_string()),
-        ]))
+        let properties = MemoryCatalogProperties::from_properties(&HashMap::from([(
+            MEMORY_CATALOG_WAREHOUSE.to_string(),
+            "memory:///warehouse".to_string(),
+        )]))
         .unwrap();
 
         assert_eq!(properties.warehouse, "memory:///warehouse");
-
-        let error = MemoryCatalogProperties::from_properties(&HashMap::from([(
-            MEMORY_CATALOG_WAREHOUSE.to_string(),
-            String::new(),
-        )]))
-        .unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::DataInvalid);
-        assert_eq!(error.message(), "Catalog warehouse is required");
     }
 
     #[test]
-    fn test_catalog_properties_with_default_warehouse() {
-        let properties = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap();
+    fn test_catalog_properties_warehouse_defaults_to_empty() {
+        let missing = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap();
+        let explicitly_empty = MemoryCatalogProperties::from_properties(&HashMap::from([(
+            MEMORY_CATALOG_WAREHOUSE.to_string(),
+            String::new(),
+        )]))
+        .unwrap();
 
-        assert_eq!(properties.warehouse, "");
+        assert_eq!(missing.warehouse, "");
+        assert_eq!(explicitly_empty.warehouse, "");
+    }
+
+    #[tokio::test]
+    async fn test_catalog_forwards_custom_properties_to_file_io() {
+        let catalog = MemoryCatalogBuilder::default()
+            .load(
+                "memory",
+                HashMap::from([
+                    (
+                        MEMORY_CATALOG_WAREHOUSE.to_string(),
+                        "memory:///warehouse".to_string(),
+                    ),
+                    ("custom.property".to_string(), "value".to_string()),
+                ]),
+            )
+            .await
+            .unwrap();
+        let file_io_props = catalog.file_io.config().props();
+
+        assert_eq!(
+            file_io_props.get("custom.property"),
+            Some(&"value".to_string())
+        );
+        assert!(!file_io_props.contains_key(MEMORY_CATALOG_WAREHOUSE));
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {
@@ -1435,32 +1442,28 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_table_throws_error_if_table_location_and_namespace_location_and_warehouse_location_are_missing()
-     {
-        let catalog = MemoryCatalogBuilder::default()
+    async fn test_load_throws_error_if_warehouse_is_missing() {
+        let error = MemoryCatalogBuilder::default()
             .load("memory", HashMap::from([]))
             .await
-            .unwrap();
-        let namespace_ident = NamespaceIdent::new("namespace".into());
-        catalog
-            .create_namespace(&namespace_ident, HashMap::new())
-            .await
-            .unwrap();
-        let error = catalog
-            .create_table(
-                &namespace_ident,
-                TableCreation::builder()
-                    .name("table".into())
-                    .schema(simple_table_schema())
-                    .build(),
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert_eq!(error.message(), "Catalog warehouse is required");
+    }
+
+    #[tokio::test]
+    async fn test_load_throws_error_if_warehouse_is_empty() {
+        let error = MemoryCatalogBuilder::default()
+            .load(
+                "memory",
+                HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), String::new())]),
             )
             .await
             .unwrap_err();
 
-        assert_eq!(
-            error.to_string(),
-            "DataInvalid => Catalog warehouse is required"
-        );
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert_eq!(error.message(), "Catalog warehouse is required");
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -85,8 +85,6 @@ impl CatalogBuilder for MemoryCatalogBuilder {
                 ));
             }
 
-            let mut props = props;
-            props.remove(MEMORY_CATALOG_WAREHOUSE);
             let runtime = self.runtime.unwrap_or_else(Runtime::current);
             let kms_client = match self.kms_client_factory {
                 Some(factory) => Some(factory.create_kms_client(&props).await?),
@@ -106,7 +104,7 @@ impl CatalogBuilder for MemoryCatalogBuilder {
 
 /// Memory catalog properties parsed from a catalog property map.
 #[derive(Debug, Properties)]
-pub struct MemoryCatalogProperties {
+pub(crate) struct MemoryCatalogProperties {
     #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
     warehouse: String,
 }
@@ -476,7 +474,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_catalog_forwards_custom_properties_to_file_io() {
+    async fn test_catalog_forwards_properties_to_file_io() {
         let catalog = MemoryCatalogBuilder::default()
             .load(
                 "memory",
@@ -496,7 +494,10 @@ pub(crate) mod tests {
             file_io_props.get("custom.property"),
             Some(&"value".to_string())
         );
-        assert!(!file_io_props.contains_key(MEMORY_CATALOG_WAREHOUSE));
+        assert_eq!(
+            file_io_props.get(MEMORY_CATALOG_WAREHOUSE),
+            Some(&"memory:///warehouse".to_string())
+        );
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -78,36 +78,42 @@ impl CatalogBuilder for MemoryCatalogBuilder {
 
         async move {
             let catalog_properties = MemoryCatalogProperties::from_properties(&props)?;
-            if catalog_properties.warehouse.is_empty() {
-                Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Catalog warehouse is required",
-                ))
-            } else {
-                let mut remaining_props = props;
-                remaining_props.remove(MEMORY_CATALOG_WAREHOUSE);
-                let runtime = self.runtime.unwrap_or_else(Runtime::current);
-                let kms_client = match self.kms_client_factory {
-                    Some(factory) => Some(factory.create_kms_client(&remaining_props).await?),
-                    None => None,
-                };
-                MemoryCatalog::new(
-                    name,
-                    catalog_properties,
-                    remaining_props,
-                    self.storage_factory,
-                    runtime,
-                    kms_client,
-                )
-            }
+            let runtime = self.runtime.unwrap_or_else(Runtime::current);
+            let kms_client = match self.kms_client_factory {
+                Some(factory) => Some(factory.create_kms_client(&props).await?),
+                None => None,
+            };
+            MemoryCatalog::new(
+                name,
+                catalog_properties,
+                props,
+                self.storage_factory,
+                runtime,
+                kms_client,
+            )
         }
+    }
+}
+
+fn parse_warehouse(warehouse: &str) -> Result<String> {
+    if warehouse.is_empty() {
+        Err(Error::new(
+            ErrorKind::DataInvalid,
+            "Catalog warehouse is required",
+        ))
+    } else {
+        Ok(warehouse.to_string())
     }
 }
 
 /// Memory catalog properties parsed from a catalog property map.
 #[derive(Debug, Properties)]
 pub struct MemoryCatalogProperties {
-    #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
+    #[property(
+        key = MEMORY_CATALOG_WAREHOUSE,
+        default = parse_warehouse("")?,
+        parse_with = parse_warehouse
+    )]
     warehouse: String,
 }
 
@@ -115,6 +121,7 @@ pub struct MemoryCatalogProperties {
 pub struct MemoryCatalog {
     name: String,
     properties: MemoryCatalogProperties,
+    props: HashMap<String, String>,
     root_namespace_state: Mutex<NamespaceState>,
     file_io: FileIO,
     runtime: Runtime,
@@ -126,6 +133,7 @@ impl std::fmt::Debug for MemoryCatalog {
         f.debug_struct("MemoryCatalog")
             .field("name", &self.name)
             .field("properties", &self.properties)
+            .field("props", &self.props)
             .finish_non_exhaustive()
     }
 }
@@ -135,7 +143,7 @@ impl MemoryCatalog {
     fn new(
         name: String,
         properties: MemoryCatalogProperties,
-        file_io_props: HashMap<String, String>,
+        props: HashMap<String, String>,
         storage_factory: Option<Arc<dyn StorageFactory>>,
         runtime: Runtime,
         kms_client: Option<Arc<dyn KeyManagementClient>>,
@@ -146,10 +154,11 @@ impl MemoryCatalog {
         Ok(Self {
             name,
             properties,
-            root_namespace_state: Mutex::new(NamespaceState::default()),
             file_io: FileIOBuilder::new(factory)
-                .with_props(file_io_props)
+                .with_props(props.clone())
                 .build(),
+            props,
+            root_namespace_state: Mutex::new(NamespaceState::default()),
             runtime,
             kms_client,
         })
@@ -465,6 +474,18 @@ pub(crate) mod tests {
         .unwrap();
 
         assert_eq!(properties.warehouse, "memory:///warehouse");
+
+        let error = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert_eq!(error.message(), "Catalog warehouse is required");
+
+        let error = MemoryCatalogProperties::from_properties(&HashMap::from([(
+            MEMORY_CATALOG_WAREHOUSE.to_string(),
+            String::new(),
+        )]))
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::DataInvalid);
+        assert_eq!(error.message(), "Catalog warehouse is required");
     }
 
     #[tokio::test]
@@ -486,15 +507,24 @@ pub(crate) mod tests {
         assert_eq!(catalog.name, "memory");
         assert_eq!(catalog.properties.warehouse, "memory:///warehouse");
         assert_eq!(
+            catalog.props.get(MEMORY_CATALOG_WAREHOUSE),
+            Some(&"memory:///warehouse".to_string())
+        );
+        assert_eq!(
+            catalog.props.get("custom.property"),
+            Some(&"value".to_string())
+        );
+        assert_eq!(
             catalog.file_io.config().props().get("custom.property"),
             Some(&"value".to_string())
         );
-        assert!(
-            !catalog
+        assert_eq!(
+            catalog
                 .file_io
                 .config()
                 .props()
-                .contains_key(MEMORY_CATALOG_WAREHOUSE)
+                .get(MEMORY_CATALOG_WAREHOUSE),
+            Some(&"memory:///warehouse".to_string())
         );
     }
 

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -44,27 +44,11 @@ pub const MEMORY_CATALOG_WAREHOUSE: &str = "warehouse";
 const LOCATION: &str = "location";
 
 /// Builder for [`MemoryCatalog`].
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MemoryCatalogBuilder {
-    config: MemoryCatalogConfig,
     storage_factory: Option<Arc<dyn StorageFactory>>,
     kms_client_factory: Option<Arc<dyn KmsClientFactory>>,
     runtime: Option<Runtime>,
-}
-
-impl Default for MemoryCatalogBuilder {
-    fn default() -> Self {
-        Self {
-            config: MemoryCatalogConfig {
-                name: None,
-                warehouse: "".to_string(),
-                props: HashMap::new(),
-            },
-            storage_factory: None,
-            kms_client_factory: None,
-            runtime: None,
-        }
-    }
 }
 
 impl CatalogBuilder for MemoryCatalogBuilder {
@@ -86,69 +70,72 @@ impl CatalogBuilder for MemoryCatalogBuilder {
     }
 
     fn load(
-        mut self,
+        self,
         name: impl Into<String>,
         props: HashMap<String, String>,
     ) -> impl Future<Output = Result<Self::C>> + Send {
-        self.config.name = Some(name.into());
+        let name = name.into();
 
         async move {
-            let mut catalog_properties = MemoryCatalogProperties::from_properties(&props)?;
-            catalog_properties.props.remove(MEMORY_CATALOG_WAREHOUSE);
-            self.config.warehouse = catalog_properties.warehouse;
-            self.config.props = catalog_properties.props;
-
-            if self.config.name.is_none() {
-                Err(Error::new(
-                    ErrorKind::DataInvalid,
-                    "Catalog name is required",
-                ))
-            } else if self.config.warehouse.is_empty() {
+            let catalog_properties = MemoryCatalogProperties::from_properties(&props)?;
+            if catalog_properties.warehouse.is_empty() {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Catalog warehouse is required",
                 ))
             } else {
+                let mut remaining_props = props;
+                remaining_props.remove(MEMORY_CATALOG_WAREHOUSE);
                 let runtime = self.runtime.unwrap_or_else(Runtime::current);
                 let kms_client = match self.kms_client_factory {
-                    Some(factory) => Some(factory.create_kms_client(&self.config.props).await?),
+                    Some(factory) => Some(factory.create_kms_client(&remaining_props).await?),
                     None => None,
                 };
-                MemoryCatalog::new(self.config, self.storage_factory, runtime, kms_client)
+                MemoryCatalog::new(
+                    name,
+                    catalog_properties,
+                    remaining_props,
+                    self.storage_factory,
+                    runtime,
+                    kms_client,
+                )
             }
         }
     }
 }
 
-#[derive(Properties)]
-struct MemoryCatalogProperties {
+/// Memory catalog properties parsed from a catalog property map.
+#[derive(Debug, Properties)]
+pub struct MemoryCatalogProperties {
     #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
     warehouse: String,
-    #[property(prefix = "")]
-    props: HashMap<String, String>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct MemoryCatalogConfig {
-    name: Option<String>,
-    warehouse: String,
-    props: HashMap<String, String>,
 }
 
 /// Memory catalog implementation.
-#[derive(Debug)]
 pub struct MemoryCatalog {
+    name: String,
+    properties: MemoryCatalogProperties,
     root_namespace_state: Mutex<NamespaceState>,
     file_io: FileIO,
-    warehouse_location: String,
     runtime: Runtime,
     kms_client: Option<Arc<dyn KeyManagementClient>>,
+}
+
+impl std::fmt::Debug for MemoryCatalog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryCatalog")
+            .field("name", &self.name)
+            .field("properties", &self.properties)
+            .finish_non_exhaustive()
+    }
 }
 
 impl MemoryCatalog {
     /// Creates a memory catalog.
     fn new(
-        config: MemoryCatalogConfig,
+        name: String,
+        properties: MemoryCatalogProperties,
+        file_io_props: HashMap<String, String>,
         storage_factory: Option<Arc<dyn StorageFactory>>,
         runtime: Runtime,
         kms_client: Option<Arc<dyn KeyManagementClient>>,
@@ -157,9 +144,12 @@ impl MemoryCatalog {
         let factory = storage_factory.unwrap_or_else(|| Arc::new(MemoryStorageFactory));
 
         Ok(Self {
+            name,
+            properties,
             root_namespace_state: Mutex::new(NamespaceState::default()),
-            file_io: FileIOBuilder::new(factory).with_props(config.props).build(),
-            warehouse_location: config.warehouse,
+            file_io: FileIOBuilder::new(factory)
+                .with_props(file_io_props)
+                .build(),
             runtime,
             kms_client,
         })
@@ -309,7 +299,11 @@ impl Catalog for MemoryCatalog {
             let namespace_properties = root_namespace_state.get_properties(namespace_ident)?;
             let location_prefix = match namespace_properties.get(LOCATION) {
                 Some(namespace_location) => namespace_location.clone(),
-                None => format!("{}/{}", self.warehouse_location, namespace_ident.join("/")),
+                None => format!(
+                    "{}/{}",
+                    self.properties.warehouse,
+                    namespace_ident.join("/")
+                ),
             };
 
             let location = format!("{}/{}", location_prefix, table_ident.name());
@@ -471,11 +465,37 @@ pub(crate) mod tests {
         .unwrap();
 
         assert_eq!(properties.warehouse, "memory:///warehouse");
+    }
+
+    #[tokio::test]
+    async fn test_catalog_retains_name_and_properties() {
+        let catalog = MemoryCatalogBuilder::default()
+            .load(
+                "memory",
+                HashMap::from([
+                    (
+                        MEMORY_CATALOG_WAREHOUSE.to_string(),
+                        "memory:///warehouse".to_string(),
+                    ),
+                    ("custom.property".to_string(), "value".to_string()),
+                ]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(catalog.name, "memory");
+        assert_eq!(catalog.properties.warehouse, "memory:///warehouse");
         assert_eq!(
-            properties.props[MEMORY_CATALOG_WAREHOUSE],
-            "memory:///warehouse"
+            catalog.file_io.config().props().get("custom.property"),
+            Some(&"value".to_string())
         );
-        assert_eq!(properties.props["custom.property"], "value");
+        assert!(
+            !catalog
+                .file_io
+                .config()
+                .props()
+                .contains_key(MEMORY_CATALOG_WAREHOUSE)
+        );
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -121,7 +121,6 @@ pub struct MemoryCatalogProperties {
 pub struct MemoryCatalog {
     name: String,
     properties: MemoryCatalogProperties,
-    props: HashMap<String, String>,
     root_namespace_state: Mutex<NamespaceState>,
     file_io: FileIO,
     runtime: Runtime,
@@ -133,7 +132,6 @@ impl std::fmt::Debug for MemoryCatalog {
         f.debug_struct("MemoryCatalog")
             .field("name", &self.name)
             .field("properties", &self.properties)
-            .field("props", &self.props)
             .finish_non_exhaustive()
     }
 }
@@ -154,10 +152,7 @@ impl MemoryCatalog {
         Ok(Self {
             name,
             properties,
-            file_io: FileIOBuilder::new(factory)
-                .with_props(props.clone())
-                .build(),
-            props,
+            file_io: FileIOBuilder::new(factory).with_props(props).build(),
             root_namespace_state: Mutex::new(NamespaceState::default()),
             runtime,
             kms_client,
@@ -481,9 +476,6 @@ pub(crate) mod tests {
 
         assert_eq!(properties.warehouse, "memory:///warehouse");
 
-        let properties = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap();
-        assert!(properties.warehouse.is_empty());
-
         let error = MemoryCatalogProperties::from_properties(&HashMap::from([(
             MEMORY_CATALOG_WAREHOUSE.to_string(),
             String::new(),
@@ -491,6 +483,13 @@ pub(crate) mod tests {
         .unwrap_err();
         assert_eq!(error.kind(), ErrorKind::DataInvalid);
         assert_eq!(error.message(), "Catalog warehouse is required");
+    }
+
+    #[test]
+    fn test_catalog_properties_with_default_warehouse() {
+        let properties = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap();
+
+        assert_eq!(properties.warehouse, "");
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::lock::{Mutex, MutexGuard};
+use iceberg_property_macro::Properties;
 use itertools::Itertools;
 
 use super::namespace_state::NamespaceState;
@@ -91,20 +92,12 @@ impl CatalogBuilder for MemoryCatalogBuilder {
     ) -> impl Future<Output = Result<Self::C>> + Send {
         self.config.name = Some(name.into());
 
-        if props.contains_key(MEMORY_CATALOG_WAREHOUSE) {
-            self.config.warehouse = props
-                .get(MEMORY_CATALOG_WAREHOUSE)
-                .cloned()
-                .unwrap_or_default()
-        }
-
-        // Collect other remaining properties
-        self.config.props = props
-            .into_iter()
-            .filter(|(k, _)| k != MEMORY_CATALOG_WAREHOUSE)
-            .collect();
-
         async move {
+            let mut catalog_properties = MemoryCatalogProperties::from_properties(&props)?;
+            catalog_properties.props.remove(MEMORY_CATALOG_WAREHOUSE);
+            self.config.warehouse = catalog_properties.warehouse;
+            self.config.props = catalog_properties.props;
+
             if self.config.name.is_none() {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
@@ -125,6 +118,14 @@ impl CatalogBuilder for MemoryCatalogBuilder {
             }
         }
     }
+}
+
+#[derive(Properties)]
+struct MemoryCatalogProperties {
+    #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
+    warehouse: String,
+    #[property(prefix = "")]
+    props: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug)]
@@ -456,6 +457,25 @@ pub(crate) mod tests {
     fn temp_path() -> String {
         let temp_dir = TempDir::new().unwrap();
         temp_dir.path().to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn test_catalog_properties() {
+        let properties = MemoryCatalogProperties::from_properties(&HashMap::from([
+            (
+                MEMORY_CATALOG_WAREHOUSE.to_string(),
+                "memory:///warehouse".to_string(),
+            ),
+            ("custom.property".to_string(), "value".to_string()),
+        ]))
+        .unwrap();
+
+        assert_eq!(properties.warehouse, "memory:///warehouse");
+        assert_eq!(
+            properties.props[MEMORY_CATALOG_WAREHOUSE],
+            "memory:///warehouse"
+        );
+        assert_eq!(properties.props["custom.property"], "value");
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -106,7 +106,7 @@ impl CatalogBuilder for MemoryCatalogBuilder {
 
 /// Memory catalog properties parsed from a catalog property map.
 #[derive(Debug, Properties)]
-pub(crate) struct MemoryCatalogProperties {
+pub struct MemoryCatalogProperties {
     #[property(key = MEMORY_CATALOG_WAREHOUSE, default = "")]
     warehouse: String,
 }

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -111,7 +111,7 @@ fn parse_warehouse(warehouse: &str) -> Result<String> {
 pub struct MemoryCatalogProperties {
     #[property(
         key = MEMORY_CATALOG_WAREHOUSE,
-        default = parse_warehouse("")?,
+        default = "",
         parse_with = parse_warehouse
     )]
     warehouse: String,
@@ -308,6 +308,12 @@ impl Catalog for MemoryCatalog {
             let namespace_properties = root_namespace_state.get_properties(namespace_ident)?;
             let location_prefix = match namespace_properties.get(LOCATION) {
                 Some(namespace_location) => namespace_location.clone(),
+                None if self.properties.warehouse.is_empty() => {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "Catalog warehouse is required",
+                    ));
+                }
                 None => format!(
                     "{}/{}",
                     self.properties.warehouse,
@@ -475,9 +481,8 @@ pub(crate) mod tests {
 
         assert_eq!(properties.warehouse, "memory:///warehouse");
 
-        let error = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::DataInvalid);
-        assert_eq!(error.message(), "Catalog warehouse is required");
+        let properties = MemoryCatalogProperties::from_properties(&HashMap::new()).unwrap();
+        assert!(properties.warehouse.is_empty());
 
         let error = MemoryCatalogProperties::from_properties(&HashMap::from([(
             MEMORY_CATALOG_WAREHOUSE.to_string(),
@@ -486,46 +491,6 @@ pub(crate) mod tests {
         .unwrap_err();
         assert_eq!(error.kind(), ErrorKind::DataInvalid);
         assert_eq!(error.message(), "Catalog warehouse is required");
-    }
-
-    #[tokio::test]
-    async fn test_catalog_retains_name_and_properties() {
-        let catalog = MemoryCatalogBuilder::default()
-            .load(
-                "memory",
-                HashMap::from([
-                    (
-                        MEMORY_CATALOG_WAREHOUSE.to_string(),
-                        "memory:///warehouse".to_string(),
-                    ),
-                    ("custom.property".to_string(), "value".to_string()),
-                ]),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(catalog.name, "memory");
-        assert_eq!(catalog.properties.warehouse, "memory:///warehouse");
-        assert_eq!(
-            catalog.props.get(MEMORY_CATALOG_WAREHOUSE),
-            Some(&"memory:///warehouse".to_string())
-        );
-        assert_eq!(
-            catalog.props.get("custom.property"),
-            Some(&"value".to_string())
-        );
-        assert_eq!(
-            catalog.file_io.config().props().get("custom.property"),
-            Some(&"value".to_string())
-        );
-        assert_eq!(
-            catalog
-                .file_io
-                .config()
-                .props()
-                .get(MEMORY_CATALOG_WAREHOUSE),
-            Some(&"memory:///warehouse".to_string())
-        );
     }
 
     pub(crate) async fn new_memory_catalog() -> impl Catalog {
@@ -1475,11 +1440,26 @@ pub(crate) mod tests {
      {
         let catalog = MemoryCatalogBuilder::default()
             .load("memory", HashMap::from([]))
-            .await;
+            .await
+            .unwrap();
+        let namespace_ident = NamespaceIdent::new("namespace".into());
+        catalog
+            .create_namespace(&namespace_ident, HashMap::new())
+            .await
+            .unwrap();
+        let error = catalog
+            .create_table(
+                &namespace_ident,
+                TableCreation::builder()
+                    .name("table".into())
+                    .schema(simple_table_schema())
+                    .build(),
+            )
+            .await
+            .unwrap_err();
 
-        assert!(catalog.is_err());
         assert_eq!(
-            catalog.unwrap_err().to_string(),
+            error.to_string(),
             "DataInvalid => Catalog warehouse is required"
         );
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3095.

## What changes are included in this PR?

- Replace manual Memory catalog property extraction with the shared `Properties` derive.
- Keep `MemoryCatalogProperties` crate-private and retain the parsed warehouse configuration inside `MemoryCatalog`.
- Preserve fail-fast validation for missing or empty warehouse properties during catalog loading.
- Forward the complete raw catalog property map to FileIO and KMS, matching Java behavior and avoiding a catalog-specific property denylist.
- Add focused coverage for typed properties, warehouse validation, and downstream forwarding of custom and warehouse properties.

## Are these changes tested?

- `cargo test -p iceberg catalog::memory`
- `cargo clippy -p iceberg --all-targets -- -D warnings`
- `cargo public-api -p iceberg --all-features -ss | diff - crates/iceberg/public-api.txt`
- `cargo fmt --all -- --check`

## AI Disclosure

This change was developed with assistance from OpenAI Codex. The contributor reviewed the resulting diff and test output.