### PR TITLE
refector: Add LiveManifestEntry

### DIFF
--- a/crates/iceberg/src/delete_file_index.rs
+++ b/crates/iceberg/src/delete_file_index.rs
@@ -113,7 +113,7 @@ impl DeleteFileIndex {
     pub(crate) async fn get_deletes_for_data_file(
         &self,
         data_file: &DataFile,
-        seq_num: Option<i64>,
+        data_sequence_number: i64,
     ) -> Vec<FileScanTaskDeleteFile> {
         // Create the `Notified` while holding the read lock. The read lock ensures that
         // when we go inside it, either the state is already at Populated or it is still
@@ -125,7 +125,7 @@ impl DeleteFileIndex {
             match &*guard {
                 DeleteFileIndexState::Populating(notifier) => notifier.clone().notified_owned(),
                 DeleteFileIndexState::Populated(index) => {
-                    return index.get_deletes_for_data_file(data_file, seq_num);
+                    return index.get_deletes_for_data_file(data_file, data_sequence_number);
                 }
             }
         };
@@ -135,7 +135,7 @@ impl DeleteFileIndex {
         let guard = self.state.read().unwrap();
         match guard.deref() {
             DeleteFileIndexState::Populated(index) => {
-                index.get_deletes_for_data_file(data_file, seq_num)
+                index.get_deletes_for_data_file(data_file, data_sequence_number)
             }
             _ => unreachable!("Cannot be any other state than loaded"),
         }
@@ -206,28 +206,20 @@ impl PopulatedDeleteFileIndex {
     fn get_deletes_for_data_file(
         &self,
         data_file: &DataFile,
-        seq_num: Option<i64>,
+        data_sequence_number: i64,
     ) -> Vec<FileScanTaskDeleteFile> {
         let mut results = vec![];
 
         self.global_equality_deletes
             .iter()
-            // filter that returns true if the provided delete file's sequence number is **greater than** `seq_num`
-            .filter(|&delete| {
-                seq_num
-                    .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
-                    .unwrap_or_else(|| true)
-            })
+            .filter(|&delete| delete.manifest_entry.data_sequence_number() > data_sequence_number)
             .for_each(|delete| results.push(delete.as_ref().into()));
 
         if let Some(deletes) = self.eq_deletes_by_partition.get(data_file.partition()) {
             deletes
                 .iter()
-                // filter that returns true if the provided delete file's sequence number is **greater than** `seq_num`
                 .filter(|&delete| {
-                    seq_num
-                        .map(|seq_num| delete.manifest_entry.sequence_number() > Some(seq_num))
-                        .unwrap_or_else(|| true)
+                    delete.manifest_entry.data_sequence_number() > data_sequence_number
                         && data_file.partition_spec_id == delete.partition_spec_id
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));
@@ -236,11 +228,8 @@ impl PopulatedDeleteFileIndex {
         if let Some(deletes) = self.pos_deletes_by_partition.get(data_file.partition()) {
             deletes
                 .iter()
-                // filter that returns true if the provided delete file's sequence number is **greater than or equal to** `seq_num`
                 .filter(|&delete| {
-                    seq_num
-                        .map(|seq_num| delete.manifest_entry.sequence_number() >= Some(seq_num))
-                        .unwrap_or_else(|| true)
+                    delete.manifest_entry.data_sequence_number() >= data_sequence_number
                         && data_file.partition_spec_id == delete.partition_spec_id
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));
@@ -252,11 +241,8 @@ impl PopulatedDeleteFileIndex {
         if let Some(deletes) = self.pos_deletes_by_path.get(data_file.file_path()) {
             deletes
                 .iter()
-                // filter that returns true if the provided delete file's sequence number is **greater than or equal to** `seq_num`
                 .filter(|&delete| {
-                    seq_num
-                        .map(|seq_num| delete.manifest_entry.sequence_number() >= Some(seq_num))
-                        .unwrap_or(true)
+                    delete.manifest_entry.data_sequence_number() >= data_sequence_number
                 })
                 .for_each(|delete| results.push(delete.as_ref().into()));
         }
@@ -271,8 +257,8 @@ mod tests {
 
     use super::*;
     use crate::spec::{
-        DataContentType, DataFileBuilder, DataFileFormat, Datum, Literal, ManifestEntry,
-        ManifestStatus, Struct,
+        DataContentType, DataFileBuilder, DataFileFormat, Datum, Literal, LiveManifestEntry,
+        ManifestEntry, ManifestStatus, Struct,
     };
 
     #[test]
@@ -292,7 +278,7 @@ mod tests {
         let delete_contexts: Vec<DeleteFileContext> = deletes
             .into_iter()
             .map(|entry| DeleteFileContext {
-                manifest_entry: entry.into(),
+                manifest_entry: live_manifest_entry(entry),
                 partition_spec_id: 0,
             })
             .collect();
@@ -303,17 +289,17 @@ mod tests {
 
         // All deletes apply to sequence 0
         let delete_files_to_apply_for_seq_0 =
-            delete_file_index.get_deletes_for_data_file(&data_file, Some(0));
+            delete_file_index.get_deletes_for_data_file(&data_file, 0);
         assert_eq!(delete_files_to_apply_for_seq_0.len(), 4);
 
         // All deletes apply to sequence 3
         let delete_files_to_apply_for_seq_3 =
-            delete_file_index.get_deletes_for_data_file(&data_file, Some(3));
+            delete_file_index.get_deletes_for_data_file(&data_file, 3);
         assert_eq!(delete_files_to_apply_for_seq_3.len(), 4);
 
         // Last 3 deletes apply to sequence 4
         let delete_files_to_apply_for_seq_4 =
-            delete_file_index.get_deletes_for_data_file(&data_file, Some(4));
+            delete_file_index.get_deletes_for_data_file(&data_file, 4);
         let actual_paths_to_apply_for_seq_4: Vec<String> = delete_files_to_apply_for_seq_4
             .into_iter()
             .map(|file| file.file_path)
@@ -326,7 +312,7 @@ mod tests {
 
         // Last 3 deletes apply to sequence 5
         let delete_files_to_apply_for_seq_5 =
-            delete_file_index.get_deletes_for_data_file(&data_file, Some(5));
+            delete_file_index.get_deletes_for_data_file(&data_file, 5);
         let actual_paths_to_apply_for_seq_5: Vec<String> = delete_files_to_apply_for_seq_5
             .into_iter()
             .map(|file| file.file_path)
@@ -338,7 +324,7 @@ mod tests {
 
         // Only the last position delete applies to sequence 6
         let delete_files_to_apply_for_seq_6 =
-            delete_file_index.get_deletes_for_data_file(&data_file, Some(6));
+            delete_file_index.get_deletes_for_data_file(&data_file, 6);
         let actual_paths_to_apply_for_seq_6: Vec<String> = delete_files_to_apply_for_seq_6
             .into_iter()
             .map(|file| file.file_path)
@@ -353,7 +339,7 @@ mod tests {
             build_partitioned_data_file(&Struct::from_iter([Some(Literal::long(100))]), 1);
 
         let delete_files_to_apply_for_partitioned_file =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(0));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 0);
         let actual_paths_to_apply_for_partitioned_file: Vec<String> =
             delete_files_to_apply_for_partitioned_file
                 .into_iter()
@@ -384,7 +370,7 @@ mod tests {
         let delete_contexts: Vec<DeleteFileContext> = deletes
             .into_iter()
             .map(|entry| DeleteFileContext {
-                manifest_entry: entry.into(),
+                manifest_entry: live_manifest_entry(entry),
                 partition_spec_id: spec_id,
             })
             .collect();
@@ -396,17 +382,17 @@ mod tests {
 
         // All deletes apply to sequence 0
         let delete_files_to_apply_for_seq_0 =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(0));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 0);
         assert_eq!(delete_files_to_apply_for_seq_0.len(), 4);
 
         // All deletes apply to sequence 3
         let delete_files_to_apply_for_seq_3 =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(3));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 3);
         assert_eq!(delete_files_to_apply_for_seq_3.len(), 4);
 
         // Last 3 deletes apply to sequence 4
         let delete_files_to_apply_for_seq_4 =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(4));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 4);
         let actual_paths_to_apply_for_seq_4: Vec<String> = delete_files_to_apply_for_seq_4
             .into_iter()
             .map(|file| file.file_path)
@@ -419,7 +405,7 @@ mod tests {
 
         // Last 3 deletes apply to sequence 5
         let delete_files_to_apply_for_seq_5 =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(5));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 5);
         let actual_paths_to_apply_for_seq_5: Vec<String> = delete_files_to_apply_for_seq_5
             .into_iter()
             .map(|file| file.file_path)
@@ -431,7 +417,7 @@ mod tests {
 
         // Only the last position delete applies to sequence 6
         let delete_files_to_apply_for_seq_6 =
-            delete_file_index.get_deletes_for_data_file(&partitioned_file, Some(6));
+            delete_file_index.get_deletes_for_data_file(&partitioned_file, 6);
         let actual_paths_to_apply_for_seq_6: Vec<String> = delete_files_to_apply_for_seq_6
             .into_iter()
             .map(|file| file.file_path)
@@ -445,7 +431,7 @@ mod tests {
         let partitioned_second_file =
             build_partitioned_data_file(&Struct::from_iter([Some(Literal::long(200))]), 1);
         let delete_files_to_apply_for_different_partition =
-            delete_file_index.get_deletes_for_data_file(&partitioned_second_file, Some(0));
+            delete_file_index.get_deletes_for_data_file(&partitioned_second_file, 0);
         let actual_paths_to_apply_for_different_partition: Vec<String> =
             delete_files_to_apply_for_different_partition
                 .into_iter()
@@ -456,7 +442,7 @@ mod tests {
         // Data file with same tuple but different spec ID does not match any delete files
         let partitioned_different_spec = build_partitioned_data_file(&partition_one, 2);
         let delete_files_to_apply_for_different_spec =
-            delete_file_index.get_deletes_for_data_file(&partitioned_different_spec, Some(0));
+            delete_file_index.get_deletes_for_data_file(&partitioned_different_spec, 0);
         let actual_paths_to_apply_for_different_spec: Vec<String> =
             delete_files_to_apply_for_different_spec
                 .into_iter()
@@ -472,17 +458,17 @@ mod tests {
 
         let pos_delete = build_pos_delete_referencing(data_file_a.file_path());
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
-        let deletes_for_a = index.get_deletes_for_data_file(&data_file_a, Some(0));
+        let deletes_for_a = index.get_deletes_for_data_file(&data_file_a, 0);
         assert_eq!(deletes_for_a.len(), 1);
         assert_eq!(deletes_for_a[0].file_path, pos_delete.file_path());
 
         // The delete references data file A, so it must not apply to data file B
         // even though B shares A's partition.
-        let deletes_for_b = index.get_deletes_for_data_file(&data_file_b, Some(0));
+        let deletes_for_b = index.get_deletes_for_data_file(&data_file_b, 0);
         assert!(deletes_for_b.is_empty());
     }
 
@@ -496,19 +482,12 @@ mod tests {
         let pos_delete =
             build_pos_delete_with_path_bounds(data_file_a.file_path(), data_file_a.file_path());
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file_a, Some(0)).len(),
-            1
-        );
-        assert!(
-            index
-                .get_deletes_for_data_file(&data_file_b, Some(0))
-                .is_empty()
-        );
+        assert_eq!(index.get_deletes_for_data_file(&data_file_a, 0).len(), 1);
+        assert!(index.get_deletes_for_data_file(&data_file_b, 0).is_empty());
     }
 
     #[test]
@@ -521,18 +500,12 @@ mod tests {
         // in the partition.
         let pos_delete = build_pos_delete_with_path_bounds("a-data.parquet", "z-data.parquet");
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file_a, Some(0)).len(),
-            1
-        );
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file_b, Some(0)).len(),
-            1
-        );
+        assert_eq!(index.get_deletes_for_data_file(&data_file_a, 0).len(), 1);
+        assert_eq!(index.get_deletes_for_data_file(&data_file_b, 0).len(), 1);
     }
 
     #[test]
@@ -544,14 +517,11 @@ mod tests {
         // An exact path match is sufficient proof that the delete applies.
         let pos_delete = build_pos_delete_referencing(data_file.file_path());
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file, Some(0)).len(),
-            1
-        );
+        assert_eq!(index.get_deletes_for_data_file(&data_file, 0).len(), 1);
     }
 
     #[test]
@@ -560,27 +530,15 @@ mod tests {
 
         let pos_delete = build_pos_delete_referencing(data_file.file_path());
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
         // Position deletes apply when the delete's sequence number is greater
         // than or equal to the data file's.
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file, Some(4)).len(),
-            1
-        );
-        assert_eq!(
-            index.get_deletes_for_data_file(&data_file, Some(5)).len(),
-            1
-        );
-        assert!(
-            index
-                .get_deletes_for_data_file(&data_file, Some(6))
-                .is_empty()
-        );
-        // Without a sequence number, the delete applies unconditionally.
-        assert_eq!(index.get_deletes_for_data_file(&data_file, None).len(), 1);
+        assert_eq!(index.get_deletes_for_data_file(&data_file, 4).len(), 1);
+        assert_eq!(index.get_deletes_for_data_file(&data_file, 5).len(), 1);
+        assert!(index.get_deletes_for_data_file(&data_file, 6).is_empty());
     }
 
     #[test]
@@ -596,21 +554,24 @@ mod tests {
 
         let index = PopulatedDeleteFileIndex::new(vec![
             DeleteFileContext {
-                manifest_entry: build_added_manifest_entry(5, &path_delete).into(),
+                manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &path_delete)),
                 partition_spec_id: 0,
             },
             DeleteFileContext {
-                manifest_entry: build_added_manifest_entry(5, &partition_delete).into(),
+                manifest_entry: live_manifest_entry(build_added_manifest_entry(
+                    5,
+                    &partition_delete,
+                )),
                 partition_spec_id: 0,
             },
             DeleteFileContext {
-                manifest_entry: build_added_manifest_entry(5, &eq_delete).into(),
+                manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &eq_delete)),
                 partition_spec_id: 0,
             },
         ]);
 
         let mut actual_paths: Vec<String> = index
-            .get_deletes_for_data_file(&data_file, Some(0))
+            .get_deletes_for_data_file(&data_file, 0)
             .into_iter()
             .map(|delete| delete.file_path)
             .collect();
@@ -635,17 +596,17 @@ mod tests {
 
         let index = PopulatedDeleteFileIndex::new(vec![
             DeleteFileContext {
-                manifest_entry: build_added_manifest_entry(5, &first_delete).into(),
+                manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &first_delete)),
                 partition_spec_id: 0,
             },
             DeleteFileContext {
-                manifest_entry: build_added_manifest_entry(6, &second_delete).into(),
+                manifest_entry: live_manifest_entry(build_added_manifest_entry(6, &second_delete)),
                 partition_spec_id: 0,
             },
         ]);
 
         let mut actual_paths: Vec<String> = index
-            .get_deletes_for_data_file(&data_file, Some(0))
+            .get_deletes_for_data_file(&data_file, 0)
             .into_iter()
             .map(|delete| delete.file_path)
             .collect();
@@ -677,17 +638,17 @@ mod tests {
         pos_delete.partition_spec_id = 1;
 
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 1,
         }]);
 
-        let deletes_for_referenced = index.get_deletes_for_data_file(&data_file, Some(0));
+        let deletes_for_referenced = index.get_deletes_for_data_file(&data_file, 0);
         assert_eq!(deletes_for_referenced.len(), 1);
         assert_eq!(deletes_for_referenced[0].file_path, pos_delete.file_path());
 
         assert!(
             index
-                .get_deletes_for_data_file(&same_partition_neighbor, Some(0))
+                .get_deletes_for_data_file(&same_partition_neighbor, 0)
                 .is_empty()
         );
     }
@@ -704,18 +665,13 @@ mod tests {
         pos_delete.upper_bounds = HashMap::default();
 
         let index = PopulatedDeleteFileIndex::new(vec![DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &pos_delete).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &pos_delete)),
             partition_spec_id: 0,
         }]);
 
+        assert_eq!(index.get_deletes_for_data_file(&data_file, 0).len(), 1);
         assert_eq!(
-            index.get_deletes_for_data_file(&data_file, Some(0)).len(),
-            1
-        );
-        assert_eq!(
-            index
-                .get_deletes_for_data_file(&other_data_file, Some(0))
-                .len(),
+            index.get_deletes_for_data_file(&other_data_file, 0).len(),
             1
         );
     }
@@ -776,7 +732,7 @@ mod tests {
             .unwrap();
 
         let ctx = DeleteFileContext {
-            manifest_entry: build_added_manifest_entry(5, &dv).into(),
+            manifest_entry: live_manifest_entry(build_added_manifest_entry(5, &dv)),
             partition_spec_id: 0,
         };
 
@@ -858,5 +814,11 @@ mod tests {
             .sequence_number(data_seq_number)
             .data_file(file.clone())
             .build()
+    }
+
+    fn live_manifest_entry(entry: ManifestEntry) -> LiveManifestEntry {
+        LiveManifestEntry::try_new(entry.into(), "test-manifest.avro")
+            .unwrap()
+            .unwrap()
     }
 }

--- a/crates/iceberg/src/scan/context.rs
+++ b/crates/iceberg/src/scan/context.rs
@@ -28,7 +28,7 @@ use crate::scan::{
     PartitionFilterCache,
 };
 use crate::spec::{
-    ManifestContentType, ManifestEntryRef, ManifestFile, ManifestList, NameMapping,
+    LiveManifestEntry, ManifestContentType, ManifestFile, ManifestList, NameMapping,
     PartitionSpecRef, SchemaRef, SnapshotRef, StructType, TableMetadataRef,
 };
 use crate::{Error, ErrorKind, Result};
@@ -52,10 +52,10 @@ pub(crate) struct ManifestFileContext {
     unified_partition_type: Option<Arc<StructType>>,
 }
 
-/// Wraps a [`ManifestEntryRef`] alongside the objects that are needed
+/// Wraps a live manifest entry alongside the objects that are needed
 /// to process it in a thread-safe manner
 pub(crate) struct ManifestEntryContext {
-    pub manifest_entry: ManifestEntryRef,
+    pub manifest_entry: LiveManifestEntry,
 
     pub expression_evaluator_cache: Arc<ExpressionEvaluatorCache>,
     pub field_ids: Arc<Vec<i32>>,
@@ -91,9 +91,14 @@ impl ManifestFileContext {
         let manifest = object_cache.get_manifest(&manifest_file).await?;
 
         for manifest_entry in manifest.entries() {
+            let Some(manifest_entry) =
+                LiveManifestEntry::try_new(manifest_entry.clone(), &manifest_file.manifest_path)?
+            else {
+                continue;
+            };
+
             let manifest_entry_context = ManifestEntryContext {
-                // TODO: refactor to avoid the expensive ManifestEntry clone
-                manifest_entry: manifest_entry.clone(),
+                manifest_entry,
                 expression_evaluator_cache: expression_evaluator_cache.clone(),
                 field_ids: field_ids.clone(),
                 partition_spec_id: manifest_file.partition_spec_id,
@@ -124,7 +129,7 @@ impl ManifestEntryContext {
             .delete_file_index
             .get_deletes_for_data_file(
                 self.manifest_entry.data_file(),
-                self.manifest_entry.sequence_number(),
+                self.manifest_entry.data_sequence_number(),
             )
             .await;
 
@@ -134,7 +139,7 @@ impl ManifestEntryContext {
             .with_length(self.manifest_entry.file_size_in_bytes())
             .with_record_count(Some(self.manifest_entry.record_count()))
             .with_first_row_id(self.manifest_entry.data_file().first_row_id())
-            .with_data_sequence_number(self.manifest_entry.sequence_number())
+            .with_data_sequence_number(Some(self.manifest_entry.data_sequence_number()))
             .with_data_file_path(self.manifest_entry.file_path().to_string())
             .with_data_file_format(self.manifest_entry.file_format())
             .with_schema(self.snapshot_schema)
@@ -144,12 +149,17 @@ impl ManifestEntryContext {
                     .map(|x| x.as_ref().snapshot_bound_predicate.clone()),
             )
             .with_deletes(deletes)
-            .with_partition(Some(self.manifest_entry.data_file.partition.clone()))
+            .with_partition(Some(self.manifest_entry.data_file().partition.clone()))
             .with_partition_spec(self.partition_spec.clone())
             .with_name_mapping(self.name_mapping)
             .with_unified_partition_type(self.unified_partition_type.clone())
             .with_case_sensitive(self.case_sensitive)
-            .with_key_metadata(self.manifest_entry.data_file.key_metadata().map(Box::from))
+            .with_key_metadata(
+                self.manifest_entry
+                    .data_file()
+                    .key_metadata()
+                    .map(Box::from),
+            )
             .build())
     }
 }

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -526,11 +526,6 @@ impl TableScan {
         manifest_entry_context: ManifestEntryContext,
         mut file_scan_task_tx: Sender<Result<FileScanTask>>,
     ) -> Result<()> {
-        // skip processing this manifest entry if it has been marked as deleted
-        if !manifest_entry_context.manifest_entry.is_alive() {
-            return Ok(());
-        }
-
         // abort the plan if we encounter a manifest entry for a delete file
         if manifest_entry_context.manifest_entry.content_type() != DataContentType::Data {
             return Err(Error::new(
@@ -583,11 +578,6 @@ impl TableScan {
         manifest_entry_context: ManifestEntryContext,
         mut delete_file_ctx_tx: Sender<DeleteFileContext>,
     ) -> Result<()> {
-        // skip processing this manifest entry if it has been marked as deleted
-        if !manifest_entry_context.manifest_entry.is_alive() {
-            return Ok(());
-        }
-
         // abort the plan if we encounter a manifest entry that is not for a delete file
         if manifest_entry_context.manifest_entry.content_type() == DataContentType::Data {
             return Err(Error::new(

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -24,7 +24,7 @@ use typed_builder::TypedBuilder;
 use crate::Result;
 use crate::expr::BoundPredicate;
 use crate::spec::{
-    DataContentType, DataFileFormat, ManifestEntryRef, NameMapping, PartitionSpec, Schema,
+    DataContentType, DataFileFormat, LiveManifestEntry, NameMapping, PartitionSpec, Schema,
     SchemaRef, Struct, StructType,
 };
 
@@ -196,7 +196,7 @@ impl FileScanTask {
 
 #[derive(Debug)]
 pub(crate) struct DeleteFileContext {
-    pub(crate) manifest_entry: ManifestEntryRef,
+    pub(crate) manifest_entry: LiveManifestEntry,
     pub(crate) partition_spec_id: i32,
 }
 
@@ -207,14 +207,14 @@ impl From<&DeleteFileContext> for FileScanTaskDeleteFile {
             .with_file_size_in_bytes(ctx.manifest_entry.file_size_in_bytes())
             .with_file_type(ctx.manifest_entry.content_type())
             .with_partition_spec_id(ctx.partition_spec_id)
-            .with_equality_ids(ctx.manifest_entry.data_file.equality_ids.clone())
-            .with_referenced_data_file(ctx.manifest_entry.data_file.referenced_data_file.clone())
-            .with_content_offset(ctx.manifest_entry.data_file.content_offset)
-            .with_content_size_in_bytes(ctx.manifest_entry.data_file.content_size_in_bytes)
+            .with_equality_ids(ctx.manifest_entry.data_file().equality_ids.clone())
+            .with_referenced_data_file(ctx.manifest_entry.data_file().referenced_data_file.clone())
+            .with_content_offset(ctx.manifest_entry.data_file().content_offset)
+            .with_content_size_in_bytes(ctx.manifest_entry.data_file().content_size_in_bytes)
             .with_record_count(Some(ctx.manifest_entry.record_count()))
             .with_key_metadata(
                 ctx.manifest_entry
-                    .data_file
+                    .data_file()
                     .key_metadata
                     .as_deref()
                     .map(Box::from),

--- a/crates/iceberg/src/spec/manifest/entry.rs
+++ b/crates/iceberg/src/spec/manifest/entry.rs
@@ -32,6 +32,64 @@ use crate::{Error, ErrorKind};
 /// Reference to [`ManifestEntry`].
 pub type ManifestEntryRef = Arc<ManifestEntry>;
 
+#[derive(Debug, Clone)]
+pub(crate) struct LiveManifestEntry {
+    entry: ManifestEntryRef,
+    data_sequence_number: i64,
+}
+
+impl LiveManifestEntry {
+    pub(crate) fn try_new(entry: ManifestEntryRef, manifest_path: &str) -> Result<Option<Self>> {
+        if !entry.is_alive() {
+            return Ok(None);
+        }
+
+        let data_sequence_number = entry.sequence_number().ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                format!(
+                    "Live manifest entry for file '{}' in manifest '{}' has no data sequence number",
+                    entry.file_path(),
+                    manifest_path
+                ),
+            )
+        })?;
+
+        Ok(Some(Self {
+            entry,
+            data_sequence_number,
+        }))
+    }
+
+    pub(crate) fn data_sequence_number(&self) -> i64 {
+        self.data_sequence_number
+    }
+
+    pub(crate) fn content_type(&self) -> DataContentType {
+        self.entry.content_type()
+    }
+
+    pub(crate) fn file_format(&self) -> DataFileFormat {
+        self.entry.file_format()
+    }
+
+    pub(crate) fn file_path(&self) -> &str {
+        self.entry.file_path()
+    }
+
+    pub(crate) fn record_count(&self) -> u64 {
+        self.entry.record_count()
+    }
+
+    pub(crate) fn file_size_in_bytes(&self) -> u64 {
+        self.entry.file_size_in_bytes()
+    }
+
+    pub(crate) fn data_file(&self) -> &DataFile {
+        self.entry.data_file()
+    }
+}
+
 /// A manifest is an immutable Avro file that lists data files or delete
 /// files, along with each file’s partition data tuple, metrics, and tracking
 /// information.
@@ -642,4 +700,60 @@ pub(super) fn manifest_schema_v1(partition_type: &StructType) -> Result<AvroSche
     ];
     let schema = Schema::builder().with_fields(fields).build()?;
     schema_to_avro_schema("manifest_entry", &schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::DataFileBuilder;
+
+    #[test]
+    fn test_live_entry_captures_data_sequence_number() {
+        let entry = manifest_entry(ManifestStatus::Added, Some(7));
+
+        let live_entry = LiveManifestEntry::try_new(entry.into(), "manifest.avro")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(live_entry.data_sequence_number(), 7);
+    }
+
+    #[test]
+    fn test_live_entry_without_data_sequence_number_is_invalid() {
+        let entry = manifest_entry(ManifestStatus::Existing, None);
+
+        let err = LiveManifestEntry::try_new(entry.into(), "manifest.avro").unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::DataInvalid);
+        assert!(err.message().contains("data.parquet"));
+        assert!(err.message().contains("manifest.avro"));
+    }
+
+    #[test]
+    fn test_deleted_entry_without_data_sequence_number_is_ignored() {
+        let entry = manifest_entry(ManifestStatus::Deleted, None);
+
+        let live_entry = LiveManifestEntry::try_new(entry.into(), "manifest.avro").unwrap();
+
+        assert!(live_entry.is_none());
+    }
+
+    fn manifest_entry(status: ManifestStatus, sequence_number: Option<i64>) -> ManifestEntry {
+        let data_file = DataFileBuilder::default()
+            .content(DataContentType::Data)
+            .file_path("data.parquet".to_string())
+            .file_format(DataFileFormat::Parquet)
+            .file_size_in_bytes(100)
+            .record_count(1)
+            .build()
+            .unwrap();
+
+        ManifestEntry {
+            status,
+            snapshot_id: None,
+            sequence_number,
+            file_sequence_number: None,
+            data_file,
+        }
+    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.
This came up as a part of the discussion in https://github.com/apache/iceberg-rust/pull/2936

## What changes are included in this PR?

This PR adds `LiveManifestEntry`, an internal representation used during scan planning. `ManifestEntry` continues to reflect the serialized manifest format, where `sequence_number` is optional because an `ADDED` entry may inherit it from the containing manifest. After inheritance, however, every live entry must have a data sequence number, so `LiveManifestEntry` represents that the value is required.

The distinction also preserves compatibility with older v2 manifests that contain deleted entries with null data sequence numbers. Those entries can still be parsed and ignored because they are no longer live, while an `ADDED` or `EXISTING` entry that remains null after inheritance is treated as invalid data.

This invariant is intentionally not enforced in ManifestReader::read. The manifest reader loads the complete manifest, including deleted historical entries, and is used outside scan planning. Rejecting null sequence numbers there would make an otherwise readable manifest fail because of an entry that cannot affect the current snapshot. Instead, the scan path applies inheritance first, filters out deleted entries, and then converts the remaining entries into LiveManifestEntry.

Scan and delete-index code now operate on `LiveManifestEntry`, removing optional sequence-number comparisons and the previous fallback that applied deletes unconditionally when the data sequence number was missing.

<!--
Provide a summary of the modifications in this PR. List the main changes such as new features, bug fixes, refactoring, or any other updates.
-->

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## AI Disclosure

<!--
https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions
-->
