### PR TITLE
perf(arrow): build repeated boolean columns with BooleanBuffer

### DIFF
--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -23,7 +23,7 @@ use arrow_array::{
     LargeListArray, LargeStringArray, ListArray, MapArray, StringArray, StructArray,
     Time64MicrosecondArray, TimestampMicrosecondArray, TimestampNanosecondArray, new_null_array,
 };
-use arrow_buffer::NullBuffer;
+use arrow_buffer::{BooleanBuffer, NullBuffer};
 use arrow_schema::{DataType, FieldRef, TimeUnit};
 use uuid::Uuid;
 
@@ -822,7 +822,12 @@ pub(crate) fn create_primitive_array_repeated(
     Ok(match (data_type, prim_lit) {
         // --- Primitive Some arms ---
         (DataType::Boolean, Some(PrimitiveLiteral::Boolean(value))) => {
-            Arc::new(BooleanArray::from(vec![*value; num_rows]))
+            let buffer = if *value {
+                BooleanBuffer::new_set(num_rows)
+            } else {
+                BooleanBuffer::new_unset(num_rows)
+            };
+            Arc::new(BooleanArray::new(buffer, None))
         }
         (DataType::Int32, Some(PrimitiveLiteral::Int(value))) => {
             Arc::new(Int32Array::from(vec![*value; num_rows]))


### PR DESCRIPTION
## What changes are included in this PR?

This is similar to https://github.com/apache/iceberg-rust/pull/3177 but for constant columns. 

create_primitive_array_repeated built a constant boolean column with BooleanArray::from(vec![*value; n]), which allocates an n-byte Vec<bool> and then bit-packs it. Set or clear the bits directly with BooleanBuffer::new_set / new_unset instead. The sibling string and binary arms already skip the throwaway Vec via from_iter_values, so this just brings the bool arm in line.

Same output, no nulls. This path materializes constant columns (partition values, defaults, metadata) on read, and boolean constants are uncommon, so it's a minor win.

## Are these changes tested?

Covered by existing tests