### PR TITLE
fix(arrow): preserve predicates across numeric schema promotion

### DIFF
--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -1147,6 +1147,173 @@ mod tests {
         file_path
     }
 
+    #[tokio::test]
+    async fn test_predicates_with_numeric_promotion() {
+        use arrow_array::{Decimal128Array, Float32Array};
+
+        use crate::expr::{Bind, Reference};
+        use crate::spec::Datum;
+
+        let cases: Vec<(ArrayRef, PrimitiveType, Datum, Datum, Datum)> = vec![
+            (
+                Arc::new(Int32Array::from(vec![
+                    None,
+                    Some(i32::MIN),
+                    Some(1),
+                    Some(i32::MAX),
+                ])),
+                PrimitiveType::Long,
+                Datum::long(i64::from(i32::MIN) - 1),
+                Datum::long(i64::from(i32::MAX) + 1),
+                Datum::long(1),
+            ),
+            (
+                Arc::new(Float32Array::from(vec![
+                    None,
+                    Some(-f32::MAX),
+                    Some(1.0),
+                    Some(f32::MAX),
+                ])),
+                PrimitiveType::Double,
+                Datum::double(-1e300),
+                Datum::double(1e300),
+                Datum::double(1.0),
+            ),
+            (
+                Arc::new(
+                    Decimal128Array::from(vec![None, Some(-999), Some(1), Some(999)])
+                        .with_precision_and_scale(3, 0)
+                        .unwrap(),
+                ),
+                PrimitiveType::Decimal {
+                    precision: 4,
+                    scale: 0,
+                },
+                Datum::decimal_from_str("-1000").unwrap(),
+                Datum::decimal_from_str("1000").unwrap(),
+                Datum::decimal_from_str("1").unwrap(),
+            ),
+        ];
+        for (column, promoted_type, below, above, one) in cases {
+            let schema = Arc::new(
+                Schema::builder()
+                    .with_fields(vec![
+                        NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::optional(2, "x", Type::Primitive(promoted_type.clone()))
+                            .into(),
+                    ])
+                    .build()
+                    .unwrap(),
+            );
+            let fields = vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("x", column.data_type().clone(), true),
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, field)| {
+                field.with_metadata(HashMap::from([(
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    (idx + 1).to_string(),
+                )]))
+            })
+            .collect::<Vec<_>>();
+            let batch = RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                column,
+            ])
+            .unwrap();
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("old-schema.parquet");
+            let mut writer =
+                ArrowWriter::try_new(File::create(&path).unwrap(), batch.schema(), None).unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+
+            let x = || Reference::new("x");
+            let mut predicates = vec![
+                (x().less_than(above.clone()), vec![2, 3, 4]),
+                (x().less_than_or_equal_to(above.clone()), vec![2, 3, 4]),
+                (x().greater_than(below.clone()), vec![2, 3, 4]),
+                (x().greater_than_or_equal_to(below.clone()), vec![2, 3, 4]),
+                (x().equal_to(above.clone()), vec![]),
+                (x().not_equal_to(above.clone()), vec![2, 3, 4]),
+                (x().less_than(below.clone()), vec![]),
+                (x().greater_than(above.clone()), vec![]),
+                (x().not_equal_to(below), vec![2, 3, 4]),
+                (x().less_than(one.clone()), vec![2]),
+                (x().less_than_or_equal_to(one.clone()), vec![2, 3]),
+                (x().greater_than(one.clone()), vec![4]),
+                (x().greater_than_or_equal_to(one.clone()), vec![3, 4]),
+                (x().equal_to(one.clone()), vec![3]),
+                (x().not_equal_to(one.clone()), vec![2, 4]),
+                (x().is_in([one.clone(), above.clone()]), vec![3]),
+                (x().is_not_in([one.clone(), above]), vec![2, 4]),
+            ];
+            if promoted_type == PrimitiveType::Double {
+                // This literal rounds to 1.0 if narrowed to f32, without overflowing.
+                let between = Datum::double(1.00000001);
+                predicates.extend([
+                    (x().less_than(between.clone()), vec![2, 3]),
+                    (x().greater_than_or_equal_to(between.clone()), vec![4]),
+                    (x().equal_to(between.clone()), vec![]),
+                    (x().not_equal_to(between.clone()), vec![2, 3, 4]),
+                    (x().is_in([between.clone(), Datum::double(2.0)]), vec![]),
+                    (x().is_not_in([between, Datum::double(2.0)]), vec![2, 3, 4]),
+                ]);
+            }
+            for (predicate, expected) in predicates {
+                for row_group_filtering in [false, true] {
+                    for project_field_ids in [vec![1], vec![1, 2]] {
+                        let task = FileScanTask::builder()
+                            .with_file_size_in_bytes(path.metadata().unwrap().len())
+                            .with_start(0)
+                            .with_length(path.metadata().unwrap().len())
+                            .with_data_file_path(path.to_str().unwrap().to_string())
+                            .with_data_file_format(DataFileFormat::Parquet)
+                            .with_schema(schema.clone())
+                            .with_project_field_ids(project_field_ids)
+                            .with_case_sensitive(true)
+                            .with_predicate(Some(
+                                predicate.clone().bind(schema.clone(), true).unwrap(),
+                            ))
+                            .build();
+                        let reader =
+                            ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current())
+                                .with_row_group_filtering_enabled(row_group_filtering)
+                                .build();
+                        let tasks =
+                            Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+                        let batches: Vec<RecordBatch> = reader
+                            .read(tasks)
+                            .unwrap()
+                            .stream()
+                            .try_collect()
+                            .await
+                            .unwrap();
+                        let actual: Vec<i32> = batches
+                            .iter()
+                            .flat_map(|batch| {
+                                batch
+                                    .column(0)
+                                    .as_any()
+                                    .downcast_ref::<Int32Array>()
+                                    .unwrap()
+                                    .values()
+                                    .iter()
+                                    .copied()
+                            })
+                            .collect();
+                        assert_eq!(
+                            actual, expected,
+                            "{promoted_type:?}: {predicate}, row_group_filtering={row_group_filtering}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     fn last_updated_seq_task(
         file_path: String,
         first_row_id: Option<i64>,

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -1150,6 +1150,7 @@ mod tests {
     #[tokio::test]
     async fn test_predicates_with_numeric_promotion() {
         use arrow_array::{Decimal128Array, Float32Array};
+        use parquet::file::properties::EnabledStatistics;
 
         use crate::expr::{Bind, Reference};
         use crate::spec::Datum;
@@ -1193,6 +1194,20 @@ mod tests {
                 Datum::decimal_from_str("1000").unwrap(),
                 Datum::decimal_from_str("1").unwrap(),
             ),
+            (
+                Arc::new(
+                    Decimal128Array::from(vec![None, Some(-999), Some(100), Some(999)])
+                        .with_precision_and_scale(3, 2)
+                        .unwrap(),
+                ),
+                PrimitiveType::Decimal {
+                    precision: 4,
+                    scale: 2,
+                },
+                Datum::decimal_from_str("-10.00").unwrap(),
+                Datum::decimal_from_str("10.00").unwrap(),
+                Datum::decimal_from_str("1.00").unwrap(),
+            ),
         ];
         for (column, promoted_type, below, above, one) in cases {
             let schema = Arc::new(
@@ -1225,10 +1240,25 @@ mod tests {
             .unwrap();
             let dir = TempDir::new().unwrap();
             let path = dir.path().join("old-schema.parquet");
+            let props = WriterProperties::builder()
+                .set_statistics_enabled(EnabledStatistics::Page)
+                .set_max_row_group_row_count(Some(3))
+                .set_data_page_row_count_limit(2)
+                .set_write_batch_size(1)
+                .build();
             let mut writer =
-                ArrowWriter::try_new(File::create(&path).unwrap(), batch.schema(), None).unwrap();
+                ArrowWriter::try_new(File::create(&path).unwrap(), batch.schema(), Some(props))
+                    .unwrap();
             writer.write(&batch).unwrap();
-            writer.close().unwrap();
+            let metadata = writer.close().unwrap();
+            assert_eq!(metadata.num_row_groups(), 2);
+            assert!(
+                metadata
+                    .row_group(0)
+                    .column(1)
+                    .column_index_offset()
+                    .is_some()
+            );
 
             let x = || Reference::new("x");
             let mut predicates = vec![
@@ -1260,54 +1290,69 @@ mod tests {
                     (x().not_equal_to(between.clone()), vec![2, 3, 4]),
                     (x().is_in([between.clone(), Datum::double(2.0)]), vec![]),
                     (x().is_not_in([between, Datum::double(2.0)]), vec![2, 3, 4]),
+                    // Rounding up to 1.0 also changes the other two inequalities.
+                    (x().less_than_or_equal_to(Datum::double(0.99999999)), vec![
+                        2,
+                    ]),
+                    (x().greater_than(Datum::double(0.99999999)), vec![3, 4]),
                 ]);
             }
+            // Decimal page-index decoding is not yet supported, even without promotion.
+            let row_selection_options: &[bool] = match promoted_type {
+                PrimitiveType::Decimal { .. } => &[false],
+                _ => &[false, true],
+            };
             for (predicate, expected) in predicates {
                 for row_group_filtering in [false, true] {
-                    for project_field_ids in [vec![1], vec![1, 2]] {
-                        let task = FileScanTask::builder()
-                            .with_file_size_in_bytes(path.metadata().unwrap().len())
-                            .with_start(0)
-                            .with_length(path.metadata().unwrap().len())
-                            .with_data_file_path(path.to_str().unwrap().to_string())
-                            .with_data_file_format(DataFileFormat::Parquet)
-                            .with_schema(schema.clone())
-                            .with_project_field_ids(project_field_ids)
-                            .with_case_sensitive(true)
-                            .with_predicate(Some(
-                                predicate.clone().bind(schema.clone(), true).unwrap(),
-                            ))
-                            .build();
-                        let reader =
-                            ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current())
-                                .with_row_group_filtering_enabled(row_group_filtering)
+                    for &row_selection in row_selection_options {
+                        for project_field_ids in [vec![1], vec![1, 2]] {
+                            let filter_only = project_field_ids.len() == 1;
+                            let task = FileScanTask::builder()
+                                .with_file_size_in_bytes(path.metadata().unwrap().len())
+                                .with_start(0)
+                                .with_length(path.metadata().unwrap().len())
+                                .with_data_file_path(path.to_str().unwrap().to_string())
+                                .with_data_file_format(DataFileFormat::Parquet)
+                                .with_schema(schema.clone())
+                                .with_project_field_ids(project_field_ids)
+                                .with_case_sensitive(true)
+                                .with_predicate(Some(
+                                    predicate.clone().bind(schema.clone(), true).unwrap(),
+                                ))
                                 .build();
-                        let tasks =
-                            Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
-                        let batches: Vec<RecordBatch> = reader
-                            .read(tasks)
-                            .unwrap()
-                            .stream()
-                            .try_collect()
-                            .await
-                            .unwrap();
-                        let actual: Vec<i32> = batches
-                            .iter()
-                            .flat_map(|batch| {
-                                batch
-                                    .column(0)
-                                    .as_any()
-                                    .downcast_ref::<Int32Array>()
-                                    .unwrap()
-                                    .values()
-                                    .iter()
-                                    .copied()
-                            })
-                            .collect();
-                        assert_eq!(
-                            actual, expected,
-                            "{promoted_type:?}: {predicate}, row_group_filtering={row_group_filtering}"
-                        );
+                            let reader =
+                                ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current())
+                                    .with_row_group_filtering_enabled(row_group_filtering)
+                                    .with_row_selection_enabled(row_selection)
+                                    .with_batch_size(1)
+                                    .build();
+                            let tasks = Box::pin(futures::stream::iter(vec![Ok(task)]))
+                                as FileScanTaskStream;
+                            let batches: Vec<RecordBatch> = reader
+                                .read(tasks)
+                                .unwrap()
+                                .stream()
+                                .try_collect()
+                                .await
+                                .unwrap();
+                            let actual: Vec<i32> = batches
+                                .iter()
+                                .flat_map(|batch| {
+                                    batch
+                                        .column(0)
+                                        .as_any()
+                                        .downcast_ref::<Int32Array>()
+                                        .unwrap()
+                                        .values()
+                                        .iter()
+                                        .copied()
+                                })
+                                .collect();
+                            assert_eq!(
+                                actual, expected,
+                                "{promoted_type:?}: {predicate}, row_group_filtering={row_group_filtering}, row_selection={row_selection}, filter_only={filter_only}"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/iceberg/src/arrow/reader/predicate_visitor.rs
+++ b/crates/iceberg/src/arrow/reader/predicate_visitor.rs
@@ -34,7 +34,7 @@ use arrow_string::like::starts_with;
 use fnv::FnvHashSet;
 use parquet::schema::types::SchemaDescriptor;
 
-use crate::arrow::get_arrow_datum;
+use crate::arrow::{get_arrow_datum, type_to_arrow_type};
 use crate::error::Result;
 use crate::expr::visitors::bound_predicate_visitor::BoundPredicateVisitor;
 use crate::expr::{BoundPredicate, BoundReference};
@@ -274,6 +274,25 @@ fn project_column(
     }
 }
 
+/// Promote physical numeric columns before evaluating predicates bound to the table schema.
+/// Narrowing the literal instead can overflow to null or lose floating-point precision.
+fn project_predicate_column(
+    batch: &RecordBatch,
+    column_idx: usize,
+    column_type: &DataType,
+) -> std::result::Result<ArrayRef, ArrowError> {
+    let column = project_column(batch, column_idx)?;
+    match (column.data_type(), column_type) {
+        (DataType::Int32, DataType::Int64) | (DataType::Float32, DataType::Float64) => {
+            cast(&column, column_type)
+        }
+        (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) if p1 < p2 && s1 == s2 => {
+            cast(&column, column_type)
+        }
+        _ => Ok(column),
+    }
+}
+
 fn compute_is_nan(array: &ArrayRef) -> std::result::Result<BooleanArray, ArrowError> {
     // Compute NaN over the contiguous values slice, then fold the null bitmap
     // in with a single bitwise AND so that null slots become false.
@@ -420,10 +439,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 lt(&left, literal.as_ref())
             }))
@@ -440,10 +460,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 lt_eq(&left, literal.as_ref())
             }))
@@ -460,10 +481,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 gt(&left, literal.as_ref())
             }))
@@ -480,10 +502,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 gt_eq(&left, literal.as_ref())
             }))
@@ -500,10 +523,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 eq(&left, literal.as_ref())
             }))
@@ -520,10 +544,11 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literal = get_arrow_datum(literal)?;
 
             Ok(Box::new(move |batch| {
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let literal = try_cast_literal(&literal, left.data_type())?;
                 neq(&left, literal.as_ref())
             }))
@@ -581,6 +606,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literals: Vec<_> = literals
                 .iter()
                 .map(|lit| get_arrow_datum(lit).unwrap())
@@ -588,7 +614,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
 
             Ok(Box::new(move |batch| {
                 // update this if arrow ever adds a native is_in kernel
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
 
                 let mut acc = BooleanArray::from(vec![false; batch.num_rows()]);
                 for literal in &literals {
@@ -611,6 +637,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
         _predicate: &BoundPredicate,
     ) -> Result<Box<PredicateResult>> {
         if let Some(idx) = self.bound_reference(reference)? {
+            let column_type = type_to_arrow_type(&reference.field().field_type)?;
             let literals: Vec<_> = literals
                 .iter()
                 .map(|lit| get_arrow_datum(lit).unwrap())
@@ -618,7 +645,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
 
             Ok(Box::new(move |batch| {
                 // update this if arrow ever adds a native not_in kernel
-                let left = project_column(&batch, idx)?;
+                let left = project_predicate_column(&batch, idx, &column_type)?;
                 let mut acc = BooleanArray::from(vec![true; batch.num_rows()]);
                 for literal in &literals {
                     let literal = try_cast_literal(literal, left.data_type())?;
@@ -639,7 +666,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
 /// i.e. LargeUtf8 and Utf8 or Utf8View and Utf8 or Utf8View and LargeUtf8.
 ///
 /// The Arrow compute kernels that we use must match the type exactly, so first cast the literal
-/// into the type of the batch we read from Parquet before sending it to the compute kernel.
+/// into the column type after applying any numeric promotion to the column.
 fn try_cast_literal(
     literal: &Arc<dyn ArrowDatum + Send + Sync>,
     column_type: &DataType,

--- a/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
@@ -273,9 +273,14 @@ impl<'a> PageIndexEvaluator<'a> {
                 .enumerate()
                 .zip(row_counts.iter())
                 .map(|((i, (min, max)), &row_count)| {
+                    // Promote the value, not just the type label, for evolved columns.
+                    let to_datum = |&val| match field_type {
+                        PrimitiveType::Long => Datum::long(val),
+                        _ => Datum::new(field_type.clone(), PrimitiveLiteral::Int(val)),
+                    };
                     predicate(
-                        min.map(|&val| Datum::new(field_type.clone(), PrimitiveLiteral::Int(val))),
-                        max.map(|&val| Datum::new(field_type.clone(), PrimitiveLiteral::Int(val))),
+                        min.map(to_datum),
+                        max.map(to_datum),
                         PageNullCount::from_row_and_null_counts(row_count, idx.null_count(i)),
                     )
                 })
@@ -299,19 +304,16 @@ impl<'a> PageIndexEvaluator<'a> {
                 .enumerate()
                 .zip(row_counts.iter())
                 .map(|((i, (min, max)), &row_count)| {
+                    let to_datum = |&val| match field_type {
+                        PrimitiveType::Double => Datum::double(f64::from(val)),
+                        _ => Datum::new(
+                            field_type.clone(),
+                            PrimitiveLiteral::Float(OrderedFloat::from(val)),
+                        ),
+                    };
                     predicate(
-                        min.map(|&val| {
-                            Datum::new(
-                                field_type.clone(),
-                                PrimitiveLiteral::Float(OrderedFloat::from(val)),
-                            )
-                        }),
-                        max.map(|&val| {
-                            Datum::new(
-                                field_type.clone(),
-                                PrimitiveLiteral::Float(OrderedFloat::from(val)),
-                            )
-                        }),
+                        min.map(to_datum),
+                        max.map(to_datum),
                         PageNullCount::from_row_and_null_counts(row_count, idx.null_count(i)),
                     )
                 })


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3122.

## What changes are included in this PR?

After numeric schema evolution, Arrow row filters compare an old physical column with a literal bound to the new table schema. Casting the literal down can turn out-of-range integers into nulls or round floating-point values, silently changing which rows match.

This change promotes `Int32` columns to `Int64`, `Float32` to `Float64`, and `Decimal128` to a wider precision at the same scale before comparison. The six binary comparisons and `IN`/`NOT IN` share this path; each membership predicate promotes the column once per batch. Existing scalar casts between equivalent Arrow string/binary representations remain unchanged.

Optional page-index pruning now also promotes integer/float min/max values to `long`/`double`, instead of attaching the new type to an old physical literal variant. Otherwise, pruning can discard matching pages before the corrected row filter executes. Other index types keep their existing behavior.

No public API, dependency, metadata format, or persisted-data changes.

Scope: this covers Arrow row filtering and integer/float page-bound promotion. General decimal page-index decoding is still unsupported upstream even without evolution; adding `FIXED_LEN_BYTE_ARRAY` support is outside this fix (see closed, unmerged #1950). Decimal row filtering and row-group pruning are covered.

## Are these changes tested?

- End-to-end Parquet regression: **472 scan configurations** covering int→long, float→double, and decimal precision widening at scales 0 and 2. It checks out-of-range and in-range literals, all six comparisons, `IN`/`NOT IN`, nulls, and double literals just above/below a stored float that round to it when narrowed.
- The fixture spans multiple pages and row groups; reads use single-row batches. Both projected and filter-only columns are covered, with row-group and page pruning toggled independently for int/float. Decimal runs omit only unsupported page-index decoding.
- The original regression fails on upstream main. The expanded regression also fails against the initial row-filter-only PR head: with page pruning enabled, `x < 2147483648` returns no rows instead of `[2, 3, 4]`. All 472 configurations pass with both fixes.
- `cargo test -p iceberg --lib arrow::reader --locked`: **103 passed**.
- `cargo test -p iceberg --lib expr::visitors --locked`: **201 passed**.
- Strict workspace Clippy (`--all-targets --all-features --workspace --locked -- -D warnings`) passed.
- Rust formatting, tracked TOML formatting, and dependency-use checks passed. The tracked-file TOML check excludes a generated trybuild manifest under `target/`.
- Full local workspace suite (`cargo nextest run --all-targets --all-features --workspace --locked --no-fail-fast --test-threads 1`): **2,157 passed**, none failed or skipped.
- Workspace doctests (`cargo test --no-fail-fast --doc --all-features --workspace --locked`): **93 passed, 23 ignored**.
- All-target/all-feature workspace build and the standalone `iceberg` build with no default features passed.
- Python bindings built with Maturin; `uv run --no-sync pytest`: **17 passed, 2 skipped** (credential-gated Hugging Face tests).

**All 21 upstream checks pass on `c598504a3`**, including the integration suite and Linux/macOS/Windows builds and Python tests. All local results above were rerun on this updated commit.

Local Rust validation uses the pinned nightly with `CARGO_PROFILE_DEV_DEBUG=0`. On this ARM Mac, integration fixtures run under Colima with native Java 8 for Hive and `ICEBERG_TEST_HMS_ENDPOINT=127.0.0.1:9083`. The full local suite uses one worker to avoid SQLite fixture write-lock contention; no repository configuration or product code is changed for these local environment adaptations.

## AI Disclosure

Codex assisted with investigation, implementation, regression tests, and this description. The regression was executed before and after the fix, and the changed comparison paths were reviewed. Expanded validation reproduced the integer/float page-pruning gap before it was fixed. The separate decimal page-index feature remains outside this PR's scope.
