### PR TITLE
ci: add Windows ARM64 build

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -144,6 +144,7 @@ jobs:
       matrix:
         include:
           - { os: windows-latest }
+          - { os: windows-11-arm }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
           - {

--- a/.github/workflows/release_python_nightly.yml
+++ b/.github/workflows/release_python_nightly.yml
@@ -77,6 +77,7 @@ jobs:
       matrix:
         include:
           - { os: windows-latest }
+          - { os: windows-11-arm }
           - { os: macos-latest, target: "universal2-apple-darwin" }
           - { os: ubuntu-latest, target: "x86_64" }
           - {


### PR DESCRIPTION
## What changes are included in this PR?

Adds Windows ARM64 wheels in the PyPI workflows. It's a trivial change because the workflows are fairly well-structured already, so I did not create an issue for discussion beforehand.

## Are these changes tested?

Similar to most other wheels generated in the PyPI workflows, the test is simply to try and install the built wheels, which [passes on my fork](https://github.com/ndabas/iceberg-rust/actions/runs/34367954562).

I should note that while the Bindings Python CI workflow currently only tests on a small subset of all supported platform and architecture combinations, so it doesn't make sense to add Windows ARM64 there, currently that would certainly fail because there is no win_arm64 binary wheel available for PyArrow. As that is not a runtime dependency, the wheels should work fine in any case. (This is similar to the linux armv7l case, which also does not have PyArrow wheels available and isn't tested beyond "it compiles".)

We could add a command to the "install wheel" step to actually try importing it as well, just as a quick smoke test.

## AI Disclosure

No AI was used for these changes.