### PR TITLE
fix(expr): reject non-string StartsWith operands instead of pruning the file

### DIFF
--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -206,10 +206,21 @@ impl BoundPredicateVisitor for ExpressionEvaluatorVisitor<'_> {
             return Ok(false);
         };
 
-        match (datum.literal(), literal.literal()) {
-            (PrimitiveLiteral::String(d), PrimitiveLiteral::String(l)) => Ok(d.starts_with(l)),
-            _ => Ok(false),
-        }
+        let PrimitiveLiteral::String(literal) = literal.literal() else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "Cannot use StartsWith operator on non-string values",
+            ));
+        };
+
+        let PrimitiveLiteral::String(datum) = datum.literal() else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "Cannot use StartsWith operator on non-string partition value",
+            ));
+        };
+
+        Ok(datum.starts_with(literal))
     }
 
     fn not_starts_with(
@@ -255,7 +266,6 @@ mod tests {
     use predicate::SetExpression;
 
     use super::ExpressionEvaluator;
-    use crate::Result;
     use crate::expr::visitors::inclusive_projection::InclusiveProjection;
     use crate::expr::{
         BinaryExpression, Bind, BoundPredicate, Predicate, PredicateOperator, Reference,
@@ -266,6 +276,7 @@ mod tests {
         PartitionSpecRef, PrimitiveType, Schema, SchemaRef, Struct, Transform, Type,
         UnboundPartitionField,
     };
+    use crate::{ErrorKind, Result};
 
     fn create_partition_spec(r#type: PrimitiveType) -> Result<(PartitionSpecRef, SchemaRef)> {
         let schema = Schema::builder()
@@ -354,6 +365,13 @@ mod tests {
             referenced_data_file: None,
             content_offset: None,
             content_size_in_bytes: None,
+        }
+    }
+
+    fn create_data_file_binary(value: &[u8]) -> DataFile {
+        DataFile {
+            partition: Struct::from_iter([Some(Literal::binary(value.to_vec()))]),
+            ..create_data_file_string()
         }
     }
 
@@ -543,6 +561,45 @@ mod tests {
         let result = expression_evaluator.eval(&data_file)?;
 
         assert!(result);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expr_starts_with_non_string_errors() -> Result<()> {
+        let case_sensitive = true;
+        let (partition_spec, schema) = create_partition_spec(PrimitiveType::Binary)?;
+
+        for op in [
+            PredicateOperator::StartsWith,
+            PredicateOperator::NotStartsWith,
+        ] {
+            let predicate = Predicate::Binary(BinaryExpression::new(
+                op,
+                Reference::new("a"),
+                Datum::binary(b"ab".to_vec()),
+            ))
+            .bind(schema.clone(), case_sensitive)?;
+
+            let expression_evaluator = create_expression_evaluator(
+                partition_spec.clone(),
+                &schema,
+                &predicate,
+                case_sensitive,
+            )?;
+
+            // The partition value does start with the prefix, so answering `false`
+            // here would prune a file that contains matching rows.
+            let err = expression_evaluator
+                .eval(&create_data_file_binary(b"abc"))
+                .expect_err("expected an error for a non-string StartsWith operand");
+
+            assert_eq!(err.kind(), ErrorKind::Unexpected);
+            assert!(
+                err.message().contains("non-string"),
+                "unexpected message: {err}"
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

None — filed directly.

## What changes are included in this PR?

`ExpressionEvaluator::starts_with` matched only `(String, String)` and fell through to
`Ok(false)`. In this visitor `false` means "this data file cannot match", so a `StartsWith`
predicate on a non-string partition column silently pruned files that do contain matching rows.

It is reachable: `Reference::new("a").starts_with(Datum::binary(b"ab"))` binds without error, and
with an identity-partitioned `binary` column a file whose partition value is `X'616263'` was
dropped from the scan.

Now it returns the same error the other four visitors already return for this input —
`inclusive_metrics_evaluator.rs:308`, `row_group_metrics_evaluator.rs:347`,
`page_index_evaluator.rs:586`, `manifest_evaluator.rs:331`.

## Are these changes tested?

Yes — `test_expr_starts_with_non_string_errors` covers `StartsWith` and `NotStartsWith` on a binary
partition; it returns `false` on the parent commit. `cargo test --release -p iceberg --lib expr::`
→ 287 passed.

## AI Disclosure

Written with AI assistance (Claude Code); I reviewed the change and ran the tests above.
Worth a reviewer's attention: this turns `NOT STARTS WITH` on a non-string column from "no pruning"
into an error. Java rejects the predicate earlier, when binding, so validating in
`BinaryExpression::bind` would be a reasonable follow-up.
