### PR TITLE
chore(deps): bump zizmor-action to 0.6.3

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -39,4 +39,9 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    # The allowlist checker recognizes ./, but not $/, as a local action prefix.
+    # Normalize its disposable checkout while preserving $/ in source workflows.
+    - name: Normalize self-repository references for the allowlist checker
+      run: |
+        find .github -type f -name '*.yml' -exec sed -i 's#uses: \$/#uses: ./#g' {} +
     - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # allowlist-check/v1.0.0

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
         with:
           rust-version: stable
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -85,7 +85,7 @@ jobs:
       # Linux maturin builds may run inside manylinux Docker, so host Rust caches only help Windows/macOS.
       - name: Setup Rust toolchain
         if: runner.os != 'Linux'
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
       - name: Cache Rust artifacts
         if: runner.os != 'Linux'
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Install lint tools
         # Keep versions in sync with the local install targets in Makefile.
@@ -93,7 +93,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cargo clippy
         run: make check-clippy
@@ -117,7 +117,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -138,7 +138,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -173,7 +173,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -249,12 +249,12 @@ jobs:
           persist-credentials: false
       - name: Get MSRV
         id: get-msrv
-        uses: ./.github/actions/get-msrv
+        uses: $/.github/actions/get-msrv
       - name: Setup MSRV Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
       - name: Setup Nightly Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
       - name: Check MSRV
         run: make check-msrv

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
 
       - name: Cache Rust artifacts
         uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,10 @@ jobs:
 
       - name: Get MSRV
         id: get-msrv
-        uses: ./.github/actions/get-msrv
+        uses: $/.github/actions/get-msrv
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -120,7 +120,7 @@ jobs:
           # Convert semver RC (0.9.0-rc.1) to PEP 440 (0.9.0rc1)
           echo "pep440=$(echo "$CARGO_VERSION" | sed 's/-rc\.\([0-9]*\)/rc\1/')" >> $GITHUB_OUTPUT
 
-      - uses: ./.github/actions/overwrite-package-version
+      - uses: $/.github/actions/overwrite-package-version
         if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
         with:
           version: ${{ steps.version.outputs.pep440 }}
@@ -167,7 +167,7 @@ jobs:
           # Convert semver RC (0.9.0-rc.1) to PEP 440 (0.9.0rc1)
           echo "pep440=$(echo "$CARGO_VERSION" | sed 's/-rc\.\([0-9]*\)/rc\1/')" >> $GITHUB_OUTPUT
 
-      - uses: ./.github/actions/overwrite-package-version
+      - uses: $/.github/actions/overwrite-package-version
         if: ${{ needs.validate-release-tag.outputs.is-rc == 'true' }}
         with:
           version: ${{ steps.version.outputs.pep440 }}
@@ -177,10 +177,10 @@ jobs:
           python-version: 3.12
       - name: Get MSRV
         id: get-msrv
-        uses: ./.github/actions/get-msrv
+        uses: $/.github/actions/get-msrv
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -53,7 +53,7 @@ jobs:
           CURRENT=$(cargo metadata --format-version 1 --no-deps -q | jq -r '.packages[0].version')
           echo "pep440=${CURRENT}.dev${TIMESTAMP}" >> $GITHUB_OUTPUT
 
-      - uses: ./.github/actions/overwrite-package-version
+      - uses: $/.github/actions/overwrite-package-version
         with:
           version: ${{ steps.version.outputs.pep440 }}
 
@@ -99,7 +99,7 @@ jobs:
           CURRENT=$(cargo metadata --format-version 1 --no-deps -q | jq -r '.packages[0].version')
           echo "pep440=${CURRENT}.dev${TIMESTAMP}" >> $GITHUB_OUTPUT
 
-      - uses: ./.github/actions/overwrite-package-version
+      - uses: $/.github/actions/overwrite-package-version
         with:
           version: ${{ steps.version.outputs.pep440 }}
 
@@ -109,10 +109,10 @@ jobs:
 
       - name: Get MSRV
         id: get-msrv
-        uses: ./.github/actions/get-msrv
+        uses: $/.github/actions/get-msrv
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: $/.github/actions/setup-builder
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -39,6 +39,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
         with:
           advanced-security: false


### PR DESCRIPTION
## Which issue does this PR close?

- None. This is a dependency maintenance follow-up to #3158.

## What changes are included in this PR?

- Bump `zizmorcore/zizmor-action` from v0.6.2 to v0.6.3.
- Migrate all 22 local action references from `./...` to GitHub self-repository `$/...` references, resolving the new zizmor 1.30 audit.
- Normalize `$/...` references only in the ASF allowlist job disposable checkout because the current checker recognizes `./...`, but not `$/...`, as local. External action references remain unchanged and fully checked.

No zizmor audit is ignored or disabled.

## Are these changes tested?

- `uvx zizmor@1.30.0 --strict-collection --persona=regular --collect=default --color=never .` (no findings; 44 existing suppressions)
- Exact pinned ASF allowlist checker against the current ASF allowlist (all 20 unique external action references accepted)
- `git diff --check upstream/main...HEAD`

## AI Disclosure

AI was used to inspect the #3158 CI failure, identify the ASF allowlist checker compatibility issue, apply the workflow updates, and draft this PR description. I reviewed the changes and validated them with the exact zizmor and ASF checker versions used by CI.