### PR TITLE
feat: Add Snapshot::into_builder for updating existing snapshots

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2454,6 +2454,7 @@ impl iceberg::spec::Snapshot
 pub fn iceberg::spec::Snapshot::added_rows_count(&self) -> core::option::Option<u64>
 pub fn iceberg::spec::Snapshot::encryption_key_id(&self) -> core::option::Option<&str>
 pub fn iceberg::spec::Snapshot::first_row_id(&self) -> core::option::Option<u64>
+pub fn iceberg::spec::Snapshot::into_builder(self) -> iceberg::spec::SnapshotUpdateBuilder
 pub fn iceberg::spec::Snapshot::manifest_list(&self) -> &str
 pub fn iceberg::spec::Snapshot::parent_snapshot_id(&self) -> core::option::Option<i64>
 pub fn iceberg::spec::Snapshot::row_range(&self) -> core::option::Option<(u64, u64)>
@@ -2534,6 +2535,23 @@ pub fn iceberg::spec::SnapshotSummaryCollector::set_partition_summary_limit(&mut
 pub fn iceberg::spec::SnapshotSummaryCollector::update_partition_metrics(&mut self, schema: iceberg::spec::SchemaRef, partition_spec: iceberg::spec::PartitionSpecRef, data_file: &iceberg::spec::DataFile, is_add_file: bool)
 impl core::default::Default for iceberg::spec::SnapshotSummaryCollector
 pub fn iceberg::spec::SnapshotSummaryCollector::default() -> iceberg::spec::SnapshotSummaryCollector
+pub struct iceberg::spec::SnapshotUpdateBuilder
+impl iceberg::spec::SnapshotUpdateBuilder
+pub fn iceberg::spec::SnapshotUpdateBuilder::build(self) -> iceberg::spec::Snapshot
+pub fn iceberg::spec::SnapshotUpdateBuilder::schema_id_opt(self, schema_id: core::option::Option<iceberg::spec::SchemaId>) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_encryption_key_id(self, encryption_key_id: core::option::Option<alloc::string::String>) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_manifest_list(self, manifest_list: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_parent_snapshot_id(self, parent_snapshot_id: core::option::Option<i64>) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_row_range(self, first_row_id: u64, added_rows: u64) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_schema_id(self, schema_id: iceberg::spec::SchemaId) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_sequence_number(self, sequence_number: i64) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_snapshot_id(self, snapshot_id: i64) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_summary(self, summary: iceberg::spec::Summary) -> Self
+pub fn iceberg::spec::SnapshotUpdateBuilder::with_timestamp_ms(self, timestamp_ms: i64) -> Self
+impl core::clone::Clone for iceberg::spec::SnapshotUpdateBuilder
+pub fn iceberg::spec::SnapshotUpdateBuilder::clone(&self) -> iceberg::spec::SnapshotUpdateBuilder
+impl core::fmt::Debug for iceberg::spec::SnapshotUpdateBuilder
+pub fn iceberg::spec::SnapshotUpdateBuilder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct iceberg::spec::SortField
 pub iceberg::spec::SortField::direction: iceberg::spec::SortDirection
 pub iceberg::spec::SortField::null_order: iceberg::spec::NullOrder

--- a/crates/iceberg/src/spec/snapshot.rs
+++ b/crates/iceberg/src/spec/snapshot.rs
@@ -121,6 +121,20 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    /// Creates a builder for modifying this snapshot, preserving fields that are not replaced.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use iceberg::spec::{Snapshot, Summary};
+    /// # fn replace_summary(snapshot: Snapshot, summary: Summary) -> Snapshot {
+    /// snapshot.into_builder().with_summary(summary).build()
+    /// # }
+    /// ```
+    pub fn into_builder(self) -> SnapshotUpdateBuilder {
+        SnapshotUpdateBuilder { snapshot: self }
+    }
+
     /// Get the id of the snapshot
     #[inline]
     pub fn snapshot_id(&self) -> i64 {
@@ -221,6 +235,84 @@ impl Snapshot {
     /// Get encryption key id, if available.
     pub fn encryption_key_id(&self) -> Option<&str> {
         self.encryption_key_id.as_deref()
+    }
+}
+
+/// A builder for modifying an existing [`Snapshot`].
+///
+/// Created by [`Snapshot::into_builder`]. Unlike [`Snapshot::builder`], all fields
+/// are already populated and setters replace their existing values.
+#[derive(Debug, Clone)]
+pub struct SnapshotUpdateBuilder {
+    snapshot: Snapshot,
+}
+
+impl SnapshotUpdateBuilder {
+    /// Sets the snapshot ID.
+    pub fn with_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.snapshot.snapshot_id = snapshot_id;
+        self
+    }
+
+    /// Sets or clears the parent snapshot ID.
+    pub fn with_parent_snapshot_id(mut self, parent_snapshot_id: Option<i64>) -> Self {
+        self.snapshot.parent_snapshot_id = parent_snapshot_id;
+        self
+    }
+
+    /// Sets the sequence number.
+    pub fn with_sequence_number(mut self, sequence_number: i64) -> Self {
+        self.snapshot.sequence_number = sequence_number;
+        self
+    }
+
+    /// Sets the timestamp in milliseconds.
+    pub fn with_timestamp_ms(mut self, timestamp_ms: i64) -> Self {
+        self.snapshot.timestamp_ms = timestamp_ms;
+        self
+    }
+
+    /// Sets the manifest list location.
+    pub fn with_manifest_list(mut self, manifest_list: impl Into<String>) -> Self {
+        self.snapshot.manifest_list = manifest_list.into();
+        self
+    }
+
+    /// Sets the snapshot summary.
+    pub fn with_summary(mut self, summary: Summary) -> Self {
+        self.snapshot.summary = summary;
+        self
+    }
+
+    /// Sets the schema ID.
+    pub fn with_schema_id(self, schema_id: SchemaId) -> Self {
+        self.schema_id_opt(Some(schema_id))
+    }
+
+    /// Sets or clears the schema ID.
+    pub fn schema_id_opt(mut self, schema_id: Option<SchemaId>) -> Self {
+        self.snapshot.schema_id = schema_id;
+        self
+    }
+
+    /// Sets or clears the encryption key ID.
+    pub fn with_encryption_key_id(mut self, encryption_key_id: Option<String>) -> Self {
+        self.snapshot.encryption_key_id = encryption_key_id;
+        self
+    }
+
+    /// Sets the row range.
+    pub fn with_row_range(mut self, first_row_id: u64, added_rows: u64) -> Self {
+        self.snapshot.row_range = Some(SnapshotRowRange {
+            first_row_id,
+            added_rows,
+        });
+        self
+    }
+
+    /// Builds the modified snapshot.
+    pub fn build(self) -> Snapshot {
+        self.snapshot
     }
 }
 
@@ -502,6 +594,76 @@ mod tests {
     use crate::spec::TableMetadata;
     use crate::spec::snapshot::_serde::SnapshotV1;
     use crate::spec::snapshot::{Operation, Snapshot, Summary};
+
+    #[test]
+    fn test_into_builder() {
+        let snapshot = Snapshot::builder()
+            .with_snapshot_id(2)
+            .with_parent_snapshot_id(Some(1))
+            .with_sequence_number(3)
+            .with_timestamp_ms(1515100955770)
+            .with_manifest_list("s3://bucket/manifest-list.avro")
+            .with_summary(Summary {
+                operation: Operation::Append,
+                additional_properties: HashMap::new(),
+            })
+            .with_schema_id(4)
+            .with_encryption_key_id(Some("key".to_string()))
+            .with_row_range(5, 6)
+            .build();
+        assert_eq!(snapshot.clone().into_builder().build(), snapshot);
+
+        let summary = Summary {
+            operation: Operation::Append,
+            additional_properties: HashMap::from([("total-files-size".into(), "100".into())]),
+        };
+        assert_eq!(
+            snapshot
+                .clone()
+                .into_builder()
+                .with_summary(summary.clone())
+                .build(),
+            Snapshot {
+                summary,
+                ..snapshot.clone()
+            }
+        );
+
+        let updated = snapshot
+            .clone()
+            .into_builder()
+            .with_snapshot_id(3)
+            .with_parent_snapshot_id(None)
+            .with_sequence_number(4)
+            .with_timestamp_ms(1515100955771)
+            .with_manifest_list("s3://bucket/updated.avro")
+            .with_schema_id(5)
+            .with_encryption_key_id(None)
+            .with_row_range(7, 8)
+            .build();
+        assert_eq!(updated, Snapshot {
+            snapshot_id: 3,
+            parent_snapshot_id: None,
+            sequence_number: 4,
+            timestamp_ms: 1515100955771,
+            manifest_list: "s3://bucket/updated.avro".into(),
+            schema_id: Some(5),
+            encryption_key_id: None,
+            row_range: Some(super::SnapshotRowRange {
+                first_row_id: 7,
+                added_rows: 8
+            }),
+            ..snapshot
+        });
+        assert_eq!(
+            updated
+                .into_builder()
+                .schema_id_opt(None)
+                .build()
+                .schema_id(),
+            None
+        );
+    }
 
     #[test]
     fn schema() {


### PR DESCRIPTION
## What changes are included in this PR?

Add `Snapshot::into_builder()` to modify an existing snapshot without manually copying every unchanged field:

```rust
let updated = snapshot.into_builder().with_summary(summary).build();
```

[`TableMetadata` already exposes the same conversion](https://github.com/apache/iceberg-rust/blob/28ede505/crates/iceberg/src/spec/table_metadata.rs#L152):

```rust
let builder = metadata.into_builder(None);
```

That delegates to `TableMetadataBuilder::new_from_metadata(metadata, None)`. Snapshots currently have only a builder for constructing a new value, so even replacing a summary requires repeating IDs, sequence number, timestamp, manifest location, and other fields.

`into_builder()` returns a `SnapshotUpdateBuilder` that owns the existing snapshot and replaces only explicitly set fields. The existing `Snapshot::builder()` and its compile-time required-field checks are unchanged: its typed builder does not permit overwriting populated fields, so it cannot serve as an editing builder directly. No dependencies or serialization changes.

## Motivation

Use case: [DataFusion Distributed #700](https://github.com/datafusion-contrib/datafusion-distributed/pull/700), where fixture tests replace snapshot summaries to exercise missing statistics. [This review comment](https://github.com/datafusion-contrib/datafusion-distributed/pull/700#discussion_r3951809665) highlights the resulting snapshot-reconstruction boilerplate.

This constructs a snapshot value only; table metadata updates and their snapshot-ID/sequence-number validation remain unchanged.

## Are these changes tested?

- Unit test covers an unchanged round trip, replacing only the summary while preserving all other fields (including encryption and row lineage), field overrides, and clearing optional IDs.
- `cargo test -p iceberg --lib --locked` — 1,675 passed.
- `cargo test -p iceberg --doc into_builder --locked` — passed.
- `cargo clippy -p iceberg --lib --tests --all-features --locked -- -D warnings` — passed.
- Public API snapshot regenerated with `cargo public-api -p iceberg --all-features -ss`.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

## AI Disclosure

Implementation, tests, and this description were prepared with AI coding assistance.
