### PR TITLE
refactor(scan): validate FileScanTask construction

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1272,30 +1272,26 @@ pub const iceberg::puffin::CREATED_BY_PROPERTY: &str
 pub const iceberg::puffin::DELETION_VECTOR_V1: &str
 pub mod iceberg::scan
 pub struct iceberg::scan::FileScanTask
-pub iceberg::scan::FileScanTask::case_sensitive: bool
-pub iceberg::scan::FileScanTask::data_file_format: iceberg::spec::DataFileFormat
-pub iceberg::scan::FileScanTask::data_file_path: alloc::string::String
-pub iceberg::scan::FileScanTask::data_sequence_number: core::option::Option<i64>
-pub iceberg::scan::FileScanTask::deletes: alloc::vec::Vec<iceberg::scan::FileScanTaskDeleteFile>
-pub iceberg::scan::FileScanTask::file_size_in_bytes: u64
-pub iceberg::scan::FileScanTask::first_row_id: core::option::Option<i64>
-pub iceberg::scan::FileScanTask::key_metadata: core::option::Option<alloc::boxed::Box<[u8]>>
-pub iceberg::scan::FileScanTask::length: u64
-pub iceberg::scan::FileScanTask::name_mapping: core::option::Option<alloc::sync::Arc<iceberg::spec::NameMapping>>
-pub iceberg::scan::FileScanTask::partition: core::option::Option<iceberg::spec::Struct>
-pub iceberg::scan::FileScanTask::partition_spec: core::option::Option<alloc::sync::Arc<iceberg::spec::PartitionSpec>>
-pub iceberg::scan::FileScanTask::predicate: core::option::Option<iceberg::expr::BoundPredicate>
-pub iceberg::scan::FileScanTask::project_field_ids: alloc::vec::Vec<i32>
-pub iceberg::scan::FileScanTask::record_count: core::option::Option<u64>
-pub iceberg::scan::FileScanTask::schema: iceberg::spec::SchemaRef
-pub iceberg::scan::FileScanTask::start: u64
-pub iceberg::scan::FileScanTask::unified_partition_type: core::option::Option<alloc::sync::Arc<iceberg::spec::StructType>>
 impl iceberg::scan::FileScanTask
+pub fn iceberg::scan::FileScanTask::case_sensitive(&self) -> bool
+pub fn iceberg::scan::FileScanTask::data_file_format(&self) -> iceberg::spec::DataFileFormat
 pub fn iceberg::scan::FileScanTask::data_file_path(&self) -> &str
+pub fn iceberg::scan::FileScanTask::data_sequence_number(&self) -> core::option::Option<i64>
+pub fn iceberg::scan::FileScanTask::deletes(&self) -> &[iceberg::scan::FileScanTaskDeleteFile]
+pub fn iceberg::scan::FileScanTask::file_size_in_bytes(&self) -> u64
+pub fn iceberg::scan::FileScanTask::first_row_id(&self) -> core::option::Option<i64>
+pub fn iceberg::scan::FileScanTask::key_metadata(&self) -> core::option::Option<&[u8]>
+pub fn iceberg::scan::FileScanTask::length(&self) -> u64
+pub fn iceberg::scan::FileScanTask::name_mapping(&self) -> core::option::Option<&alloc::sync::Arc<iceberg::spec::NameMapping>>
+pub fn iceberg::scan::FileScanTask::partition(&self) -> core::option::Option<&iceberg::spec::Struct>
+pub fn iceberg::scan::FileScanTask::partition_spec(&self) -> core::option::Option<&alloc::sync::Arc<iceberg::spec::PartitionSpec>>
 pub fn iceberg::scan::FileScanTask::predicate(&self) -> core::option::Option<&iceberg::expr::BoundPredicate>
 pub fn iceberg::scan::FileScanTask::project_field_ids(&self) -> &[i32]
+pub fn iceberg::scan::FileScanTask::record_count(&self) -> core::option::Option<u64>
 pub fn iceberg::scan::FileScanTask::schema(&self) -> &iceberg::spec::Schema
 pub fn iceberg::scan::FileScanTask::schema_ref(&self) -> iceberg::spec::SchemaRef
+pub fn iceberg::scan::FileScanTask::start(&self) -> u64
+pub fn iceberg::scan::FileScanTask::unified_partition_type(&self) -> core::option::Option<&alloc::sync::Arc<iceberg::spec::StructType>>
 impl core::clone::Clone for iceberg::scan::FileScanTask
 pub fn iceberg::scan::FileScanTask::clone(&self) -> iceberg::scan::FileScanTask
 impl core::cmp::PartialEq for iceberg::scan::FileScanTask

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1296,6 +1296,8 @@ impl core::clone::Clone for iceberg::scan::FileScanTask
 pub fn iceberg::scan::FileScanTask::clone(&self) -> iceberg::scan::FileScanTask
 impl core::cmp::PartialEq for iceberg::scan::FileScanTask
 pub fn iceberg::scan::FileScanTask::eq(&self, other: &iceberg::scan::FileScanTask) -> bool
+impl core::convert::From<iceberg::scan::FileScanTask> for iceberg::Result<iceberg::scan::FileScanTask>
+pub fn iceberg::Result<iceberg::scan::FileScanTask>::from(task: iceberg::scan::FileScanTask) -> Self
 impl core::fmt::Debug for iceberg::scan::FileScanTask
 pub fn iceberg::scan::FileScanTask::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::scan::FileScanTask

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -949,7 +949,10 @@ mod tests {
         let file_scan_tasks = setup(table_location);
 
         let delete_filter = delete_file_loader
-            .load_deletes(&file_scan_tasks[0].deletes, file_scan_tasks[0].schema_ref())
+            .load_deletes(
+                file_scan_tasks[0].deletes(),
+                file_scan_tasks[0].schema_ref(),
+            )
             .await
             .unwrap()
             .unwrap();
@@ -1268,13 +1271,14 @@ mod tests {
             .with_project_field_ids(vec![2, 3])
             .with_deletes(vec![pos_del, eq_del])
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         // Load the deletes - should handle both types without error
         let delete_file_loader =
             CachingDeleteFileLoader::new(file_io.clone(), 10, Runtime::current());
         let delete_filter = delete_file_loader
-            .load_deletes(&file_scan_task.deletes, file_scan_task.schema_ref())
+            .load_deletes(file_scan_task.deletes(), file_scan_task.schema_ref())
             .await
             .unwrap()
             .unwrap();
@@ -1351,14 +1355,20 @@ mod tests {
 
         // Load deletes for the first time
         let delete_filter_1 = delete_file_loader
-            .load_deletes(&file_scan_tasks[0].deletes, file_scan_tasks[0].schema_ref())
+            .load_deletes(
+                file_scan_tasks[0].deletes(),
+                file_scan_tasks[0].schema_ref(),
+            )
             .await
             .unwrap()
             .unwrap();
 
         // Load deletes for the second time (same task/files)
         let delete_filter_2 = delete_file_loader
-            .load_deletes(&file_scan_tasks[0].deletes, file_scan_tasks[0].schema_ref())
+            .load_deletes(
+                file_scan_tasks[0].deletes(),
+                file_scan_tasks[0].schema_ref(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/crates/iceberg/src/arrow/delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/delete_file_loader.rs
@@ -162,7 +162,7 @@ mod tests {
 
         let result = delete_file_loader
             .read_delete_file(
-                &file_scan_tasks[0].deletes[0],
+                &file_scan_tasks[0].deletes()[0],
                 file_scan_tasks[0].schema_ref(),
             )
             .await

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -197,7 +197,7 @@ impl DeleteFilter {
         // * Bind the predicate to the task's schema to get a `BoundPredicate`
 
         let mut combined_predicate = AlwaysTrue;
-        for delete in &file_scan_task.deletes {
+        for delete in file_scan_task.deletes() {
             if !is_equality_delete(delete) {
                 continue;
             }
@@ -223,7 +223,7 @@ impl DeleteFilter {
         }
 
         let bound_predicate = combined_predicate
-            .bind(file_scan_task.schema.clone(), file_scan_task.case_sensitive)?;
+            .bind(file_scan_task.schema_ref(), file_scan_task.case_sensitive())?;
         Ok(Some(bound_predicate))
     }
 
@@ -345,7 +345,10 @@ pub(crate) mod tests {
         let file_scan_tasks = setup(table_location);
 
         let delete_filter = delete_file_loader
-            .load_deletes(&file_scan_tasks[0].deletes, file_scan_tasks[0].schema_ref())
+            .load_deletes(
+                file_scan_tasks[0].deletes(),
+                file_scan_tasks[0].schema_ref(),
+            )
             .await
             .unwrap()
             .unwrap();
@@ -356,7 +359,10 @@ pub(crate) mod tests {
         assert_eq!(result.lock().unwrap().len(), 12); // pos dels from pos del file 1 and 2
 
         let delete_filter = delete_file_loader
-            .load_deletes(&file_scan_tasks[1].deletes, file_scan_tasks[1].schema_ref())
+            .load_deletes(
+                file_scan_tasks[1].deletes(),
+                file_scan_tasks[1].schema_ref(),
+            )
             .await
             .unwrap()
             .unwrap();
@@ -483,7 +489,8 @@ pub(crate) mod tests {
                 .with_project_field_ids(vec![])
                 .with_deletes(vec![pos_del_1, pos_del_2.clone()])
                 .with_case_sensitive(false)
-                .build(),
+                .build()
+                .unwrap(),
             FileScanTask::builder()
                 .with_file_size_in_bytes(0)
                 .with_start(0)
@@ -494,7 +501,8 @@ pub(crate) mod tests {
                 .with_project_field_ids(vec![])
                 .with_deletes(vec![pos_del_3])
                 .with_case_sensitive(false)
-                .build(),
+                .build()
+                .unwrap(),
         ];
 
         file_scan_tasks
@@ -547,7 +555,8 @@ pub(crate) mod tests {
                     .build(),
             ])
             .with_case_sensitive(true)
-            .build();
+            .build()
+            .unwrap();
 
         let filter = DeleteFilter::new(Runtime::current());
 

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -3544,7 +3544,7 @@ mod tests {
     #[tokio::test]
     async fn test_spec_id_only_reads_no_data_columns() {
         use crate::metadata_columns::{RESERVED_COL_NAME_SPEC_ID, RESERVED_FIELD_ID_SPEC_ID};
-        use crate::spec::{PartitionSpec, Transform};
+        use crate::spec::{Literal, PartitionSpec, Struct, Transform};
 
         // `SELECT _spec_id` materializes an int constant from the task's partition spec id,
         // with no physical column to read. The RowNumber counter sizes it, so the scan
@@ -3570,6 +3570,7 @@ mod tests {
                 .with_data_file_format(DataFileFormat::Parquet)
                 .with_schema(schema.clone())
                 .with_project_field_ids(project_field_ids)
+                .with_partition(Some(Struct::from_iter([Some(Literal::int(42))])))
                 .with_partition_spec(Some(spec.clone()))
                 .with_case_sensitive(false)
                 .build()

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -129,23 +129,23 @@ struct FileScanTaskReader {
 
 impl FileScanTaskReader {
     async fn process(self, task: FileScanTask) -> Result<ArrowRecordBatchStream> {
-        let should_load_page_index =
-            (self.row_selection_enabled && task.predicate.is_some()) || !task.deletes.is_empty();
+        let should_load_page_index = (self.row_selection_enabled && task.predicate().is_some())
+            || !task.deletes().is_empty();
         let mut parquet_read_options = self.parquet_read_options;
         parquet_read_options.preload_page_index = should_load_page_index;
 
         let delete_filter_rx = self
             .delete_file_loader
-            .load_deletes(&task.deletes, Arc::clone(&task.schema));
+            .load_deletes(task.deletes(), task.schema_ref());
 
         // Open the Parquet file once, loading its metadata
         let (parquet_file_reader, arrow_metadata) = ArrowReader::open_parquet_file(
-            &task.data_file_path,
+            task.data_file_path(),
             &self.file_io,
-            task.file_size_in_bytes,
+            task.file_size_in_bytes(),
             parquet_read_options,
             self.scan_metrics.bytes_read_counter(),
-            task.key_metadata.as_deref(),
+            task.key_metadata(),
         )
         .await?;
 
@@ -163,7 +163,7 @@ impl FileScanTaskReader {
         // AND no name mapping is available. With a name mapping, field IDs are assigned
         // to the Arrow schema below, and projection/predicate planning must use them
         // (see #2403).
-        let use_position_fallback = missing_field_ids && task.name_mapping.is_none();
+        let use_position_fallback = missing_field_ids && task.name_mapping().is_none();
 
         // Three-branch schema resolution strategy matching Java's ReadConf constructor
         //
@@ -182,7 +182,7 @@ impl FileScanTaskReader {
         // - Branch 3: fallback → addFallbackIds(), then pruneColumnsFallback()
         let arrow_metadata = if missing_field_ids {
             // Parquet file lacks field IDs - must assign them before reading
-            let arrow_schema = if let Some(name_mapping) = &task.name_mapping {
+            let arrow_schema = if let Some(name_mapping) = task.name_mapping() {
                 // Branch 2: Apply name mapping to assign correct Iceberg field IDs
                 // Per spec rule #2: "Use schema.name-mapping.default metadata to map field id
                 // to columns without field id"
@@ -215,7 +215,7 @@ impl FileScanTaskReader {
         // Coerce INT96 timestamp columns to the resolution specified by the Iceberg schema.
         // This must happen before building the stream reader to avoid i64 overflow in arrow-rs.
         let arrow_metadata = if let Some(coerced_schema) =
-            coerce_int96_timestamps(arrow_metadata.schema(), &task.schema)
+            coerce_int96_timestamps(arrow_metadata.schema(), task.schema())
         {
             let options = ArrowReaderOptions::new().with_schema(Arc::clone(&coerced_schema));
             ArrowReaderMetadata::try_new(Arc::clone(arrow_metadata.metadata()), options).map_err(
@@ -240,7 +240,7 @@ impl FileScanTaskReader {
         // positional fallback for `_row_id` (`first_row_id + pos`), so add it whenever
         // `_row_id` is synthesized. A null `first_row_id` nulls the whole `_row_id`
         // column, so nothing is synthesized and the column is not needed.
-        let need_row_number = project_pos || (project_row_id && task.first_row_id.is_some());
+        let need_row_number = project_pos || (project_row_id && task.first_row_id().is_some());
 
         let field_ids = task.project_field_ids();
         let metadata_only_projection = !field_ids.is_empty()
@@ -317,7 +317,7 @@ impl FileScanTaskReader {
         // column below, discarding any per-row values the file carries -- matching Java
         // (`ValueReaders.lastUpdated` nulls when the base row id is null).
         let coalesce_last_updated_seq_leaf = phys_last_updated_seq_leaf
-            .filter(|_| task.first_row_id.is_some() && task.data_sequence_number.is_some());
+            .filter(|_| task.first_row_id().is_some() && task.data_sequence_number().is_some());
 
         let phys_row_id_leaf = if project_row_id {
             find_leaf_by_field_id(
@@ -344,11 +344,11 @@ impl FileScanTaskReader {
 
         // Read the physical column only when first_row_id is set. A null first_row_id
         // nulls the whole column below (matching Java `ValueReaders.rowIds`).
-        let coalesce_row_id_leaf = phys_row_id_leaf.filter(|_| task.first_row_id.is_some());
+        let coalesce_row_id_leaf = phys_row_id_leaf.filter(|_| task.first_row_id().is_some());
 
         // Filter out metadata fields for Parquet projection (they don't exist in files)
         let project_field_ids_without_metadata: Vec<i32> = task
-            .project_field_ids
+            .project_field_ids()
             .iter()
             .filter(|&&id| !is_metadata_field(id))
             .copied()
@@ -361,7 +361,7 @@ impl FileScanTaskReader {
         // - Otherwise: position-based fallback projection
         let mut projection_mask = ArrowReader::get_arrow_projection_mask(
             &project_field_ids_without_metadata,
-            &task.schema,
+            task.schema(),
             record_batch_stream_builder.parquet_schema(),
             record_batch_stream_builder.schema(),
             use_position_fallback, // Whether to use position-based (true) or field-ID-based (false) projection
@@ -406,7 +406,7 @@ impl FileScanTaskReader {
 
         // Add the _file metadata column if it's in the projected fields
         if task.project_field_ids().contains(&RESERVED_FIELD_ID_FILE) {
-            let file_datum = Datum::string(task.data_file_path.clone());
+            let file_datum = Datum::string(task.data_file_path().to_string());
             record_batch_transformer_builder =
                 record_batch_transformer_builder.with_constant(RESERVED_FIELD_ID_FILE, file_datum);
         }
@@ -416,8 +416,7 @@ impl FileScanTaskReader {
             .contains(&RESERVED_FIELD_ID_SPEC_ID)
         {
             let partition_spec = task
-                .partition_spec
-                .as_ref()
+                .partition_spec()
                 .ok_or_else(|| Error::new(ErrorKind::Unexpected, "Partition spec is missing"))?;
 
             let spec_id_datum = Datum::int(partition_spec.spec_id());
@@ -430,52 +429,55 @@ impl FileScanTaskReader {
             // it this way (`ValueReaders.lastUpdated` returns nulls when the base row id is
             // null); the spec itself only says the column is assigned the manifest entry's
             // sequence number on read.
-            record_batch_transformer_builder = match (task.first_row_id, task.data_sequence_number)
-            {
-                (Some(_), Some(seq)) => {
-                    let datum = Datum::long(seq);
-                    if coalesce_last_updated_seq_leaf.is_some() {
-                        // The file physically carries the column: read the per-row value,
-                        // falling back to the data sequence number only where null.
-                        record_batch_transformer_builder.with_coalesced_last_updated_seq_column(
-                            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
-                            datum,
-                        )
-                    } else if last_updated_seq_present_by_name_only {
-                        // Present by name but without the embedded field id (name mapping /
-                        // positional fallback). The transformer keys the source column by
-                        // field id, so we can't thread it; no real writer produces this, so
-                        // reject loudly rather than silently overwrite with the constant.
-                        // Arm-local by design: only this arm reads the physical column, so
-                        // only here can a name-only column defeat us. The `(None, _)` arm
-                        // nulls the column without reading it, so it needs no such guard.
-                        return Err(Error::new(
-                            ErrorKind::FeatureUnsupported,
-                            "Reading a physically-stored _last_updated_sequence_number column \
+            record_batch_transformer_builder =
+                match (task.first_row_id(), task.data_sequence_number()) {
+                    (Some(_), Some(seq)) => {
+                        let datum = Datum::long(seq);
+                        if coalesce_last_updated_seq_leaf.is_some() {
+                            // The file physically carries the column: read the per-row value,
+                            // falling back to the data sequence number only where null.
+                            record_batch_transformer_builder.with_coalesced_last_updated_seq_column(
+                                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                                datum,
+                            )
+                        } else if last_updated_seq_present_by_name_only {
+                            // Present by name but without the embedded field id (name mapping /
+                            // positional fallback). The transformer keys the source column by
+                            // field id, so we can't thread it; no real writer produces this, so
+                            // reject loudly rather than silently overwrite with the constant.
+                            // Arm-local by design: only this arm reads the physical column, so
+                            // only here can a name-only column defeat us. The `(None, _)` arm
+                            // nulls the column without reading it, so it needs no such guard.
+                            return Err(Error::new(
+                                ErrorKind::FeatureUnsupported,
+                                "Reading a physically-stored _last_updated_sequence_number column \
                              without an embedded field id is not supported",
-                        ));
-                    } else {
-                        // Column absent: derive it from the data sequence number.
-                        record_batch_transformer_builder
-                            .with_constant(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER, datum)
+                            ));
+                        } else {
+                            // Column absent: derive it from the data sequence number.
+                            record_batch_transformer_builder.with_constant(
+                                RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                                datum,
+                            )
+                        }
                     }
-                }
-                // Null first_row_id (v1/v2, or a pre-upgrade v3 snapshot): the column is null.
-                (None, _) => record_batch_transformer_builder
-                    .with_null_metadata_column(RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER)?,
-                // first_row_id present but no data sequence number: after manifest
-                // inheritance a committed entry always has one, so this is a malformed
-                // manifest rather than a legitimate null.
-                (Some(_), None) => {
-                    return Err(Error::new(
-                        ErrorKind::DataInvalid,
-                        format!(
-                            "Data file {} has a first_row_id but no data sequence number",
-                            task.data_file_path
-                        ),
-                    ));
-                }
-            };
+                    // Null first_row_id (v1/v2, or a pre-upgrade v3 snapshot): the column is null.
+                    (None, _) => record_batch_transformer_builder.with_null_metadata_column(
+                        RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+                    )?,
+                    // first_row_id present but no data sequence number: after manifest
+                    // inheritance a committed entry always has one, so this is a malformed
+                    // manifest rather than a legitimate null.
+                    (Some(_), None) => {
+                        return Err(Error::new(
+                            ErrorKind::DataInvalid,
+                            format!(
+                                "Data file {} has a first_row_id but no data sequence number",
+                                task.data_file_path()
+                            ),
+                        ));
+                    }
+                };
         }
 
         if project_row_id {
@@ -484,7 +486,7 @@ impl FileScanTaskReader {
             // leaf is never read and `_row_id` is nulled out downstream (matching Java
             // `ValueReaders.rowIds`), so a pre-v3 file with a user column named `_row_id`
             // reads back as null rather than erroring.
-            if task.first_row_id.is_some() && row_id_present_by_name_only {
+            if task.first_row_id().is_some() && row_id_present_by_name_only {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
                     "Reading a physically-stored _row_id column without an embedded field id \
@@ -500,10 +502,10 @@ impl FileScanTaskReader {
         }
 
         if let (Some(partition_spec), Some(partition_data)) =
-            (task.partition_spec.clone(), task.partition.clone())
+            (task.partition_spec(), task.partition())
         {
-            record_batch_transformer_builder =
-                record_batch_transformer_builder.with_partition(partition_spec, partition_data)?;
+            record_batch_transformer_builder = record_batch_transformer_builder
+                .with_partition(Arc::clone(partition_spec), partition_data.clone())?;
         }
 
         if project_pos {
@@ -516,10 +518,10 @@ impl FileScanTaskReader {
         if task
             .project_field_ids()
             .contains(&RESERVED_FIELD_ID_PARTITION)
-            && let Some(unified_type) = &task.unified_partition_type
+            && let Some(unified_type) = task.unified_partition_type()
         {
-            let (spec, partition_data) = match (&task.partition_spec, &task.partition) {
-                (Some(spec), Some(data)) => (spec.clone(), data.clone()),
+            let (spec, partition_data) = match (task.partition_spec(), task.partition()) {
+                (Some(spec), Some(data)) => (Arc::clone(spec), data.clone()),
                 // A missing spec/data is only acceptable when there are no partition
                 // fields to fill (unpartitioned table). If the unified type has fields
                 // but we lack a spec or data, the task is inconsistent and we cannot
@@ -553,7 +555,7 @@ impl FileScanTaskReader {
         // we also have an optional predicate resulting from equality delete files.
         // If both are present, we logical-AND them together to form a single filter
         // predicate that we can pass to the `RecordBatchStreamBuilder`.
-        let final_predicate = match (&task.predicate, delete_predicate) {
+        let final_predicate = match (task.predicate(), delete_predicate) {
             (None, None) => None,
             (Some(predicate), None) => Some(predicate.clone()),
             (None, Some(ref predicate)) => Some(predicate.clone()),
@@ -582,11 +584,11 @@ impl FileScanTaskReader {
 
         // Filter row groups based on byte range from task.start and task.length.
         // If both start and length are 0, read the entire file (backwards compatibility).
-        if task.start != 0 || task.length != 0 {
+        if task.start() != 0 || task.length() != 0 {
             let byte_range_filtered_row_groups = ArrowReader::filter_row_groups_by_byte_range(
                 record_batch_stream_builder.metadata(),
-                task.start,
-                task.length,
+                task.start(),
+                task.length(),
             )?;
             selected_row_group_indices = Some(byte_range_filtered_row_groups);
         }
@@ -612,7 +614,7 @@ impl FileScanTaskReader {
                     &predicate,
                     record_batch_stream_builder.metadata(),
                     &field_id_map,
-                    &task.schema,
+                    task.schema(),
                 )?;
 
                 // Merge predicate-based filtering with byte range filtering (if present)
@@ -636,7 +638,7 @@ impl FileScanTaskReader {
                     record_batch_stream_builder.metadata(),
                     &selected_row_group_indices,
                     &field_id_map,
-                    &task.schema,
+                    task.schema(),
                 )?;
             }
         }
@@ -678,7 +680,7 @@ impl FileScanTaskReader {
         // to the requester. When `_row_id` is projected, synthesize it over the raw parquet
         // batches (using the reader-produced `_pos` position) before the transformer, which
         // then passes it through as a virtual field.
-        let first_row_id = task.first_row_id;
+        let first_row_id = task.first_row_id();
         let record_batch_stream = record_batch_stream_builder.build()?.map(move |batch| {
             let mut batch = batch.map_err(|err| -> Error { err.into() })?;
             if project_row_id {
@@ -793,7 +795,7 @@ mod tests {
         RESERVED_COL_NAME_POS, RESERVED_COL_NAME_ROW_ID, RESERVED_FIELD_ID_FILE,
         RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_ROW_ID,
     };
-    use crate::scan::{FileScanTask, FileScanTaskStream};
+    use crate::scan::{FileScanTask, FileScanTaskDeleteFile, FileScanTaskStream};
     use crate::spec::{DataFileFormat, NestedField, PrimitiveType, Schema, SchemaRef, Type};
 
     // INT96 encoding: [nanos_low_u32, nanos_high_u32, julian_day_u32]
@@ -834,7 +836,8 @@ mod tests {
             .with_schema(schema)
             .with_project_field_ids(project_field_ids)
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         reader
@@ -1023,7 +1026,8 @@ mod tests {
             .with_project_field_ids(vec![1])
             .with_case_sensitive(false)
             .with_key_metadata(Some(key_metadata))
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let batches: Vec<RecordBatch> = reader
@@ -1095,7 +1099,8 @@ mod tests {
             .with_schema(schema)
             .with_project_field_ids(vec![1])
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let result: Result<Vec<RecordBatch>, _> =
@@ -1176,6 +1181,7 @@ mod tests {
             .with_data_sequence_number(data_sequence_number)
             .with_case_sensitive(false)
             .build()
+            .unwrap()
     }
 
     /// Asserts the logical per-row values of the `_last_updated_sequence_number`
@@ -1419,7 +1425,8 @@ mod tests {
             .with_first_row_id(Some(100))
             .with_data_sequence_number(Some(9))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
@@ -1535,6 +1542,16 @@ mod tests {
 
     /// A scan task projecting `id` + `_row_id`, with the given `first_row_id`.
     fn row_id_task(file_path: String, first_row_id: Option<i64>) -> FileScanTask {
+        row_id_task_with_options(file_path, first_row_id, 0, 0, vec![])
+    }
+
+    fn row_id_task_with_options(
+        file_path: String,
+        first_row_id: Option<i64>,
+        start: u64,
+        length: u64,
+        deletes: Vec<FileScanTaskDeleteFile>,
+    ) -> FileScanTask {
         let schema = Arc::new(
             Schema::builder()
                 .with_schema_id(1)
@@ -1547,15 +1564,17 @@ mod tests {
 
         FileScanTask::builder()
             .with_file_size_in_bytes(std::fs::metadata(&file_path).unwrap().len())
-            .with_start(0)
-            .with_length(0)
+            .with_start(start)
+            .with_length(length)
             .with_data_file_path(file_path)
             .with_data_file_format(DataFileFormat::Parquet)
             .with_schema(schema)
             .with_project_field_ids(vec![1, RESERVED_FIELD_ID_ROW_ID])
             .with_first_row_id(first_row_id)
+            .with_deletes(deletes)
             .with_case_sensitive(false)
             .build()
+            .unwrap()
     }
 
     /// Asserts the logical per-row values of the `_row_id` column across all batches,
@@ -1650,24 +1669,24 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
 
-        let mut meta_only = metadata_projection_task(
+        let meta_only = metadata_projection_task_with_first_row_id(
             write_parquet_with_wide_column(dir, "row_id_only.parquet", vec![], vec![]),
             id_and_wide_schema(),
             vec![RESERVED_FIELD_ID_ROW_ID],
+            Some(100),
         );
-        meta_only.first_row_id = Some(100);
         let (batches, meta_only_bytes) = scan_task(meta_only).await;
 
         assert_eq!(batches[0].num_columns(), 1);
         assert_row_id_column(&batches, &[Some(100), Some(101), Some(102)]);
 
         // A scan that also projects the wide data column must read materially more.
-        let mut with_data = metadata_projection_task(
+        let with_data = metadata_projection_task_with_first_row_id(
             write_parquet_with_wide_column(dir, "row_id_only_ref.parquet", vec![], vec![]),
             id_and_wide_schema(),
             vec![2, RESERVED_FIELD_ID_ROW_ID],
+            Some(100),
         );
-        with_data.first_row_id = Some(100);
         let (_, with_data_bytes) = scan_task(with_data).await;
 
         assert!(
@@ -1686,23 +1705,23 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let dir = tmp_dir.path().to_str().unwrap();
 
-        let mut meta_only = metadata_projection_task(
+        let meta_only = metadata_projection_task_with_first_row_id(
             write_parquet_with_wide_column(dir, "row_id_null.parquet", vec![], vec![]),
             id_and_wide_schema(),
             vec![RESERVED_FIELD_ID_ROW_ID],
+            None,
         );
-        meta_only.first_row_id = None;
         let (batches, meta_only_bytes) = scan_task(meta_only).await;
 
         assert_eq!(batches[0].num_columns(), 1);
         assert_row_id_column(&batches, &[None, None, None]);
 
-        let mut with_data = metadata_projection_task(
+        let with_data = metadata_projection_task_with_first_row_id(
             write_parquet_with_wide_column(dir, "row_id_null_ref.parquet", vec![], vec![]),
             id_and_wide_schema(),
             vec![2, RESERVED_FIELD_ID_ROW_ID],
+            None,
         );
-        with_data.first_row_id = None;
         let (_, with_data_bytes) = scan_task(with_data).await;
 
         assert!(
@@ -1736,6 +1755,7 @@ mod tests {
                 .with_data_sequence_number(Some(7))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = lusn_only_task(
@@ -1798,6 +1818,7 @@ mod tests {
                 .with_unified_partition_type(Some(unified_type.clone()))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = partition_task(
@@ -1910,7 +1931,8 @@ mod tests {
             .with_first_row_id(Some(100))
             .with_data_sequence_number(Some(9))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
@@ -1993,7 +2015,8 @@ mod tests {
             .with_project_field_ids(vec![1, RESERVED_FIELD_ID_POS, RESERVED_FIELD_ID_ROW_ID])
             .with_first_row_id(Some(100))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
@@ -2160,6 +2183,7 @@ mod tests {
             .with_first_row_id(first_row_id)
             .with_case_sensitive(false)
             .build()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -2320,9 +2344,7 @@ mod tests {
         let start = 4 + metadata.row_group(0).compressed_size() as u64;
         let file_size = std::fs::metadata(&file_path).unwrap().len();
 
-        let mut task = row_id_task(file_path, Some(100));
-        task.start = start;
-        task.length = file_size - start;
+        let task = row_id_task_with_options(file_path, Some(100), start, file_size - start, vec![]);
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
@@ -2378,7 +2400,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_row_id_survives_positional_delete() {
-        use crate::scan::FileScanTaskDeleteFile;
         use crate::spec::DataContentType;
 
         let tmp_dir = TempDir::new().unwrap();
@@ -2387,19 +2408,13 @@ mod tests {
         let data_path = write_plain_parquet(dir, "row_id_posdel_data.parquet", vec![], vec![]);
         let del_path = write_positional_delete(dir, "row_id_posdel.parquet", &data_path, &[1]);
 
-        let mut task = row_id_task(data_path, Some(100));
-        task.deletes = vec![FileScanTaskDeleteFile {
-            file_path: del_path.clone(),
-            file_size_in_bytes: std::fs::metadata(&del_path).unwrap().len(),
-            file_type: DataContentType::PositionDeletes,
-            partition_spec_id: 0,
-            equality_ids: None,
-            referenced_data_file: None,
-            content_offset: None,
-            content_size_in_bytes: None,
-            record_count: None,
-            key_metadata: None,
-        }];
+        let delete = FileScanTaskDeleteFile::builder()
+            .with_file_path(del_path.clone())
+            .with_file_size_in_bytes(std::fs::metadata(&del_path).unwrap().len())
+            .with_file_type(DataContentType::PositionDeletes)
+            .with_partition_spec_id(0)
+            .build();
+        let task = row_id_task_with_options(data_path, Some(100), 0, 0, vec![delete]);
 
         let reader = ArrowReaderBuilder::new(FileIO::new_with_fs(), Runtime::current()).build();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
@@ -2508,7 +2523,8 @@ mod tests {
             .with_project_field_ids(vec![1])
             .with_case_sensitive(false)
             .with_key_metadata(Some(wrong_key_metadata))
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let result: Result<Vec<RecordBatch>, _> =
@@ -2597,7 +2613,8 @@ mod tests {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build()),
+                .build()
+                .unwrap()),
             Ok(FileScanTask::builder()
                 .with_file_size_in_bytes(
                     std::fs::metadata(format!("{table_location}/file_1.parquet"))
@@ -2611,7 +2628,8 @@ mod tests {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build()),
+                .build()
+                .unwrap()),
             Ok(FileScanTask::builder()
                 .with_file_size_in_bytes(
                     std::fs::metadata(format!("{table_location}/file_2.parquet"))
@@ -2625,7 +2643,8 @@ mod tests {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build()),
+                .build()
+                .unwrap()),
         ];
 
         let tasks_stream = Box::pin(futures::stream::iter(tasks)) as FileScanTaskStream;
@@ -3112,6 +3131,15 @@ mod tests {
         schema: SchemaRef,
         project_field_ids: Vec<i32>,
     ) -> FileScanTask {
+        metadata_projection_task_with_first_row_id(file_path, schema, project_field_ids, None)
+    }
+
+    fn metadata_projection_task_with_first_row_id(
+        file_path: String,
+        schema: SchemaRef,
+        project_field_ids: Vec<i32>,
+        first_row_id: Option<i64>,
+    ) -> FileScanTask {
         FileScanTask::builder()
             .with_file_size_in_bytes(std::fs::metadata(&file_path).unwrap().len())
             .with_start(0)
@@ -3120,8 +3148,10 @@ mod tests {
             .with_data_file_format(DataFileFormat::Parquet)
             .with_schema(schema)
             .with_project_field_ids(project_field_ids)
+            .with_first_row_id(first_row_id)
             .with_case_sensitive(false)
             .build()
+            .unwrap()
     }
 
     /// Runs a single-task scan and returns the batches plus the bytes read from storage.
@@ -3203,7 +3233,8 @@ mod tests {
             .with_project_field_ids(vec![RESERVED_FIELD_ID_POS])
             .with_predicate(Some(bound))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         // Row selection must be enabled for the predicate to filter rows. The row filter
         // reads `id` for its own evaluation even though `id` is not projected; the surviving
@@ -3299,6 +3330,7 @@ mod tests {
                 .with_data_sequence_number(Some(9))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = seq_task(write("pos_seq.parquet"), vec![
@@ -3373,6 +3405,7 @@ mod tests {
                 .with_data_sequence_number(Some(9))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = seq_task(write("seq_only.parquet"), vec![
@@ -3437,6 +3470,7 @@ mod tests {
                 .with_data_sequence_number(Some(9))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = seq_task("seq_only_null_first.parquet", vec![
@@ -3539,6 +3573,7 @@ mod tests {
                 .with_partition_spec(Some(spec.clone()))
                 .with_case_sensitive(false)
                 .build()
+                .unwrap()
         };
 
         let meta_only = spec_id_task(

--- a/crates/iceberg/src/arrow/reader/positional_deletes.rs
+++ b/crates/iceberg/src/arrow/reader/positional_deletes.rs
@@ -453,7 +453,8 @@ mod tests {
                     .build(),
             ])
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let result = reader
@@ -671,7 +672,8 @@ mod tests {
                     .build(),
             ])
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let result = reader
@@ -883,7 +885,8 @@ mod tests {
                     .build(),
             ])
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let result = reader

--- a/crates/iceberg/src/arrow/reader/projection.rs
+++ b/crates/iceberg/src/arrow/reader/projection.rs
@@ -735,7 +735,8 @@ message schema {
                 .with_schema(new_schema.clone())
                 .with_project_field_ids(vec![1, 2]) // Request both columns 'a' and 'b'
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -834,7 +835,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -937,7 +939,8 @@ message schema {
                 .with_project_field_ids(vec![2, 4])
                 .with_case_sensitive(false)
                 .with_name_mapping(Some(name_mapping))
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1045,7 +1048,8 @@ message schema {
                 .with_case_sensitive(false)
                 .with_name_mapping(Some(name_mapping))
                 .with_predicate(Some(predicate.bind(schema, true).unwrap()))
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1138,7 +1142,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 3])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1225,7 +1230,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2, 3])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1326,7 +1332,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1456,7 +1463,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 2])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1553,7 +1561,8 @@ message schema {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1, 5, 2])
                 .with_case_sensitive(false)
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1664,7 +1673,8 @@ message schema {
                 .with_project_field_ids(vec![1, 2, 3])
                 .with_case_sensitive(false)
                 .with_predicate(Some(predicate.bind(schema, true).unwrap()))
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -1806,7 +1816,8 @@ message schema {
                 .with_case_sensitive(false)
                 .with_partition(Some(partition_data))
                 .with_partition_spec(Some(partition_spec))
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 
@@ -2013,7 +2024,8 @@ message schema {
                 .with_project_field_ids(vec![4])
                 .with_case_sensitive(false)
                 .with_predicate(Some(predicate.bind(iceberg_schema, true).unwrap()))
-                .build())]
+                .build()
+                .unwrap())]
             .into_iter(),
         )) as FileScanTaskStream;
 

--- a/crates/iceberg/src/arrow/reader/row_filter.rs
+++ b/crates/iceberg/src/arrow/reader/row_filter.rs
@@ -259,7 +259,8 @@ mod tests {
                 .with_project_field_ids(vec![1])
                 .with_predicate(Some(predicate.bind(schema, true).unwrap()))
                 .with_case_sensitive(false)
-                .build();
+                .build()
+                .unwrap();
             Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream
         };
 
@@ -551,7 +552,8 @@ mod tests {
             .with_project_field_ids(vec![1])
             .with_record_count(Some(100))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         // Task 2: read the second and third row groups
         let task2 = FileScanTask::builder()
@@ -564,7 +566,8 @@ mod tests {
             .with_project_field_ids(vec![1])
             .with_record_count(Some(200))
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
 
         let tasks1 = Box::pin(futures::stream::iter(vec![Ok(task1)])) as FileScanTaskStream;
         let result1 = reader
@@ -699,7 +702,8 @@ mod tests {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1])
                 .with_case_sensitive(false)
-                .build();
+                .build()
+                .unwrap();
 
             let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
             let batches = reader
@@ -806,7 +810,8 @@ mod tests {
                 .with_schema(schema.clone())
                 .with_project_field_ids(vec![1])
                 .with_case_sensitive(false)
-                .build();
+                .build()
+                .unwrap();
 
             let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
             let batches = reader
@@ -1133,26 +1138,18 @@ mod tests {
             .build();
 
         let file_size = std::fs::metadata(&file_path).unwrap().len();
-        let task = FileScanTask {
-            file_size_in_bytes: file_size,
-            start: 0,
-            length: 0,
-            record_count: None,
-            first_row_id: None,
-            data_sequence_number: None,
-            data_file_path: file_path.clone(),
-            data_file_format: DataFileFormat::Parquet,
-            schema: iceberg_schema.clone(),
-            project_field_ids: vec![1, 2],
-            predicate: Some(predicate),
-            deletes: vec![],
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            unified_partition_type: None,
-            case_sensitive: false,
-            key_metadata: None,
-        };
+        let task = FileScanTask::builder()
+            .with_file_size_in_bytes(file_size)
+            .with_start(0)
+            .with_length(0)
+            .with_data_file_path(file_path.clone())
+            .with_data_file_format(DataFileFormat::Parquet)
+            .with_schema(iceberg_schema.clone())
+            .with_project_field_ids(vec![1, 2])
+            .with_predicate(Some(predicate))
+            .with_case_sensitive(false)
+            .build()
+            .unwrap();
 
         let stream = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let batches: Vec<RecordBatch> = reader
@@ -1228,19 +1225,16 @@ mod tests {
             .with_row_selection_enabled(true)
             .build();
 
-        let task_sub2 = FileScanTask {
-            file_size_in_bytes: file_size,
-            start: 0,
-            length: 0,
-            record_count: None,
-            first_row_id: None,
-            data_sequence_number: None,
-            data_file_path: file_path.clone(),
-            data_file_format: DataFileFormat::Parquet,
-            schema: iceberg_schema.clone(),
-            project_field_ids: vec![1, 2],
-            predicate: Some(predicate_sub2),
-            deletes: vec![FileScanTaskDeleteFile {
+        let task_sub2 = FileScanTask::builder()
+            .with_file_size_in_bytes(file_size)
+            .with_start(0)
+            .with_length(0)
+            .with_data_file_path(file_path.clone())
+            .with_data_file_format(DataFileFormat::Parquet)
+            .with_schema(iceberg_schema.clone())
+            .with_project_field_ids(vec![1, 2])
+            .with_predicate(Some(predicate_sub2))
+            .with_deletes(vec![FileScanTaskDeleteFile {
                 file_path: pos_del_path.clone(),
                 file_type: DataContentType::PositionDeletes,
                 partition_spec_id: 0,
@@ -1251,14 +1245,10 @@ mod tests {
                 content_size_in_bytes: None,
                 record_count: None,
                 key_metadata: None,
-            }],
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            unified_partition_type: None,
-            case_sensitive: false,
-            key_metadata: None,
-        };
+            }])
+            .with_case_sensitive(false)
+            .build()
+            .unwrap();
 
         let stream_sub2 =
             Box::pin(futures::stream::iter(vec![Ok(task_sub2)])) as FileScanTaskStream;

--- a/crates/iceberg/src/scan/context.rs
+++ b/crates/iceberg/src/scan/context.rs
@@ -128,7 +128,7 @@ impl ManifestEntryContext {
             )
             .await;
 
-        Ok(FileScanTask::builder()
+        FileScanTask::builder()
             .with_file_size_in_bytes(self.manifest_entry.file_size_in_bytes())
             .with_start(0)
             .with_length(self.manifest_entry.file_size_in_bytes())
@@ -150,7 +150,7 @@ impl ManifestEntryContext {
             .with_unified_partition_type(self.unified_partition_type.clone())
             .with_case_sensitive(self.case_sensitive)
             .with_key_metadata(self.manifest_entry.data_file.key_metadata().map(Box::from))
-            .build())
+            .build()
     }
 }
 

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -2081,14 +2081,9 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn test_filtered_scan_with_dropped_partition_source_column() {
+    async fn test_filtered_scan_rejects_dropped_partition_source_column() {
         let mut fixture = TableTestFixture::new();
         fixture.setup_manifest_files().await;
-
-        // baseline: the same filtered scan against the table before evolution
-        let baseline = scan_y_gte_5(&fixture.table).await;
-        assert!(!baseline.is_empty());
-        assert!(baseline.iter().all(|y| *y >= 5));
 
         // Evolve the table so that the manifests reference a historical spec whose source
         // column is no longer in the current schema: make an unpartitioned spec the
@@ -2139,37 +2134,23 @@ pub mod tests {
             .metadata;
         let table = fixture.table.clone().with_metadata(Arc::new(metadata));
 
-        // planning and reading must succeed, and the results must match the table before
-        // evolution: no rows wrongly pruned and none returned unfiltered
-        let evolved = scan_y_gte_5(&table).await;
-        assert_eq!(evolved, baseline);
-    }
-
-    async fn scan_y_gte_5(table: &Table) -> Vec<i64> {
         let table_scan = table
             .scan()
             .select(["y"])
             .with_filter(Reference::new("y").greater_than_or_equal_to(Datum::long(5)))
             .build()
             .unwrap();
-        let batches: Vec<_> = table_scan
-            .to_arrow()
+
+        let err = table_scan
+            .plan_files()
             .await
             .unwrap()
-            .try_collect()
+            .try_collect::<Vec<_>>()
             .await
-            .unwrap();
+            .unwrap_err();
 
-        let mut values: Vec<i64> = batches
-            .iter()
-            .flat_map(|batch| {
-                let col = batch.column_by_name("y").unwrap();
-                let arr = col.as_any().downcast_ref::<Int64Array>().unwrap();
-                (0..arr.len()).map(|i| arr.value(i)).collect::<Vec<_>>()
-            })
-            .collect();
-        values.sort_unstable();
-        values
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(err.message().contains("No column with source column id 1"));
     }
 
     #[tokio::test]

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -1960,8 +1960,7 @@ pub mod tests {
         assert!(!tasks.is_empty(), "expected at least one FileScanTask");
         for task in &tasks {
             let mapping = task
-                .name_mapping
-                .as_ref()
+                .name_mapping()
                 .expect("name_mapping should reach the FileScanTask");
             assert_eq!(mapping.fields().len(), 1);
             assert_eq!(mapping.fields()[0].field_id(), Some(1));
@@ -2002,17 +2001,17 @@ pub mod tests {
 
         assert_eq!(tasks.len(), 2);
 
-        tasks.sort_by_key(|t| t.data_file_path.to_string());
+        tasks.sort_by_key(|t| t.data_file_path().to_string());
 
         // Check first task is added data file
         assert_eq!(
-            tasks[0].data_file_path,
+            tasks[0].data_file_path(),
             format!("{}/1.parquet", &fixture.table_location)
         );
 
         // Check second task is existing data file
         assert_eq!(
-            tasks[1].data_file_path,
+            tasks[1].data_file_path(),
             format!("{}/3.parquet", &fixture.table_location)
         );
     }
@@ -2035,23 +2034,23 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(tasks.len(), 2);
-        tasks.sort_by_key(|task| task.data_file_path.to_string());
+        tasks.sort_by_key(|task| task.data_file_path().to_string());
 
         // The added file inherits the current snapshot's data sequence number,
         // the existing file keeps the one it was written with.
         assert_eq!(
-            tasks[0].data_file_path,
+            tasks[0].data_file_path(),
             format!("{}/1.parquet", &fixture.table_location)
         );
-        assert_eq!(tasks[0].data_sequence_number, Some(1));
+        assert_eq!(tasks[0].data_sequence_number(), Some(1));
         assert_eq!(
-            tasks[1].data_file_path,
+            tasks[1].data_file_path(),
             format!("{}/3.parquet", &fixture.table_location)
         );
-        assert_eq!(tasks[1].data_sequence_number, Some(0));
+        assert_eq!(tasks[1].data_sequence_number(), Some(0));
 
         // first_row_id is a v3 concept; a v2 manifest carries none.
-        assert!(tasks.iter().all(|task| task.first_row_id.is_none()));
+        assert!(tasks.iter().all(|task| task.first_row_id().is_none()));
     }
 
     #[tokio::test]
@@ -2076,9 +2075,9 @@ pub mod tests {
 
         // The manifest-level first_row_id (42) is inherited onto the entry on
         // read, then carried onto the task.
-        assert_eq!(task.first_row_id, Some(42));
+        assert_eq!(task.first_row_id(), Some(42));
         // The data sequence number is threaded through the same v3 read path.
-        assert_eq!(task.data_sequence_number, Some(1));
+        assert_eq!(task.data_sequence_number(), Some(1));
     }
 
     #[tokio::test]
@@ -2654,14 +2653,7 @@ pub mod tests {
             let serialized = serde_json::to_string(&task).unwrap();
             let deserialized: FileScanTask = serde_json::from_str(&serialized).unwrap();
 
-            assert_eq!(task.data_file_path, deserialized.data_file_path);
-            assert_eq!(task.start, deserialized.start);
-            assert_eq!(task.length, deserialized.length);
-            assert_eq!(task.project_field_ids, deserialized.project_field_ids);
-            assert_eq!(task.predicate, deserialized.predicate);
-            assert_eq!(task.schema, deserialized.schema);
-            assert_eq!(task.first_row_id, deserialized.first_row_id);
-            assert_eq!(task.data_sequence_number, deserialized.data_sequence_number);
+            assert_eq!(task, deserialized);
         };
 
         // without predicate
@@ -2687,7 +2679,8 @@ pub mod tests {
             .with_data_sequence_number(Some(5))
             .with_data_file_format(DataFileFormat::Parquet)
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
         test_fn(task);
 
         // with predicate
@@ -2701,7 +2694,8 @@ pub mod tests {
             .with_schema(schema)
             .with_data_file_format(DataFileFormat::Avro)
             .with_case_sensitive(false)
-            .build();
+            .build()
+            .unwrap();
         test_fn(task);
     }
 
@@ -3560,12 +3554,12 @@ pub mod tests {
         assert_eq!(tasks.len(), 1, "expected a single FileScanTask");
         let task = &tasks[0];
         assert!(
-            task.project_field_ids.contains(&RESERVED_FIELD_ID_POS),
+            task.project_field_ids().contains(&RESERVED_FIELD_ID_POS),
             "_pos field id must be projected into the FileScanTask"
         );
-        assert_eq!(task.start, 0, "TableScan should plan whole-file tasks");
-        assert_eq!(task.length, task.file_size_in_bytes);
-        assert!(task.deletes.is_empty());
+        assert_eq!(task.start(), 0, "TableScan should plan whole-file tasks");
+        assert_eq!(task.length(), task.file_size_in_bytes());
+        assert!(task.deletes().is_empty());
 
         // Reading that task yields absolute _pos 0..300 in order.
         let batches: Vec<_> = fixture
@@ -3632,12 +3626,12 @@ pub mod tests {
             .unwrap();
         assert_eq!(tasks.len(), 1);
         assert_eq!(
-            tasks[0].deletes.len(),
+            tasks[0].deletes().len(),
             1,
             "positional delete file should be planned into the task"
         );
         assert_eq!(
-            tasks[0].deletes[0].file_type,
+            tasks[0].deletes()[0].file_type,
             DataContentType::PositionDeletes
         );
 

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -21,12 +21,12 @@ use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize, Serializer};
 use typed_builder::TypedBuilder;
 
-use crate::Result;
 use crate::expr::BoundPredicate;
 use crate::spec::{
     DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec, Schema,
     SchemaRef, Struct, StructType,
 };
+use crate::{Error, ErrorKind, Result};
 
 /// A stream of [`FileScanTask`].
 pub type FileScanTaskStream = BoxStream<'static, Result<FileScanTask>>;
@@ -51,21 +51,24 @@ where D: serde::Deserializer<'de> {
 
 /// A task to scan part of file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TypedBuilder)]
-#[builder(field_defaults(setter(prefix = "with_")))]
+#[builder(
+    field_defaults(setter(prefix = "with_")),
+    build_method(vis = "", name = build_unchecked)
+)]
 pub struct FileScanTask {
     /// The total size of the data file in bytes, from the manifest entry.
     /// Used to skip a stat/HEAD request when reading Parquet footers.
-    pub file_size_in_bytes: u64,
+    file_size_in_bytes: u64,
     /// The start offset of the file to scan.
-    pub start: u64,
+    start: u64,
     /// The length of the file to scan.
-    pub length: u64,
+    length: u64,
     /// The number of records in the file to scan.
     ///
     /// This is an optional field, and only available if we are
     /// reading the entire data file.
     #[builder(default)]
-    pub record_count: Option<u64>,
+    record_count: Option<u64>,
 
     /// The first row id assigned to the data file.
     ///
@@ -73,7 +76,7 @@ pub struct FileScanTask {
     /// explicit `_row_id`, it is this value plus the row's ordinal position.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub first_row_id: Option<i64>,
+    first_row_id: Option<i64>,
 
     /// The data sequence number of the file, as opposed to its file sequence
     /// number: the sequence number preserved when a file is carried forward
@@ -83,26 +86,26 @@ pub struct FileScanTask {
     /// Used to derive the `_last_updated_sequence_number` metadata column.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub data_sequence_number: Option<i64>,
+    data_sequence_number: Option<i64>,
 
     /// The data file path corresponding to the task.
-    pub data_file_path: String,
+    data_file_path: String,
 
     /// The format of the file to scan.
-    pub data_file_format: DataFileFormat,
+    data_file_format: DataFileFormat,
 
     /// The schema of the file to scan.
-    pub schema: SchemaRef,
+    schema: SchemaRef,
     /// The field ids to project.
-    pub project_field_ids: Vec<i32>,
+    project_field_ids: Vec<i32>,
     /// The predicate to filter.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub predicate: Option<BoundPredicate>,
+    predicate: Option<BoundPredicate>,
 
     /// The list of delete files that may need to be applied to this data file
     #[builder(default)]
-    pub deletes: Vec<FileScanTaskDeleteFile>,
+    deletes: Vec<FileScanTaskDeleteFile>,
 
     /// Partition data from the manifest entry, used to identify which columns can use
     /// constant values from partition metadata vs. reading from the data file.
@@ -112,7 +115,7 @@ pub struct FileScanTask {
     #[serde(serialize_with = "serialize_not_implemented")]
     #[serde(deserialize_with = "deserialize_not_implemented")]
     #[builder(default)]
-    pub partition: Option<Struct>,
+    partition: Option<Struct>,
 
     /// The partition spec for this file, used to distinguish identity transforms
     /// (which use partition metadata constants) from non-identity transforms like
@@ -122,7 +125,7 @@ pub struct FileScanTask {
     #[serde(serialize_with = "serialize_not_implemented")]
     #[serde(deserialize_with = "deserialize_not_implemented")]
     #[builder(default)]
-    pub partition_spec: Option<Arc<PartitionSpec>>,
+    partition_spec: Option<Arc<PartitionSpec>>,
 
     /// Name mapping from table metadata (property: schema.name-mapping.default),
     /// used to resolve field IDs from column names when Parquet files lack field IDs
@@ -132,7 +135,7 @@ pub struct FileScanTask {
     #[serde(serialize_with = "serialize_not_implemented")]
     #[serde(deserialize_with = "deserialize_not_implemented")]
     #[builder(default)]
-    pub name_mapping: Option<Arc<NameMapping>>,
+    name_mapping: Option<Arc<NameMapping>>,
 
     /// The unified partition type across all specs in the table.
     /// When `RESERVED_FIELD_ID_PARTITION` is in the projected field IDs, the reader
@@ -148,10 +151,10 @@ pub struct FileScanTask {
     #[serde(serialize_with = "serialize_not_implemented")]
     #[serde(deserialize_with = "deserialize_not_implemented")]
     #[builder(default)]
-    pub unified_partition_type: Option<Arc<StructType>>,
+    unified_partition_type: Option<Arc<StructType>>,
 
     /// Whether this scan task should treat column names as case-sensitive when binding predicates.
-    pub case_sensitive: bool,
+    case_sensitive: bool,
 
     /// Key metadata for encrypted data files (Parquet Modular Encryption).
     /// When present, the reader uses this to build `FileDecryptionProperties`.
@@ -164,13 +167,58 @@ pub struct FileScanTask {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub key_metadata: Option<Box<[u8]>>,
+    key_metadata: Option<Box<[u8]>>,
 }
 
 impl FileScanTask {
+    /// Returns the total size of the data file in bytes.
+    pub fn file_size_in_bytes(&self) -> u64 {
+        self.file_size_in_bytes
+    }
+
+    /// Returns the start offset of the file to scan.
+    pub fn start(&self) -> u64 {
+        self.start
+    }
+
+    /// Returns the length of the file to scan.
+    pub fn length(&self) -> u64 {
+        self.length
+    }
+
+    /// Returns the number of records in the file when the whole file is scanned.
+    pub fn record_count(&self) -> Option<u64> {
+        self.record_count
+    }
+
+    /// Returns the first row id assigned to the data file.
+    pub fn first_row_id(&self) -> Option<i64> {
+        self.first_row_id
+    }
+
+    /// Returns the data sequence number of the file.
+    pub fn data_sequence_number(&self) -> Option<i64> {
+        self.data_sequence_number
+    }
+
     /// Returns the data file path of this file scan task.
     pub fn data_file_path(&self) -> &str {
         &self.data_file_path
+    }
+
+    /// Returns the format of the data file.
+    pub fn data_file_format(&self) -> DataFileFormat {
+        self.data_file_format
+    }
+
+    /// Returns the schema of this file scan task as a reference.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    /// Returns the schema of this file scan task as a [`SchemaRef`].
+    pub fn schema_ref(&self) -> SchemaRef {
+        self.schema.clone()
     }
 
     /// Returns the project field id of this file scan task.
@@ -183,14 +231,97 @@ impl FileScanTask {
         self.predicate.as_ref()
     }
 
-    /// Returns the schema of this file scan task as a reference
-    pub fn schema(&self) -> &Schema {
-        &self.schema
+    /// Returns the delete files that may need to be applied to the data file.
+    pub fn deletes(&self) -> &[FileScanTaskDeleteFile] {
+        &self.deletes
     }
 
-    /// Returns the schema of this file scan task as a SchemaRef
-    pub fn schema_ref(&self) -> SchemaRef {
-        self.schema.clone()
+    /// Returns the partition data from the manifest entry.
+    pub fn partition(&self) -> Option<&Struct> {
+        self.partition.as_ref()
+    }
+
+    /// Returns the partition spec for the data file.
+    pub fn partition_spec(&self) -> Option<&Arc<PartitionSpec>> {
+        self.partition_spec.as_ref()
+    }
+
+    /// Returns the name mapping used to resolve field ids.
+    pub fn name_mapping(&self) -> Option<&Arc<NameMapping>> {
+        self.name_mapping.as_ref()
+    }
+
+    /// Returns the unified partition type across all table partition specs.
+    pub fn unified_partition_type(&self) -> Option<&Arc<StructType>> {
+        self.unified_partition_type.as_ref()
+    }
+
+    /// Returns whether names are treated as case-sensitive.
+    pub fn case_sensitive(&self) -> bool {
+        self.case_sensitive
+    }
+
+    /// Returns the key metadata for the encrypted data file.
+    pub fn key_metadata(&self) -> Option<&[u8]> {
+        self.key_metadata.as_deref()
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.partition_spec.is_none()
+            && self
+                .partition
+                .as_ref()
+                .is_some_and(|partition| !partition.fields().is_empty())
+        {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Non-empty FileScanTask partition requires a partition spec",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(non_camel_case_types)]
+impl<
+    __record_count: typed_builder::Optional<Option<u64>>,
+    __first_row_id: typed_builder::Optional<Option<i64>>,
+    __data_sequence_number: typed_builder::Optional<Option<i64>>,
+    __predicate: typed_builder::Optional<Option<BoundPredicate>>,
+    __deletes: typed_builder::Optional<Vec<FileScanTaskDeleteFile>>,
+    __partition: typed_builder::Optional<Option<Struct>>,
+    __partition_spec: typed_builder::Optional<Option<Arc<PartitionSpec>>>,
+    __name_mapping: typed_builder::Optional<Option<Arc<NameMapping>>>,
+    __unified_partition_type: typed_builder::Optional<Option<Arc<StructType>>>,
+    __key_metadata: typed_builder::Optional<Option<Box<[u8]>>>,
+>
+    FileScanTaskBuilder<(
+        (u64,),
+        (u64,),
+        (u64,),
+        __record_count,
+        __first_row_id,
+        __data_sequence_number,
+        (String,),
+        (DataFileFormat,),
+        (SchemaRef,),
+        (Vec<i32>,),
+        __predicate,
+        __deletes,
+        __partition,
+        __partition_spec,
+        __name_mapping,
+        __unified_partition_type,
+        (bool,),
+        __key_metadata,
+    )>
+{
+    /// Validates the configured fields and builds a [`FileScanTask`].
+    pub fn build(self) -> Result<FileScanTask> {
+        let task = self.build_unchecked();
+        task.validate()?;
+        Ok(task)
     }
 }
 
@@ -281,4 +412,43 @@ pub struct FileScanTaskDeleteFile {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub key_metadata: Option<Box<[u8]>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorKind;
+    use crate::spec::Literal;
+
+    fn build_file_scan_task_with_partition(partition: Struct) -> Result<FileScanTask> {
+        FileScanTask::builder()
+            .with_file_size_in_bytes(100)
+            .with_start(0)
+            .with_length(100)
+            .with_data_file_path("data_file_path".to_string())
+            .with_data_file_format(DataFileFormat::Parquet)
+            .with_schema(Arc::new(Schema::builder().build().unwrap()))
+            .with_project_field_ids(vec![])
+            .with_partition(Some(partition))
+            .with_case_sensitive(false)
+            .build()
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_rejects_non_empty_partition_without_spec() {
+        // Regression test for https://github.com/apache/iceberg-rust/issues/3130.
+        let err = build_file_scan_task_with_partition(Struct::from_iter([Some(Literal::long(42))]))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert_eq!(
+            err.message(),
+            "Non-empty FileScanTask partition requires a partition spec"
+        );
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_accepts_empty_partition_without_spec() {
+        build_file_scan_task_with_partition(Struct::empty()).unwrap();
+    }
 }

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -23,8 +23,8 @@ use typed_builder::TypedBuilder;
 
 use crate::expr::BoundPredicate;
 use crate::spec::{
-    DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec, Schema,
-    SchemaRef, Struct, StructType,
+    DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec,
+    PrimitiveLiteral, PrimitiveType, Schema, SchemaRef, Struct, StructType,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -267,16 +267,70 @@ impl FileScanTask {
     }
 
     fn validate(&self) -> Result<()> {
-        if self.partition_spec.is_none()
-            && self
-                .partition
-                .as_ref()
-                .is_some_and(|partition| !partition.fields().is_empty())
-        {
+        let Some(partition) = self.partition.as_ref() else {
+            return Ok(());
+        };
+        let Some(partition_spec) = self.partition_spec.as_deref() else {
+            return if partition.fields().is_empty() {
+                Ok(())
+            } else {
+                Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Non-empty FileScanTask partition requires a partition spec",
+                ))
+            };
+        };
+
+        if partition.fields().len() != partition_spec.fields().len() {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
-                "Non-empty FileScanTask partition requires a partition spec",
+                format!(
+                    "FileScanTask partition has {} fields but partition spec has {} fields",
+                    partition.fields().len(),
+                    partition_spec.fields().len()
+                ),
             ));
+        }
+
+        if partition_spec
+            .fields()
+            .iter()
+            .any(|field| self.schema.field_by_id(field.source_id).is_none())
+        {
+            // A historical partition spec may legally reference a source column that has
+            // since been dropped. Without its type information, the partition values cannot
+            // be validated, but they are still valid advisory metadata for the scan task.
+            return Ok(());
+        }
+
+        for (partition_value, partition_field) in
+            partition.fields().iter().zip(partition_spec.fields())
+        {
+            let Some(partition_value) = partition_value else {
+                continue;
+            };
+            let source_field = self.schema.field_by_id(partition_field.source_id).unwrap();
+            let result_type = partition_field
+                .transform
+                .result_type(&source_field.field_type)?;
+            let literal = partition_value.as_primitive_literal();
+            let compatible = match (result_type.as_primitive_type(), literal.as_ref()) {
+                (
+                    Some(PrimitiveType::Fixed(expected_len)),
+                    Some(PrimitiveLiteral::Binary(value)),
+                ) => value.len() == *expected_len as usize,
+                (Some(primitive_type), Some(literal)) => primitive_type.compatible(literal),
+                _ => false,
+            };
+            if !compatible {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    format!(
+                        "FileScanTask partition field '{}' is incompatible with type {}",
+                        partition_field.name, result_type
+                    ),
+                ));
+            }
         }
 
         Ok(())
@@ -381,29 +435,64 @@ pub struct FileScanTaskDeleteFile {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
     use crate::ErrorKind;
-    use crate::spec::Literal;
+    use crate::spec::{Literal, NestedField, PrimitiveType, Transform, Type};
 
-    fn build_file_scan_task_with_partition(partition: Struct) -> Result<FileScanTask> {
+    fn build_file_scan_task(
+        schema: SchemaRef,
+        partition: Option<Struct>,
+        partition_spec: Option<Arc<PartitionSpec>>,
+    ) -> Result<FileScanTask> {
         FileScanTask::builder()
             .with_file_size_in_bytes(100)
             .with_start(0)
             .with_length(100)
             .with_data_file_path("data_file_path".to_string())
             .with_data_file_format(DataFileFormat::Parquet)
-            .with_schema(Arc::new(Schema::builder().build().unwrap()))
+            .with_schema(schema)
             .with_project_field_ids(vec![])
-            .with_partition(Some(partition))
+            .with_partition(partition)
+            .with_partition_spec(partition_spec)
             .with_case_sensitive(false)
             .build()
+    }
+
+    fn schema_and_spec(
+        primitive_type: PrimitiveType,
+        transform: Transform,
+    ) -> (SchemaRef, Arc<PartitionSpec>) {
+        let schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![Arc::new(NestedField::required(
+                    1,
+                    "x",
+                    Type::Primitive(primitive_type),
+                ))])
+                .build()
+                .unwrap(),
+        );
+        let partition_spec = Arc::new(
+            PartitionSpec::builder(schema.clone())
+                .add_partition_field("x", "x_partition", transform)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        (schema, partition_spec)
     }
 
     #[test]
     fn test_file_scan_task_builder_rejects_non_empty_partition_without_spec() {
         // Regression test for https://github.com/apache/iceberg-rust/issues/3130.
-        let err = build_file_scan_task_with_partition(Struct::from_iter([Some(Literal::long(42))]))
-            .unwrap_err();
+        let err = build_file_scan_task(
+            Arc::new(Schema::builder().build().unwrap()),
+            Some(Struct::from_iter([Some(Literal::long(42))])),
+            None,
+        )
+        .unwrap_err();
 
         assert_eq!(err.kind(), ErrorKind::DataInvalid);
         assert_eq!(
@@ -414,6 +503,118 @@ mod tests {
 
     #[test]
     fn test_file_scan_task_builder_accepts_empty_partition_without_spec() {
-        build_file_scan_task_with_partition(Struct::empty()).unwrap();
+        build_file_scan_task(
+            Arc::new(Schema::builder().build().unwrap()),
+            Some(Struct::empty()),
+            None,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_accepts_supported_partition_encodings() {
+        let cases = [
+            (
+                PrimitiveType::Date,
+                Transform::Identity,
+                Literal::date(19_000),
+            ),
+            (
+                PrimitiveType::TimestampNs,
+                Transform::Identity,
+                Literal::timestamp_nano(1_510_871_468_123_456_789),
+            ),
+            (
+                PrimitiveType::TimestamptzNs,
+                Transform::Identity,
+                Literal::timestamptz_nano(1_510_871_468_123_456_789),
+            ),
+            (
+                PrimitiveType::Decimal {
+                    precision: 9,
+                    scale: 2,
+                },
+                Transform::Identity,
+                Literal::decimal(12_345),
+            ),
+            (
+                PrimitiveType::Uuid,
+                Transform::Identity,
+                Literal::uuid(Uuid::from_u128(0x12345678_90ab_cdef_1234_567890abcdef)),
+            ),
+            (
+                PrimitiveType::Fixed(4),
+                Transform::Identity,
+                Literal::fixed([1, 2, 3, 4]),
+            ),
+            (PrimitiveType::String, Transform::Bucket(4), Literal::int(2)),
+        ];
+
+        for (primitive_type, transform, partition_value) in cases {
+            let case = format!("{primitive_type} with {transform}");
+            let (schema, partition_spec) = schema_and_spec(primitive_type, transform);
+            build_file_scan_task(
+                schema,
+                Some(Struct::from_iter([Some(partition_value)])),
+                Some(partition_spec),
+            )
+            .unwrap_or_else(|err| panic!("{case}: {err:?}"));
+        }
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_rejects_partition_arity_mismatch() {
+        let (schema, partition_spec) = schema_and_spec(PrimitiveType::Long, Transform::Identity);
+
+        let err =
+            build_file_scan_task(schema, Some(Struct::empty()), Some(partition_spec)).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("partition has 0 fields"));
+        assert!(err.message().contains("partition spec has 1 fields"));
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_rejects_partition_type_mismatch() {
+        let cases = [
+            (PrimitiveType::Long, Literal::string("not a long")),
+            (PrimitiveType::Fixed(4), Literal::fixed([1, 2])),
+        ];
+
+        for (primitive_type, partition_value) in cases {
+            let (schema, partition_spec) = schema_and_spec(primitive_type, Transform::Identity);
+            let err = build_file_scan_task(
+                schema,
+                Some(Struct::from_iter([Some(partition_value)])),
+                Some(partition_spec),
+            )
+            .unwrap_err();
+
+            assert_eq!(err.kind(), ErrorKind::DataInvalid);
+            assert!(err.message().contains("x_partition"));
+        }
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_accepts_dropped_partition_source_column() {
+        let (_historical_schema, partition_spec) =
+            schema_and_spec(PrimitiveType::Long, Transform::Identity);
+        let current_schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![Arc::new(NestedField::required(
+                    2,
+                    "y",
+                    Type::Primitive(PrimitiveType::String),
+                ))])
+                .build()
+                .unwrap(),
+        );
+
+        build_file_scan_task(
+            current_schema,
+            Some(Struct::from_iter([Some(Literal::long(42))])),
+            Some(partition_spec),
+        )
+        .unwrap();
     }
 }

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -291,7 +291,21 @@ impl FileScanTask {
                     ),
                 ))
             }
-            (Some(_), Some(_)) => Ok(()),
+            (Some(_), Some(partition_spec)) => {
+                if partition_spec
+                    .fields()
+                    .iter()
+                    .any(|field| self.schema.field_by_id(field.source_id).is_none())
+                {
+                    // Historical specs may reference source columns that were later dropped.
+                    // Without those source types, the spec cannot be checked against the
+                    // current schema, but the partition metadata remains valid for the task.
+                    return Ok(());
+                }
+
+                partition_spec.partition_type(&self.schema)?;
+                Ok(())
+            }
         }
     }
 }
@@ -524,5 +538,30 @@ mod tests {
             Some(partition_spec),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_rejects_partition_spec_incompatible_with_schema() {
+        let (_historical_schema, partition_spec) =
+            schema_and_spec(PrimitiveType::Timestamp, Transform::Day);
+        let current_schema = Arc::new(
+            Schema::builder()
+                .with_fields(vec![Arc::new(NestedField::required(
+                    1,
+                    "x",
+                    Type::Primitive(PrimitiveType::String),
+                ))])
+                .build()
+                .unwrap(),
+        );
+
+        let err = build_file_scan_task(
+            current_schema,
+            Some(Struct::from_iter([Some(Literal::date(20_000))])),
+            Some(partition_spec),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
     }
 }

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -292,17 +292,6 @@ impl FileScanTask {
                 ))
             }
             (Some(_), Some(partition_spec)) => {
-                if partition_spec
-                    .fields()
-                    .iter()
-                    .any(|field| self.schema.field_by_id(field.source_id).is_none())
-                {
-                    // Historical specs may reference source columns that were later dropped.
-                    // Without those source types, the spec cannot be checked against the
-                    // current schema, but the partition metadata remains valid for the task.
-                    return Ok(());
-                }
-
                 partition_spec.partition_type(&self.schema)?;
                 Ok(())
             }
@@ -518,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn test_file_scan_task_builder_accepts_dropped_partition_source_column() {
+    fn test_file_scan_task_builder_rejects_dropped_partition_source_column() {
         let (_historical_schema, partition_spec) =
             schema_and_spec(PrimitiveType::Long, Transform::Identity);
         let current_schema = Arc::new(
@@ -532,12 +521,15 @@ mod tests {
                 .unwrap(),
         );
 
-        build_file_scan_task(
+        let err = build_file_scan_task(
             current_schema,
             Some(Struct::from_iter([Some(Literal::long(42))])),
             Some(partition_spec),
         )
-        .unwrap();
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(err.message().contains("No column with source column id 1"));
     }
 
     #[test]

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -23,8 +23,8 @@ use typed_builder::TypedBuilder;
 
 use crate::expr::BoundPredicate;
 use crate::spec::{
-    DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec,
-    PrimitiveLiteral, PrimitiveType, Schema, SchemaRef, Struct, StructType,
+    DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec, Schema,
+    SchemaRef, Struct, StructType,
 };
 use crate::{Error, ErrorKind, Result};
 
@@ -267,73 +267,32 @@ impl FileScanTask {
     }
 
     fn validate(&self) -> Result<()> {
-        let Some(partition) = self.partition.as_ref() else {
-            return Ok(());
-        };
-        let Some(partition_spec) = self.partition_spec.as_deref() else {
-            return if partition.fields().is_empty() {
-                Ok(())
-            } else {
+        match (self.partition.as_ref(), self.partition_spec.as_deref()) {
+            (None, None) => Ok(()),
+            (None, Some(partition_spec)) if partition_spec.is_unpartitioned() => Ok(()),
+            (None, Some(_)) => Err(Error::new(
+                ErrorKind::DataInvalid,
+                "FileScanTask with a partitioned spec requires partition values",
+            )),
+            (Some(partition), None) if partition.fields().is_empty() => Ok(()),
+            (Some(_), None) => Err(Error::new(
+                ErrorKind::DataInvalid,
+                "Non-empty FileScanTask partition requires a partition spec",
+            )),
+            (Some(partition), Some(partition_spec))
+                if partition.fields().len() != partition_spec.fields().len() =>
+            {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
-                    "Non-empty FileScanTask partition requires a partition spec",
-                ))
-            };
-        };
-
-        if partition.fields().len() != partition_spec.fields().len() {
-            return Err(Error::new(
-                ErrorKind::DataInvalid,
-                format!(
-                    "FileScanTask partition has {} fields but partition spec has {} fields",
-                    partition.fields().len(),
-                    partition_spec.fields().len()
-                ),
-            ));
-        }
-
-        if partition_spec
-            .fields()
-            .iter()
-            .any(|field| self.schema.field_by_id(field.source_id).is_none())
-        {
-            // A historical partition spec may legally reference a source column that has
-            // since been dropped. Without its type information, the partition values cannot
-            // be validated, but they are still valid advisory metadata for the scan task.
-            return Ok(());
-        }
-
-        for (partition_value, partition_field) in
-            partition.fields().iter().zip(partition_spec.fields())
-        {
-            let Some(partition_value) = partition_value else {
-                continue;
-            };
-            let source_field = self.schema.field_by_id(partition_field.source_id).unwrap();
-            let result_type = partition_field
-                .transform
-                .result_type(&source_field.field_type)?;
-            let literal = partition_value.as_primitive_literal();
-            let compatible = match (result_type.as_primitive_type(), literal.as_ref()) {
-                (
-                    Some(PrimitiveType::Fixed(expected_len)),
-                    Some(PrimitiveLiteral::Binary(value)),
-                ) => value.len() == *expected_len as usize,
-                (Some(primitive_type), Some(literal)) => primitive_type.compatible(literal),
-                _ => false,
-            };
-            if !compatible {
-                return Err(Error::new(
-                    ErrorKind::DataInvalid,
                     format!(
-                        "FileScanTask partition field '{}' is incompatible with type {}",
-                        partition_field.name, result_type
+                        "FileScanTask partition has {} fields but partition spec has {} fields",
+                        partition.fields().len(),
+                        partition_spec.fields().len()
                     ),
-                ));
+                ))
             }
+            (Some(_), Some(_)) => Ok(()),
         }
-
-        Ok(())
     }
 }
 
@@ -435,8 +394,6 @@ pub struct FileScanTaskDeleteFile {
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
-
     use super::*;
     use crate::ErrorKind;
     use crate::spec::{Literal, NestedField, PrimitiveType, Transform, Type};
@@ -512,54 +469,26 @@ mod tests {
     }
 
     #[test]
-    fn test_file_scan_task_builder_accepts_supported_partition_encodings() {
-        let cases = [
-            (
-                PrimitiveType::Date,
-                Transform::Identity,
-                Literal::date(19_000),
-            ),
-            (
-                PrimitiveType::TimestampNs,
-                Transform::Identity,
-                Literal::timestamp_nano(1_510_871_468_123_456_789),
-            ),
-            (
-                PrimitiveType::TimestamptzNs,
-                Transform::Identity,
-                Literal::timestamptz_nano(1_510_871_468_123_456_789),
-            ),
-            (
-                PrimitiveType::Decimal {
-                    precision: 9,
-                    scale: 2,
-                },
-                Transform::Identity,
-                Literal::decimal(12_345),
-            ),
-            (
-                PrimitiveType::Uuid,
-                Transform::Identity,
-                Literal::uuid(Uuid::from_u128(0x12345678_90ab_cdef_1234_567890abcdef)),
-            ),
-            (
-                PrimitiveType::Fixed(4),
-                Transform::Identity,
-                Literal::fixed([1, 2, 3, 4]),
-            ),
-            (PrimitiveType::String, Transform::Bucket(4), Literal::int(2)),
-        ];
+    fn test_file_scan_task_builder_rejects_partitioned_spec_without_partition() {
+        let (schema, partition_spec) = schema_and_spec(PrimitiveType::Long, Transform::Identity);
 
-        for (primitive_type, transform, partition_value) in cases {
-            let case = format!("{primitive_type} with {transform}");
-            let (schema, partition_spec) = schema_and_spec(primitive_type, transform);
-            build_file_scan_task(
-                schema,
-                Some(Struct::from_iter([Some(partition_value)])),
-                Some(partition_spec),
-            )
-            .unwrap_or_else(|err| panic!("{case}: {err:?}"));
-        }
+        let err = build_file_scan_task(schema, None, Some(partition_spec)).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert_eq!(
+            err.message(),
+            "FileScanTask with a partitioned spec requires partition values"
+        );
+    }
+
+    #[test]
+    fn test_file_scan_task_builder_accepts_unpartitioned_spec_without_partition() {
+        build_file_scan_task(
+            Arc::new(Schema::builder().build().unwrap()),
+            None,
+            Some(Arc::new(PartitionSpec::unpartition_spec())),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -572,27 +501,6 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::DataInvalid);
         assert!(err.message().contains("partition has 0 fields"));
         assert!(err.message().contains("partition spec has 1 fields"));
-    }
-
-    #[test]
-    fn test_file_scan_task_builder_rejects_partition_type_mismatch() {
-        let cases = [
-            (PrimitiveType::Long, Literal::string("not a long")),
-            (PrimitiveType::Fixed(4), Literal::fixed([1, 2])),
-        ];
-
-        for (primitive_type, partition_value) in cases {
-            let (schema, partition_spec) = schema_and_spec(primitive_type, Transform::Identity);
-            let err = build_file_scan_task(
-                schema,
-                Some(Struct::from_iter([Some(partition_value)])),
-                Some(partition_spec),
-            )
-            .unwrap_err();
-
-            assert_eq!(err.kind(), ErrorKind::DataInvalid);
-            assert!(err.message().contains("x_partition"));
-        }
     }
 
     #[test]

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -53,7 +53,7 @@ where D: serde::Deserializer<'de> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[builder(
     field_defaults(setter(prefix = "with_")),
-    build_method(vis = "", name = build_unchecked)
+    build_method(into = Result<FileScanTask>)
 )]
 pub struct FileScanTask {
     /// The total size of the data file in bytes, from the manifest entry.
@@ -283,43 +283,8 @@ impl FileScanTask {
     }
 }
 
-#[allow(non_camel_case_types)]
-impl<
-    __record_count: typed_builder::Optional<Option<u64>>,
-    __first_row_id: typed_builder::Optional<Option<i64>>,
-    __data_sequence_number: typed_builder::Optional<Option<i64>>,
-    __predicate: typed_builder::Optional<Option<BoundPredicate>>,
-    __deletes: typed_builder::Optional<Vec<FileScanTaskDeleteFile>>,
-    __partition: typed_builder::Optional<Option<Struct>>,
-    __partition_spec: typed_builder::Optional<Option<Arc<PartitionSpec>>>,
-    __name_mapping: typed_builder::Optional<Option<Arc<NameMapping>>>,
-    __unified_partition_type: typed_builder::Optional<Option<Arc<StructType>>>,
-    __key_metadata: typed_builder::Optional<Option<Box<[u8]>>>,
->
-    FileScanTaskBuilder<(
-        (u64,),
-        (u64,),
-        (u64,),
-        __record_count,
-        __first_row_id,
-        __data_sequence_number,
-        (String,),
-        (DataFileFormat,),
-        (SchemaRef,),
-        (Vec<i32>,),
-        __predicate,
-        __deletes,
-        __partition,
-        __partition_spec,
-        __name_mapping,
-        __unified_partition_type,
-        (bool,),
-        __key_metadata,
-    )>
-{
-    /// Validates the configured fields and builds a [`FileScanTask`].
-    pub fn build(self) -> Result<FileScanTask> {
-        let task = self.build_unchecked();
+impl From<FileScanTask> for Result<FileScanTask> {
+    fn from(task: FileScanTask) -> Self {
         task.validate()?;
         Ok(task)
     }

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -1096,7 +1096,8 @@ mod tests {
             .with_project_field_ids(vec![1])
             .with_case_sensitive(false)
             .with_key_metadata(data_file.key_metadata().map(Box::from))
-            .build();
+            .build()
+            .unwrap();
         let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
         let batches: Vec<RecordBatch> = reader
             .read(tasks)

--- a/crates/integration_tests/tests/read_positional_deletes.rs
+++ b/crates/integration_tests/tests/read_positional_deletes.rs
@@ -58,7 +58,7 @@ async fn test_read_table_with_positional_deletes() {
 
     // Scan plan phase should include delete files in file plan
     // when with_delete_file_processing_enabled == true
-    assert_eq!(plan[0].deletes.len(), 1);
+    assert_eq!(plan[0].deletes().len(), 1);
 
     // we should see two rows deleted, returning 10 rows instead of 12
     let batch_stream = scan.to_arrow().await.unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3130.

## What changes are included in this PR?

- Make FileScanTask fields private and expose read-only public getters.
- Make FileScanTaskBuilder::build() validate its result without depending on generated typestate arguments.
- Validate symmetric partition/spec presence and partition tuple arity.
- Validate partition specs against the task schema by calling PartitionSpec::partition_type directly.
- Keep task construction lightweight by avoiding per-value partition validation.
- Update internal call sites for the fallible builder and regenerate the public API snapshot.

## Are these changes tested?

- Added builder regression coverage for non-empty partitions without specs, partitioned specs without values, valid unpartitioned forms, arity mismatches, incompatible evolved schemas, and missing partition source columns.
- Updated scan and metadata-only Arrow fixtures for the validated construction rules.
- Ported the construction checks from #3091 while following review direction to omit per-value validation from this path.
- cargo test -p iceberg --lib (1,623 passed)
- cargo clippy --workspace --all-targets -- -D warnings
- make check-public-api
- cargo fmt --all -- --check

## AI Disclosure

Codex (GPT-5) was used for implementation, call-site refactoring, review follow-up, and unit-test scaffolding. The resulting diff was reviewed against issue #3130, the relevant checks in PR #3091, the latest inline reviews, and repository conventions. All listed checks were run locally; there are no known uncertainties.