### PR TITLE
test(transaction): add round-trip tests for transaction APIs against MemoryCatalog

### DIFF
--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -697,15 +697,6 @@ mod test_row_lineage {
 
 #[cfg(test)]
 mod test_commit_against_memory_catalog {
-    //! End-to-end tests for transaction APIs against an in-process `MemoryCatalog`.
-    //!
-    //! Each test constructs a table inside a fresh memory catalog, builds a
-    //! transaction, commits it, and then asserts that the catalog's view of the
-    //! table reflects the action's intended metadata change. This complements
-    //! the action-level unit tests in the per-action modules (which only inspect
-    //! the produced `ActionCommit`) and the mock-catalog tests in this file
-    //! (which exercise the retry loop).
-
     use crate::memory::tests::new_memory_catalog;
     use crate::transaction::tests::make_v3_minimal_table_in_catalog;
     use crate::transaction::{ApplyTransactionAction, Transaction};
@@ -716,7 +707,6 @@ mod test_commit_against_memory_catalog {
         let catalog = new_memory_catalog().await;
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
 
-        // Sanity: the keys we are about to set are not already present.
         assert!(!table.metadata().properties().contains_key("owner"));
         assert!(!table.metadata().properties().contains_key("team"));
 
@@ -730,7 +720,6 @@ mod test_commit_against_memory_catalog {
 
         let committed = tx.commit(&catalog).await.unwrap();
 
-        // The table returned from commit reflects the new properties.
         assert_eq!(
             committed
                 .metadata()
@@ -748,8 +737,7 @@ mod test_commit_against_memory_catalog {
             Some("storage")
         );
 
-        // A fresh load from the catalog also sees the properties, confirming the
-        // commit was persisted rather than only mutated in the returned table.
+        // A fresh load proves the commit was persisted, not just applied in-memory.
         let reloaded = catalog.load_table(committed.identifier()).await.unwrap();
         assert_eq!(
             reloaded
@@ -768,7 +756,6 @@ mod test_commit_against_memory_catalog {
             Some("storage")
         );
 
-        // The metadata pointer must have advanced.
         assert_ne!(
             committed.metadata_location(),
             table.metadata_location(),
@@ -798,8 +785,6 @@ mod test_commit_against_memory_catalog {
 
     #[tokio::test]
     async fn test_chained_actions_commit_atomically() {
-        // A transaction can carry multiple actions. Committing once should apply
-        // all of them together and produce a single new metadata version.
         let catalog = new_memory_catalog().await;
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
         let initial_metadata_log_len = table.metadata().metadata_log().len();
@@ -838,8 +823,6 @@ mod test_commit_against_memory_catalog {
 
     #[tokio::test]
     async fn test_failing_chained_actions_do_not_commit() {
-        // If any action in the transaction fails to apply, the whole commit must
-        // be rejected and the catalog must be left untouched.
         let catalog = new_memory_catalog().await;
         let table = make_v3_minimal_table_in_catalog(&catalog).await;
         let initial_location = table.metadata().location().to_string();
@@ -858,8 +841,7 @@ mod test_commit_against_memory_catalog {
             .set_location(new_location)
             .apply(tx)
             .unwrap();
-        // Deleting a column that does not exist makes the schema update fail when
-        // the transaction is applied at commit time, aborting the whole commit.
+        // Deleting a non-existent column makes the schema action fail at commit time.
         let tx = tx
             .update_schema()
             .delete_column("nonexistent")

--- a/crates/iceberg/src/transaction/mod.rs
+++ b/crates/iceberg/src/transaction/mod.rs
@@ -694,3 +694,193 @@ mod test_row_lineage {
         assert_eq!(manifest_file.first_row_id, Some(30));
     }
 }
+
+#[cfg(test)]
+mod test_commit_against_memory_catalog {
+    //! End-to-end tests for transaction APIs against an in-process `MemoryCatalog`.
+    //!
+    //! Each test constructs a table inside a fresh memory catalog, builds a
+    //! transaction, commits it, and then asserts that the catalog's view of the
+    //! table reflects the action's intended metadata change. This complements
+    //! the action-level unit tests in the per-action modules (which only inspect
+    //! the produced `ActionCommit`) and the mock-catalog tests in this file
+    //! (which exercise the retry loop).
+
+    use crate::memory::tests::new_memory_catalog;
+    use crate::transaction::tests::make_v3_minimal_table_in_catalog;
+    use crate::transaction::{ApplyTransactionAction, Transaction};
+    use crate::{Catalog, ErrorKind};
+
+    #[tokio::test]
+    async fn test_update_properties_commit_round_trip() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+
+        // Sanity: the keys we are about to set are not already present.
+        assert!(!table.metadata().properties().contains_key("owner"));
+        assert!(!table.metadata().properties().contains_key("team"));
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("owner".to_string(), "iceberg-rust".to_string())
+            .set("team".to_string(), "storage".to_string())
+            .apply(tx)
+            .unwrap();
+
+        let committed = tx.commit(&catalog).await.unwrap();
+
+        // The table returned from commit reflects the new properties.
+        assert_eq!(
+            committed
+                .metadata()
+                .properties()
+                .get("owner")
+                .map(String::as_str),
+            Some("iceberg-rust")
+        );
+        assert_eq!(
+            committed
+                .metadata()
+                .properties()
+                .get("team")
+                .map(String::as_str),
+            Some("storage")
+        );
+
+        // A fresh load from the catalog also sees the properties, confirming the
+        // commit was persisted rather than only mutated in the returned table.
+        let reloaded = catalog.load_table(committed.identifier()).await.unwrap();
+        assert_eq!(
+            reloaded
+                .metadata()
+                .properties()
+                .get("owner")
+                .map(String::as_str),
+            Some("iceberg-rust")
+        );
+        assert_eq!(
+            reloaded
+                .metadata()
+                .properties()
+                .get("team")
+                .map(String::as_str),
+            Some("storage")
+        );
+
+        // The metadata pointer must have advanced.
+        assert_ne!(
+            committed.metadata_location(),
+            table.metadata_location(),
+            "commit should advance the metadata pointer"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_location_commit_round_trip() {
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let new_location = format!("{}/relocated", table.metadata().location());
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_location()
+            .set_location(new_location.clone())
+            .apply(tx)
+            .unwrap();
+
+        let committed = tx.commit(&catalog).await.unwrap();
+        assert_eq!(committed.metadata().location(), new_location);
+
+        let reloaded = catalog.load_table(committed.identifier()).await.unwrap();
+        assert_eq!(reloaded.metadata().location(), new_location);
+    }
+
+    #[tokio::test]
+    async fn test_chained_actions_commit_atomically() {
+        // A transaction can carry multiple actions. Committing once should apply
+        // all of them together and produce a single new metadata version.
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let initial_metadata_log_len = table.metadata().metadata_log().len();
+        let new_location = format!("{}/relocated", table.metadata().location());
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("owner".to_string(), "iceberg-rust".to_string())
+            .apply(tx)
+            .unwrap();
+        let tx = tx
+            .update_location()
+            .set_location(new_location.clone())
+            .apply(tx)
+            .unwrap();
+
+        let committed = tx.commit(&catalog).await.unwrap();
+        let reloaded = catalog.load_table(committed.identifier()).await.unwrap();
+
+        assert_eq!(
+            reloaded
+                .metadata()
+                .properties()
+                .get("owner")
+                .map(String::as_str),
+            Some("iceberg-rust")
+        );
+        assert_eq!(reloaded.metadata().location(), new_location);
+        // Both actions collapse into a single new metadata-log entry.
+        assert_eq!(
+            reloaded.metadata().metadata_log().len(),
+            initial_metadata_log_len + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_failing_chained_actions_do_not_commit() {
+        // If any action in the transaction fails to apply, the whole commit must
+        // be rejected and the catalog must be left untouched.
+        let catalog = new_memory_catalog().await;
+        let table = make_v3_minimal_table_in_catalog(&catalog).await;
+        let initial_location = table.metadata().location().to_string();
+        let initial_metadata_location = table.metadata_location().map(str::to_string);
+        let initial_metadata_log_len = table.metadata().metadata_log().len();
+        let new_location = format!("{initial_location}/relocated");
+
+        let tx = Transaction::new(&table);
+        let tx = tx
+            .update_table_properties()
+            .set("owner".to_string(), "iceberg-rust".to_string())
+            .apply(tx)
+            .unwrap();
+        let tx = tx
+            .update_location()
+            .set_location(new_location)
+            .apply(tx)
+            .unwrap();
+        // Deleting a column that does not exist makes the schema update fail when
+        // the transaction is applied at commit time, aborting the whole commit.
+        let tx = tx
+            .update_schema()
+            .delete_column("nonexistent")
+            .apply(tx)
+            .unwrap();
+
+        let error = tx.commit(&catalog).await.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PreconditionFailed);
+        assert!(error.message().contains("nonexistent"));
+
+        // None of the earlier actions in the transaction leaked into the catalog.
+        let reloaded = catalog.load_table(table.identifier()).await.unwrap();
+        assert!(!reloaded.metadata().properties().contains_key("owner"));
+        assert_eq!(reloaded.metadata().location(), initial_location);
+        assert_eq!(
+            reloaded.metadata_location(),
+            initial_metadata_location.as_deref()
+        );
+        assert_eq!(
+            reloaded.metadata().metadata_log().len(),
+            initial_metadata_log_len
+        );
+    }
+}


### PR DESCRIPTION
Reviving #2392, which added these tests but was auto-closed as stale.

Most of the per-action tests in `transaction/mod.rs` only check the `ActionCommit` an action produces. Fast-append is already exercised end-to-end through a catalog (see `test_transaction_snapshot_summary` and `test_fast_append_with_row_lineage`), but the property, location, and multi-action paths don't have that kind of round-trip coverage yet. This adds it.

## Which issue does this PR close?

Part of #1322.

## What changes are included in this PR?

A new `test_commit_against_memory_catalog` module, built on the existing `make_v3_minimal_table_in_catalog` helper, covering:

* setting properties and reading them back after commit
* updating the table location
* chaining a property update and a location update, and checking it lands as a single metadata-log entry rather than two separate commits
* a chained transaction whose last action is invalid, checking the whole commit is rejected and the catalog is left untouched

The last two also fold in @andybradshaw's review feedback from #2392 (asserting the chained update is a single commit via the metadata-log length, and adding the failing-transaction case).

## Are these changes tested?

They are the tests. Ran them locally with `cargo test -p iceberg`; fmt and clippy are clean too.