### PR TITLE
fix(hms): use `get_table_req` for Hive 4 metastore compatibility

### DIFF
--- a/crates/catalog/hms/src/catalog.rs
+++ b/crates/catalog/hms/src/catalog.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use hive_metastore::{
-    ThriftHiveMetastoreClient, ThriftHiveMetastoreClientBuilder,
-    ThriftHiveMetastoreGetDatabaseException, ThriftHiveMetastoreGetTableException,
+    GetTableRequest, ThriftHiveMetastoreClient, ThriftHiveMetastoreClientBuilder,
+    ThriftHiveMetastoreGetDatabaseException, ThriftHiveMetastoreGetTableReqException,
 };
 use iceberg::encryption::kms::{KeyManagementClient, KmsClientFactory};
 use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
@@ -583,10 +583,15 @@ impl Catalog for HmsCatalog {
         let hive_table = self
             .client
             .0
-            .get_table(db_name.clone().into(), table.name.clone().into())
+            .get_table_req(GetTableRequest {
+                db_name: db_name.clone().into(),
+                tbl_name: table.name.clone().into(),
+                ..Default::default()
+            })
             .await
             .map(from_thrift_exception)
-            .map_err(from_thrift_error)??;
+            .map_err(from_thrift_error)??
+            .table;
 
         let metadata_location = get_metadata_location(&hive_table.parameters)?;
 
@@ -661,12 +666,18 @@ impl Catalog for HmsCatalog {
         let resp = self
             .client
             .0
-            .get_table(db_name.into(), table_name.into())
+            .get_table_req(GetTableRequest {
+                db_name: db_name.into(),
+                tbl_name: table_name.into(),
+                ..Default::default()
+            })
             .await;
 
         match resp {
             Ok(MaybeException::Ok(_)) => Ok(true),
-            Ok(MaybeException::Exception(ThriftHiveMetastoreGetTableException::O2(_))) => Ok(false),
+            Ok(MaybeException::Exception(ThriftHiveMetastoreGetTableReqException::O2(_))) => {
+                Ok(false)
+            }
             Ok(MaybeException::Exception(exception)) => Err(Error::new(
                 ErrorKind::Unexpected,
                 "Operation failed for hitting thrift error".to_string(),
@@ -698,10 +709,15 @@ impl Catalog for HmsCatalog {
         let mut tbl = self
             .client
             .0
-            .get_table(src_dbname.clone().into(), src_tbl_name.clone().into())
+            .get_table_req(GetTableRequest {
+                db_name: src_dbname.clone().into(),
+                tbl_name: src_tbl_name.clone().into(),
+                ..Default::default()
+            })
             .await
             .map(from_thrift_exception)
-            .map_err(from_thrift_error)??;
+            .map_err(from_thrift_error)??
+            .table;
 
         tbl.db_name = Some(dest_dbname.into());
         tbl.table_name = Some(dest_tbl_name.into());

--- a/dev/hms/Dockerfile
+++ b/dev/hms/Dockerfile
@@ -13,20 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/hive:3.1.3
-
-ENV AWSSDK_VERSION=2.20.18
-ENV HADOOP_VERSION=3.1.0
+FROM apache/hive:4.2.1
 
 USER root
 
-ADD --chmod=644 --checksum=sha256:a18508b9348af095ea41301e439354dbd449e304ac44c6885b2b4fe78de88126 \
-    https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar \
-    /opt/hive/lib/hadoop-aws-${HADOOP_VERSION}.jar
-ADD --chmod=644 --checksum=sha256:faf78ac4880f56cf52791d84ec1068ce7c66acc4295d580a726104b734c01fcd \
-    https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.271/aws-java-sdk-bundle-1.11.271.jar \
-    /opt/hive/lib/aws-java-sdk-bundle-1.11.271.jar
+# Link the hadoop-aws and AWS SDK jars that the image ships into the metastore classpath
+RUN ln -s /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-*.jar /opt/hive/lib/ && \
+    ln -s /opt/hadoop/share/hadoop/tools/lib/bundle-*.jar /opt/hive/lib/
 
-COPY core-site.xml /opt/hadoop/etc/hadoop/core-site.xml
+# The entrypoint links this directory into the Hive config directory, over its own core-site.xml
+ENV HIVE_CUSTOM_CONF_DIR=/opt/hive/custom-conf
+COPY core-site.xml ${HIVE_CUSTOM_CONF_DIR}/core-site.xml
 
 USER hive


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3186.

## What changes are included in this PR?

Follow up to #3174. Debian Bullseye reached EOL and broke `apt-get` in the `apache/hive:3.1.3` image we use for HMS integration tests. #3174 worked around it by downloading the jars without apt, but the base image is still EOL. pyiceberg hit the same thing and moved to `apache/hive:4.2.1` in apache/iceberg-python#3924. This does the same here.

Moving to Hive 4 exposed a real bug: Hive 4.0.1 dropped the `get_table` thrift method, so the HMS catalog fails with `Invalid method name: 'get_table'` against any Hive 4 metastore.

- Switch `load_table`, `table_exists`, and `rename_table` to `get_table_req`. It exists since Hive 2.3, which is the IDL `hive_metastore` is generated from, so nothing we could talk to before stops working.
- Bump the test metastore to `apache/hive:4.2.1`, same Dockerfile as pyiceberg. 3.1.3 still serves `get_table`, so CI could never catch this.

## Are these changes tested?

Existing HMS cases in the catalog suite (`crates/catalog/loader/tests`), now running against Hive 4.2.1.

Locally, the 21 HMS cases pass against both 4.2.1 and 3.1.3. Without the code change they fail against 4.2.1 with the error above.

## AI Disclosure

Written with Claude Code, reviewed by me.
