### PR TITLE
fix: Address merge conflicts raising Clippy issues (#3137)

### DIFF
--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -2410,6 +2410,7 @@ mod tests {
 
         let delete = FileScanTaskDeleteFile::builder()
             .with_file_path(del_path.clone())
+            .with_file_format(DataFileFormat::Parquet)
             .with_file_size_in_bytes(std::fs::metadata(&del_path).unwrap().len())
             .with_file_type(DataContentType::PositionDeletes)
             .with_partition_spec_id(0)

--- a/crates/iceberg/src/arrow/reader/positional_deletes.rs
+++ b/crates/iceberg/src/arrow/reader/positional_deletes.rs
@@ -1010,7 +1010,7 @@ mod tests {
             .with_case_sensitive(false)
             .build();
 
-        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let tasks = Box::pin(futures::stream::iter(vec![task])) as FileScanTaskStream;
         let result = reader
             .read(tasks)
             .unwrap()
@@ -1107,7 +1107,7 @@ mod tests {
             .with_case_sensitive(false)
             .build();
 
-        let tasks = Box::pin(futures::stream::iter(vec![Ok(task)])) as FileScanTaskStream;
+        let tasks = Box::pin(futures::stream::iter(vec![task])) as FileScanTaskStream;
         let result: Result<Vec<RecordBatch>, _> =
             reader.read(tasks).unwrap().stream().try_collect().await;
 


### PR DESCRIPTION
## Which issue does this PR close?

This fixes the release branch for 0.11.x, allowing release to continue.

## What changes are included in this PR?

This is a cherry pick of commit c8fc70e5dcf4591a4c0d834223b4c7078ddb28c2.

- Add missing data file parameter when constructing FileScanTaskDeleteFile
- Remove unnecessary wrapping of FileScanTask in Result, as its build() method now returns a result itself.

## Are these changes tested?

N/A

## AI Disclosure

No AI used.
