### PR TITLE
chore(deps): remove dead datafusion-ffi, unused workspace deps, and stale audit ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,37 +21,10 @@ ignore = [
   # Marvin Attack: potential key recovery through timing sidechannels
   # Issues: https://github.com/apache/iceberg-rust/issues/221
   "RUSTSEC-2023-0071",
-  # `derivative` is unmaintained; consider using an alternative
-  #
-  # Introduced by hive_metastore, tracked at https://github.com/cloudwego/pilota/issues/293
-  "RUSTSEC-2024-0388",
   # `paste` is unmaintained; consider using an alternative
   #
   # Introduced by hive_metastore, tracked at https://github.com/cloudwego/pilota/issues/293
   "RUSTSEC-2024-0436",
-  # `generational-arena` is unmaintained; consider using an alternative
-  #
-  # Introduced by datafusion-ffi through abi_stable/async-ffi until upstream
-  # provides a replacement path.
-  "RUSTSEC-2024-0014",
-  # `rustls-pemfile` is unmaintained
-  #
-  # Introduced by object_store, see https://github.com/apache/arrow-rs-object-store/issues/564
-  "RUSTSEC-2025-0134",
-  # `rand` unsoundness with custom logger using `rand::rng()`
-  #
-  # Direct dependency upgraded to 0.9.3+. Transitive rand 0.8.5 remains
-  # from reqsign/sqllogictest/rustc-hash — no 0.8.x patch exists.
-  "RUSTSEC-2026-0097",
-  # pyo3 < 0.29: out-of-bounds read in PyList/PyTuple `nth`/`nth_back`, and
-  # missing `Sync` bound on `PyCFunction::new_closure` closures.
-  #
-  # Pulled only transitively through arrow's `pyarrow` feature
-  # (arrow-pyarrow), which still pins pyo3 ^0.28 in its latest release; no
-  # arrow build supports the patched pyo3 0.29 yet. Remove once arrow-pyarrow
-  # moves to pyo3 >=0.29.
-  "RUSTSEC-2026-0176",
-  "RUSTSEC-2026-0177",
   # `quick-xml` < 0.41.0 has quadratic duplicate-attribute validation and
   # unbounded namespace-declaration allocation (parser DoS).
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ rust-version = "1.95"
 unused_qualifications = "deny"
 
 [workspace.dependencies]
-aes = { version = "0.8", features = ["zeroize"] }
 aes-gcm = "0.10"
 anyhow = "1.0.72"
 apache-avro = { version = "0.21", features = ["snappy", "zstandard"] }
@@ -81,7 +80,6 @@ crc32fast = "1"
 dashmap = "6"
 datafusion = "55.0.0"
 datafusion-cli = "55.0.0"
-datafusion-ffi = "55.0.0"
 datafusion-sqllogictest = "55.0.0"
 derive_builder = "0.20"
 dirs = "6"
@@ -148,7 +146,6 @@ stacker = "0.1.20"
 strum = "0.27.2"
 syn = "2"
 tempfile = "3.18"
-thrift = "0.17.0"
 tokio = { version = "1.47", default-features = false, features = [
   "sync",
   "rt-multi-thread",

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,5 @@ exceptions = [
   # The MPL license is allowed (binary-only):
   # https://www.apache.org/legal/resolved.html#category-b
   { allow = ["MPL-2.0"], crate = "colored" },
-  { allow = ["MPL-2.0"], crate = "generational-arena" },
   { allow = ["MPL-2.0"], crate = "option-ext" },
 ]


### PR DESCRIPTION
## Which issue does this PR close?

None. Follow-up cleanup after the DataFusion `TableProvider` removal in #3143.

## What changes are included in this PR?

While looking for DataFusion-related cleanup after #3143 I found `datafusion-ffi` was still declared in the workspace with no consumer. Checking the rest of the workspace turned up a few more entries in the same state.

- Remove `datafusion-ffi` from `[workspace.dependencies]`; nothing inherits it.
- Remove `aes` and `thrift` workspace deps; no crate inherits them (`thrift` is not even in `Cargo.lock`).
- Drop audit ignores in `.cargo/audit.toml` whose advisory no longer matches any locked crate:
  - RUSTSEC-2024-0014 (`generational-arena`, only pulled in via `datafusion-ffi`)
  - RUSTSEC-2024-0388 (`derivative`, not in lock)
  - RUSTSEC-2025-0134 (`rustls-pemfile`, not in lock)
  - RUSTSEC-2026-0097 (`rand`, all locked versions are patched)
  - RUSTSEC-2026-0176 / 0177 (`pyo3`, lock is on 0.29.1)
- Drop the unmatched MPL-2.0 license exception for `generational-arena` in `deny.toml`.

`Cargo.lock` is unchanged.

## Are these changes tested?

- `cargo check --workspace --all-targets --all-features` passes.
- `cargo audit` (fresh advisory DB) passes with no vulnerabilities.
- `cargo deny check licenses` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
