### PR TITLE
fix: Fix CI failure due to integration test's Hive install

### DIFF
--- a/dev/hms/Dockerfile
+++ b/dev/hms/Dockerfile
@@ -20,10 +20,12 @@ ENV HADOOP_VERSION=3.1.0
 
 USER root
 
-RUN apt-get update -qq && apt-get -qq -y install curl && \
-    curl https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar -Lo /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar && \
-    curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar -Lo /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+ADD --chmod=644 --checksum=sha256:a18508b9348af095ea41301e439354dbd449e304ac44c6885b2b4fe78de88126 \
+    https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar \
+    /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar
+ADD --chmod=644 --checksum=sha256:faf78ac4880f56cf52791d84ec1068ce7c66acc4295d580a726104b734c01fcd \
+    https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar \
+    /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar
 
 COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
 


### PR DESCRIPTION
## Which issue does this PR close?

- No issue. This is a narrow CI hotfix.
- Follow-up issue: https://github.com/apache/iceberg-rust/issues/3175

## What changes are included in this PR?

The Hive Metastore test image currently installs `curl` through Debian Bullseye before downloading its Hadoop AWS dependencies.

Debian Bullseye reached end of LTS support on August 31, 2026. Its final `bullseye-security` repository metadata subsequently expired, causing `apt-get update` to fail while building the integration-test environment. This also affected unrelated PRs such as #3170.

This change removes the unnecessary Debian package-manager dependency. Docker now downloads the two required JARs directly from Maven Central using `ADD`:

- `hadoop-aws` 3.1.0
- `aws-java-sdk-bundle` 1.11.271

Both downloads are pinned to their SHA-256 checksums, and their permissions are explicitly set to `0644` so that the non-root `hive` user can load them.

The Hive, Hadoop, and AWS SDK versions remain unchanged. This is intentional: Hive 3 is EOL, but upgrading to Hive 4 requires a separate migration because the current Rust HMS Thrift client is not fully compatible with Hive 4.

## Are these changes tested?

Yes.

- Built `dev/hms/Dockerfile` directly with Docker.
- Built the `hive-metastore` service through `dev/docker-compose.yaml`, matching the CI build path.
- Verified that both downloaded JARs have the expected filenames and are readable by the non-root `hive` user.
- Ran `git diff --check`.

No new automated test is included because this only changes how existing, checksum-pinned test dependencies are installed. The existing integration-test suite exercises the resulting Hive Metastore image.

## AI Disclosure

AI assistance was used to inspect the CI failure, investigate the Debian and Hive lifecycle, draft the Dockerfile change, and identify relevant validation. I reviewed the resulting change and ran the validation commands listed above.
