### PR TITLE
ci: document that publishing is trusted-publishing only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,11 @@ jobs:
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 
+      # Publishing uses crates.io trusted publishing only. The token is minted per
+      # run via OIDC; there is no long-lived CARGO_REGISTRY_TOKEN secret and one
+      # should not be added as a fallback. Trusted publishing cannot create a
+      # crate, so new crates are reserved before their PR merges instead; see
+      # "Adding a new crate" in website/src/release.md.
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 


### PR DESCRIPTION
## Which issue does this PR close?

- Follow-up to #2593 and #3185.

## What changes are included in this PR?

Adds a comment to `publish.yml` stating that publishing is trusted publishing only, and that a `CARGO_REGISTRY_TOKEN` secret should not be added back as a fallback.

Context: the repo still has a `CARGO_REGISTRY_TOKEN` secret from the 0.5.x release (INFRA-26882). Nothing has referenced it since #2593 switched the workflow to OIDC, and the 0.10.0 and 0.10.1 publishes ran without it. I'm removing the secret from the repo settings.

Why not keep it as a fallback:

- It's a long-lived token tied to one person's crates.io account, readable by any workflow in the repo.
- The only thing OIDC can't do is create a new crate, and #3185 handles that by reserving the crate before its PR merges. So the workflow never needs to create one.
- If we ever turn on "enforce trusted publishing" on crates.io, token-based publishes are rejected anyway.

No functional change to the workflow.

## Are these changes tested?

Comment only. Checked that no release branch (`main`, `0.11.x`, `0.10.x`) references `secrets.CARGO_REGISTRY_TOKEN`.

## AI Disclosure

Drafted with Claude Code, reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
