### PR TITLE
chore(dev): run REST fixture's SQLite backend in WAL mode

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
       - CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
-      - CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory
+      - CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest.db?journal_mode=WAL
       - CATALOG_WAREHOUSE=s3://icebergdata/demo
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio:9000


### PR DESCRIPTION
## Which issue does this PR close?

Part of apache/iceberg#18043. Anoop ran into this while verifying the 0.11.0 RC1:

> I also hit one flaky test. iceberg-catalog-loader::table_rename_suite::test_catalog_rename_table_across_namespaces::case_1_rest_catalog, which failed under parallel load with a server-side SQLITE_BUSY ("database is locked") from the REST catalog test fixture's JDBC/SQLite backend. It passes reliably when re-run in isolation, and the same test passes for all other catalog backends, it is not a blocker.

## What changes are included in this PR?

Enable SQLite `WAL` mode for the Iceberg REST fixture.

By default, SQLite allows only limited concurrency: a writer can be blocked by active readers, and competing writes can fail with `SQLITE_BUSY`.

`nextest` runs tests in separate processes, so multiple tests can hit the REST fixture concurrently. Eventually, two requests contend for the database and one fails. Enabling WAL mode allows readers and a writer to operate concurrently, which removes that contention instead of masking it with retries or serializing the REST tests.

Also remove `_mode=memory` from the database path. `iceberg_rest_mode` is not a SQLite or driver option, and because the old URI had no `?`, the entire string was treated as the filename. The database has therefore always been disk-backed.

## Are these changes tested?

I hammered `apache/iceberg-rest-fixture:1.10.1` with a small script that does the same thing as the flaky test (create namespaces, create table, rename, drop) from N clients at once:

| config | first `SQLITE_BUSY` | max clients | `SQLITE_BUSY` / ops |
|---|---|---|---|
| rollback journal (old) | 16 | 128 | 9 / ~24k |
| `journal_mode=WAL` | none | 1024 | 0 / ~155k |

Loader suites pass as before.

## AI Disclosure

Used Claude Code to dig into the root cause and write the stress script. I reviewed the change and the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



