### PR TITLE
fix!(io): bound S3 write request size with a configurable part size

### DIFF
--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -1031,6 +1031,7 @@ pub const iceberg::io::S3_ASSUME_ROLE_SESSION_NAME: &str
 pub const iceberg::io::S3_DISABLE_CONFIG_LOAD: &str
 pub const iceberg::io::S3_DISABLE_EC2_METADATA: &str
 pub const iceberg::io::S3_ENDPOINT: &str
+pub const iceberg::io::S3_MULTIPART_PART_SIZE_BYTES: &str
 pub const iceberg::io::S3_PATH_STYLE_ACCESS: &str
 pub const iceberg::io::S3_REGION: &str
 pub const iceberg::io::S3_SECRET_ACCESS_KEY: &str

--- a/crates/iceberg/src/io/storage/config/s3.rs
+++ b/crates/iceberg/src/io/storage/config/s3.rs
@@ -64,6 +64,9 @@ pub const S3_ALLOW_ANONYMOUS: &str = "s3.allow-anonymous";
 pub const S3_DISABLE_EC2_METADATA: &str = "s3.disable-ec2-metadata";
 /// Option to skip loading configuration from config file and the env.
 pub const S3_DISABLE_CONFIG_LOAD: &str = "s3.disable-config-load";
+/// Size in bytes of each part of a multipart upload. Must be at least 5 MiB.
+/// Defaults to 32 MiB, matching Java `S3FileIOProperties.MULTIPART_SIZE`.
+pub const S3_MULTIPART_PART_SIZE_BYTES: &str = "s3.multipart.part-size-bytes";
 
 /// Amazon S3 storage configuration.
 ///

--- a/crates/storage/opendal/public-api.txt
+++ b/crates/storage/opendal/public-api.txt
@@ -15,6 +15,7 @@ pub iceberg_storage_opendal::OpenDalStorage::Oss::config: alloc::sync::Arc<opend
 pub iceberg_storage_opendal::OpenDalStorage::S3
 pub iceberg_storage_opendal::OpenDalStorage::S3::config: alloc::sync::Arc<opendal_service_s3::config::S3Config>
 pub iceberg_storage_opendal::OpenDalStorage::S3::customized_credential_load: core::option::Option<iceberg_storage_opendal::CustomAwsCredentialLoader>
+pub iceberg_storage_opendal::OpenDalStorage::S3::multipart_part_size: u64
 impl core::clone::Clone for iceberg_storage_opendal::OpenDalStorage
 pub fn iceberg_storage_opendal::OpenDalStorage::clone(&self) -> iceberg_storage_opendal::OpenDalStorage
 impl core::fmt::Debug for iceberg_storage_opendal::OpenDalStorage

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -237,7 +237,7 @@ pub enum OpenDalStorage {
         config: Arc<S3Config>,
         /// Bytes carried by one multipart upload request.
         #[serde(default = "default_multipart_part_size")]
-        multipart_part_size: usize,
+        multipart_part_size: u64,
         /// Custom AWS credential loader.
         #[serde(skip)]
         customized_credential_load: Option<CustomAwsCredentialLoader>,
@@ -412,7 +412,7 @@ impl OpenDalStorage {
                 multipart_part_size,
                 ..
             } => WriteOptions {
-                chunk: Some(*multipart_part_size),
+                chunk: Some(usize::try_from(*multipart_part_size).unwrap_or(usize::MAX)),
                 ..WriteOptions::default()
             },
             _ => WriteOptions::default(),

--- a/crates/storage/opendal/src/lib.rs
+++ b/crates/storage/opendal/src/lib.rs
@@ -40,6 +40,7 @@ use iceberg::io::{
 use iceberg::{Error, ErrorKind, Result};
 use opendal::Operator;
 use opendal::layers::{RetryLayer, TimeoutLayer};
+use opendal::options::WriteOptions;
 use serde::{Deserialize, Serialize};
 use utils::from_opendal_error;
 
@@ -175,6 +176,7 @@ impl StorageFactory for OpenDalStorageFactory {
                 customized_credential_load,
             } => Ok(Arc::new(OpenDalStorage::S3 {
                 config: s3_config_parse(config.props().clone())?.into(),
+                multipart_part_size: s3_multipart_part_size_parse(config.props())?,
                 customized_credential_load: customized_credential_load.clone(),
             })),
             #[cfg(feature = "opendal-gcs")]
@@ -233,6 +235,9 @@ pub enum OpenDalStorage {
     S3 {
         /// S3 configuration.
         config: Arc<S3Config>,
+        /// Bytes carried by one multipart upload request.
+        #[serde(default = "default_multipart_part_size")]
+        multipart_part_size: usize,
         /// Custom AWS credential loader.
         #[serde(skip)]
         customized_credential_load: Option<CustomAwsCredentialLoader>,
@@ -313,6 +318,7 @@ impl OpenDalStorage {
             OpenDalStorage::S3 {
                 config,
                 customized_credential_load,
+                ..
             } => {
                 let op = s3_config_build(config, customized_credential_load, path)?;
                 let op_info = op.info();
@@ -393,6 +399,24 @@ impl OpenDalStorage {
         // benefits non-object-store backends.
         let operator = operator.layer(TimeoutLayer::new()).layer(RetryLayer::new());
         Ok((operator, relative_path))
+    }
+
+    /// Bounds the S3 request size. Without a chunk size OpenDAL turns each caller
+    /// buffer into one request, and `ParquetWriter` hands over a whole row group
+    /// at a time. Other backends keep OpenDAL's defaults.
+    #[allow(unreachable_patterns)]
+    fn write_options(&self) -> WriteOptions {
+        match self {
+            #[cfg(feature = "opendal-s3")]
+            OpenDalStorage::S3 {
+                multipart_part_size,
+                ..
+            } => WriteOptions {
+                chunk: Some(*multipart_part_size),
+                ..WriteOptions::default()
+            },
+            _ => WriteOptions::default(),
+        }
     }
 
     /// Returns a cache key used by `delete_stream` to group paths by storage operator.
@@ -543,7 +567,7 @@ impl Storage for OpenDalStorage {
 
     async fn write(&self, path: &str, bs: Bytes) -> Result<()> {
         let (op, relative_path) = self.create_operator(&path)?;
-        op.write(relative_path, bs)
+        op.write_options(relative_path, bs, self.write_options())
             .await
             .map_err(from_opendal_error)?;
         Ok(())
@@ -552,7 +576,9 @@ impl Storage for OpenDalStorage {
     async fn writer(&self, path: &str) -> Result<Box<dyn FileWrite>> {
         let (op, relative_path) = self.create_operator(&path)?;
         Ok(Box::new(OpenDalWriter(
-            op.writer(relative_path).await.map_err(from_opendal_error)?,
+            op.writer_options(relative_path, self.write_options())
+                .await
+                .map_err(from_opendal_error)?,
         )))
     }
 
@@ -733,6 +759,7 @@ mod tests {
     fn test_relativize_path_s3() {
         let storage = OpenDalStorage::S3 {
             config: Arc::new(S3Config::default()),
+            multipart_part_size: default_multipart_part_size(),
             customized_credential_load: None,
         };
 

--- a/crates/storage/opendal/src/resolving.rs
+++ b/crates/storage/opendal/src/resolving.rs
@@ -92,6 +92,7 @@ fn build_storage_for_scheme(
             let config = crate::s3::s3_config_parse(props.clone())?;
             Ok(OpenDalStorage::S3 {
                 config: Arc::new(config),
+                multipart_part_size: crate::s3::s3_multipart_part_size_parse(props)?,
                 customized_credential_load: customized_credential_load.clone(),
             })
         }

--- a/crates/storage/opendal/src/s3.rs
+++ b/crates/storage/opendal/src/s3.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use iceberg::io::{
     CLIENT_REGION, S3_ACCESS_KEY_ID, S3_ALLOW_ANONYMOUS, S3_ASSUME_ROLE_ARN,
     S3_ASSUME_ROLE_EXTERNAL_ID, S3_ASSUME_ROLE_SESSION_NAME, S3_DISABLE_CONFIG_LOAD,
-    S3_DISABLE_EC2_METADATA, S3_ENDPOINT, S3_PATH_STYLE_ACCESS, S3_REGION, S3_SECRET_ACCESS_KEY,
-    S3_SESSION_TOKEN, S3_SSE_KEY, S3_SSE_MD5, S3_SSE_TYPE,
+    S3_DISABLE_EC2_METADATA, S3_ENDPOINT, S3_MULTIPART_PART_SIZE_BYTES, S3_PATH_STYLE_ACCESS,
+    S3_REGION, S3_SECRET_ACCESS_KEY, S3_SESSION_TOKEN, S3_SSE_KEY, S3_SSE_MD5, S3_SSE_TYPE,
 };
 use iceberg::{Error, ErrorKind, Result};
 use opendal::services::S3Config;
@@ -35,6 +35,36 @@ use reqsign_core::{ProvideCredentialChain, ProvideCredentialDyn};
 use url::Url;
 
 use crate::utils::{from_opendal_error, is_truthy};
+
+/// S3 rejects a non-final part smaller than this.
+const MULTIPART_PART_SIZE_MIN: usize = 5 * 1024 * 1024;
+
+/// Matches Java `S3FileIOProperties.MULTIPART_SIZE_DEFAULT`.
+pub(crate) fn default_multipart_part_size() -> usize {
+    32 * 1024 * 1024
+}
+
+/// Parse iceberg props to s3 multipart upload part size.
+pub(crate) fn s3_multipart_part_size_parse(m: &HashMap<String, String>) -> Result<usize> {
+    let Some(value) = m.get(S3_MULTIPART_PART_SIZE_BYTES) else {
+        return Ok(default_multipart_part_size());
+    };
+    let part_size = value.parse::<usize>().map_err(|e| {
+        Error::new(
+            ErrorKind::DataInvalid,
+            format!("Invalid {S3_MULTIPART_PART_SIZE_BYTES}: {value}: {e}"),
+        )
+    })?;
+    if part_size < MULTIPART_PART_SIZE_MIN {
+        return Err(Error::new(
+            ErrorKind::DataInvalid,
+            format!(
+                "Invalid {S3_MULTIPART_PART_SIZE_BYTES}: {part_size} is below the S3 minimum part size of {MULTIPART_PART_SIZE_MIN}"
+            ),
+        ));
+    }
+    Ok(part_size)
+}
 
 /// Parse iceberg props to s3 config.
 pub(crate) fn s3_config_parse(mut m: HashMap<String, String>) -> Result<S3Config> {
@@ -184,9 +214,9 @@ impl CustomAwsCredentialLoader {
 mod tests {
     use std::collections::HashMap;
 
-    use iceberg::io::S3_PATH_STYLE_ACCESS;
+    use iceberg::io::{S3_MULTIPART_PART_SIZE_BYTES, S3_PATH_STYLE_ACCESS};
 
-    use super::s3_config_parse;
+    use super::*;
 
     fn parse_with(prop: Option<&str>) -> bool {
         let mut props = HashMap::new();
@@ -202,5 +232,28 @@ mod tests {
         assert!(parse_with(None));
         assert!(parse_with(Some("false")));
         assert!(!parse_with(Some("true")));
+    }
+
+    fn parse_part_size(prop: Option<&str>) -> Result<usize> {
+        let mut props = HashMap::new();
+        if let Some(v) = prop {
+            props.insert(S3_MULTIPART_PART_SIZE_BYTES.to_string(), v.to_string());
+        }
+        s3_multipart_part_size_parse(&props)
+    }
+
+    #[test]
+    fn s3_multipart_part_size_parse_defaults_and_overrides() {
+        // Match Iceberg S3FileIOProperties.MULTIPART_SIZE_DEFAULT = 32 MiB.
+        assert_eq!(parse_part_size(None).unwrap(), 32 * 1024 * 1024);
+        assert_eq!(parse_part_size(Some("8388608")).unwrap(), 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn s3_multipart_part_size_parse_rejects_invalid() {
+        // Match Iceberg S3FileIOProperties.MULTIPART_SIZE_MIN = 5 MiB.
+        assert!(parse_part_size(Some("5242880")).is_ok());
+        assert!(parse_part_size(Some("5242879")).is_err());
+        assert!(parse_part_size(Some("not-a-number")).is_err());
     }
 }

--- a/crates/storage/opendal/src/s3.rs
+++ b/crates/storage/opendal/src/s3.rs
@@ -37,19 +37,19 @@ use url::Url;
 use crate::utils::{from_opendal_error, is_truthy};
 
 /// S3 rejects a non-final part smaller than this.
-const MULTIPART_PART_SIZE_MIN: usize = 5 * 1024 * 1024;
+const MULTIPART_PART_SIZE_MIN: u64 = 5 * 1024 * 1024;
 
 /// Matches Java `S3FileIOProperties.MULTIPART_SIZE_DEFAULT`.
-pub(crate) fn default_multipart_part_size() -> usize {
+pub(crate) fn default_multipart_part_size() -> u64 {
     32 * 1024 * 1024
 }
 
 /// Parse iceberg props to s3 multipart upload part size.
-pub(crate) fn s3_multipart_part_size_parse(m: &HashMap<String, String>) -> Result<usize> {
+pub(crate) fn s3_multipart_part_size_parse(m: &HashMap<String, String>) -> Result<u64> {
     let Some(value) = m.get(S3_MULTIPART_PART_SIZE_BYTES) else {
         return Ok(default_multipart_part_size());
     };
-    let part_size = value.parse::<usize>().map_err(|e| {
+    let part_size = value.parse::<u64>().map_err(|e| {
         Error::new(
             ErrorKind::DataInvalid,
             format!("Invalid {S3_MULTIPART_PART_SIZE_BYTES}: {value}: {e}"),
@@ -234,7 +234,7 @@ mod tests {
         assert!(!parse_with(Some("true")));
     }
 
-    fn parse_part_size(prop: Option<&str>) -> Result<usize> {
+    fn parse_part_size(prop: Option<&str>) -> Result<u64> {
         let mut props = HashMap::new();
         if let Some(v) = prop {
             props.insert(S3_MULTIPART_PART_SIZE_BYTES.to_string(), v.to_string());

--- a/crates/storage/opendal/tests/file_io_s3_test.rs
+++ b/crates/storage/opendal/tests/file_io_s3_test.rs
@@ -26,31 +26,60 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use iceberg::io::{
-        FileIO, FileIOBuilder, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_PATH_STYLE_ACCESS, S3_REGION,
-        S3_SECRET_ACCESS_KEY,
+        FileIO, FileIOBuilder, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_MULTIPART_PART_SIZE_BYTES,
+        S3_PATH_STYLE_ACCESS, S3_REGION, S3_SECRET_ACCESS_KEY,
     };
     use iceberg_storage_opendal::{
         AwsCredential, CustomAwsCredentialLoader, OpenDalStorageFactory, ProvideCredential,
     };
     use iceberg_test_utils::{get_minio_endpoint, normalize_test_name_with_parts, set_up};
+    use opendal::Configurator;
     use reqsign_core::Context;
 
     async fn get_file_io() -> FileIO {
+        get_file_io_with_props(vec![]).await
+    }
+
+    async fn get_file_io_with_props(extra: Vec<(&'static str, String)>) -> FileIO {
         set_up();
 
         let minio_endpoint = get_minio_endpoint();
 
-        FileIOBuilder::new(Arc::new(OpenDalStorageFactory::S3 {
-            customized_credential_load: None,
-        }))
-        .with_props(vec![
+        let mut props = vec![
             (S3_ENDPOINT, minio_endpoint),
             (S3_ACCESS_KEY_ID, "admin".to_string()),
             (S3_SECRET_ACCESS_KEY, "password".to_string()),
             (S3_REGION, "us-east-1".to_string()),
             (S3_PATH_STYLE_ACCESS, "true".to_string()),
-        ])
+        ];
+        props.extend(extra);
+
+        FileIOBuilder::new(Arc::new(OpenDalStorageFactory::S3 {
+            customized_credential_load: None,
+        }))
+        .with_props(props)
         .build()
+    }
+
+    /// Number of upload parts S3 recorded for `key`. A multipart upload reports
+    /// a `<md5>-<part-count>` ETag; a single-request upload reports a bare MD5.
+    async fn upload_part_count(key: &str) -> usize {
+        let mut config = opendal::services::S3Config::default();
+        config.endpoint = Some(get_minio_endpoint());
+        config.access_key_id = Some("admin".to_string());
+        config.secret_access_key = Some("password".to_string());
+        config.region = Some("us-east-1".to_string());
+        config.bucket = "bucket1".to_string();
+        let op = opendal::Operator::new(config.into_builder()).unwrap();
+        let meta = op.stat(key).await.unwrap();
+        let etag = meta
+            .etag()
+            .expect("MinIO reports an ETag")
+            .trim_matches('"');
+        match etag.rsplit_once('-') {
+            Some((_, parts)) => parts.parse().unwrap(),
+            None => 1,
+        }
     }
 
     fn roundtrip_file_io(file_io: &FileIO) -> FileIO {
@@ -104,6 +133,33 @@ mod tests {
             output_file.write("123".into()).await.unwrap();
         }
         assert!(file_io.exists(&output_path).await.unwrap());
+    }
+
+    /// `ParquetWriter` hands over a whole row group in one `write` call, so an
+    /// unbounded part size would make the request as large as that row group.
+    #[tokio::test]
+    async fn test_file_io_s3_writer_splits_write_into_bounded_parts() {
+        const PART_SIZE: usize = 5 * 1024 * 1024;
+        const PARTS: usize = 3;
+
+        let file_io =
+            get_file_io_with_props(vec![(S3_MULTIPART_PART_SIZE_BYTES, PART_SIZE.to_string())])
+                .await;
+        let key = normalize_test_name_with_parts!(
+            "test_file_io_s3_writer_splits_write_into_bounded_parts"
+        );
+        let path = format!("s3://bucket1/{key}");
+
+        let _ = file_io.delete(&path).await;
+        let mut writer = file_io.new_output(&path).unwrap().writer().await.unwrap();
+        writer
+            .write(Bytes::from(vec![0u8; PART_SIZE * PARTS]))
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
+
+        assert_eq!(upload_part_count(&key).await, PARTS);
+        file_io.delete(&path).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #2977.

## What changes are included in this PR?

OpenDAL turns one caller buffer into one request, and `ParquetWriter` hands over a whole row group per `write` call. A 128 MiB row group therefore became a single `UploadPart` racing the hard-coded 10s IO timeout, and since every retry re-sends the same oversized request, the write fails deterministically rather than flakily.

Bound the request size so it follows configuration instead of the caller's buffer:

- Add `s3.multipart.part-size-bytes`, default 32 MiB (matching Java `S3FileIOProperties.MULTIPART_SIZE_DEFAULT`), rejected below the 5 MiB S3 minimum for a non-final part.
- `OpenDalStorage::S3` applies it through `write_options` / `writer_options`. Other backends keep OpenDAL's defaults.


## Are these changes tested?

- Unit tests for property parsing: default, override, 5 MiB boundary, non-numeric input.
- Integration test against MinIO asserting one `FileWrite::write` is split into the configured number of upload parts, counted from the multipart ETag suffix.
- Verified with `mc admin trace`: a 160 MiB Parquet write previously issued one request, now issues 5 x 32 MiB parts plus a remainder.

## AI Disclosure
- AI-assisted implementation.