### PR TITLE
ci: check new crates are reserved on crates.io before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,19 @@ jobs:
       - name: Check crates package LICENSE and NOTICE
         run: make check-license-notice
 
+      # Trusted publishing cannot create a crate (https://crates.io/docs/trusted-publishing),
+      # so a new publishable crate must be reserved on crates.io before it is merged.
+      # See "Adding a new crate" in website/src/release.md.
+      - name: Check publishable crates exist on crates.io
+        run: |
+          for pkg in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.publish == null) | .name'); do
+            # --registry is required, otherwise cargo resolves the local workspace member.
+            if ! cargo info --registry crates-io "$pkg" >/dev/null; then
+              echo "::error::$pkg is not on crates.io. Reserve it before merging; see 'Adding a new crate' in website/src/release.md"
+              exit 1
+            fi
+          done
+
       - name: Cargo Machete
         run: cargo machete
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       # See "Adding a new crate" in website/src/release.md.
       - name: Check publishable crates exist on crates.io
         run: |
-          for pkg in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.publish == null) | .name'); do
+          for pkg in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.publish != []) | .name'); do
             # --registry is required, otherwise cargo resolves the local workspace member.
             if ! cargo info --registry crates-io "$pkg" >/dev/null; then
               echo "::error::$pkg is not on crates.io. Reserve it before merging; see 'Adding a new crate' in website/src/release.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
       # See "Adding a new crate" in website/src/release.md.
       - name: Check publishable crates exist on crates.io
         run: |
-          for pkg in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.publish != []) | .name'); do
+          pkgs=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.publish != []) | .name')
+          # A failed `cargo metadata` would otherwise leave the loop empty and the step green.
+          [ -n "$pkgs" ] || { echo "::error::No publishable crates found in the workspace, expected at least one"; exit 1; }
+          for pkg in $pkgs; do
             # --registry is required, otherwise cargo resolves the local workspace member.
             if ! cargo info --registry crates-io "$pkg" >/dev/null; then
               echo "::error::$pkg is not on crates.io. Reserve it before merging; see 'Adding a new crate' in website/src/release.md"

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -610,45 +610,75 @@ however it is in the community's best interest to publish it soon after.
 
 ## Appendix
 
-### Publishing a crate for the first time
+### Adding a new crate
 
-Publishing the Iceberg crates is automated using GitHub Actions,
-which authenticates with crates.io using trusted publishing.
+Every publishable crate must exist on crates.io before the pull request that adds it is merged.
+CI enforces this with a check that fails for any publishable crate missing from crates.io.
 
-Trusted publishing must first be configured for each crate.
-If the crate has never been published, crates.io rejects attempts to publish.
+The release workflow publishes crates with [trusted publishing](https://crates.io/docs/trusted-publishing), which cannot create a crate.
+crates.io requires the first version of a crate to be published manually with an API token ([announcement](https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/)).
+Publishing the crate by hand after the release workflow fails does not work either: the workflow runs `cargo publish --workspace`, which refuses to run if any crate already exists at the release version.
 
-When a release workflow fails due to the presence of a new crate, a committer must perform steps enumerated below.
-Once complete, future versions can be published automatically using GitHub Actions.
+A committer therefore reserves the crate when it is added, in three steps: publish a placeholder version, configure owners, and configure trusted publishing.
 
-#### Initial crate publish
+#### Prerequisites
 
-Manually publish the crate using the following command.
-You **must** have the source code checked out matching the pushed Git tag for the release.
+Any crates.io account can publish an unclaimed name, and the first publisher becomes the crate's only owner.
+Reserve the crate promptly once the pull request is open, and have a committer do it, since the reserver must hand ownership to the project.
 
-```shell
-cargo publish --package <package-name>
-```
+The committer needs:
 
-#### Configure crate permissions
+- A crates.io account linked to their GitHub account.
+- A crates.io API token with the `publish-new` and `change-owners` scopes, used with `cargo login`.
+- Membership in the `apache/iceberg-private` GitHub team, with the `read:org` permission granted to crates.io, in order to add that team as an owner.
 
-After publishing succeeds, the crate must be configured to allow other committers to publish.
+Committers who already own the existing Iceberg crates meet all of these.
+List them with `cargo owner --list iceberg`.
 
-Add the GitHub team that Apache Iceberg committers are a member of.
+#### Step 1: Reserve the crate name
 
-```shell
-cargo owner --add github:<github-team-org>:<github-team-name>
-```
-
-Additionally, add two PMC members (excluding yourself) as owners of the crate.
-A GitHub team cannot manage permissions for the crate, so it is important that individuals have ownership to continue being able to manage the crate should a PMC member become inactive.
-See the [Cargo documentation for `cargo owner`](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner) for reference.
+Check out the pull request branch and publish the crate as version `0.0.0`, so the placeholder never collides with a real release.
 
 ```shell
-cargo owner --add <github-handle>
+cd crates/<crate-dir>
+sed -i.bak 's/^version = { workspace = true }/version = "0.0.0"/' Cargo.toml
+cargo publish --package <package-name> --allow-dirty
+mv Cargo.toml.bak Cargo.toml
 ```
 
-#### Configure trusted publishing
+Do not commit the version change.
 
-Review the [crates.io trusted publishing documentation](https://crates.io/docs/trusted-publishing) for the latest instructions on how to configure it.
-You should also review another already-existing crate for reference.
+#### Step 2: Configure crate owners
+
+Add the GitHub team that owns the existing Iceberg crates.
+
+```shell
+cargo owner --add github:apache:iceberg-private <package-name>
+```
+
+Then add two PMC members other than yourself as individual owners.
+
+```shell
+cargo owner --add <github-handle> <package-name>
+```
+
+Individual owners are required because a team owner can publish and yank versions but cannot add or remove owners.
+Without them, the crate could become unmanageable if a PMC member becomes inactive.
+See the [Cargo documentation for `cargo owner`](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner).
+
+#### Step 3: Configure trusted publishing
+
+As a crate owner, open the crate's settings on the crates.io website and add a trusted publisher, following the [crates.io trusted publishing documentation](https://crates.io/docs/trusted-publishing).
+Use an existing Iceberg crate as the reference:
+
+- Repository: `apache/iceberg-rust`
+- Workflow: `publish.yml`
+- Environment: `publish`
+
+Then re-run CI on the pull request.
+The next release publishes the crate's first real version along with the rest of the workspace.
+
+#### If the Publish workflow fails on a missing crate
+
+Reserve the crate as above, using the `0.0.0` placeholder and never the release version, then re-run the failed workflow run from the GitHub Actions UI.
+The workflow fails before uploading anything, and re-running keeps the original tag as the workflow ref, so the publish step runs as if the tag had just been pushed.

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -527,9 +527,8 @@ The creation of the final release tag triggers the publish workflow for crates.
 Python packages are manually triggered later.
 Please verify that the triggered workflows for the crates succeeded.
 
-Note, this workflow for crates is expected to fail if new crates are being published for the first time.
-In this instance, a committer must manually publish the crate in order to continue.
-See [publishing a crate for the first time](#publishing-a-crate-for-the-first-time) for what steps to take.
+New crates are reserved on crates.io when they are added, so the workflow should not fail on a new crate.
+If it does, see [if the Publish workflow fails on a missing crate](#if-the-publish-workflow-fails-on-a-missing-crate).
 Once all the crates are published, Python publishing should start.
 
 Python publishing is performed by a GitHub workflow, however the trigger is manual.
@@ -642,8 +641,9 @@ Publish an empty placeholder crate as version `0.0.0`, so it never collides with
 The placeholder is created outside the repository; overriding the version inside the workspace does not work because other workspace crates depend on the new crate at the workspace version.
 
 ```shell
-cargo new --lib --vcs none --name <package-name> /tmp/<package-name>
+mkdir -p /tmp/<package-name>/src
 cd /tmp/<package-name>
+touch src/lib.rs
 cat > Cargo.toml <<'EOF'
 [package]
 name = "<package-name>"
@@ -672,6 +672,8 @@ Then add two PMC members other than yourself as individual owners.
 ```shell
 cargo owner --add <github-handle> <package-name>
 ```
+
+This sends an invitation; ask each invitee to accept it on crates.io.
 
 Individual owners are required because a team owner can publish and yank versions but cannot add or remove owners.
 Without them, the crate could become unmanageable if a PMC member becomes inactive.

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -688,5 +688,13 @@ The next release publishes the crate's first real version along with the rest of
 
 #### If the Publish workflow fails on a missing crate
 
-Reserve the crate as above, using the `0.0.0` placeholder and never the release version, then re-run the failed workflow run from the GitHub Actions UI.
-The workflow fails before uploading anything, and re-running keeps the original tag as the workflow ref, so the publish step runs as if the tag had just been pushed.
+Reserve the crate as above, using the `0.0.0` placeholder and never the release version.
+
+Then check the failed run's log for `Uploaded` lines to see which crates were already published, since cargo uploads crates one at a time in dependency order.
+
+- If nothing was uploaded, re-run the failed workflow run from the GitHub Actions UI. Re-running keeps the original tag as the workflow ref.
+- If some crates were uploaded, publish the rest from a clean checkout of the release tag, excluding each crate that was already published:
+
+```shell
+cargo publish --workspace --all-features --exclude <published-crate> --exclude <published-crate>
+```

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -629,10 +629,11 @@ Reserve the crate promptly once the pull request is open, and have a committer d
 The committer needs:
 
 - A crates.io account linked to their GitHub account.
-- A crates.io API token with the `publish-new` and `change-owners` scopes, used with `cargo login`.
 - Membership in the `apache/iceberg-private` GitHub team, with the `read:org` permission granted to crates.io, in order to add that team as an owner.
+- A crates.io API token with the `publish-new` and `change-owners` scopes, used with `cargo login`.
+  Existing tokens usually lack `publish-new`; create one at [crates.io/settings/tokens](https://crates.io/settings/tokens).
 
-Committers who already own the existing Iceberg crates meet all of these.
+Committers who already own the existing Iceberg crates meet the first two.
 List them with `cargo owner --list iceberg`.
 
 #### Step 1: Reserve the crate name
@@ -655,6 +656,8 @@ EOF
 cargo publish --dry-run
 cargo publish
 ```
+
+A `403 Forbidden: authentication failed` error means the token lacks the `publish-new` scope.
 
 #### Step 2: Configure crate owners
 

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -637,16 +637,24 @@ List them with `cargo owner --list iceberg`.
 
 #### Step 1: Reserve the crate name
 
-Check out the pull request branch and publish the crate as version `0.0.0`, so the placeholder never collides with a real release.
+Publish an empty placeholder crate as version `0.0.0`, so it never collides with a real release.
+The placeholder is created outside the repository; overriding the version inside the workspace does not work because other workspace crates depend on the new crate at the workspace version.
 
 ```shell
-cd crates/<crate-dir>
-sed -i.bak 's/^version = { workspace = true }/version = "0.0.0"/' Cargo.toml
-cargo publish --package <package-name> --allow-dirty
-mv Cargo.toml.bak Cargo.toml
+cargo new --lib --vcs none --name <package-name> /tmp/<package-name>
+cd /tmp/<package-name>
+cat > Cargo.toml <<'EOF'
+[package]
+name = "<package-name>"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Placeholder that reserves the crate name for Apache Iceberg Rust. See the repository for the real crate."
+repository = "https://github.com/apache/iceberg-rust"
+EOF
+cargo publish --dry-run
+cargo publish
 ```
-
-Do not commit the version change.
 
 #### Step 2: Configure crate owners
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to #3034. Follow-up to #3184.

## What changes are included in this PR?

While looking at the 0.11.0 RC1 publish failure, I noticed our "Publishing a crate for the first time" instructions no longer work.

**Why the current instructions don't work**

- crates.io trusted publishing can't create a new crate. The first version has to be published manually with an API token ([crates.io docs](https://crates.io/docs/trusted-publishing)).
- The current instructions say to let the release workflow fail, publish the new crate by hand from the tag, then re-run the workflow.
- That was fine when the workflow published crates one at a time. Since #2489 it runs `cargo publish --workspace`, and cargo bails if any crate already exists at that version, so the re-run fails for every crate.
- The instructions were written in #3037 after the switch, but 0.10 didn't add a new crate so we never hit this. 0.11.0 adds `iceberg-property-macro`, so we hit it now.

**What this PR does**

Reserve the crate when it's added instead of at release time.

- Add a PR CI check (in the `lint` job) that fails if a publishable crate doesn't exist on crates.io, so the PR that adds a crate can't merge until the crate is reserved. Uses `cargo info --registry crates-io`.
- Rewrite the release guide appendix: publish a `0.0.0` placeholder from the PR branch, add owners, configure trusted publishing, then merge. Also spells out who can do this and what token scopes and team membership they need.

**Note**

This PR's CI will stay red until `iceberg-property-macro` is reserved on crates.io. That's the check doing its job. Reserving it now also means the 0.11.0 publish goes through the workflow like any other release.

## Are these changes tested?

Ran the check locally. The 10 existing crates pass and `iceberg-property-macro` fails, which is correct today.

Also verified that `cargo info` without `--registry` resolves the local workspace member and would pass incorrectly, hence the flag.

Dry-ran the reservation instructions with `cargo publish --dry-run`. The first version (overriding the version inside the workspace) failed because `iceberg` depends on the new crate at the workspace version, so the doc now uses a standalone placeholder crate, which packages and verifies cleanly.

## AI Disclosure

Investigated and drafted with Claude Code, reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
