### PR TITLE
fix: break dev-dependency cycle that blocks publishing iceberg-property-macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,11 @@ jobs:
             cargo check -p "$pkg" --all-targets || exit 1
           done
 
+      # Dry-runs the publish.yml command to catch crates that cannot be published,
+      # such as packages missing files or dependency cycles between workspace crates.
+      - name: Check each crate can be published
+        run: cargo publish --workspace --all-features --dry-run
+
   # Verifies the core iceberg crate compiles without default features, ensuring
   # optional functionality is properly gated behind feature flags.
   build_with_no_default_features:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,10 +152,11 @@ jobs:
             cargo check -p "$pkg" --all-targets || exit 1
           done
 
-      # Dry-runs the publish.yml command to catch crates that cannot be published,
-      # such as packages missing files or dependency cycles between workspace crates.
+      # Dry-runs the publish without compiling, which catches dependency cycles between
+      # workspace crates, versions that do not resolve on crates.io, and missing metadata.
+      # publish.yml runs the full dry-run with compilation on release candidate tags.
       - name: Check each crate can be published
-        run: cargo publish --workspace --all-features --dry-run
+        run: cargo publish --workspace --all-features --dry-run --no-verify
 
   # Verifies the core iceberg crate compiles without default features, ensuring
   # optional functionality is properly gated behind feature flags.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,13 @@ jobs:
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 
+      # Packages and builds every crate as it would be published, without uploading,
+      # so publish failures are caught during the release candidate process.
+      - name: Dry-run publish for release candidates
+        if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') }}
+        run: cargo publish --workspace --all-features --dry-run
+        shell: bash
+
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 

--- a/crates/property-macro/Cargo.toml
+++ b/crates/property-macro/Cargo.toml
@@ -28,7 +28,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 categories = ["database"]
-description = "Property derive macro for Apache Iceberg Rust"
+description = "Apache Iceberg Rust property macros, internal to the iceberg crate"
 keywords = ["iceberg"]
 
 [lib]
@@ -40,7 +40,9 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-iceberg = { workspace = true }
+# Path-only so cargo strips it when packaging; a versioned dev-dependency would
+# create a publish cycle, since `iceberg` depends on this crate.
+iceberg = { path = "../iceberg" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 trybuild = { workspace = true }

--- a/crates/property-macro/README.md
+++ b/crates/property-macro/README.md
@@ -19,6 +19,11 @@
 
 # Iceberg property macros
 
+This crate contains the property macros used internally by
+[`iceberg`](https://crates.io/crates/iceberg). It is published only because
+`iceberg` depends on it and has no API stability guarantees, so depend on
+`iceberg` rather than on this crate.
+
 ## `Properties` derive macro
 
 `#[derive(Properties)]` parses an owned typed struct from a flat

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -42,7 +42,7 @@ Common options:
 dev/release/create_rc.sh 0.9.1 2 --release_ref <commit-ish>
 dev/release/create_rc.sh 0.9.1 2 --create_rc_tag 0 --sign 0
 dev/release/create_rc.sh 0.9.1 2 --upload_svn 1
-dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0
+dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0 --check_publish 0
 ```
 
 Defaults:
@@ -52,6 +52,7 @@ Defaults:
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.
 - `--check_deps 1`: run dependency license checks before artifact creation.
+- `--check_publish 1`: dry-run publishing every crate to crates.io before artifact creation.
 - `--sign 1`: create and verify the detached GPG signature.
 - `--upload_svn 0`: upload RC artifacts to the ASF dev dist SVN repository.
 - `--svn_dist_url https://dist.apache.org/repos/dist/dev/iceberg`: SVN directory URL where the RC artifact directory will be uploaded.

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -65,6 +65,9 @@ Defaults:
 cargo install --locked cargo-deny
 ```
 
+`--check_publish 1` runs `cargo publish --workspace --dry-run`, which packages and compiles every crate and needs network access to crates.io.
+Pass `--check_publish 0` to skip it when offline or when iterating on the script.
+
 ## Verify an RC
 
 ```shell

--- a/dev/release/create_rc.sh
+++ b/dev/release/create_rc.sh
@@ -69,6 +69,10 @@ Options:
       Whether to run the dependency license check before creating artifacts.
       Default: 1
 
+  --check_publish <0|1>
+      Whether to dry-run publishing every crate to crates.io before creating artifacts.
+      Default: 1
+
   --sign <0|1>
       Whether to create and verify the detached GPG signature for the source archive.
       Default: 1
@@ -227,6 +231,12 @@ parse_args() {
         CHECK_DEPS="$2"
         shift 2
         ;;
+      --check_publish | --check-publish)
+        require_option_value "$1" "${2:-}"
+        validate_bool_option "$1" "$2"
+        CHECK_PUBLISH="$2"
+        shift 2
+        ;;
       --sign)
         require_option_value "$1" "${2:-}"
         validate_bool_option "$1" "$2"
@@ -313,6 +323,13 @@ check_dependency_licenses() {
     cd "${REPO_ROOT}"
     cargo deny check license
   )
+}
+
+# Packages and builds every crate as `cargo publish` would, without uploading,
+# so crates that cannot be published fail RC creation.
+check_crates_publishable() {
+  require_command cargo
+  cargo publish --workspace --all-features --dry-run --manifest-path "${REPO_ROOT}/Cargo.toml"
 }
 
 prepare_output_directory() {
@@ -500,6 +517,7 @@ RELEASE_DIST_DIR="dist"
 CREATE_RC_TAG="1"
 CHECK_HEADERS="1"
 CHECK_DEPS="1"
+CHECK_PUBLISH="1"
 SIGN_ARCHIVE="1"
 UPLOAD_SVN="0"
 SVN_DIST_URL="https://dist.apache.org/repos/dist/dev/iceberg"
@@ -521,6 +539,12 @@ if enabled "${CHECK_DEPS}"; then
   run_step "Check dependency licenses" check_dependency_licenses
 else
   skip_step "Check dependency licenses"
+fi
+
+if enabled "${CHECK_PUBLISH}"; then
+  run_step "Check crates can be published" check_crates_publishable
+else
+  skip_step "Check crates can be published"
 fi
 
 run_step "Prepare output directory ${RC_DIR}" prepare_output_directory

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -202,6 +202,7 @@ Useful options include:
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.
 - `--check_deps 1`: run dependency license checks before artifact creation.
+- `--check_publish 1`: dry-run publishing every crate to crates.io before artifact creation.
 - `--sign 1`: create and verify the detached GPG signature.
 - `--upload_svn 0`: upload RC artifacts to the ASF dev dist SVN repository.
 - `--svn_dist_url https://dist.apache.org/repos/dist/dev/iceberg`: SVN directory URL where the RC artifact directory will be uploaded.
@@ -214,6 +215,7 @@ This script creates:
 - SHA-512 checksum: `apache-iceberg-rust-${iceberg_version}.tar.gz.sha512`
 - Signed annotated RC tag: `v${iceberg_version}-rc.${rc}`
 
+The publish dry-run packages and builds every crate as the final release would, so a crate that cannot be published fails RC creation.
 The script checks license headers against the generated source archive, not the live Git worktree. If enabled, SVN upload runs after local artifact verification and before RC tag creation. The script creates the signed RC tag as the final release step, then prints a draft VOTE email for `dev@iceberg.apache.org`.
 
 To upload artifacts to ASF dev dist as part of RC creation, pass:
@@ -227,6 +229,15 @@ The script does not push the RC tag. Review the output, then push the tag manual
 ```shell
 git push origin "v${iceberg_version}-rc.${rc}"
 ```
+
+Pushing the RC tag triggers the publish workflow for crates, which dry-runs the crate publish without uploading anything.
+Verify that the run succeeded before starting the vote, using the following GitHub CLI command or the equivalent on the GitHub website:
+
+```shell
+gh run list --repo apache/iceberg-rust --workflow publish.yml --branch "v${iceberg_version}-rc.${rc}"
+```
+
+A failed run means the crates cannot be published as tagged, so the problem must be fixed in a new RC.
 
 If an RC has a problem, abandon that RC and increment the RC number.
 

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -230,15 +230,6 @@ The script does not push the RC tag. Review the output, then push the tag manual
 git push origin "v${iceberg_version}-rc.${rc}"
 ```
 
-Pushing the RC tag triggers the publish workflow for crates, which dry-runs the crate publish without uploading anything.
-Verify that the run succeeded before starting the vote, using the following GitHub CLI command or the equivalent on the GitHub website:
-
-```shell
-gh run list --repo apache/iceberg-rust --workflow publish.yml --branch "v${iceberg_version}-rc.${rc}"
-```
-
-A failed run means the crates cannot be published as tagged, so the problem must be fixed in a new RC.
-
 If an RC has a problem, abandon that RC and increment the RC number.
 
 ### Trigger release candidate PyPI publish

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -215,8 +215,10 @@ This script creates:
 - SHA-512 checksum: `apache-iceberg-rust-${iceberg_version}.tar.gz.sha512`
 - Signed annotated RC tag: `v${iceberg_version}-rc.${rc}`
 
-The publish dry-run packages and builds every crate as the final release would, so a crate that cannot be published fails RC creation.
-The script checks license headers against the generated source archive, not the live Git worktree. If enabled, SVN upload runs after local artifact verification and before RC tag creation. The script creates the signed RC tag as the final release step, then prints a draft VOTE email for `dev@iceberg.apache.org`.
+The script runs a number of verifications.
+It performs a dry-run packaging step and builds every crate as the final release would, so a crate that cannot be published fails RC creation.
+It also checks license headers against the generated source archive.
+If enabled, SVN upload runs after local artifact verification and before RC tag creation. The script creates the signed RC tag as the final release step, then prints a draft VOTE email for `dev@iceberg.apache.org`.
 
 To upload artifacts to ASF dev dist as part of RC creation, pass:
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to #3034 (0.11.0 release tracking). Found while verifying [0.11.0 RC1](https://lists.apache.org/thread/nj95255r4ofqszpfx6pd8hbf8yxxydzv).

## What changes are included in this PR?

Fix publishing `iceberg-property-macro` as part of the workspace release.

`iceberg-property-macro` is new in 0.11.0 and must be published because `iceberg` depends on it. The macro crate also had a dev-dependency on `iceberg` declared with `workspace = true`, which gives it the workspace version.

When Cargo packages the macro crate for publishing, it tries to resolve `iceberg ^0.11.0` from crates.io. That version does not exist yet because `iceberg` is published later in the workspace release, so `cargo publish --workspace` fails on the `v0.11.0-rc.1` tag:

```text
error: failed to prepare local package for uploading
  failed to select a version for the requirement `iceberg = "^0.11.0"`
  required by package `iceberg-property-macro v0.11.0`
```

This is the same failure mode that broke the 0.5.0 publish (#1325).

This PR:

* Changes the dev-dependency to path-only (`iceberg = { path = "../iceberg" }`), so Cargo strips it when packaging. This matches the pattern already used for `iceberg_test_utils` across the workspace.
* Marks `iceberg-property-macro` as internal to `iceberg` in its package description and README, since it is published only because `iceberg` depends on it.
* Adds `cargo publish --workspace --all-features --dry-run --no-verify` to the `check_standalone` CI job, so publishing problems like dependency cycles and unresolvable versions are caught on the PR instead of during the post-vote release. `--no-verify` skips compiling each packaged crate, which took 13 minutes per PR.
* Adds the full `cargo publish --workspace --all-features --dry-run` to `dev/release/create_rc.sh` as a `--check_publish` step, before any artifact or the RC tag is created, so a crate that cannot be published fails RC creation.
* Adds the same full dry-run to `publish.yml` on RC tag pushes, which previously ran no steps, so the exact tag is also checked on the MSRV toolchain the real publish uses.

Follow-ups outside this PR: cherry-pick the fix and the `create_rc.sh` change to `0.11.x` before RC2, since RC2 is created from the release branch. The macro crate's first publish will also need to use an API token, since crates.io does not allow Trusted Publishing for the first version of a new crate.

## Are these changes tested?

- `cargo publish --workspace --all-features --dry-run` fails on the current manifest and passes with this change, on both stable 1.95 (the publish workflow's toolchain) and the pinned nightly. The `--no-verify` variant fails on the current manifest with "circular dependency detected" in about 10 seconds.
- `dev/release/create_rc.sh` with the new step: an uncommitted change inside a crate fails with `FAILED: Check crates can be published` before any artifact is created, a clean tree verifies all 11 crates, and `--check_publish 0` skips the step.
- `cargo test -p iceberg-property-macro --all-features` passes with the path-only dev-dependency, including the trybuild compile-fail tests and README doctests.
- The new CI step runs on this PR. The `publish.yml` step only runs on an RC tag push, so it is untested until RC2.

## AI Disclosure

Investigated and drafted with Claude Code; changes reviewed and verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

