### PR TITLE
perf(arrow): build constant filter masks with BooleanBuffer instead of Vec<bool>

### DIFF
--- a/crates/iceberg/src/arrow/reader/predicate_visitor.rs
+++ b/crates/iceberg/src/arrow/reader/predicate_visitor.rs
@@ -246,14 +246,20 @@ impl PredicateConverter<'_> {
     /// Build an Arrow predicate that always returns true.
     fn build_always_true(&self) -> Result<Box<PredicateResult>> {
         Ok(Box::new(|batch| {
-            Ok(BooleanArray::from(vec![true; batch.num_rows()]))
+            Ok(BooleanArray::new(
+                BooleanBuffer::new_set(batch.num_rows()),
+                None,
+            ))
         }))
     }
 
     /// Build an Arrow predicate that always returns false.
     fn build_always_false(&self) -> Result<Box<PredicateResult>> {
         Ok(Box::new(|batch| {
-            Ok(BooleanArray::from(vec![false; batch.num_rows()]))
+            Ok(BooleanArray::new(
+                BooleanBuffer::new_unset(batch.num_rows()),
+                None,
+            ))
         }))
     }
 }
@@ -590,7 +596,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
                 // update this if arrow ever adds a native is_in kernel
                 let left = project_column(&batch, idx)?;
 
-                let mut acc = BooleanArray::from(vec![false; batch.num_rows()]);
+                let mut acc = BooleanArray::new(BooleanBuffer::new_unset(batch.num_rows()), None);
                 for literal in &literals {
                     let literal = try_cast_literal(literal, left.data_type())?;
                     acc = or(&acc, &eq(&left, literal.as_ref())?)?
@@ -619,7 +625,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
             Ok(Box::new(move |batch| {
                 // update this if arrow ever adds a native not_in kernel
                 let left = project_column(&batch, idx)?;
-                let mut acc = BooleanArray::from(vec![true; batch.num_rows()]);
+                let mut acc = BooleanArray::new(BooleanBuffer::new_set(batch.num_rows()), None);
                 for literal in &literals {
                     let literal = try_cast_literal(literal, left.data_type())?;
                     acc = and(&acc, &neq(&left, literal.as_ref())?)?

--- a/crates/iceberg/src/arrow/reader/predicate_visitor.rs
+++ b/crates/iceberg/src/arrow/reader/predicate_visitor.rs
@@ -246,22 +246,27 @@ impl PredicateConverter<'_> {
     /// Build an Arrow predicate that always returns true.
     fn build_always_true(&self) -> Result<Box<PredicateResult>> {
         Ok(Box::new(|batch| {
-            Ok(BooleanArray::new(
-                BooleanBuffer::new_set(batch.num_rows()),
-                None,
-            ))
+            Ok(constant_bool_array(true, batch.num_rows()))
         }))
     }
 
     /// Build an Arrow predicate that always returns false.
     fn build_always_false(&self) -> Result<Box<PredicateResult>> {
         Ok(Box::new(|batch| {
-            Ok(BooleanArray::new(
-                BooleanBuffer::new_unset(batch.num_rows()),
-                None,
-            ))
+            Ok(constant_bool_array(false, batch.num_rows()))
         }))
     }
+}
+
+/// Builds a non-null `BooleanArray` of `len` elements all set to `value`.
+fn constant_bool_array(value: bool, len: usize) -> BooleanArray {
+    let buffer = if value {
+        BooleanBuffer::new_set(len)
+    } else {
+        BooleanBuffer::new_unset(len)
+    };
+
+    BooleanArray::new(buffer, None)
 }
 
 /// Gets the leaf column from the record batch for the required column index. Only
@@ -596,7 +601,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
                 // update this if arrow ever adds a native is_in kernel
                 let left = project_column(&batch, idx)?;
 
-                let mut acc = BooleanArray::new(BooleanBuffer::new_unset(batch.num_rows()), None);
+                let mut acc = constant_bool_array(false, batch.num_rows());
                 for literal in &literals {
                     let literal = try_cast_literal(literal, left.data_type())?;
                     acc = or(&acc, &eq(&left, literal.as_ref())?)?
@@ -625,7 +630,7 @@ impl BoundPredicateVisitor for PredicateConverter<'_> {
             Ok(Box::new(move |batch| {
                 // update this if arrow ever adds a native not_in kernel
                 let left = project_column(&batch, idx)?;
-                let mut acc = BooleanArray::new(BooleanBuffer::new_set(batch.num_rows()), None);
+                let mut acc = constant_bool_array(true, batch.num_rows());
                 for literal in &literals {
                     let literal = try_cast_literal(literal, left.data_type())?;
                     acc = and(&acc, &neq(&left, literal.as_ref())?)?
@@ -671,7 +676,7 @@ mod tests {
     use parquet::schema::parser::parse_message_type;
     use parquet::schema::types::SchemaDescriptor;
 
-    use super::{CollectFieldIdVisitor, PredicateConverter};
+    use super::{CollectFieldIdVisitor, PredicateConverter, constant_bool_array};
     use crate::expr::visitors::bound_predicate_visitor::visit;
     use crate::expr::{Bind, Predicate, Reference};
     use crate::spec::{NestedField, PrimitiveType, Schema, SchemaRef, Type};
@@ -747,6 +752,21 @@ mod tests {
         expected.insert(3);
 
         assert_eq!(visitor.field_ids, expected);
+    }
+
+    #[test]
+    fn test_constant_bool_array() {
+        for len in [0, 8192] {
+            let all_true = constant_bool_array(true, len);
+            assert_eq!(all_true.len(), len);
+            assert_eq!(all_true.null_count(), 0);
+            assert!(all_true.iter().all(|v| v == Some(true)));
+
+            let all_false = constant_bool_array(false, len);
+            assert_eq!(all_false.len(), len);
+            assert_eq!(all_false.null_count(), 0);
+            assert!(all_false.iter().all(|v| v == Some(false)));
+        }
     }
 
     fn apply_predicate_to_batch(


### PR DESCRIPTION
## What changes are included in this PR?

The predicate converter builds all-true and all-false boolean masks with BooleanArray::from(vec![b; n]), which allocates an n-byte Vec<bool> and then bit-packs it into the array. BooleanBuffer::new_set/new_unset write the packed bits directly, skipping the throwaway Vec and the pack pass.

Covers the always-true/false predicates and the initial accumulators for is_in / not_in, built once per batch. Output is identical (all-set/all-unset, no nulls). Isolated construction is ~125x faster at 8192 rows; the real per-batch win is smaller since this is a fraction of filter evaluation.

## Profiling

Isolated construction, release build, 2M iterations with warmup, on an
Apple M4. Each iteration observes the whole buffer via
`count_set_bits()` so the fill can't be elided under inlining/LTO. This is
a conservative floor.

| rows | old (`Vec<bool>`) | new (`BooleanBuffer`) | speedup |
|------|-------------------|-----------------------|---------|
| 0    | ~60 ns            | ~18 ns                | ~3x     |
| 1024 | ~820 ns           | ~36 ns                | ~23x    |
| 8192 | ~5.8-6.3 us       | ~63-73 ns             | ~90x    |

The per-batch win in real filter evaluation is a fraction of this, since
constant-mask construction is one step of many.

<details>
<summary>Throwaway harness</summary>

```rust
use std::hint::black_box;
use std::time::Instant;

use arrow_array::{Array, BooleanArray};
use arrow_buffer::BooleanBuffer;

fn old_path(value: bool, len: usize) -> BooleanArray {
    BooleanArray::from(vec![value; len])
}

fn new_path(value: bool, len: usize) -> BooleanArray {
    let buffer = if value {
        BooleanBuffer::new_set(len)
    } else {
        BooleanBuffer::new_unset(len)
    };
    BooleanArray::new(buffer, None)
}

fn bench<F: Fn(bool, usize) -> BooleanArray>(name: &str, len: usize, iters: u64, f: F) {
    for _ in 0..1000 {
        black_box(f(black_box(true), black_box(len)).values().count_set_bits());
    }
    let start = Instant::now();
    for i in 0..iters {
        let arr = f(black_box(i & 1 == 0), black_box(len));
        // Observe the whole buffer so the fill can't be elided under inlining/LTO.
        black_box(arr.values().count_set_bits());
    }
    let per_iter = start.elapsed().as_nanos() as f64 / iters as f64;
    println!("{name:<28} len={len:<6} {per_iter:>10.2} ns/iter");
}

fn main() {
    let iters = 2_000_000u64;
    for len in [0usize, 1024, 8192] {
        bench("old (Vec<bool>)", len, iters, old_path);
        bench("new (BooleanBuffer)", len, iters, new_path);
        println!();
    }
}
```
</details>

## Are these changes tested?

Added `test_constant_bool_array`