### PR TITLE
chore: exclude repo-only files from the source archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
+# Paths left out of the source archive built by dev/release/create_rc.sh.
+# Files needed to build, test, and verify from source (dev/, .licenserc.yaml,
+# lint configs) must stay in.
 website export-ignore
+.asf.yaml export-ignore
+.devcontainer export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+.idea export-ignore


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## What changes are included in this PR?

Trim the source tarball. We build it with `git archive`, which includes everything in the repo. This adds `export-ignore` for the repo-only files: `.asf.yaml`, `.devcontainer`, `.github`, `.gitignore`, `.gitattributes`, and `.idea`.

This came up twice in RC votes. 
- Ryan mentioned the archive ships `.gitignore`, `.github`, `.asf.yaml` etc. in the 0.2.0 vote: https://lists.apache.org/thread/1rnk9c1ldjhd160bfxvdyk7mlkzrjj03. 
- Kurtis called out `.idea/vcs.xml` in the 0.9.1 RC3 vote: https://lists.apache.org/thread/24bsb6hllp6kvk3ow7b4gsncp5cjf79o

Everything the verify script needs stays in: `.licenserc.yaml` for the header check, the lint configs for `make check`, `dev/` for tests and release scripts.

## Are these changes tested?

Extracted the archive and ran the header check, `make check-toml`, and `dev/check_license_notice.sh` from it. All pass. None of the excluded paths show up in `git archive HEAD | tar -t`.

## AI Disclosure

Drafted with Claude Code, reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
