### PR TITLE
API: Add fallible NestedField builder

### DIFF
--- a/crates/catalog/glue/src/schema.rs
+++ b/crates/catalog/glue/src/schema.rs
@@ -103,14 +103,14 @@ impl SchemaVisitor for GlueSchemaBuilder {
 
     fn field(&mut self, field: &iceberg::spec::NestedFieldRef, value: String) -> Result<String> {
         if self.is_inside_struct() {
-            return Ok(format!("{}:{}", field.name, value));
+            return Ok(format!("{}:{}", field.name(), value));
         }
 
         let parameters = HashMap::from([
-            (ICEBERG_FIELD_ID.to_string(), format!("{}", field.id)),
+            (ICEBERG_FIELD_ID.to_string(), format!("{}", field.id())),
             (
                 ICEBERG_FIELD_OPTIONAL.to_string(),
-                format!("{}", !field.required).to_lowercase(),
+                format!("{}", !field.is_required()).to_lowercase(),
             ),
             (
                 ICEBERG_FIELD_CURRENT.to_string(),
@@ -119,11 +119,11 @@ impl SchemaVisitor for GlueSchemaBuilder {
         ]);
 
         let mut builder = Column::builder()
-            .name(field.name.clone())
+            .name(field.name().to_string())
             .r#type(&value)
             .set_parameters(Some(parameters));
 
-        if let Some(comment) = field.doc.as_ref() {
+        if let Some(comment) = field.doc() {
             builder = builder.comment(comment);
         }
 

--- a/crates/catalog/glue/src/utils.rs
+++ b/crates/catalog/glue/src/utils.rs
@@ -349,7 +349,9 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 

--- a/crates/catalog/hms/src/schema.rs
+++ b/crates/catalog/hms/src/schema.rs
@@ -73,13 +73,13 @@ impl SchemaVisitor for HiveSchemaBuilder {
 
     fn field(&mut self, field: &iceberg::spec::NestedFieldRef, value: String) -> Result<String> {
         if self.is_inside_struct() {
-            return Ok(format!("{}:{}", field.name, value));
+            return Ok(format!("{}:{}", field.name(), value));
         }
 
         self.schema.push(FieldSchema {
-            name: Some(field.name.clone().into()),
+            name: Some(field.name().to_string().into()),
             r#type: Some(value.clone().into()),
-            comment: field.doc.clone().map(|doc| doc.into()),
+            comment: field.doc().map(|doc| doc.to_string().into()),
         });
 
         Ok(value)

--- a/crates/catalog/hms/src/utils.rs
+++ b/crates/catalog/hms/src/utils.rs
@@ -347,8 +347,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 

--- a/crates/catalog/loader/tests/common/mod.rs
+++ b/crates/catalog/loader/tests/common/mod.rs
@@ -328,8 +328,12 @@ pub fn table_creation(name: impl ToString) -> TableCreation {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()
         .unwrap();

--- a/crates/catalog/loader/tests/schema_update_suite.rs
+++ b/crates/catalog/loader/tests/schema_update_suite.rs
@@ -33,9 +33,15 @@ use rstest::rstest;
 fn base_schema() -> Schema {
     Schema::builder()
         .with_fields(vec![
-            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                .expect("valid nested field")
+                .into(),
         ])
         .with_identifier_field_ids(vec![2])
         .build()
@@ -88,8 +94,8 @@ async fn test_catalog_schema_add_column(#[case] kind: CatalogKind) -> Result<()>
 
     let schema = updated.metadata().current_schema();
     let field_a = schema.field_by_name("a").expect("field 'a' should exist");
-    assert_eq!(field_a.id, 4);
-    assert_eq!(*field_a.field_type, Type::Primitive(PrimitiveType::Int));
+    assert_eq!(field_a.id(), 4);
+    assert_eq!(field_a.field_type(), &Type::Primitive(PrimitiveType::Int));
 
     Ok(())
 }
@@ -139,7 +145,9 @@ async fn test_catalog_schema_add_nested_and_delete_column(#[case] kind: CatalogK
         .add_column(AddColumn::optional(
             "info",
             Type::Struct(StructType::new(vec![
-                NestedField::optional(0, "city", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(0, "city", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])),
         ))
         .apply(tx)?;

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -3696,8 +3696,11 @@ mod tests {
             vec![&Arc::new(
                 Schema::builder()
                     .with_fields(vec![
-                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                         NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .build()
@@ -3819,9 +3822,13 @@ mod tests {
                 Schema::builder()
                     .with_fields(vec![
                         NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                         NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .with_schema_id(1)
@@ -3893,9 +3900,13 @@ mod tests {
                 Schema::builder()
                     .with_fields(vec![
                         NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                         NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .with_schema_id(0)
@@ -3969,9 +3980,13 @@ mod tests {
                 Schema::builder()
                     .with_fields(vec![
                         NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                         NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .with_schema_id(1)
@@ -4097,9 +4112,13 @@ mod tests {
                 Schema::builder()
                     .with_fields(vec![
                         NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                        NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                         NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .with_schema_id(0)

--- a/crates/catalog/s3tables/src/catalog.rs
+++ b/crates/catalog/s3tables/src/catalog.rs
@@ -871,8 +871,12 @@ mod tests {
             let schema = Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap();
@@ -929,8 +933,12 @@ mod tests {
             let schema = Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap();
@@ -1267,7 +1275,9 @@ mod tests {
 
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/catalog/sql/src/catalog.rs
+++ b/crates/catalog/sql/src/catalog.rs
@@ -1309,7 +1309,9 @@ mod tests {
     fn simple_table_schema() -> Schema {
         Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()

--- a/crates/examples/src/rest_catalog_table.rs
+++ b/crates/examples/src/rest_catalog_table.rs
@@ -60,9 +60,15 @@ async fn main() {
     // Build the table schema.
     let table_schema = Schema::builder()
         .with_fields(vec![
-            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                .expect("valid nested field")
+                .into(),
         ])
         .with_schema_id(1)
         .with_identifier_field_ids(vec![2])

--- a/crates/iceberg/public-api.txt
+++ b/crates/iceberg/public-api.txt
@@ -2214,8 +2214,8 @@ pub iceberg::spec::MapType::key_field: iceberg::spec::NestedFieldRef
 pub iceberg::spec::MapType::value_field: iceberg::spec::NestedFieldRef
 impl iceberg::spec::MapType
 pub fn iceberg::spec::MapType::new(key_field: iceberg::spec::NestedFieldRef, value_field: iceberg::spec::NestedFieldRef) -> Self
-pub fn iceberg::spec::MapType::optional(key_id: i32, key_type: iceberg::spec::Type, value_id: i32, value_type: iceberg::spec::Type) -> Self
-pub fn iceberg::spec::MapType::required(key_id: i32, key_type: iceberg::spec::Type, value_id: i32, value_type: iceberg::spec::Type) -> Self
+pub fn iceberg::spec::MapType::optional(key_id: i32, key_type: iceberg::spec::Type, value_id: i32, value_type: iceberg::spec::Type) -> iceberg::Result<Self>
+pub fn iceberg::spec::MapType::required(key_id: i32, key_type: iceberg::spec::Type, value_id: i32, value_type: iceberg::spec::Type) -> iceberg::Result<Self>
 impl core::clone::Clone for iceberg::spec::MapType
 pub fn iceberg::spec::MapType::clone(&self) -> iceberg::spec::MapType
 impl core::cmp::Eq for iceberg::spec::MapType
@@ -2279,33 +2279,34 @@ pub fn iceberg::spec::NameMapping::serialize<__S>(&self, __serializer: __S) -> c
 impl<'de> serde_core::de::Deserialize<'de> for iceberg::spec::NameMapping
 pub fn iceberg::spec::NameMapping::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub struct iceberg::spec::NestedField
-pub iceberg::spec::NestedField::doc: core::option::Option<alloc::string::String>
-pub iceberg::spec::NestedField::field_type: alloc::boxed::Box<iceberg::spec::Type>
-pub iceberg::spec::NestedField::id: i32
-pub iceberg::spec::NestedField::initial_default: core::option::Option<iceberg::spec::Literal>
-pub iceberg::spec::NestedField::name: alloc::string::String
-pub iceberg::spec::NestedField::required: bool
-pub iceberg::spec::NestedField::write_default: core::option::Option<iceberg::spec::Literal>
 impl iceberg::spec::NestedField
-pub fn iceberg::spec::NestedField::list_element(id: i32, field_type: iceberg::spec::Type, required: bool) -> Self
-pub fn iceberg::spec::NestedField::map_key_element(id: i32, field_type: iceberg::spec::Type) -> Self
-pub fn iceberg::spec::NestedField::map_value_element(id: i32, field_type: iceberg::spec::Type, required: bool) -> Self
-pub fn iceberg::spec::NestedField::new(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type, required: bool) -> Self
-pub fn iceberg::spec::NestedField::optional(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type) -> Self
-pub fn iceberg::spec::NestedField::required(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type) -> Self
-pub fn iceberg::spec::NestedField::with_doc(self, doc: impl alloc::string::ToString) -> Self
-pub fn iceberg::spec::NestedField::with_initial_default(self, value: iceberg::spec::Literal) -> Self
-pub fn iceberg::spec::NestedField::with_write_default(self, value: iceberg::spec::Literal) -> Self
+pub fn iceberg::spec::NestedField::doc(&self) -> core::option::Option<&str>
+pub fn iceberg::spec::NestedField::field_type(&self) -> &iceberg::spec::Type
+pub fn iceberg::spec::NestedField::id(&self) -> i32
+pub fn iceberg::spec::NestedField::initial_default(&self) -> core::option::Option<&iceberg::spec::Literal>
+pub fn iceberg::spec::NestedField::is_required(&self) -> bool
+pub fn iceberg::spec::NestedField::list_element(id: i32, field_type: iceberg::spec::Type, required: bool) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::map_key_element(id: i32, field_type: iceberg::spec::Type) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::map_value_element(id: i32, field_type: iceberg::spec::Type, required: bool) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::name(&self) -> &str
+pub fn iceberg::spec::NestedField::new(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type, required: bool) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::optional(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::required(id: i32, name: impl alloc::string::ToString, field_type: iceberg::spec::Type) -> iceberg::Result<Self>
+pub fn iceberg::spec::NestedField::write_default(&self) -> core::option::Option<&iceberg::spec::Literal>
 impl core::clone::Clone for iceberg::spec::NestedField
 pub fn iceberg::spec::NestedField::clone(&self) -> iceberg::spec::NestedField
 impl core::cmp::Eq for iceberg::spec::NestedField
 impl core::cmp::PartialEq for iceberg::spec::NestedField
 pub fn iceberg::spec::NestedField::eq(&self, other: &iceberg::spec::NestedField) -> bool
+impl core::convert::From<iceberg::spec::NestedField> for iceberg::Result<iceberg::spec::NestedField>
+pub fn iceberg::Result<iceberg::spec::NestedField>::from(field: iceberg::spec::NestedField) -> Self
 impl core::fmt::Debug for iceberg::spec::NestedField
 pub fn iceberg::spec::NestedField::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for iceberg::spec::NestedField
 pub fn iceberg::spec::NestedField::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for iceberg::spec::NestedField
+impl iceberg::spec::NestedField
+pub fn iceberg::spec::NestedField::builder() -> NestedFieldBuilder<((), (), (), (), (), (), ())>
 impl serde_core::ser::Serialize for iceberg::spec::NestedField
 pub fn iceberg::spec::NestedField::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for iceberg::spec::NestedField

--- a/crates/iceberg/src/arrow/caching_delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/caching_delete_file_loader.rs
@@ -760,11 +760,13 @@ impl SchemaWithPartnerVisitor<ArrayRef> for EqDelColumnProcessor<'_> {
     }
 
     fn field(&mut self, field: &NestedFieldRef, partner: &ArrayRef, _value: ()) -> Result<()> {
-        if self.equality_ids.contains(&field.id) && field.field_type.as_primitive_type().is_some() {
+        if self.equality_ids.contains(&field.id())
+            && field.field_type().as_primitive_type().is_some()
+        {
             self.collected_columns.push((
                 partner.clone(),
-                field.name.clone(),
-                field.field_type.as_ref().clone(),
+                field.name().to_string(),
+                field.field_type().clone(),
             ));
         }
         Ok(())
@@ -823,14 +825,14 @@ impl PartnerAccessor<ArrayRef> for EqDelRecordBatchPartnerAccessor {
 
         // Find the field by name within the struct
         for (i, field_def) in struct_array.fields().iter().enumerate() {
-            if field_def.name() == &field.name {
+            if field_def.name() == field.name() {
                 return Ok(struct_array.column(i));
             }
         }
 
         Err(Error::new(
             ErrorKind::Unexpected,
-            format!("Field {} not found in parent struct", field.name),
+            format!("Field {} not found in parent struct", field.name()),
         ))
     }
 
@@ -1290,8 +1292,12 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1380,8 +1386,12 @@ mod tests {
         let data_file_schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
-                    NestedField::optional(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::optional(2, "y", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "z", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1619,7 +1629,9 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1672,7 +1684,9 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1714,7 +1728,9 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::optional(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/delete_file_loader.rs
+++ b/crates/iceberg/src/arrow/delete_file_loader.rs
@@ -218,12 +218,14 @@ mod tests {
                         "file_path",
                         crate::spec::Type::Primitive(crate::spec::PrimitiveType::String),
                     )
+                    .expect("valid nested field")
                     .into(),
                     crate::spec::NestedField::required(
                         2147483545,
                         "pos",
                         crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -303,6 +305,7 @@ mod tests {
                         "id",
                         crate::spec::Type::Primitive(crate::spec::PrimitiveType::Long),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()

--- a/crates/iceberg/src/arrow/delete_filter.rs
+++ b/crates/iceberg/src/arrow/delete_filter.rs
@@ -534,7 +534,9 @@ pub(crate) mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "Id", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::required(1, "Id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/int96.rs
+++ b/crates/iceberg/src/arrow/int96.rs
@@ -87,7 +87,7 @@ impl<'a> Int96CoercionVisitor<'a> {
             .get(PARQUET_FIELD_ID_META_KEY)
             .and_then(|id_str| id_str.parse::<i32>().ok())
             .and_then(|field_id| self.iceberg_schema.field_by_id(field_id))
-            .and_then(|f| match &*f.field_type {
+            .and_then(|f| match f.field_type() {
                 Type::Primitive(PrimitiveType::Timestamp | PrimitiveType::Timestamptz) => {
                     Some(TimeUnit::Microsecond)
                 }
@@ -261,8 +261,12 @@ mod tests {
         Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
-                NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()
@@ -295,7 +299,9 @@ mod tests {
         let iceberg = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamptz)).into(),
+                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamptz))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -321,7 +327,9 @@ mod tests {
         let iceberg = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::TimestampNs)).into(),
+                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::TimestampNs))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -340,6 +348,7 @@ mod tests {
             .with_schema_id(1)
             .with_fields(vec![
                 NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::TimestamptzNs))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -395,7 +404,9 @@ mod tests {
         let iceberg = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -437,9 +448,11 @@ mod tests {
                     "data",
                     Type::Struct(StructType::new(vec![
                         NestedField::optional(2, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -485,9 +498,11 @@ mod tests {
                             "element",
                             Type::Primitive(PrimitiveType::Timestamp),
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -529,15 +544,18 @@ mod tests {
                             "key",
                             Type::Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::optional(
                             3,
                             "value",
                             Type::Primitive(PrimitiveType::Timestamp),
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()

--- a/crates/iceberg/src/arrow/nan_val_cnt_visitor.rs
+++ b/crates/iceberg/src/arrow/nan_val_cnt_visitor.rs
@@ -127,25 +127,25 @@ impl SchemaWithPartnerVisitor<ArrayRef> for NanValueCountVisitor {
     }
 
     fn after_struct_field(&mut self, field: &NestedFieldRef, partner: &ArrayRef) -> Result<()> {
-        let field_id = field.id;
+        let field_id = field.id();
         count_float_nans!(partner, self, field_id);
         Ok(())
     }
 
     fn after_list_element(&mut self, field: &NestedFieldRef, partner: &ArrayRef) -> Result<()> {
-        let field_id = field.id;
+        let field_id = field.id();
         count_float_nans!(partner, self, field_id);
         Ok(())
     }
 
     fn after_map_key(&mut self, field: &NestedFieldRef, partner: &ArrayRef) -> Result<()> {
-        let field_id = field.id;
+        let field_id = field.id();
         count_float_nans!(partner, self, field_id);
         Ok(())
     }
 
     fn after_map_value(&mut self, field: &NestedFieldRef, partner: &ArrayRef) -> Result<()> {
-        let field_id = field.id;
+        let field_id = field.id();
         count_float_nans!(partner, self, field_id);
         Ok(())
     }

--- a/crates/iceberg/src/arrow/partition_value_calculator.rs
+++ b/crates/iceberg/src/arrow/partition_value_calculator.rs
@@ -182,8 +182,12 @@ mod tests {
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -198,7 +202,10 @@ mod tests {
 
         // Verify partition type
         assert_eq!(calculator.partition_type().fields().len(), 1);
-        assert_eq!(calculator.partition_type().fields()[0].name, "id_partition");
+        assert_eq!(
+            calculator.partition_type().fields()[0].name(),
+            "id_partition"
+        );
 
         // Create test batch
         let arrow_schema = Arc::new(ArrowSchema::new(vec![
@@ -233,7 +240,9 @@ mod tests {
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/arrow/reader/pipeline.rs
+++ b/crates/iceberg/src/arrow/reader/pipeline.rs
@@ -985,7 +985,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1065,7 +1067,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1163,7 +1167,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1405,7 +1411,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1556,7 +1564,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1911,7 +1921,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2000,7 +2012,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2160,7 +2174,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2484,7 +2500,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2550,8 +2568,11 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(2, "file_num", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -2708,8 +2729,11 @@ mod tests {
                 .with_schema_id(1)
                 .with_fields(vec![
                     NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2730,8 +2754,11 @@ mod tests {
                 .with_schema_id(1)
                 .with_fields(vec![
                     NestedField::optional(1, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2807,9 +2834,11 @@ mod tests {
                                 "ts",
                                 Type::Primitive(PrimitiveType::Timestamp),
                             )
+                            .expect("valid nested field")
                             .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -2914,9 +2943,11 @@ mod tests {
                                 "element",
                                 Type::Primitive(PrimitiveType::Timestamp),
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -3041,15 +3072,18 @@ mod tests {
                                 "key",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::optional(
                                 3,
                                 "value",
                                 Type::Primitive(PrimitiveType::Timestamp),
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -3118,8 +3152,12 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "wide", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "wide", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -3215,7 +3253,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -3616,7 +3656,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/reader/positional_deletes.rs
+++ b/crates/iceberg/src/arrow/reader/positional_deletes.rs
@@ -352,7 +352,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -548,7 +550,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -773,7 +777,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -946,7 +952,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1049,7 +1057,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/reader/predicate_visitor.rs
+++ b/crates/iceberg/src/arrow/reader/predicate_visitor.rs
@@ -76,22 +76,22 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
     }
 
     fn is_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
     fn not_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
     fn is_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
     fn not_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -101,7 +101,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -141,7 +141,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -151,7 +151,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -161,7 +161,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -171,7 +171,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literal: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 
@@ -191,7 +191,7 @@ impl BoundPredicateVisitor for CollectFieldIdVisitor {
         _literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<()> {
-        self.field_ids.insert(reference.field().id);
+        self.field_ids.insert(reference.field().id());
         Ok(())
     }
 }
@@ -213,13 +213,13 @@ impl PredicateConverter<'_> {
     /// due to schema evolution.
     fn bound_reference(&mut self, reference: &BoundReference) -> Result<Option<usize>> {
         // The leaf column's index in Parquet schema.
-        if let Some(column_idx) = self.column_map.get(&reference.field().id) {
+        if let Some(column_idx) = self.column_map.get(&reference.field().id()) {
             if self.parquet_schema.get_column_root(*column_idx).is_group() {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Leaf column `{}` in predicates isn't a root column in Parquet schema.",
-                        reference.field().name
+                        reference.field().name()
                     ),
                 ));
             }
@@ -233,7 +233,7 @@ impl PredicateConverter<'_> {
                     ErrorKind::DataInvalid,
                     format!(
                 "Leaf column `{}` in predicates cannot be found in the required column indices.",
-                reference.field().name
+                reference.field().name()
             ),
                 ))?;
 
@@ -676,10 +676,18 @@ mod tests {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![2])
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
-                    NestedField::optional(4, "qux", Type::Primitive(PrimitiveType::Float)).into(),
+                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(4, "qux", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/reader/projection.rs
+++ b/crates/iceberg/src/arrow/reader/projection.rs
@@ -65,9 +65,9 @@ impl ArrowReader {
     /// Recursively extract leaf field IDs because Parquet projection works at the leaf column level.
     /// Nested types (struct/list/map) are flattened in Parquet's columnar format.
     fn include_leaf_field_id(field: &NestedField, field_ids: &mut Vec<i32>) {
-        match field.field_type.as_ref() {
+        match field.field_type() {
             Type::Primitive(_) => {
-                field_ids.push(field.id);
+                field_ids.push(field.id());
             }
             Type::Struct(struct_type) => {
                 for nested_field in struct_type.fields() {
@@ -84,7 +84,7 @@ impl ArrowReader {
             // Variant projection is rejected earlier (in `get_arrow_projection_mask`); this
             // arm only keeps the match exhaustive. Treat it as a leaf, like a primitive.
             Type::Variant(_) => {
-                field_ids.push(field.id);
+                field_ids.push(field.id());
             }
         }
     }
@@ -128,7 +128,7 @@ impl ArrowReader {
         // projection that touches a variant, rather than returning a partial/incorrect batch.
         for field_id in field_ids {
             if let Some(field) = iceberg_schema_of_task.field_by_id(*field_id)
-                && type_contains_variant(&field.field_type)
+                && type_contains_variant(field.field_type())
             {
                 return Err(Error::new(
                     ErrorKind::FeatureUnsupported,
@@ -208,9 +208,9 @@ impl ArrowReader {
             if !type_promotion_is_valid(
                 parquet_iceberg_field
                     .unwrap()
-                    .field_type
+                    .field_type()
                     .as_primitive_type(),
-                iceberg_field.unwrap().field_type.as_primitive_type(),
+                iceberg_field.unwrap().field_type().as_primitive_type(),
             ) {
                 return false;
             }
@@ -272,11 +272,11 @@ fn type_contains_variant(field_type: &Type) -> bool {
         Type::Struct(s) => s
             .fields()
             .iter()
-            .any(|f| type_contains_variant(&f.field_type)),
-        Type::List(l) => type_contains_variant(&l.element_field.field_type),
+            .any(|f| type_contains_variant(f.field_type())),
+        Type::List(l) => type_contains_variant(l.element_field.field_type()),
         Type::Map(m) => {
-            type_contains_variant(&m.key_field.field_type)
-                || type_contains_variant(&m.value_field.field_type)
+            type_contains_variant(m.key_field.field_type())
+                || type_contains_variant(m.value_field.field_type())
         }
         Type::Primitive(_) => false,
     }
@@ -534,8 +534,12 @@ mod tests {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "c1", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(2, "c2", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "c1", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "c2", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::optional(
                         3,
                         "c3",
@@ -544,6 +548,7 @@ mod tests {
                             scale: 3,
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -627,26 +632,37 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "v", Type::Variant(VariantType))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(
                         3,
                         "s",
                         Type::Struct(StructType::new(vec![
-                            NestedField::optional(4, "vv", Type::Variant(VariantType)).into(),
+                            NestedField::optional(4, "vv", Type::Variant(VariantType))
+                                .expect("valid nested field")
+                                .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         5,
                         "m",
-                        Type::Map(crate::spec::MapType::required(
-                            6,
-                            Type::Primitive(PrimitiveType::String),
-                            7,
-                            Type::Variant(VariantType),
-                        )),
+                        Type::Map(
+                            crate::spec::MapType::required(
+                                6,
+                                Type::Primitive(PrimitiveType::String),
+                                7,
+                                Type::Variant(VariantType),
+                            )
+                            .expect("valid nested field"),
+                        ),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -688,8 +704,12 @@ message schema {
             Schema::builder()
                 .with_schema_id(2)
                 .with_fields(vec![
-                    NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "b", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "b", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -783,8 +803,12 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "age", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "age", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -883,10 +907,17 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(3, "dept", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "dept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::optional(4, "subdept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -985,10 +1016,17 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(3, "dept", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "dept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::optional(4, "subdept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -1086,10 +1124,18 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(3, "col3", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(4, "col4", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(3, "col3", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(4, "col4", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1181,9 +1227,15 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "age", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "city", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "age", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "city", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1275,8 +1327,12 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "value", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "value", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1383,7 +1439,9 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(
                         2,
                         "person",
@@ -1393,11 +1451,14 @@ message schema {
                                 "name",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             NestedField::required(4, "age", Type::Primitive(PrimitiveType::Int))
+                                .expect("valid nested field")
                                 .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -1518,9 +1579,15 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::optional(1, "col0", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(5, "newCol", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "col1", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(1, "col0", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(5, "newCol", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "col1", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1612,9 +1679,14 @@ message schema {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "value", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -1746,8 +1818,12 @@ message schema {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1937,11 +2013,14 @@ message schema {
                                 "name",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             NestedField::required(6, "age", Type::Primitive(PrimitiveType::Int))
+                                .expect("valid nested field")
                                 .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         2,
@@ -1956,18 +2035,22 @@ message schema {
                                         "name",
                                         Type::Primitive(PrimitiveType::String),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                     NestedField::required(
                                         9,
                                         "age",
                                         Type::Primitive(PrimitiveType::Int),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                 ])),
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         3,
@@ -1978,17 +2061,22 @@ message schema {
                                 "key",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::required(
                                 11,
                                 "value",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
-                    NestedField::required(4, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(4, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/reader/row_filter.rs
+++ b/crates/iceberg/src/arrow/reader/row_filter.rs
@@ -288,7 +288,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::optional(1, "a", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "a", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -458,7 +460,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -648,7 +652,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -748,7 +754,9 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -849,11 +857,10 @@ mod tests {
         Arc::new(
             Schema::builder()
                 .with_schema_id(1)
-                .with_fields(vec![Arc::new(NestedField::required(
-                    1,
-                    "x",
-                    Type::Primitive(PrimitiveType::Int),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         )
@@ -1066,8 +1073,12 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/record_batch_partition_splitter.rs
+++ b/crates/iceberg/src/arrow/record_batch_partition_splitter.rs
@@ -237,12 +237,14 @@ mod tests {
                         "id",
                         Type::Primitive(crate::spec::PrimitiveType::Int),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         2,
                         "name",
                         Type::Primitive(crate::spec::PrimitiveType::String),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -351,12 +353,14 @@ mod tests {
                         "id",
                         Type::Primitive(crate::spec::PrimitiveType::Int),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         2,
                         "name",
                         Type::Primitive(crate::spec::PrimitiveType::String),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()

--- a/crates/iceberg/src/arrow/record_batch_projector.rs
+++ b/crates/iceberg/src/arrow/record_batch_projector.rs
@@ -342,9 +342,15 @@ mod test {
         let iceberg_schema = IcebergSchema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(3, "age", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "age", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/arrow/record_batch_transformer.rs
+++ b/crates/iceberg/src/arrow/record_batch_transformer.rs
@@ -89,14 +89,15 @@ fn constants_map(
             };
 
             // Ensure the field type is primitive
-            let prim_type = match &*iceberg_field.field_type {
+            let prim_type = match iceberg_field.field_type() {
                 crate::spec::Type::Primitive(prim_type) => prim_type,
                 _ => {
                     return Err(Error::new(
                         ErrorKind::Unexpected,
                         format!(
                             "Partition field {} has non-primitive type {:?}",
-                            field.source_id, iceberg_field.field_type
+                            field.source_id,
+                            iceberg_field.field_type()
                         ),
                     ));
                 }
@@ -343,14 +344,15 @@ impl RecordBatchTransformerBuilder {
     pub(crate) fn with_null_metadata_column(mut self, field_id: i32) -> Result<Self> {
         let iceberg_field = get_metadata_field(field_id)?;
         let prim_type = iceberg_field
-            .field_type
+            .field_type()
             .as_primitive_type()
             .ok_or_else(|| {
                 Error::new(
                     ErrorKind::Unexpected,
                     format!(
                         "Metadata column {} has non-primitive type {:?}",
-                        iceberg_field.name, iceberg_field.field_type
+                        iceberg_field.name(),
+                        iceberg_field.field_type()
                     ),
                 )
             })?;
@@ -553,10 +555,10 @@ impl RecordBatchTransformer {
                         if let Ok(iceberg_field) = get_metadata_field(*field_id) {
                             let arrow_type = datum_to_arrow_type_with_ree(datum);
                             let arrow_field = field_with_id(
-                                &iceberg_field.name,
+                                iceberg_field.name(),
                                 arrow_type,
-                                !iceberg_field.required,
-                                iceberg_field.id,
+                                !iceberg_field.is_required(),
+                                iceberg_field.id(),
                             );
                             return Ok(Arc::new(arrow_field));
                         }
@@ -568,10 +570,10 @@ impl RecordBatchTransformer {
                         // Always nullable: this arm produces an all-null column regardless
                         // of the field's declared optionality.
                         let arrow_field = field_with_id(
-                            &iceberg_field.name,
+                            iceberg_field.name(),
                             arrow_type.clone(),
                             true,
-                            iceberg_field.id,
+                            iceberg_field.id(),
                         );
                         return Ok(Arc::new(arrow_field));
                     }
@@ -581,10 +583,10 @@ impl RecordBatchTransformer {
                         // constant, or is nulled.
                         let iceberg_field = get_metadata_field(*field_id)?;
                         let arrow_field = field_with_id(
-                            &iceberg_field.name,
+                            iceberg_field.name(),
                             datum_to_arrow_type_with_ree(datum),
                             true,
-                            iceberg_field.id,
+                            iceberg_field.id(),
                         );
                         return Ok(Arc::new(arrow_field));
                     }
@@ -593,12 +595,12 @@ impl RecordBatchTransformer {
 
                 if virtual_fields.contains(field_id) {
                     let virtual_field = get_metadata_field(*field_id)?;
-                    let arrow_type = type_to_arrow_type(&virtual_field.field_type)?;
+                    let arrow_type = type_to_arrow_type(virtual_field.field_type())?;
                     let arrow_field = field_with_id(
-                        &virtual_field.name,
+                        virtual_field.name(),
                         arrow_type,
-                        !virtual_field.required,
-                        virtual_field.id,
+                        !virtual_field.is_required(),
+                        virtual_field.id(),
                     );
                     return Ok(Arc::new(arrow_field));
                 }
@@ -862,14 +864,14 @@ impl RecordBatchTransformer {
                     // column that violates the field's required constraint. This matches
                     // Iceberg-Java's Parquet readers (BaseParquetReaders / SparkParquetReaders),
                     // which raise "Missing required field: <name>".
-                    if iceberg_field.initial_default.is_none() && iceberg_field.required {
+                    if iceberg_field.initial_default().is_none() && iceberg_field.is_required() {
                         return Err(Error::new(
                             ErrorKind::DataInvalid,
-                            format!("Missing required field: {}", iceberg_field.name),
+                            format!("Missing required field: {}", iceberg_field.name()),
                         ));
                     }
 
-                    let default_value = iceberg_field.initial_default.as_ref().and_then(|lit| {
+                    let default_value = iceberg_field.initial_default().as_ref().and_then(|lit| {
                         if let Literal::Primitive(prim) = lit {
                             Some(prim.clone())
                         } else {
@@ -1111,20 +1113,20 @@ pub(crate) fn build_partition_constant(
     let mut child_values = Vec::with_capacity(unified_partition_type.fields().len());
 
     for unified_field in unified_partition_type.fields() {
-        let arrow_type = type_to_arrow_type(&unified_field.field_type)?;
+        let arrow_type = type_to_arrow_type(unified_field.field_type())?;
         // Don't attach PARQUET_FIELD_ID_META_KEY metadata to child fields --
         // Spark's output schema for _partition doesn't include it, and Arrow's
         // Field::eq checks metadata, causing the schema adapter to insert an
         // unnecessary cast operation per batch.
         // Always nullable: partition evolution means any field may be absent
         // for files written under a different spec.
-        let arrow_field = Field::new(&unified_field.name, arrow_type, true);
+        let arrow_field = Field::new(unified_field.name(), arrow_type, true);
         arrow_fields.push(Arc::new(arrow_field));
 
         // Find matching field in this file's partition spec by field_id
         let value = spec_fields
             .iter()
-            .position(|f| f.field_id == unified_field.id)
+            .position(|f| f.field_id == unified_field.id())
             .and_then(|pos| {
                 // Get the value from partition_data at this position
                 match &partition_data[pos] {
@@ -1267,9 +1269,14 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::optional(3, "date_col", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -1337,8 +1344,11 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(2, "missing_str", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -1378,8 +1388,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::optional(
                         3,
                         "struct_col",
@@ -1389,9 +1403,11 @@ mod test {
                                 "inner_field",
                                 Type::Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -1510,13 +1526,29 @@ mod test {
         Schema::builder()
             .with_schema_id(2)
             .with_fields(vec![
-                NestedField::optional(10, "a", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(11, "b", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(12, "c", Type::Primitive(PrimitiveType::Double)).into(),
-                NestedField::required(13, "d", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(14, "e", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(15, "f", Type::Primitive(PrimitiveType::String))
-                    .with_initial_default(Literal::string("(╯°□°）╯"))
+                NestedField::optional(10, "a", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(11, "b", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(12, "c", Type::Primitive(PrimitiveType::Double))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(13, "d", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(14, "e", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::builder()
+                    .id(15)
+                    .name("f")
+                    .required(true)
+                    .field_type(Type::Primitive(PrimitiveType::String))
+                    .initial_default(Literal::string("(╯°□°）╯"))
+                    .build()
+                    .unwrap()
                     .into(),
             ])
             .build()
@@ -1575,14 +1607,29 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
-                        .with_initial_default(Literal::int(1))
+                    NestedField::builder()
+                        .id(1)
+                        .name("id")
+                        .required(false)
+                        .field_type(Type::Primitive(PrimitiveType::Int))
+                        .initial_default(Literal::int(1))
+                        .build()
+                        .unwrap()
                         .into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(3, "dept", Type::Primitive(PrimitiveType::String))
-                        .with_initial_default(Literal::string("hr"))
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::builder()
+                        .id(3)
+                        .name("dept")
+                        .required(false)
+                        .field_type(Type::Primitive(PrimitiveType::String))
+                        .initial_default(Literal::string("hr"))
+                        .build()
+                        .unwrap()
                         .into(),
                     NestedField::optional(4, "subdept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -1705,8 +1752,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1826,9 +1877,15 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1906,9 +1963,15 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -1929,8 +1992,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2012,8 +2079,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "row_id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "row_id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2106,17 +2177,30 @@ mod test {
                 .with_schema_id(0)
                 .with_fields(vec![
                     // Field in Parquet by field ID (normal case)
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     // Rule #1: Identity-partitioned field - should use partition metadata
-                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(2, "dept", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     // Rule #2: Field resolved by name mapping (ArrowReader already applied)
-                    NestedField::required(3, "data", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(3, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     // Rule #3: Field with initial_default
-                    NestedField::optional(4, "category", Type::Primitive(PrimitiveType::String))
-                        .with_initial_default(Literal::string("default_category"))
+                    NestedField::builder()
+                        .id(4)
+                        .name("category")
+                        .required(false)
+                        .field_type(Type::Primitive(PrimitiveType::String))
+                        .initial_default(Literal::string("default_category"))
+                        .build()
+                        .unwrap()
                         .into(),
                     // Rule #4: Field with no default - should be null
                     NestedField::optional(5, "notes", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -2213,8 +2297,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2277,8 +2365,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2347,7 +2439,9 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2396,7 +2490,9 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2447,7 +2543,9 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2546,8 +2644,11 @@ mod test {
                 .with_schema_id(0)
                 .with_fields(vec![
                     NestedField::required(1, "id_long", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2615,8 +2716,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -2714,9 +2819,15 @@ mod test {
             Schema::builder()
                 .with_schema_id(0)
                 .with_fields(vec![
-                    NestedField::required(1, "year", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "month", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "data", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "year", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "month", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -399,15 +399,13 @@ impl ArrowSchemaConverter {
             let field_type = &field_results[i];
             let id = self.get_field_id(field)?;
             let doc = get_field_doc(field);
-            let nested_field = NestedField {
-                id,
-                doc,
-                name: field.name().clone(),
-                required: !field.is_nullable(),
-                field_type: Box::new(field_type.clone()),
-                initial_default: None,
-                write_default: None,
-            };
+            let nested_field = NestedField::builder()
+                .id(id)
+                .doc_opt(doc)
+                .name(field.name())
+                .required(!field.is_nullable())
+                .field_type(field_type.clone())
+                .build()?;
             results.push(Arc::new(nested_field));
         }
         Ok(results)
@@ -447,11 +445,13 @@ impl ArrowSchemaVisitor for ArrowSchemaConverter {
 
         let id = self.get_field_id(element_field)?;
         let doc = get_field_doc(element_field);
-        let mut element_field =
-            NestedField::list_element(id, value.clone(), !element_field.is_nullable());
-        if let Some(doc) = doc {
-            element_field = element_field.with_doc(doc);
-        }
+        let element_field = NestedField::builder()
+            .id(id)
+            .name(crate::spec::LIST_FIELD_NAME)
+            .field_type(value.clone())
+            .required(!element_field.is_nullable())
+            .doc_opt(doc)
+            .build()?;
         let element_field = Arc::new(element_field);
         Ok(Type::List(ListType { element_field }))
     }
@@ -472,22 +472,24 @@ impl ArrowSchemaVisitor for ArrowSchemaConverter {
 
                     let key_id = self.get_field_id(key_field)?;
                     let key_doc = get_field_doc(key_field);
-                    let mut key_field = NestedField::map_key_element(key_id, key_value.clone());
-                    if let Some(doc) = key_doc {
-                        key_field = key_field.with_doc(doc);
-                    }
+                    let key_field = NestedField::builder()
+                        .id(key_id)
+                        .name(crate::spec::MAP_KEY_FIELD_NAME)
+                        .field_type(key_value.clone())
+                        .required(true)
+                        .doc_opt(key_doc)
+                        .build()?;
                     let key_field = Arc::new(key_field);
 
                     let value_id = self.get_field_id(value_field)?;
                     let value_doc = get_field_doc(value_field);
-                    let mut value_field = NestedField::map_value_element(
-                        value_id,
-                        value.clone(),
-                        !value_field.is_nullable(),
-                    );
-                    if let Some(doc) = value_doc {
-                        value_field = value_field.with_doc(doc);
-                    }
+                    let value_field = NestedField::builder()
+                        .id(value_id)
+                        .name(crate::spec::MAP_VALUE_FIELD_NAME)
+                        .field_type(value.clone())
+                        .required(!value_field.is_nullable())
+                        .doc_opt(value_doc)
+                        .build()?;
                     let value_field = Arc::new(value_field);
 
                     Ok(Type::Map(MapType {
@@ -620,19 +622,25 @@ impl SchemaVisitor for ToArrowSchemaConverter {
             ArrowSchemaOrFieldOrType::Type(ty) => ty,
             _ => unreachable!(),
         };
-        let metadata = if let Some(doc) = &field.doc {
+        let metadata = if let Some(doc) = field.doc() {
             HashMap::from([
-                (PARQUET_FIELD_ID_META_KEY.to_string(), field.id.to_string()),
-                (ARROW_FIELD_DOC_KEY.to_string(), doc.clone()),
+                (
+                    PARQUET_FIELD_ID_META_KEY.to_string(),
+                    field.id().to_string(),
+                ),
+                (ARROW_FIELD_DOC_KEY.to_string(), doc.to_string()),
             ])
         } else {
-            HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), field.id.to_string())])
+            HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                field.id().to_string(),
+            )])
         };
         let arrow_field =
-            Field::new(field.name.clone(), ty, !field.required).with_metadata(metadata);
+            Field::new(field.name().to_string(), ty, !field.is_required()).with_metadata(metadata);
         // A variant column's storage is a struct; tag the field with the canonical
         // `arrow.parquet.variant` extension type so consumers read it as a Variant, not a struct.
-        let arrow_field = if field.field_type.is_variant() {
+        let arrow_field = if field.field_type().is_variant() {
             arrow_field.with_extension_type(VariantExtensionType)
         } else {
             arrow_field
@@ -2039,7 +2047,9 @@ mod tests {
         // canonical `arrow.parquet.variant` extension type (the struct storage stays as-is).
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2073,19 +2083,26 @@ mod tests {
                     1,
                     "l",
                     Type::List(ListType::new(
-                        NestedField::optional(2, "element", Type::Variant(VariantType)).into(),
+                        NestedField::optional(2, "element", Type::Variant(VariantType))
+                            .expect("valid nested field")
+                            .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     3,
                     "m",
                     Type::Map(MapType::new(
                         NestedField::map_key_element(4, Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::map_value_element(5, Type::Variant(VariantType), false).into(),
+                        NestedField::map_value_element(5, Type::Variant(VariantType), false)
+                            .expect("valid nested field")
+                            .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -2130,7 +2147,9 @@ mod tests {
         let converted = arrow_schema_to_schema(&arrow_schema).unwrap();
         let expected = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2143,32 +2162,44 @@ mod tests {
         // top-level, nested in a struct, as a list element, and as a map value.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::optional(
                     2,
                     "s",
                     Type::Struct(StructType::new(vec![
-                        NestedField::optional(3, "sv", Type::Variant(VariantType)).into(),
+                        NestedField::optional(3, "sv", Type::Variant(VariantType))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     4,
                     "l",
                     Type::List(ListType::new(
-                        NestedField::optional(5, "element", Type::Variant(VariantType)).into(),
+                        NestedField::optional(5, "element", Type::Variant(VariantType))
+                            .expect("valid nested field")
+                            .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     6,
                     "m",
                     Type::Map(MapType::new(
                         NestedField::map_key_element(7, Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
-                        NestedField::map_value_element(8, Type::Variant(VariantType), false).into(),
+                        NestedField::map_value_element(8, Type::Variant(VariantType), false)
+                            .expect("valid nested field")
+                            .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -2190,7 +2221,9 @@ mod tests {
         let converted = arrow_schema_to_schema_auto_assign_ids(&arrow_schema).unwrap();
         let expected = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2250,54 +2283,38 @@ mod tests {
                 )])),
             ]));
             let iceberg_type = Type::Struct(StructType::new(vec![
-                NestedField {
-                    id: 1,
-                    doc: None,
-                    name: "a".to_string(),
-                    required: true,
-                    field_type: Box::new(Type::Primitive(PrimitiveType::Long)),
-                    initial_default: None,
-                    write_default: None,
-                }
-                .into(),
-                NestedField {
-                    id: 2,
-                    doc: None,
-                    name: "b".to_string(),
-                    required: false,
-                    field_type: Box::new(Type::Primitive(PrimitiveType::String)),
-                    initial_default: None,
-                    write_default: None,
-                }
-                .into(),
+                NestedField::required(1, "a", Type::Primitive(PrimitiveType::Long))
+                    .unwrap()
+                    .into(),
+                NestedField::optional(2, "b", Type::Primitive(PrimitiveType::String))
+                    .unwrap()
+                    .into(),
             ]));
             assert_eq!(iceberg_type, arrow_type_to_type(&arrow_type).unwrap());
             assert_eq!(arrow_type, type_to_arrow_type(&iceberg_type).unwrap());
 
             // initial_default and write_default is ignored
             let iceberg_type = Type::Struct(StructType::new(vec![
-                NestedField {
-                    id: 1,
-                    doc: None,
-                    name: "a".to_string(),
-                    required: true,
-                    field_type: Box::new(Type::Primitive(PrimitiveType::Long)),
-                    initial_default: Some(Literal::Primitive(PrimitiveLiteral::Int(114514))),
-                    write_default: None,
-                }
-                .into(),
-                NestedField {
-                    id: 2,
-                    doc: None,
-                    name: "b".to_string(),
-                    required: false,
-                    field_type: Box::new(Type::Primitive(PrimitiveType::String)),
-                    initial_default: None,
-                    write_default: Some(Literal::Primitive(PrimitiveLiteral::String(
+                NestedField::builder()
+                    .id(1)
+                    .name("a")
+                    .required(true)
+                    .field_type(Type::Primitive(PrimitiveType::Long))
+                    .initial_default(Literal::Primitive(PrimitiveLiteral::Long(114514)))
+                    .build()
+                    .unwrap()
+                    .into(),
+                NestedField::builder()
+                    .id(2)
+                    .name("b")
+                    .required(false)
+                    .field_type(Type::Primitive(PrimitiveType::String))
+                    .write_default(Literal::Primitive(PrimitiveLiteral::String(
                         "514".to_string(),
-                    ))),
-                }
-                .into(),
+                    )))
+                    .build()
+                    .unwrap()
+                    .into(),
             ]));
             assert_eq!(arrow_type, type_to_arrow_type(&iceberg_type).unwrap());
         }
@@ -2338,7 +2355,7 @@ mod tests {
             let iceberg_field = iceberg_schema.as_struct().fields().first().unwrap();
 
             assert!(
-                matches!(iceberg_field.field_type.as_ref(), Type::Primitive(t) if *t == expected_iceberg_type),
+                matches!(iceberg_field.field_type(), Type::Primitive(t) if *t == expected_iceberg_type),
                 "Expected {arrow_type:?} to map to {expected_iceberg_type:?}"
             );
         }
@@ -2549,8 +2566,12 @@ mod tests {
         // Level 2: orders.element.{order_id=16,amount=17}
         let expected = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "price",
@@ -2559,8 +2580,10 @@ mod tests {
                         scale: 2,
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(4, "created_at", Type::Primitive(PrimitiveType::Timestamptz))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::optional(
                     5,
@@ -2571,22 +2594,28 @@ mod tests {
                             Type::Primitive(PrimitiveType::String),
                             false,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     6,
                     "address",
                     Type::Struct(StructType::new(vec![
                         NestedField::optional(10, "street", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::required(11, "city", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::optional(12, "zip", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     7,
@@ -2596,15 +2625,18 @@ mod tests {
                             13,
                             Type::Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::map_value_element(
                             14,
                             Type::Primitive(PrimitiveType::String),
                             false,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     8,
@@ -2618,19 +2650,23 @@ mod tests {
                                     "order_id",
                                     Type::Primitive(PrimitiveType::Long),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 NestedField::required(
                                     17,
                                     "amount",
                                     Type::Primitive(PrimitiveType::Double),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                             false,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()

--- a/crates/iceberg/src/arrow/value.rs
+++ b/crates/iceberg/src/arrow/value.rs
@@ -56,13 +56,13 @@ impl SchemaWithPartnerVisitor<ArrayRef> for ArrowArrayToIcebergStructConverter {
         value: Vec<Option<Literal>>,
     ) -> Result<Vec<Option<Literal>>> {
         // Make there is no null value if the field is required
-        if field.required && value.iter().any(Option::is_none) {
+        if field.is_required() && value.iter().any(Option::is_none) {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 "The field is required but has null value",
             )
-            .with_context("field_id", field.id.to_string())
-            .with_context("field_name", &field.name));
+            .with_context("field_id", field.id().to_string())
+            .with_context("field_name", field.name()));
         }
         Ok(value)
     }
@@ -110,7 +110,7 @@ impl SchemaWithPartnerVisitor<ArrayRef> for ArrowArrayToIcebergStructConverter {
         array: &ArrayRef,
         elements: Vec<Option<Literal>>,
     ) -> Result<Vec<Option<Literal>>> {
-        if list.element_field.required && elements.iter().any(Option::is_none) {
+        if list.element_field.is_required() && elements.iter().any(Option::is_none) {
             return Err(Error::new(
                 ErrorKind::DataInvalid,
                 "The list should not have null value",
@@ -458,9 +458,9 @@ impl FieldMatchMode {
     pub fn match_field(&self, arrow_field: &FieldRef, iceberg_field: &NestedField) -> bool {
         match self {
             FieldMatchMode::Id => get_field_id_from_metadata(arrow_field)
-                .map(|id| id == iceberg_field.id)
+                .map(|id| id == iceberg_field.id())
                 .unwrap_or(false),
-            FieldMatchMode::Name => arrow_field.name() == &iceberg_field.name,
+            FieldMatchMode::Name => arrow_field.name() == iceberg_field.name(),
         }
     }
 }
@@ -526,7 +526,7 @@ impl PartnerAccessor<ArrayRef> for ArrowArrayAccessor {
             .ok_or_else(|| {
                 Error::new(
                     ErrorKind::DataInvalid,
-                    format!("Field id {} not found in struct array", field.id),
+                    format!("Field id {} not found in struct array", field.id()),
                 )
             })?;
 
@@ -1134,69 +1134,69 @@ mod test {
         ])) as ArrayRef;
 
         let iceberg_struct_type = StructType::new(vec![
-            Arc::new(NestedField::optional(
-                0,
-                "bool_field",
-                Type::Primitive(PrimitiveType::Boolean),
-            )),
-            Arc::new(NestedField::optional(
-                2,
-                "int32_field",
-                Type::Primitive(PrimitiveType::Int),
-            )),
-            Arc::new(NestedField::optional(
-                3,
-                "int64_field",
-                Type::Primitive(PrimitiveType::Long),
-            )),
-            Arc::new(NestedField::optional(
-                4,
-                "float32_field",
-                Type::Primitive(PrimitiveType::Float),
-            )),
-            Arc::new(NestedField::optional(
-                5,
-                "float64_field",
-                Type::Primitive(PrimitiveType::Double),
-            )),
-            Arc::new(NestedField::optional(
-                6,
-                "decimal_field",
-                Type::Primitive(PrimitiveType::Decimal {
-                    precision: 10,
-                    scale: 2,
-                }),
-            )),
-            Arc::new(NestedField::optional(
-                7,
-                "date_field",
-                Type::Primitive(PrimitiveType::Date),
-            )),
-            Arc::new(NestedField::optional(
-                8,
-                "time_field",
-                Type::Primitive(PrimitiveType::Time),
-            )),
-            Arc::new(NestedField::optional(
-                9,
-                "timestamp_micro_field",
-                Type::Primitive(PrimitiveType::Timestamp),
-            )),
-            Arc::new(NestedField::optional(
-                10,
-                "timestamp_nao_field",
-                Type::Primitive(PrimitiveType::TimestampNs),
-            )),
-            Arc::new(NestedField::optional(
-                11,
-                "string_field",
-                Type::Primitive(PrimitiveType::String),
-            )),
-            Arc::new(NestedField::optional(
-                12,
-                "binary_field",
-                Type::Primitive(PrimitiveType::Binary),
-            )),
+            Arc::new(
+                NestedField::optional(0, "bool_field", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(2, "int32_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(3, "int64_field", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(4, "float32_field", Type::Primitive(PrimitiveType::Float))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(5, "float64_field", Type::Primitive(PrimitiveType::Double))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(
+                    6,
+                    "decimal_field",
+                    Type::Primitive(PrimitiveType::Decimal {
+                        precision: 10,
+                        scale: 2,
+                    }),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(7, "date_field", Type::Primitive(PrimitiveType::Date))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(8, "time_field", Type::Primitive(PrimitiveType::Time))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(
+                    9,
+                    "timestamp_micro_field",
+                    Type::Primitive(PrimitiveType::Timestamp),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(
+                    10,
+                    "timestamp_nao_field",
+                    Type::Primitive(PrimitiveType::TimestampNs),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(11, "string_field", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(12, "binary_field", Type::Primitive(PrimitiveType::Binary))
+                    .expect("valid nested field"),
+            ),
         ]);
 
         let result = arrow_struct_to_literal(&struct_array, &iceberg_struct_type).unwrap();
@@ -1292,16 +1292,14 @@ mod test {
         };
 
         let iceberg_struct_type = StructType::new(vec![
-            Arc::new(NestedField::optional(
-                0,
-                "a",
-                Type::Primitive(PrimitiveType::Int),
-            )),
-            Arc::new(NestedField::optional(
-                1,
-                "b",
-                Type::Primitive(PrimitiveType::Int),
-            )),
+            Arc::new(
+                NestedField::optional(0, "a", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(1, "b", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
+            ),
         ]);
 
         let result = arrow_struct_to_literal(&struct_array, &iceberg_struct_type).unwrap();
@@ -1348,7 +1346,9 @@ mod test {
         )])) as ArrayRef;
 
         let ty = StructType::new(vec![
-            NestedField::required(1, "v", Type::Variant(VariantType)).into(),
+            NestedField::required(1, "v", Type::Variant(VariantType))
+                .expect("valid nested field")
+                .into(),
         ]);
 
         let err = arrow_struct_to_literal(&struct_array, &ty).unwrap_err();
@@ -1430,24 +1430,24 @@ mod test {
             3,
             "nested_struct",
             Type::Struct(StructType::new(vec![
-                Arc::new(NestedField::optional(
-                    1,
-                    "field_a",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "field_b",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(2, "field_b", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])),
-        );
+        )
+        .expect("valid nested field");
         let nested_partner = accessor
             .field_partner(&struct_array, &nested_field)
             .unwrap();
 
         // Verify we can access the nested field
-        let field_a = NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int));
+        let field_a = NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int))
+            .expect("valid nested field");
         let field_a_partner = accessor.field_partner(nested_partner, &field_a).unwrap();
 
         // Verify the field has the expected value
@@ -1507,24 +1507,24 @@ mod test {
             3,
             "nested_struct",
             Type::Struct(StructType::new(vec![
-                Arc::new(NestedField::optional(
-                    1,
-                    "field_a",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "field_b",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(2, "field_b", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])),
-        );
+        )
+        .expect("valid nested field");
         let nested_partner = accessor
             .field_partner(&struct_array, &nested_field)
             .unwrap();
 
         // Verify we can access the nested field by name
-        let field_a = NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int));
+        let field_a = NestedField::optional(1, "field_a", Type::Primitive(PrimitiveType::Int))
+            .expect("valid nested field");
         let field_a_partner = accessor.field_partner(nested_partner, &field_a).unwrap();
 
         // Verify the field has the expected value
@@ -1546,53 +1546,90 @@ mod test {
         //   C: list< list<int> >,
         // >
         let struct_type = StructType::new(vec![
-            Arc::new(NestedField::required(
-                0,
-                "A",
-                Type::List(ListType::new(Arc::new(NestedField::required(
-                    1,
-                    "item",
-                    Type::Struct(StructType::new(vec![
-                        Arc::new(NestedField::required(
-                            2,
-                            "a1",
-                            Type::Primitive(PrimitiveType::Int),
-                        )),
-                        Arc::new(NestedField::required(
-                            3,
-                            "a2",
-                            Type::Primitive(PrimitiveType::Int),
-                        )),
-                    ])),
-                )))),
-            )),
-            Arc::new(NestedField::required(
-                4,
-                "B",
-                Type::List(ListType::new(Arc::new(NestedField::required(
-                    5,
-                    "item",
-                    Type::Map(MapType::new(
-                        NestedField::optional(6, "keys", Type::Primitive(PrimitiveType::Int))
-                            .into(),
-                        NestedField::optional(7, "values", Type::Primitive(PrimitiveType::Int))
-                            .into(),
-                    )),
-                )))),
-            )),
-            Arc::new(NestedField::required(
-                8,
-                "C",
-                Type::List(ListType::new(Arc::new(NestedField::required(
-                    9,
-                    "item",
-                    Type::List(ListType::new(Arc::new(NestedField::optional(
-                        10,
-                        "item",
-                        Type::Primitive(PrimitiveType::Int),
-                    )))),
-                )))),
-            )),
+            Arc::new(
+                NestedField::required(
+                    0,
+                    "A",
+                    Type::List(ListType::new(Arc::new(
+                        NestedField::required(
+                            1,
+                            "item",
+                            Type::Struct(StructType::new(vec![
+                                Arc::new(
+                                    NestedField::required(
+                                        2,
+                                        "a1",
+                                        Type::Primitive(PrimitiveType::Int),
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                                Arc::new(
+                                    NestedField::required(
+                                        3,
+                                        "a2",
+                                        Type::Primitive(PrimitiveType::Int),
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                            ])),
+                        )
+                        .expect("valid nested field"),
+                    ))),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::required(
+                    4,
+                    "B",
+                    Type::List(ListType::new(Arc::new(
+                        NestedField::required(
+                            5,
+                            "item",
+                            Type::Map(MapType::new(
+                                NestedField::optional(
+                                    6,
+                                    "keys",
+                                    Type::Primitive(PrimitiveType::Int),
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                                NestedField::optional(
+                                    7,
+                                    "values",
+                                    Type::Primitive(PrimitiveType::Int),
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                            )),
+                        )
+                        .expect("valid nested field"),
+                    ))),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::required(
+                    8,
+                    "C",
+                    Type::List(ListType::new(Arc::new(
+                        NestedField::required(
+                            9,
+                            "item",
+                            Type::List(ListType::new(Arc::new(
+                                NestedField::optional(
+                                    10,
+                                    "item",
+                                    Type::Primitive(PrimitiveType::Int),
+                                )
+                                .expect("valid nested field"),
+                            ))),
+                        )
+                        .expect("valid nested field"),
+                    ))),
+                )
+                .expect("valid nested field"),
+            ),
         ]);
 
         // Generate a complex nested struct array

--- a/crates/iceberg/src/avro/schema.rs
+++ b/crates/iceberg/src/avro/schema.rs
@@ -71,27 +71,27 @@ impl SchemaVisitor for SchemaToAvroSchema {
     ) -> Result<AvroSchemaOrField> {
         let mut field_schema = avro_schema.unwrap_left();
         if let AvroSchema::Record(record) = &mut field_schema {
-            record.name = Name::from(format!("r{}", field.id).as_str());
+            record.name = Name::from(format!("r{}", field.id()).as_str());
         }
 
-        if !field.required {
+        if !field.is_required() {
             field_schema = avro_optional(field_schema)?;
         }
 
-        let default = if let Some(literal) = &field.initial_default {
-            Some(literal.clone().try_into_json(&field.field_type)?)
-        } else if !field.required {
+        let default = if let Some(literal) = field.initial_default() {
+            Some(literal.clone().try_into_json(field.field_type())?)
+        } else if !field.is_required() {
             Some(Value::Null)
         } else {
             None
         };
 
         let mut avro_record_field = AvroRecordField {
-            name: field.name.clone(),
+            name: field.name().to_string(),
             schema: field_schema,
             order: RecordFieldOrder::Ignore,
             position: 0,
-            doc: field.doc.clone(),
+            doc: field.doc().map(ToString::to_string),
             aliases: None,
             default,
             custom_attributes: Default::default(),
@@ -99,7 +99,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
 
         avro_record_field.custom_attributes.insert(
             FIELD_ID_PROP.to_string(),
-            Value::Number(Number::from(field.id)),
+            Value::Number(Number::from(field.id())),
         );
 
         Ok(Either::Right(avro_record_field))
@@ -123,10 +123,10 @@ impl SchemaVisitor for SchemaToAvroSchema {
         let mut field_schema = value.unwrap_left();
 
         if let AvroSchema::Record(record) = &mut field_schema {
-            record.name = Name::from(format!("r{}", list.element_field.id).as_str());
+            record.name = Name::from(format!("r{}", list.element_field.id()).as_str());
         }
 
-        if !list.element_field.required {
+        if !list.element_field.is_required() {
             field_schema = avro_optional(field_schema)?;
         }
 
@@ -134,7 +134,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
             items: Box::new(field_schema),
             attributes: BTreeMap::from([(
                 ELEMENT_ID.to_string(),
-                Value::Number(Number::from(list.element_field.id)),
+                Value::Number(Number::from(list.element_field.id())),
             )]),
         })))
     }
@@ -147,7 +147,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
     ) -> Result<AvroSchemaOrField> {
         let key_field_schema = key_value.unwrap_left();
         let mut value_field_schema = value.unwrap_left();
-        if !map.value_field.required {
+        if !map.value_field.is_required() {
             value_field_schema = avro_optional(value_field_schema)?;
         }
 
@@ -157,11 +157,11 @@ impl SchemaVisitor for SchemaToAvroSchema {
                 attributes: BTreeMap::from([
                     (
                         KEY_ID.to_string(),
-                        Value::Number(Number::from(map.key_field.id)),
+                        Value::Number(Number::from(map.key_field.id())),
                     ),
                     (
                         VALUE_ID.to_string(),
-                        Value::Number(Number::from(map.value_field.id)),
+                        Value::Number(Number::from(map.value_field.id())),
                     ),
                 ]),
             })))
@@ -170,7 +170,7 @@ impl SchemaVisitor for SchemaToAvroSchema {
             // not string type.
             let key_field = {
                 let mut field = AvroRecordField {
-                    name: map.key_field.name.clone(),
+                    name: map.key_field.name().to_string(),
                     doc: None,
                     aliases: None,
                     default: None,
@@ -181,14 +181,14 @@ impl SchemaVisitor for SchemaToAvroSchema {
                 };
                 field.custom_attributes.insert(
                     FIELD_ID_PROP.to_string(),
-                    Value::Number(Number::from(map.key_field.id)),
+                    Value::Number(Number::from(map.key_field.id())),
                 );
                 field
             };
 
             let value_field = {
                 let mut field = AvroRecordField {
-                    name: map.value_field.name.clone(),
+                    name: map.value_field.name().to_string(),
                     doc: None,
                     aliases: None,
                     default: None,
@@ -199,14 +199,14 @@ impl SchemaVisitor for SchemaToAvroSchema {
                 };
                 field.custom_attributes.insert(
                     FIELD_ID_PROP.to_string(),
-                    Value::Number(Number::from(map.value_field.id)),
+                    Value::Number(Number::from(map.value_field.id())),
                 );
                 field
             };
 
             let fields = vec![key_field, value_field];
             let item_avro_schema = avro_record_schema(
-                format!("k{}_v{}", map.key_field.id, map.value_field.id).as_str(),
+                format!("k{}_v{}", map.key_field.id(), map.value_field.id()).as_str(),
                 fields,
             )?;
 
@@ -449,12 +449,13 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
 
             let optional = is_avro_optional(&avro_field.schema);
 
-            let mut field =
-                NestedField::new(field_id, &avro_field.name, field_type.unwrap(), !optional);
-
-            if let Some(doc) = &avro_field.doc {
-                field = field.with_doc(doc);
-            }
+            let field = NestedField::builder()
+                .id(field_id)
+                .name(&avro_field.name)
+                .field_type(field_type.unwrap())
+                .required(!optional)
+                .doc_opt(avro_field.doc.clone())
+                .build()?;
 
             fields.push(field.into());
         }
@@ -494,7 +495,7 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
             element_field_id,
             item.unwrap(),
             !is_avro_optional(&array.items),
-        )
+        )?
         .into();
         Ok(Some(Type::List(ListType { element_field })))
     }
@@ -502,13 +503,13 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
     fn map(&mut self, map: &MapSchema, value: Option<Type>) -> Result<Option<Type>> {
         let key_field_id = Self::get_element_id_from_attributes(&map.attributes, KEY_ID)?;
         let key_field =
-            NestedField::map_key_element(key_field_id, Type::Primitive(PrimitiveType::String));
+            NestedField::map_key_element(key_field_id, Type::Primitive(PrimitiveType::String))?;
         let value_field_id = Self::get_element_id_from_attributes(&map.attributes, VALUE_ID)?;
         let value_field = NestedField::map_value_element(
             value_field_id,
             value.unwrap(),
             !is_avro_optional(&map.types),
-        );
+        )?;
         Ok(Some(Type::Map(MapType {
             key_field: key_field.into(),
             value_field: value_field.into(),
@@ -571,12 +572,12 @@ impl AvroSchemaVisitor for AvroSchemaToSchema {
             &array.fields[1].custom_attributes,
             FIELD_ID_PROP,
         )?;
-        let key_field = NestedField::map_key_element(key_id, key);
+        let key_field = NestedField::map_key_element(key_id, key)?;
         let value_field = NestedField::map_value_element(
             value_id,
             value,
             !is_avro_optional(&array.fields[1].schema),
-        );
+        )?;
         Ok(Some(Type::Map(MapType {
             key_field: key_field.into(),
             value_field: value_field.into(),
@@ -659,76 +660,144 @@ mod tests {
         assert_eq!(iceberg_schema, converted_avro_converted_iceberg_schema);
     }
 
+    fn field_with_doc(
+        id: i32,
+        name: &str,
+        field_type: Type,
+        required: bool,
+        doc: &str,
+    ) -> NestedFieldRef {
+        Arc::new(
+            NestedField::builder()
+                .id(id)
+                .name(name)
+                .field_type(field_type)
+                .required(required)
+                .doc(doc)
+                .build()
+                .unwrap(),
+        )
+    }
+
     #[test]
     fn test_manifest_file_v1_schema() {
         let fields = vec![
-            NestedField::required(500, "manifest_path", PrimitiveType::String.into())
-                .with_doc("Location URI with FS scheme")
-                .into(),
-            NestedField::required(501, "manifest_length", PrimitiveType::Long.into())
-                .with_doc("Total file size in bytes")
-                .into(),
-            NestedField::required(502, "partition_spec_id", PrimitiveType::Int.into())
-                .with_doc("Spec ID used to write")
-                .into(),
-            NestedField::optional(503, "added_snapshot_id", PrimitiveType::Long.into())
-                .with_doc("Snapshot ID that added the manifest")
-                .into(),
-            NestedField::optional(504, "added_data_files_count", PrimitiveType::Int.into())
-                .with_doc("Added entry count")
-                .into(),
-            NestedField::optional(505, "existing_data_files_count", PrimitiveType::Int.into())
-                .with_doc("Existing entry count")
-                .into(),
-            NestedField::optional(506, "deleted_data_files_count", PrimitiveType::Int.into())
-                .with_doc("Deleted entry count")
-                .into(),
-            NestedField::optional(
+            field_with_doc(
+                500,
+                "manifest_path",
+                PrimitiveType::String.into(),
+                true,
+                "Location URI with FS scheme",
+            ),
+            field_with_doc(
+                501,
+                "manifest_length",
+                PrimitiveType::Long.into(),
+                true,
+                "Total file size in bytes",
+            ),
+            field_with_doc(
+                502,
+                "partition_spec_id",
+                PrimitiveType::Int.into(),
+                true,
+                "Spec ID used to write",
+            ),
+            field_with_doc(
+                503,
+                "added_snapshot_id",
+                PrimitiveType::Long.into(),
+                false,
+                "Snapshot ID that added the manifest",
+            ),
+            field_with_doc(
+                504,
+                "added_data_files_count",
+                PrimitiveType::Int.into(),
+                false,
+                "Added entry count",
+            ),
+            field_with_doc(
+                505,
+                "existing_data_files_count",
+                PrimitiveType::Int.into(),
+                false,
+                "Existing entry count",
+            ),
+            field_with_doc(
+                506,
+                "deleted_data_files_count",
+                PrimitiveType::Int.into(),
+                false,
+                "Deleted entry count",
+            ),
+            field_with_doc(
                 507,
                 "partitions",
                 ListType {
                     element_field: NestedField::list_element(
                         508,
                         StructType::new(vec![
-                            NestedField::required(
+                            field_with_doc(
                                 509,
                                 "contains_null",
                                 PrimitiveType::Boolean.into(),
-                            )
-                            .with_doc("True if any file has a null partition value")
-                            .into(),
-                            NestedField::optional(
+                                true,
+                                "True if any file has a null partition value",
+                            ),
+                            field_with_doc(
                                 518,
                                 "contains_nan",
                                 PrimitiveType::Boolean.into(),
-                            )
-                            .with_doc("True if any file has a nan partition value")
-                            .into(),
-                            NestedField::optional(510, "lower_bound", PrimitiveType::Binary.into())
-                                .with_doc("Partition lower bound for all files")
-                                .into(),
-                            NestedField::optional(511, "upper_bound", PrimitiveType::Binary.into())
-                                .with_doc("Partition upper bound for all files")
-                                .into(),
+                                false,
+                                "True if any file has a nan partition value",
+                            ),
+                            field_with_doc(
+                                510,
+                                "lower_bound",
+                                PrimitiveType::Binary.into(),
+                                false,
+                                "Partition lower bound for all files",
+                            ),
+                            field_with_doc(
+                                511,
+                                "upper_bound",
+                                PrimitiveType::Binary.into(),
+                                false,
+                                "Partition upper bound for all files",
+                            ),
                         ])
                         .into(),
                         true,
                     )
+                    .expect("valid nested field")
                     .into(),
                 }
                 .into(),
-            )
-            .with_doc("Summary for each partition")
-            .into(),
-            NestedField::optional(512, "added_rows_count", PrimitiveType::Long.into())
-                .with_doc("Added rows count")
-                .into(),
-            NestedField::optional(513, "existing_rows_count", PrimitiveType::Long.into())
-                .with_doc("Existing rows count")
-                .into(),
-            NestedField::optional(514, "deleted_rows_count", PrimitiveType::Long.into())
-                .with_doc("Deleted rows count")
-                .into(),
+                false,
+                "Summary for each partition",
+            ),
+            field_with_doc(
+                512,
+                "added_rows_count",
+                PrimitiveType::Long.into(),
+                false,
+                "Added rows count",
+            ),
+            field_with_doc(
+                513,
+                "existing_rows_count",
+                PrimitiveType::Long.into(),
+                false,
+                "Existing rows count",
+            ),
+            field_with_doc(
+                514,
+                "deleted_rows_count",
+                PrimitiveType::Long.into(),
+                false,
+                "Deleted rows count",
+            ),
         ];
 
         let iceberg_schema = Schema::builder().with_fields(fields).build().unwrap();
@@ -775,10 +844,12 @@ mod tests {
                                 PrimitiveType::String.into(),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }
                         .into(),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -826,10 +897,12 @@ mod tests {
                                 PrimitiveType::String.into(),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }
                         .into(),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -894,21 +967,25 @@ mod tests {
                                         "contains_null",
                                         PrimitiveType::Boolean.into(),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                     NestedField::optional(
                                         103,
                                         "contains_nan",
                                         PrimitiveType::Boolean.into(),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                 ])
                                 .into(),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }
                         .into(),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -996,57 +1073,72 @@ mod tests {
         let iceberg_schema = {
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        100,
-                        "optional",
-                        Type::Map(MapType {
-                            key_field: NestedField::map_key_element(
-                                102,
-                                PrimitiveType::Boolean.into(),
-                            )
-                            .into(),
-                            value_field: NestedField::map_value_element(
-                                103,
-                                PrimitiveType::Boolean.into(),
-                                false,
-                            )
-                            .into(),
-                        }),
-                    )),
-                    Arc::new(NestedField::required(
-                        104,
-                        "required",
-                        Type::Map(MapType {
-                            key_field: NestedField::map_key_element(
-                                105,
-                                PrimitiveType::Boolean.into(),
-                            )
-                            .into(),
-                            value_field: NestedField::map_value_element(
-                                106,
-                                PrimitiveType::Boolean.into(),
-                                true,
-                            )
-                            .into(),
-                        }),
-                    )),
-                    Arc::new(NestedField::required(
-                        107,
-                        "string_map",
-                        Type::Map(MapType {
-                            key_field: NestedField::map_key_element(
-                                108,
-                                PrimitiveType::String.into(),
-                            )
-                            .into(),
-                            value_field: NestedField::map_value_element(
-                                109,
-                                PrimitiveType::Long.into(),
-                                false,
-                            )
-                            .into(),
-                        }),
-                    )),
+                    Arc::new(
+                        NestedField::required(
+                            100,
+                            "optional",
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    102,
+                                    PrimitiveType::Boolean.into(),
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    103,
+                                    PrimitiveType::Boolean.into(),
+                                    false,
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            104,
+                            "required",
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    105,
+                                    PrimitiveType::Boolean.into(),
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    106,
+                                    PrimitiveType::Boolean.into(),
+                                    true,
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            107,
+                            "string_map",
+                            Type::Map(MapType {
+                                key_field: NestedField::map_key_element(
+                                    108,
+                                    PrimitiveType::String.into(),
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                                value_field: NestedField::map_value_element(
+                                    109,
+                                    PrimitiveType::Long.into(),
+                                    false,
+                                )
+                                .expect("valid nested field")
+                                .into(),
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap()
@@ -1107,8 +1199,11 @@ mod tests {
 
         let mut converter = AvroSchemaToSchema;
         let iceberg_type = Type::Map(MapType {
-            key_field: NestedField::map_key_element(101, PrimitiveType::String.into()).into(),
+            key_field: NestedField::map_key_element(101, PrimitiveType::String.into())
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(102, PrimitiveType::Long.into(), false)
+                .expect("valid nested field")
                 .into(),
         });
 
@@ -1228,7 +1323,9 @@ mod tests {
         // than emit an incorrect schema.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/catalog/memory/catalog.rs
+++ b/crates/iceberg/src/catalog/memory/catalog.rs
@@ -531,7 +531,9 @@ pub(crate) mod tests {
     fn simple_table_schema() -> Schema {
         Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()

--- a/crates/iceberg/src/catalog/mod.rs
+++ b/crates/iceberg/src/catalog/mod.rs
@@ -1535,9 +1535,15 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2076,9 +2082,15 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/encryption/key_metadata.rs
+++ b/crates/iceberg/src/encryption/key_metadata.rs
@@ -143,21 +143,22 @@ mod _serde {
     pub(super) static AVRO_SCHEMA_V1: LazyLock<AvroSchema> = LazyLock::new(|| {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    0,
-                    "encryption_key",
-                    Type::Primitive(PrimitiveType::Binary),
-                )),
-                Arc::new(NestedField::optional(
-                    1,
-                    "aad_prefix",
-                    Type::Primitive(PrimitiveType::Binary),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "file_length",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(
+                        0,
+                        "encryption_key",
+                        Type::Primitive(PrimitiveType::Binary),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(1, "aad_prefix", Type::Primitive(PrimitiveType::Binary))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(2, "file_length", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .expect("Failed to build StandardKeyMetadata Iceberg schema");

--- a/crates/iceberg/src/expr/predicate.rs
+++ b/crates/iceberg/src/expr/predicate.rs
@@ -387,22 +387,22 @@ impl Bind for Predicate {
 
                 match &bound_expr.op {
                     &PredicateOperator::IsNull => {
-                        if bound_expr.term.field().required {
+                        if bound_expr.term.field().is_required() {
                             return Ok(BoundPredicate::AlwaysFalse);
                         }
                     }
                     &PredicateOperator::NotNull => {
-                        if bound_expr.term.field().required {
+                        if bound_expr.term.field().is_required() {
                             return Ok(BoundPredicate::AlwaysTrue);
                         }
                     }
                     &PredicateOperator::IsNan | &PredicateOperator::NotNan => {
-                        if !bound_expr.term.field().field_type.is_floating_type() {
+                        if !bound_expr.term.field().field_type().is_floating_type() {
                             return Err(Error::new(
                                 ErrorKind::DataInvalid,
                                 format!(
                                     "Expecting floating point type, but found {}",
-                                    bound_expr.term.field().field_type
+                                    bound_expr.term.field().field_type()
                                 ),
                             ));
                         }
@@ -419,7 +419,9 @@ impl Bind for Predicate {
             }
             Predicate::Binary(expr) => {
                 let bound_expr = expr.bind(schema, case_sensitive)?;
-                let bound_literal = bound_expr.literal.to(&bound_expr.term.field().field_type)?;
+                let bound_literal = bound_expr
+                    .literal
+                    .to(bound_expr.term.field().field_type())?;
 
                 match bound_literal.literal() {
                     PrimitiveLiteral::AboveMax => match &bound_expr.op {
@@ -462,7 +464,7 @@ impl Bind for Predicate {
                 let bound_literals = bound_expr
                     .literals
                     .into_iter()
-                    .map(|l| l.to(&bound_expr.term.field().field_type))
+                    .map(|l| l.to(bound_expr.term.field().field_type()))
                     .collect::<Result<FnvHashSet<Datum>>>()?;
 
                 match &bound_expr.op {
@@ -1011,10 +1013,18 @@ mod tests {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![2])
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
-                    NestedField::optional(4, "qux", Type::Primitive(PrimitiveType::Float)).into(),
+                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(4, "qux", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/expr/term.rs
+++ b/crates/iceberg/src/expr/term.rs
@@ -323,7 +323,7 @@ impl Bind for Reference {
             )
         })?;
 
-        let accessor = schema.accessor_by_field_id(field.id).ok_or_else(|| {
+        let accessor = schema.accessor_by_field_id(field.id()).ok_or_else(|| {
             Error::new(
                 ErrorKind::DataInvalid,
                 format!("Accessor for Field {} not found", self.name),
@@ -396,9 +396,15 @@ mod tests {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![2])
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                    NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -413,7 +419,9 @@ mod tests {
         let accessor_ref = Arc::new(StructAccessor::new(1, PrimitiveType::Int));
         let expected_ref = BoundReference::new(
             "bar",
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
             accessor_ref.clone(),
         );
 
@@ -428,7 +436,9 @@ mod tests {
         let accessor_ref = Arc::new(StructAccessor::new(1, PrimitiveType::Int));
         let expected_ref = BoundReference::new(
             "BAR",
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
             accessor_ref.clone(),
         );
 

--- a/crates/iceberg/src/expr/visitors/bound_predicate_visitor.rs
+++ b/crates/iceberg/src/expr/visitors/bound_predicate_visitor.rs
@@ -391,21 +391,18 @@ mod tests {
     fn create_test_schema() -> SchemaRef {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "a",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "b",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    3,
-                    "c",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
+                Arc::new(
+                    NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "b", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(3, "c", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/expr/visitors/expression_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/expression_evaluator.rs
@@ -269,11 +269,9 @@ mod tests {
 
     fn create_partition_spec(r#type: PrimitiveType) -> Result<(PartitionSpecRef, SchemaRef)> {
         let schema = Schema::builder()
-            .with_fields(vec![Arc::new(NestedField::optional(
-                1,
-                "a",
-                Type::Primitive(r#type),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::optional(1, "a", Type::Primitive(r#type)).expect("valid nested field"),
+            )])
             .build()?;
 
         let spec = PartitionSpec::builder(schema.clone())

--- a/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/inclusive_metrics_evaluator.rs
@@ -101,7 +101,7 @@ impl<'a> InclusiveMetricsEvaluator<'a> {
         cmp_fn: fn(&Datum, &Datum) -> bool,
         use_lower_bound: bool,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -159,7 +159,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         match self.null_count(field_id) {
             Some(&0) => ROWS_CANNOT_MATCH,
@@ -173,7 +173,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -187,7 +187,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         match self.nan_count(field_id) {
             Some(&0) => ROWS_CANNOT_MATCH,
@@ -201,7 +201,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nans_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -252,7 +252,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -299,7 +299,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -357,7 +357,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.may_contain_null(field_id) {
             return ROWS_MIGHT_MATCH;
@@ -426,7 +426,7 @@ impl BoundPredicateVisitor for InclusiveMetricsEvaluator<'_> {
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> crate::Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
             return ROWS_CANNOT_MATCH;
@@ -1648,11 +1648,10 @@ mod test {
 
     fn create_test_partition_spec() -> (PartitionSpecRef, SchemaRef) {
         let table_schema = Schema::builder()
-            .with_fields(vec![Arc::new(NestedField::optional(
-                1,
-                "a",
-                Type::Primitive(PrimitiveType::Float),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::optional(1, "a", Type::Primitive(PrimitiveType::Float))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
         let table_schema_ref = Arc::new(table_schema);
@@ -1903,76 +1902,78 @@ mod test {
     fn create_test_schema() -> Arc<Schema> {
         let table_schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "no_stats",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::required(
-                    3,
-                    "required",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    4,
-                    "all_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    5,
-                    "some_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    6,
-                    "no_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    7,
-                    "all_nans",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    8,
-                    "some_nans",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    9,
-                    "no_nans",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    10,
-                    "all_nulls_double",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    11,
-                    "all_nans_v1_stats",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    12,
-                    "nan_and_null_only",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    13,
-                    "no_nan_stats",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    14,
-                    "some_empty",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(2, "no_stats", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(3, "required", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(4, "all_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(5, "some_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(6, "no_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(7, "all_nans", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(8, "some_nans", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(9, "no_nans", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        10,
+                        "all_nulls_double",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        11,
+                        "all_nans_v1_stats",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        12,
+                        "nan_and_null_only",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        13,
+                        "no_nan_stats",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(14, "some_empty", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/expr/visitors/inclusive_projection.rs
+++ b/crates/iceberg/src/expr/visitors/inclusive_projection.rs
@@ -61,7 +61,7 @@ impl InclusiveProjection {
         reference: &BoundReference,
         predicate: &BoundPredicate,
     ) -> Result<Predicate, Error> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         // This could be made a bit neater if `try_reduce` ever becomes stable
         self.get_parts_for_field_id(field_id)
@@ -245,21 +245,18 @@ mod tests {
     fn build_test_schema() -> Schema {
         Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "a",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "date",
-                    Type::Primitive(PrimitiveType::Date),
-                )),
-                Arc::new(NestedField::required(
-                    3,
-                    "name",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(1, "a", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "date", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(3, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap()

--- a/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/manifest_evaluator.rs
@@ -144,7 +144,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
 
         // contains_null encodes whether at least one partition value is null,
         // lowerBound is null if all partition values are null
-        if ManifestFilterVisitor::are_all_null(field, &reference.field().field_type) {
+        if ManifestFilterVisitor::are_all_null(field, reference.field().field_type()) {
             ROWS_CANNOT_MATCH
         } else {
             ROWS_MIGHT_MATCH
@@ -159,7 +159,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
             return ROWS_CANNOT_MATCH;
         }
 
-        if ManifestFilterVisitor::are_all_null(field, &reference.field().field_type) {
+        if ManifestFilterVisitor::are_all_null(field, reference.field().field_type()) {
             return ROWS_CANNOT_MATCH;
         }
 
@@ -189,7 +189,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
             Some(bound_bytes) => {
                 let bound = ManifestFilterVisitor::bytes_to_datum(
                     bound_bytes,
-                    *reference.field().field_type.clone(),
+                    reference.field().field_type().clone(),
                 );
                 if datum <= &bound {
                     ROWS_CANNOT_MATCH
@@ -212,7 +212,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
             Some(bound_bytes) => {
                 let bound = ManifestFilterVisitor::bytes_to_datum(
                     bound_bytes,
-                    *reference.field().field_type.clone(),
+                    reference.field().field_type().clone(),
                 );
                 if datum < &bound {
                     ROWS_CANNOT_MATCH
@@ -235,7 +235,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
             Some(bound_bytes) => {
                 let bound = ManifestFilterVisitor::bytes_to_datum(
                     bound_bytes,
-                    *reference.field().field_type.clone(),
+                    reference.field().field_type().clone(),
                 );
                 if datum >= &bound {
                     ROWS_CANNOT_MATCH
@@ -258,7 +258,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
             Some(bound_bytes) => {
                 let bound = ManifestFilterVisitor::bytes_to_datum(
                     bound_bytes,
-                    *reference.field().field_type.clone(),
+                    reference.field().field_type().clone(),
                 );
                 if datum > &bound {
                     ROWS_CANNOT_MATCH
@@ -285,7 +285,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         if let Some(lower_bound_bytes) = &field.lower_bound {
             let lower_bound = ManifestFilterVisitor::bytes_to_datum(
                 lower_bound_bytes,
-                *reference.field().field_type.clone(),
+                reference.field().field_type().clone(),
             );
             if &lower_bound > datum {
                 return ROWS_CANNOT_MATCH;
@@ -295,7 +295,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         if let Some(upper_bound_bytes) = &field.upper_bound {
             let upper_bound = ManifestFilterVisitor::bytes_to_datum(
                 upper_bound_bytes,
-                *reference.field().field_type.clone(),
+                reference.field().field_type().clone(),
             );
             if &upper_bound < datum {
                 return ROWS_CANNOT_MATCH;
@@ -412,7 +412,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         if let Some(lower_bound) = &field.lower_bound {
             let lower_bound = ManifestFilterVisitor::bytes_to_datum(
                 lower_bound,
-                *reference.field().clone().field_type,
+                reference.field().field_type().clone(),
             );
             if literals.iter().all(|datum| &lower_bound > datum) {
                 return ROWS_CANNOT_MATCH;
@@ -422,7 +422,7 @@ impl BoundPredicateVisitor for ManifestFilterVisitor<'_> {
         if let Some(upper_bound) = &field.upper_bound {
             let upper_bound = ManifestFilterVisitor::bytes_to_datum(
                 upper_bound,
-                *reference.field().clone().field_type,
+                reference.field().field_type().clone(),
             );
             if literals.iter().all(|datum| &upper_bound < datum) {
                 return ROWS_CANNOT_MATCH;
@@ -507,71 +507,90 @@ mod test {
     fn create_schema() -> Result<SchemaRef> {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "all_nulls_missing_nan",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    3,
-                    "some_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    4,
-                    "no_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    5,
-                    "float",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    6,
-                    "all_nulls_double",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    7,
-                    "all_nulls_no_nans",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    8,
-                    "all_nans",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    9,
-                    "both_nan_and_null",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    10,
-                    "no_nan_or_null",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    11,
-                    "all_nulls_missing_nan_float",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    12,
-                    "all_same_value_or_null",
-                    Type::Primitive(PrimitiveType::String),
-                )),
-                Arc::new(NestedField::optional(
-                    13,
-                    "no_nulls_same_value_a",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        2,
+                        "all_nulls_missing_nan",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(3, "some_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(4, "no_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(5, "float", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        6,
+                        "all_nulls_double",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        7,
+                        "all_nulls_no_nans",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(8, "all_nans", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        9,
+                        "both_nan_and_null",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        10,
+                        "no_nan_or_null",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        11,
+                        "all_nulls_missing_nan_float",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        12,
+                        "all_same_value_or_null",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        13,
+                        "no_nulls_same_value_a",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .expect("valid nested field"),
+                ),
             ])
             .build()?;
 

--- a/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/page_index_evaluator.rs
@@ -154,7 +154,7 @@ impl<'a> PageIndexEvaluator<'a> {
             ));
         };
 
-        let Some(field_type) = field.field_type.as_primitive_type() else {
+        let Some(field_type) = field.field_type().as_primitive_type() else {
             return Err(Error::new(
                 ErrorKind::Unexpected,
                 format!("Field with id {field_id} not convertible to primitive type"),
@@ -386,7 +386,7 @@ impl<'a> PageIndexEvaluator<'a> {
         cmp_fn: fn(&Datum, &Datum) -> bool,
         use_lower_bound: bool,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         self.calc_row_selection(
             field_id,
@@ -448,7 +448,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         self.calc_row_selection(
             field_id,
@@ -462,7 +462,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         self.calc_row_selection(
             field_id,
@@ -478,7 +478,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
     ) -> Result<RowSelection> {
         // NaN counts not present in ColumnChunkMetadata Statistics.
         // Only float columns can be NaN.
-        if reference.field().field_type.is_floating_type() {
+        if reference.field().field_type().is_floating_type() {
             self.select_all_rows()
         } else {
             self.skip_all_rows()
@@ -536,7 +536,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         self.calc_row_selection(
             field_id,
@@ -581,7 +581,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         let PrimitiveLiteral::String(datum) = datum.literal() else {
             return Err(Error::new(
@@ -647,7 +647,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         // notStartsWith will match unless all values must start with the prefix.
         // This happens when the lower and upper bounds both start with the prefix.
@@ -722,7 +722,7 @@ impl BoundPredicateVisitor for PageIndexEvaluator<'_> {
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<RowSelection> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if literals.len() > IN_PREDICATE_LIMIT {
             // skip evaluating the predicate if the number of values is too big
@@ -1344,18 +1344,19 @@ mod tests {
     fn build_iceberg_schema_and_field_map() -> Result<(Arc<Schema>, HashMap<i32, usize>)> {
         let iceberg_schema = Schema::builder()
             .with_fields([
-                Arc::new(NestedField::new(
-                    1,
-                    "col_float",
-                    Type::Primitive(PrimitiveType::Float),
-                    false,
-                )),
-                Arc::new(NestedField::new(
-                    2,
-                    "col_string",
-                    Type::Primitive(PrimitiveType::String),
-                    false,
-                )),
+                Arc::new(
+                    NestedField::new(1, "col_float", Type::Primitive(PrimitiveType::Float), false)
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::new(
+                        2,
+                        "col_string",
+                        Type::Primitive(PrimitiveType::String),
+                        false,
+                    )
+                    .expect("valid nested field"),
+                ),
             ])
             .build()?;
         let iceberg_schema_ref = Arc::new(iceberg_schema);

--- a/crates/iceberg/src/expr/visitors/rewrite_not.rs
+++ b/crates/iceberg/src/expr/visitors/rewrite_not.rs
@@ -330,8 +330,12 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "foo", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "foo", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/expr/visitors/row_group_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/row_group_metrics_evaluator.rs
@@ -122,7 +122,7 @@ impl<'a> RowGroupMetricsEvaluator<'a> {
             ));
         };
 
-        let Some(primitive_type) = field.field_type.as_primitive_type() else {
+        let Some(primitive_type) = field.field_type().as_primitive_type() else {
             return Err(Error::new(
                 ErrorKind::Unexpected,
                 format!(
@@ -158,7 +158,7 @@ impl<'a> RowGroupMetricsEvaluator<'a> {
         cmp_fn: fn(&Datum, &Datum) -> bool,
         use_lower_bound: bool,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROW_GROUP_CANT_MATCH;
@@ -212,7 +212,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
     }
 
     fn is_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         match self.null_count(field_id) {
             Some(0) => ROW_GROUP_CANT_MATCH,
@@ -226,7 +226,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROW_GROUP_CANT_MATCH;
@@ -291,7 +291,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROW_GROUP_CANT_MATCH;
@@ -338,7 +338,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROW_GROUP_CANT_MATCH;
@@ -396,7 +396,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.may_contain_null(field_id) {
             return ROW_GROUP_MIGHT_MATCH;
@@ -465,7 +465,7 @@ impl BoundPredicateVisitor for RowGroupMetricsEvaluator<'_> {
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROW_GROUP_CANT_MATCH;
@@ -1845,18 +1845,19 @@ mod tests {
     fn build_iceberg_schema_and_field_map() -> Result<(Arc<Schema>, HashMap<i32, usize>)> {
         let iceberg_schema = Schema::builder()
             .with_fields([
-                Arc::new(NestedField::new(
-                    1,
-                    "col_float",
-                    Type::Primitive(PrimitiveType::Float),
-                    false,
-                )),
-                Arc::new(NestedField::new(
-                    2,
-                    "col_string",
-                    Type::Primitive(PrimitiveType::String),
-                    false,
-                )),
+                Arc::new(
+                    NestedField::new(1, "col_float", Type::Primitive(PrimitiveType::Float), false)
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::new(
+                        2,
+                        "col_string",
+                        Type::Primitive(PrimitiveType::String),
+                        false,
+                    )
+                    .expect("valid nested field"),
+                ),
             ])
             .build()?;
         let iceberg_schema_ref = Arc::new(iceberg_schema);

--- a/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
+++ b/crates/iceberg/src/expr/visitors/strict_metrics_evaluator.rs
@@ -117,7 +117,7 @@ impl<'a> StrictMetricsEvaluator<'a> {
         cmp_fn: fn(&Datum, &Datum) -> bool,
         use_lower_bound: bool,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
             return ROWS_MIGHT_NOT_MATCH;
@@ -166,7 +166,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
     }
 
     fn is_null(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) {
             return ROWS_MUST_MATCH;
@@ -180,7 +180,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         reference: &BoundReference,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if let Some(&count) = self.null_count(field_id) {
             if count == 0 {
@@ -193,7 +193,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
     }
 
     fn is_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         let contains_only = self.contains_nans_only(field_id);
 
@@ -205,7 +205,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
     }
 
     fn not_nan(&mut self, reference: &BoundReference, _predicate: &BoundPredicate) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if let Some(&nan_count) = self.nan_count(field_id)
             && nan_count == 0
@@ -244,7 +244,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if let Some(lower) = self.lower_bound(field_id)
             && lower.is_nan()
@@ -270,7 +270,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
             return ROWS_MIGHT_NOT_MATCH;
@@ -296,7 +296,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         datum: &Datum,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
             return ROWS_MUST_MATCH;
@@ -347,7 +347,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.may_contain_null(field_id) || self.may_contain_nan(field_id) {
             return ROWS_MIGHT_NOT_MATCH;
@@ -371,7 +371,7 @@ impl BoundPredicateVisitor for StrictMetricsEvaluator<'_> {
         literals: &FnvHashSet<Datum>,
         _predicate: &BoundPredicate,
     ) -> Result<bool> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         if self.contains_nulls_only(field_id) || self.contains_nans_only(field_id) {
             return ROWS_MUST_MATCH;
@@ -431,89 +431,91 @@ mod test {
         let table_schema = Schema::builder()
             .with_fields(vec![
                 // field id=1: "id" (Int)
-                Arc::new(NestedField::required(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
+                Arc::new(
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
                 // field id=2: "no_stats" (Int)
-                Arc::new(NestedField::optional(
-                    2,
-                    "no_stats",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
+                Arc::new(
+                    NestedField::optional(2, "no_stats", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field"),
+                ),
                 // field id=3: "required" (String)
-                Arc::new(NestedField::required(
-                    3,
-                    "required",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(3, "required", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
                 // field id=4: "all_nulls" (String)
-                Arc::new(NestedField::optional(
-                    4,
-                    "all_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(4, "all_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
                 // field id=5: "some_nulls" (String)
-                Arc::new(NestedField::optional(
-                    5,
-                    "some_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(5, "some_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
                 // field id=6: "no_nulls" (String)
-                Arc::new(NestedField::optional(
-                    6,
-                    "no_nulls",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(6, "no_nulls", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
                 // field id=7: "all_nans" (Double)
-                Arc::new(NestedField::optional(
-                    7,
-                    "all_nans",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
+                Arc::new(
+                    NestedField::optional(7, "all_nans", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field"),
+                ),
                 // field id=8: "some_nans" (Float)
-                Arc::new(NestedField::optional(
-                    8,
-                    "some_nans",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
+                Arc::new(
+                    NestedField::optional(8, "some_nans", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
                 // field id=9: "no_nans" (Float)
-                Arc::new(NestedField::optional(
-                    9,
-                    "no_nans",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
+                Arc::new(
+                    NestedField::optional(9, "no_nans", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field"),
+                ),
                 // field id=10: "all_nulls_double" (Double)
-                Arc::new(NestedField::optional(
-                    10,
-                    "all_nulls_double",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
+                Arc::new(
+                    NestedField::optional(
+                        10,
+                        "all_nulls_double",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
                 // field id=11: "all_nans_v1_stats" (Float)
-                Arc::new(NestedField::optional(
-                    11,
-                    "all_nans_v1_stats",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
+                Arc::new(
+                    NestedField::optional(
+                        11,
+                        "all_nans_v1_stats",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
                 // field id=12: "nan_and_null_only" (Double)
-                Arc::new(NestedField::optional(
-                    12,
-                    "nan_and_null_only",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
+                Arc::new(
+                    NestedField::optional(
+                        12,
+                        "nan_and_null_only",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
                 // field id=13: "no_nan_stats" (Double)
-                Arc::new(NestedField::optional(
-                    13,
-                    "no_nan_stats",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
+                Arc::new(
+                    NestedField::optional(
+                        13,
+                        "no_nan_stats",
+                        Type::Primitive(PrimitiveType::Double),
+                    )
+                    .expect("valid nested field"),
+                ),
                 // field id=14: "some_empty" (String)
-                Arc::new(NestedField::optional(
-                    14,
-                    "some_empty",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(14, "some_empty", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/expr/visitors/strict_projection.rs
+++ b/crates/iceberg/src/expr/visitors/strict_projection.rs
@@ -68,7 +68,7 @@ impl StrictProjection {
         reference: &BoundReference,
         predicate: &BoundPredicate,
     ) -> Result<Predicate, Error> {
-        let field_id = reference.field().id;
+        let field_id = reference.field().id();
 
         // This could be made a bit neater if `try_reduce` ever becomes stable
         self.get_parts_for_field_id(field_id).iter().try_fold(
@@ -263,31 +263,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -450,31 +457,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -689,31 +703,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -917,31 +938,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1145,31 +1173,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1299,31 +1334,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1527,31 +1569,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1755,31 +1804,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1983,31 +2039,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -2187,31 +2250,38 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::TimestamptzNs),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Timestamp))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            4,
+                            "col4",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            5,
+                            "col5",
+                            Type::Primitive(PrimitiveType::TimestamptzNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -2416,39 +2486,37 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Decimal {
-                            precision: 9,
-                            scale: 2,
-                        }),
-                    )),
-                    Arc::new(NestedField::required(
-                        4,
-                        "col4",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::required(
-                        5,
-                        "col5",
-                        Type::Primitive(PrimitiveType::Binary),
-                    )),
-                    Arc::new(NestedField::required(
-                        6,
-                        "col6",
-                        Type::Primitive(PrimitiveType::Uuid),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Decimal {
+                                precision: 9,
+                                scale: 2,
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(4, "col4", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(5, "col5", Type::Primitive(PrimitiveType::Binary))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(6, "col6", Type::Primitive(PrimitiveType::Uuid))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -2600,11 +2668,10 @@ mod tests {
     async fn test_strict_projection_identity() {
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::optional(
-                    1,
-                    "col1",
-                    Type::Primitive(PrimitiveType::Long),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::optional(1, "col1", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );
@@ -2707,24 +2774,25 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Decimal {
-                            precision: 9,
-                            scale: 2,
-                        }),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Decimal {
+                                precision: 9,
+                                scale: 2,
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -2930,24 +2998,25 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::required(
-                        1,
-                        "col1",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::required(
-                        2,
-                        "col2",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::required(
-                        3,
-                        "col3",
-                        Type::Primitive(PrimitiveType::Decimal {
-                            precision: 9,
-                            scale: 2,
-                        }),
-                    )),
+                    Arc::new(
+                        NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::required(
+                            3,
+                            "col3",
+                            Type::Primitive(PrimitiveType::Decimal {
+                                precision: 9,
+                                scale: 2,
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -3152,11 +3221,10 @@ mod tests {
     async fn test_strict_projection_truncate_string() {
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::required(
-                    1,
-                    "col1",
-                    Type::Primitive(PrimitiveType::String),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );

--- a/crates/iceberg/src/inspect/history.rs
+++ b/crates/iceberg/src/inspect/history.rs
@@ -60,14 +60,18 @@ impl<'a> HistoryTable<'a> {
                 1,
                 "made_current_at",
                 Type::Primitive(PrimitiveType::Timestamptz),
-            ),
-            NestedField::required(2, "snapshot_id", Type::Primitive(PrimitiveType::Long)),
-            NestedField::optional(3, "parent_id", Type::Primitive(PrimitiveType::Long)),
+            )
+            .expect("valid nested field"),
+            NestedField::required(2, "snapshot_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+            NestedField::optional(3, "parent_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
             NestedField::required(
                 4,
                 "is_current_ancestor",
                 Type::Primitive(PrimitiveType::Boolean),
-            ),
+            )
+            .expect("valid nested field"),
         ];
         crate::spec::Schema::builder()
             .with_fields(fields.into_iter().map(|f| f.into()))

--- a/crates/iceberg/src/inspect/manifests.rs
+++ b/crates/iceberg/src/inspect/manifests.rs
@@ -46,95 +46,122 @@ impl<'a> ManifestsTable<'a> {
     /// Returns the iceberg schema of the manifests table.
     pub fn schema(&self) -> crate::spec::Schema {
         let fields = vec![
-            NestedField::new(14, "content", Type::Primitive(PrimitiveType::Int), true),
-            NestedField::new(1, "path", Type::Primitive(PrimitiveType::String), true),
-            NestedField::new(2, "length", Type::Primitive(PrimitiveType::Long), true),
+            NestedField::new(14, "content", Type::Primitive(PrimitiveType::Int), true)
+                .expect("valid nested field"),
+            NestedField::new(1, "path", Type::Primitive(PrimitiveType::String), true)
+                .expect("valid nested field"),
+            NestedField::new(2, "length", Type::Primitive(PrimitiveType::Long), true)
+                .expect("valid nested field"),
             NestedField::new(
                 3,
                 "partition_spec_id",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 4,
                 "added_snapshot_id",
                 Type::Primitive(PrimitiveType::Long),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 5,
                 "added_data_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 6,
                 "existing_data_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 7,
                 "deleted_data_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 15,
                 "added_delete_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 16,
                 "existing_delete_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 17,
                 "deleted_delete_files_count",
                 Type::Primitive(PrimitiveType::Int),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
             NestedField::new(
                 8,
                 "partition_summaries",
                 Type::List(ListType {
-                    element_field: Arc::new(NestedField::new(
-                        9,
-                        "item",
-                        Type::Struct(StructType::new(vec![
-                            Arc::new(NestedField::new(
-                                10,
-                                "contains_null",
-                                Type::Primitive(PrimitiveType::Boolean),
-                                true,
-                            )),
-                            Arc::new(NestedField::new(
-                                11,
-                                "contains_nan",
-                                Type::Primitive(PrimitiveType::Boolean),
-                                false,
-                            )),
-                            Arc::new(NestedField::new(
-                                12,
-                                "lower_bound",
-                                Type::Primitive(PrimitiveType::String),
-                                false,
-                            )),
-                            Arc::new(NestedField::new(
-                                13,
-                                "upper_bound",
-                                Type::Primitive(PrimitiveType::String),
-                                false,
-                            )),
-                        ])),
-                        true,
-                    )),
+                    element_field: Arc::new(
+                        NestedField::new(
+                            9,
+                            "item",
+                            Type::Struct(StructType::new(vec![
+                                Arc::new(
+                                    NestedField::new(
+                                        10,
+                                        "contains_null",
+                                        Type::Primitive(PrimitiveType::Boolean),
+                                        true,
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                                Arc::new(
+                                    NestedField::new(
+                                        11,
+                                        "contains_nan",
+                                        Type::Primitive(PrimitiveType::Boolean),
+                                        false,
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                                Arc::new(
+                                    NestedField::new(
+                                        12,
+                                        "lower_bound",
+                                        Type::Primitive(PrimitiveType::String),
+                                        false,
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                                Arc::new(
+                                    NestedField::new(
+                                        13,
+                                        "upper_bound",
+                                        Type::Primitive(PrimitiveType::String),
+                                        false,
+                                    )
+                                    .expect("valid nested field"),
+                                ),
+                            ])),
+                            true,
+                        )
+                        .expect("valid nested field"),
+                    ),
                 }),
                 true,
-            ),
+            )
+            .expect("valid nested field"),
         ];
 
         crate::spec::Schema::builder()
@@ -264,17 +291,23 @@ impl<'a> ManifestsTable<'a> {
                 .field_builder::<StringBuilder>(2)
                 .unwrap()
                 .append_option(summary.lower_bound.as_ref().map(|v| {
-                    Datum::try_from_bytes(v, field.field_type.as_primitive_type().unwrap().clone())
-                        .unwrap()
-                        .to_string()
+                    Datum::try_from_bytes(
+                        v,
+                        field.field_type().as_primitive_type().unwrap().clone(),
+                    )
+                    .unwrap()
+                    .to_string()
                 }));
             partition_summaries_builder
                 .field_builder::<StringBuilder>(3)
                 .unwrap()
                 .append_option(summary.upper_bound.as_ref().map(|v| {
-                    Datum::try_from_bytes(v, field.field_type.as_primitive_type().unwrap().clone())
-                        .unwrap()
-                        .to_string()
+                    Datum::try_from_bytes(
+                        v,
+                        field.field_type().as_primitive_type().unwrap().clone(),
+                    )
+                    .unwrap()
+                    .to_string()
                 }));
             partition_summaries_builder.append(true);
         }

--- a/crates/iceberg/src/inspect/snapshots.rs
+++ b/crates/iceberg/src/inspect/snapshots.rs
@@ -51,26 +51,35 @@ impl<'a> SnapshotsTable<'a> {
                 1,
                 "committed_at",
                 Type::Primitive(PrimitiveType::Timestamptz),
-            ),
-            NestedField::required(2, "snapshot_id", Type::Primitive(PrimitiveType::Long)),
-            NestedField::optional(3, "parent_id", Type::Primitive(PrimitiveType::Long)),
-            NestedField::optional(4, "operation", Type::Primitive(PrimitiveType::String)),
-            NestedField::optional(5, "manifest_list", Type::Primitive(PrimitiveType::String)),
+            )
+            .expect("valid nested field"),
+            NestedField::required(2, "snapshot_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+            NestedField::optional(3, "parent_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+            NestedField::optional(4, "operation", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
+            NestedField::optional(5, "manifest_list", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
             NestedField::optional(
                 6,
                 "summary",
                 Type::Map(MapType {
-                    key_field: Arc::new(NestedField::map_key_element(
-                        7,
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    value_field: Arc::new(NestedField::map_value_element(
-                        8,
-                        Type::Primitive(PrimitiveType::String),
-                        false,
-                    )),
+                    key_field: Arc::new(
+                        NestedField::map_key_element(7, Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::map_value_element(
+                            8,
+                            Type::Primitive(PrimitiveType::String),
+                            false,
+                        )
+                        .expect("valid nested field"),
+                    ),
                 }),
-            ),
+            )
+            .expect("valid nested field"),
         ];
         crate::spec::Schema::builder()
             .with_fields(fields.into_iter().map(|f| f.into()))

--- a/crates/iceberg/src/io/object_cache.rs
+++ b/crates/iceberg/src/io/object_cache.rs
@@ -453,7 +453,9 @@ mod tests {
 
         let schema: SchemaRef = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()

--- a/crates/iceberg/src/metadata_columns.rs
+++ b/crates/iceberg/src/metadata_columns.rs
@@ -101,148 +101,154 @@ pub const RESERVED_COL_NAME_ROW_ID: &str = "_row_id";
 /// Reserved column name for the last updated sequence number metadata column
 pub const RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER: &str = "_last_updated_sequence_number";
 
+fn metadata_field(
+    id: i32,
+    name: &str,
+    field_type: Type,
+    required: bool,
+    doc: &str,
+) -> NestedFieldRef {
+    Arc::new(
+        NestedField::builder()
+            .id(id)
+            .name(name)
+            .field_type(field_type)
+            .required(required)
+            .doc(doc)
+            .build()
+            .expect("metadata fields must be valid"),
+    )
+}
+
 /// Lazy-initialized Iceberg field definition for the _file metadata column.
 /// This field represents the file path as a required string field.
 static FILE_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_FILE,
-            RESERVED_COL_NAME_FILE,
-            Type::Primitive(PrimitiveType::String),
-        )
-        .with_doc("Path of the file in which a row is stored"),
+    metadata_field(
+        RESERVED_FIELD_ID_FILE,
+        RESERVED_COL_NAME_FILE,
+        Type::Primitive(PrimitiveType::String),
+        true,
+        "Path of the file in which a row is stored",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _pos metadata column.
 /// This field represents the ordinal position of a row in the source data file.
 static POS_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_POS,
-            RESERVED_COL_NAME_POS,
-            Type::Primitive(PrimitiveType::Long),
-        )
-        .with_doc("Ordinal position of a row in the source data file"),
+    metadata_field(
+        RESERVED_FIELD_ID_POS,
+        RESERVED_COL_NAME_POS,
+        Type::Primitive(PrimitiveType::Long),
+        true,
+        "Ordinal position of a row in the source data file",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _deleted metadata column.
 /// This field indicates whether a row has been deleted.
 static DELETED_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_DELETED,
-            RESERVED_COL_NAME_DELETED,
-            Type::Primitive(PrimitiveType::Boolean),
-        )
-        .with_doc("Whether the row has been deleted"),
+    metadata_field(
+        RESERVED_FIELD_ID_DELETED,
+        RESERVED_COL_NAME_DELETED,
+        Type::Primitive(PrimitiveType::Boolean),
+        true,
+        "Whether the row has been deleted",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _spec_id metadata column.
 /// This field represents the spec ID used to track the file containing a row.
 static SPEC_ID_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_SPEC_ID,
-            RESERVED_COL_NAME_SPEC_ID,
-            Type::Primitive(PrimitiveType::Int),
-        )
-        .with_doc("Spec ID used to track the file containing a row"),
+    metadata_field(
+        RESERVED_FIELD_ID_SPEC_ID,
+        RESERVED_COL_NAME_SPEC_ID,
+        Type::Primitive(PrimitiveType::Int),
+        true,
+        "Spec ID used to track the file containing a row",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the file_path column in position delete files.
 /// This field represents the path of a file in position-based delete files.
 static DELETE_FILE_PATH_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_DELETE_FILE_PATH,
-            RESERVED_COL_NAME_DELETE_FILE_PATH,
-            Type::Primitive(PrimitiveType::String),
-        )
-        .with_doc("Path of a file, used in position-based delete files"),
+    metadata_field(
+        RESERVED_FIELD_ID_DELETE_FILE_PATH,
+        RESERVED_COL_NAME_DELETE_FILE_PATH,
+        Type::Primitive(PrimitiveType::String),
+        true,
+        "Path of a file, used in position-based delete files",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the pos column in position delete files.
 /// This field represents the ordinal position of a row in position-based delete files.
 static DELETE_FILE_POS_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_DELETE_FILE_POS,
-            RESERVED_COL_NAME_DELETE_FILE_POS,
-            Type::Primitive(PrimitiveType::Long),
-        )
-        .with_doc("Ordinal position of a row, used in position-based delete files"),
+    metadata_field(
+        RESERVED_FIELD_ID_DELETE_FILE_POS,
+        RESERVED_COL_NAME_DELETE_FILE_POS,
+        Type::Primitive(PrimitiveType::Long),
+        true,
+        "Ordinal position of a row, used in position-based delete files",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _change_type metadata column.
 /// This field represents the record type in the changelog.
 static CHANGE_TYPE_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_CHANGE_TYPE,
-            RESERVED_COL_NAME_CHANGE_TYPE,
-            Type::Primitive(PrimitiveType::String),
-        )
-        .with_doc(
-            "The record type in the changelog (INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER)",
-        ),
+    metadata_field(
+        RESERVED_FIELD_ID_CHANGE_TYPE,
+        RESERVED_COL_NAME_CHANGE_TYPE,
+        Type::Primitive(PrimitiveType::String),
+        true,
+        "The record type in the changelog (INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER)",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _change_ordinal metadata column.
 /// This field represents the order of the change.
 static CHANGE_ORDINAL_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_CHANGE_ORDINAL,
-            RESERVED_COL_NAME_CHANGE_ORDINAL,
-            Type::Primitive(PrimitiveType::Int),
-        )
-        .with_doc("The order of the change"),
+    metadata_field(
+        RESERVED_FIELD_ID_CHANGE_ORDINAL,
+        RESERVED_COL_NAME_CHANGE_ORDINAL,
+        Type::Primitive(PrimitiveType::Int),
+        true,
+        "The order of the change",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _commit_snapshot_id metadata column.
 /// This field represents the snapshot ID in which the change occurred.
 static COMMIT_SNAPSHOT_ID_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_COMMIT_SNAPSHOT_ID,
-            RESERVED_COL_NAME_COMMIT_SNAPSHOT_ID,
-            Type::Primitive(PrimitiveType::Long),
-        )
-        .with_doc("The snapshot ID in which the change occurred"),
+    metadata_field(
+        RESERVED_FIELD_ID_COMMIT_SNAPSHOT_ID,
+        RESERVED_COL_NAME_COMMIT_SNAPSHOT_ID,
+        Type::Primitive(PrimitiveType::Long),
+        true,
+        "The snapshot ID in which the change occurred",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _row_id metadata column.
 /// This field represents a unique long assigned for row lineage.
 static ROW_ID_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::optional(
-            RESERVED_FIELD_ID_ROW_ID,
-            RESERVED_COL_NAME_ROW_ID,
-            Type::Primitive(PrimitiveType::Long),
-        )
-        .with_doc("A unique long assigned for row lineage"),
+    metadata_field(
+        RESERVED_FIELD_ID_ROW_ID,
+        RESERVED_COL_NAME_ROW_ID,
+        Type::Primitive(PrimitiveType::Long),
+        false,
+        "A unique long assigned for row lineage",
     )
 });
 
 /// Lazy-initialized Iceberg field definition for the _last_updated_sequence_number metadata column.
 /// This field represents the sequence number which last updated this row.
 static LAST_UPDATED_SEQUENCE_NUMBER_FIELD: Lazy<NestedFieldRef> = Lazy::new(|| {
-    Arc::new(
-        NestedField::optional(
-            RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
-            RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
-            Type::Primitive(PrimitiveType::Long),
-        )
-        .with_doc("The sequence number which last updated this row"),
+    metadata_field(
+        RESERVED_FIELD_ID_LAST_UPDATED_SEQUENCE_NUMBER,
+        RESERVED_COL_NAME_LAST_UPDATED_SEQUENCE_NUMBER,
+        Type::Primitive(PrimitiveType::Long),
+        false,
+        "The sequence number which last updated this row",
     )
 });
 
@@ -353,29 +359,26 @@ pub fn last_updated_sequence_number_field() -> &'static NestedFieldRef {
 /// use iceberg::spec::{NestedField, PrimitiveType, Type};
 ///
 /// let fields = vec![
-///     Arc::new(NestedField::required(
-///         1,
-///         "year",
-///         Type::Primitive(PrimitiveType::Int),
-///     )),
-///     Arc::new(NestedField::required(
-///         2,
-///         "month",
-///         Type::Primitive(PrimitiveType::Int),
-///     )),
+///     Arc::new(
+///         NestedField::required(1, "year", Type::Primitive(PrimitiveType::Int))
+///             .expect("valid nested field"),
+///     ),
+///     Arc::new(
+///         NestedField::required(2, "month", Type::Primitive(PrimitiveType::Int))
+///             .expect("valid nested field"),
+///     ),
 /// ];
 /// let partition_field = partition_field(fields);
 /// ```
 pub fn partition_field(partition_fields: Vec<NestedFieldRef>) -> NestedFieldRef {
     use crate::spec::StructType;
 
-    Arc::new(
-        NestedField::required(
-            RESERVED_FIELD_ID_PARTITION,
-            RESERVED_COL_NAME_PARTITION,
-            Type::Struct(StructType::new(partition_fields)),
-        )
-        .with_doc("Partition to which a row belongs"),
+    metadata_field(
+        RESERVED_FIELD_ID_PARTITION,
+        RESERVED_COL_NAME_PARTITION,
+        Type::Struct(StructType::new(partition_fields)),
+        true,
+        "Partition to which a row belongs",
     )
 }
 
@@ -529,31 +532,29 @@ mod tests {
     fn test_partition_field_creation() {
         // Create partition fields for a hypothetical year/month partition
         let partition_fields = vec![
-            Arc::new(NestedField::required(
-                1000,
-                "year",
-                Type::Primitive(PrimitiveType::Int),
-            )),
-            Arc::new(NestedField::required(
-                1001,
-                "month",
-                Type::Primitive(PrimitiveType::Int),
-            )),
+            Arc::new(
+                NestedField::required(1000, "year", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::required(1001, "month", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
+            ),
         ];
 
         // Create the _partition metadata field
         let partition = partition_field(partition_fields);
 
         // Verify field properties
-        assert_eq!(partition.id, RESERVED_FIELD_ID_PARTITION);
-        assert_eq!(partition.name, RESERVED_COL_NAME_PARTITION);
-        assert!(partition.required);
+        assert_eq!(partition.id(), RESERVED_FIELD_ID_PARTITION);
+        assert_eq!(partition.name(), RESERVED_COL_NAME_PARTITION);
+        assert!(partition.is_required());
 
         // Verify it's a struct type with correct fields
-        if let Type::Struct(struct_type) = partition.field_type.as_ref() {
+        if let Type::Struct(struct_type) = partition.field_type() {
             assert_eq!(struct_type.fields().len(), 2);
-            assert_eq!(struct_type.fields()[0].name, "year");
-            assert_eq!(struct_type.fields()[1].name, "month");
+            assert_eq!(struct_type.fields()[0].name(), "year");
+            assert_eq!(struct_type.fields()[1].name(), "month");
         } else {
             panic!("Expected struct type for _partition field");
         }
@@ -606,8 +607,8 @@ mod tests {
         // The spec requires readers to produce null for these columns in
         // legitimate cases (e.g. a data file with a null first_row_id), so the
         // fields must be optional rather than required.
-        assert!(!row_id_field().required);
-        assert!(!last_updated_sequence_number_field().required);
+        assert!(!row_id_field().is_required());
+        assert!(!last_updated_sequence_number_field().is_required());
     }
 
     #[test]

--- a/crates/iceberg/src/partitioning.rs
+++ b/crates/iceberg/src/partitioning.rs
@@ -89,7 +89,7 @@ pub fn compute_unified_partition_type<'a>(
 
             match field_map.get(&field_id) {
                 None => {
-                    let res_type = field.transform.result_type(&source_field.field_type)?;
+                    let res_type = field.transform.result_type(source_field.field_type())?;
                     field_map.insert(field_id, field);
                     type_map.insert(field_id, res_type);
                     name_map.insert(field_id, field.name.clone());
@@ -112,7 +112,7 @@ pub fn compute_unified_partition_type<'a>(
                     // newer spec voided the field but an older spec has a real transform,
                     // keep the older spec's type.
                     if is_void_transform(existing) && !is_void_transform(field) {
-                        let res_type = field.transform.result_type(&source_field.field_type)?;
+                        let res_type = field.transform.result_type(source_field.field_type())?;
                         field_map.insert(field_id, field);
                         type_map.insert(field_id, res_type);
                     }
@@ -139,7 +139,9 @@ pub fn compute_unified_partition_type<'a>(
                     format!("Missing type for partition field {fid}"),
                 )
             })?;
-            Ok(NestedField::optional(fid, name, ty).into())
+            Ok(NestedField::optional(fid, name, ty)
+                .expect("valid nested field")
+                .into())
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -186,10 +188,18 @@ mod tests {
     fn test_schema() -> Schema {
         Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
-                NestedField::required(4, "category", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "category", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()
@@ -216,9 +226,9 @@ mod tests {
 
         let result = compute_unified_partition_type([&spec].into_iter(), &schema).unwrap();
         assert_eq!(result.fields().len(), 1);
-        assert_eq!(result.fields()[0].name, "category");
+        assert_eq!(result.fields()[0].name(), "category");
         assert_eq!(
-            *result.fields()[0].field_type,
+            *result.fields()[0].field_type(),
             Type::Primitive(PrimitiveType::String)
         );
     }
@@ -230,9 +240,9 @@ mod tests {
 
         let result = compute_unified_partition_type([&spec].into_iter(), &schema).unwrap();
         assert_eq!(result.fields().len(), 1);
-        assert_eq!(result.fields()[0].name, "ts_year");
+        assert_eq!(result.fields()[0].name(), "ts_year");
         assert_eq!(
-            *result.fields()[0].field_type,
+            *result.fields()[0].field_type(),
             Type::Primitive(PrimitiveType::Int)
         );
     }
@@ -255,7 +265,7 @@ mod tests {
 
         let result = compute_unified_partition_type([&spec].into_iter(), &schema).unwrap();
         assert_eq!(result.fields().len(), 2);
-        assert!(result.fields()[0].id < result.fields()[1].id);
+        assert!(result.fields()[0].id() < result.fields()[1].id());
     }
 
     #[test]
@@ -291,7 +301,7 @@ mod tests {
         let result =
             compute_unified_partition_type([&spec_v0, &spec_v1].into_iter(), &schema).unwrap();
         assert_eq!(result.fields().len(), 1);
-        assert_eq!(result.fields()[0].name, "cat_new");
+        assert_eq!(result.fields()[0].name(), "cat_new");
     }
 
     #[test]
@@ -329,10 +339,10 @@ mod tests {
 
         assert_eq!(result.fields().len(), 1);
         // Name from newer spec
-        assert_eq!(result.fields()[0].name, "category_v2");
+        assert_eq!(result.fields()[0].name(), "category_v2");
         // Type from older non-void spec
         assert_eq!(
-            *result.fields()[0].field_type,
+            *result.fields()[0].field_type(),
             Type::Primitive(PrimitiveType::String)
         );
     }
@@ -342,8 +352,12 @@ mod tests {
         // Schema without field 4 (category was dropped)
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/scan/cache.rs
+++ b/crates/iceberg/src/scan/cache.rs
@@ -279,8 +279,12 @@ mod tests {
     fn dropped_partition_source_column_falls_back_to_always_true() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "part", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "part", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -295,7 +299,9 @@ mod tests {
         // Evolve the schema so that `part` is no longer present, leaving spec 0 unresolvable.
         let evolved_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/scan/mod.rs
+++ b/crates/iceberg/src/scan/mod.rs
@@ -56,7 +56,7 @@ fn resolve_field_id(schema: &Schema, column_name: &str, case_sensitive: bool) ->
     } else {
         schema
             .field_by_name_case_insensitive(column_name)
-            .map(|field| field.id)
+            .map(|field| field.id())
     }
 }
 
@@ -66,7 +66,7 @@ fn collect_scan_field_ids(
     case_sensitive: bool,
 ) -> Result<Vec<i32>> {
     let Some(column_names) = column_names else {
-        return Ok(schema.as_struct().fields().iter().map(|f| f.id).collect());
+        return Ok(schema.as_struct().fields().iter().map(|f| f.id()).collect());
     };
 
     column_names
@@ -2097,7 +2097,7 @@ pub mod tests {
                     .as_struct()
                     .fields()
                     .iter()
-                    .filter(|field| field.id != 1)
+                    .filter(|field| field.id() != 1)
                     .cloned(),
             )
             .with_identifier_field_ids(vec![2])
@@ -2633,11 +2633,10 @@ pub mod tests {
     fn file_scan_task_test_schema(primitive_type: PrimitiveType) -> Arc<Schema> {
         Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::required(
-                    1,
-                    "x",
-                    Type::Primitive(primitive_type),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(primitive_type))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         )
@@ -3182,8 +3181,12 @@ pub mod tests {
         let schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, column_name, Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, column_name, Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/scan/task.rs
+++ b/crates/iceberg/src/scan/task.rs
@@ -566,11 +566,10 @@ mod tests {
     ) -> (SchemaRef, Arc<PartitionSpec>) {
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::required(
-                    1,
-                    "x",
-                    Type::Primitive(primitive_type),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(primitive_type))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );
@@ -652,11 +651,10 @@ mod tests {
             schema_and_spec(PrimitiveType::Long, Transform::Identity);
         let current_schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::required(
-                    2,
-                    "y",
-                    Type::Primitive(PrimitiveType::String),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(2, "y", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );
@@ -678,11 +676,10 @@ mod tests {
             schema_and_spec(PrimitiveType::Timestamp, Transform::Day);
         let current_schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::required(
-                    1,
-                    "x",
-                    Type::Primitive(PrimitiveType::String),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );

--- a/crates/iceberg/src/spec/datatypes.rs
+++ b/crates/iceberg/src/spec/datatypes.rs
@@ -27,6 +27,7 @@ use ::serde::de::{MapAccess, Visitor};
 use serde::de::{Error, IntoDeserializer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
+use typed_builder::TypedBuilder;
 
 use super::values::Literal;
 use crate::ensure_data_valid;
@@ -312,7 +313,7 @@ impl<'de> Deserialize<'de> for Type {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where D: Deserializer<'de> {
         let type_serde = _serde::SerdeType::deserialize(deserializer)?;
-        Ok(Type::from(type_serde))
+        Type::try_from(type_serde).map_err(D::Error::custom)
     }
 }
 
@@ -552,26 +553,32 @@ impl fmt::Display for StructType {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Eq, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Eq, Clone, TypedBuilder)]
 #[serde(try_from = "SerdeNestedField", into = "SerdeNestedField")]
+#[builder(build_method(into = Result<NestedField>))]
 /// A struct is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema.
 /// Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type.
 /// Fields may have an optional comment or doc string. Fields can have default values.
 pub struct NestedField {
     /// Id unique in table schema
-    pub id: i32,
+    id: i32,
     /// Field Name
-    pub name: String,
+    #[builder(setter(into))]
+    name: String,
     /// Optional or required
-    pub required: bool,
+    required: bool,
     /// Datatype
-    pub field_type: Box<Type>,
+    #[builder(setter(transform = |field_type: Type| Box::new(field_type)))]
+    field_type: Box<Type>,
     /// Fields may have an optional comment or doc string.
-    pub doc: Option<String>,
+    #[builder(default, setter(strip_option(fallback = doc_opt), into))]
+    doc: Option<String>,
     /// Used to populate the field’s value for all records that were written before the field was added to the schema
-    pub initial_default: Option<Literal>,
+    #[builder(default, setter(strip_option(fallback = initial_default_opt)))]
+    initial_default: Option<Literal>,
     /// Used to populate the field’s value for any records written after the field was added to the schema, if the writer does not supply the field’s value
-    pub write_default: Option<Literal>,
+    #[builder(default, setter(strip_option(fallback = write_default_opt)))]
+    write_default: Option<Literal>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -605,22 +612,28 @@ impl TryFrom<SerdeNestedField> for NestedField {
             .transpose()?
             .flatten();
 
-        Ok(NestedField {
-            id: value.id,
-            name: value.name,
-            required: value.required,
-            initial_default,
-            write_default,
-            field_type: value.field_type,
-            doc: value.doc,
-        })
+        NestedField::builder()
+            .id(value.id)
+            .name(value.name)
+            .required(value.required)
+            .field_type(*value.field_type)
+            .doc_opt(value.doc)
+            .initial_default_opt(initial_default)
+            .write_default_opt(write_default)
+            .build()
     }
 }
 
 impl From<NestedField> for SerdeNestedField {
     fn from(value: NestedField) -> Self {
-        let initial_default = value.initial_default.map(|x| x.try_into_json(&value.field_type).expect("We should have checked this in NestedField::with_initial_default, it can't be converted to json value"));
-        let write_default = value.write_default.map(|x| x.try_into_json(&value.field_type).expect("We should have checked this in NestedField::with_write_default, it can't be converted to json value"));
+        let initial_default = value.initial_default.map(|x| {
+            x.try_into_json(&value.field_type)
+                .expect("NestedFieldBuilder validates initial defaults")
+        });
+        let write_default = value.write_default.map(|x| {
+            x.try_into_json(&value.field_type)
+                .expect("NestedFieldBuilder validates write defaults")
+        });
         SerdeNestedField {
             id: value.id,
             name: value.name,
@@ -637,66 +650,113 @@ impl From<NestedField> for SerdeNestedField {
 pub type NestedFieldRef = Arc<NestedField>;
 
 impl NestedField {
+    /// Get the id unique in the table schema.
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+
+    /// Get the field name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get whether the field is required.
+    pub fn is_required(&self) -> bool {
+        self.required
+    }
+
+    /// Get the field's data type.
+    pub fn field_type(&self) -> &Type {
+        &self.field_type
+    }
+
+    /// Get the field's documentation string.
+    pub fn doc(&self) -> Option<&str> {
+        self.doc.as_deref()
+    }
+
+    /// Get the field's initial default value.
+    pub fn initial_default(&self) -> Option<&Literal> {
+        self.initial_default.as_ref()
+    }
+
+    /// Get the field's write default value.
+    pub fn write_default(&self) -> Option<&Literal> {
+        self.write_default.as_ref()
+    }
+
     /// Construct a new field.
-    pub fn new(id: i32, name: impl ToString, field_type: Type, required: bool) -> Self {
-        Self {
-            id,
-            name: name.to_string(),
-            required,
-            field_type: Box::new(field_type),
-            doc: None,
-            initial_default: None,
-            write_default: None,
-        }
+    pub fn new(id: i32, name: impl ToString, field_type: Type, required: bool) -> Result<Self> {
+        Self::builder()
+            .id(id)
+            .name(name.to_string())
+            .required(required)
+            .field_type(field_type)
+            .build()
     }
 
     /// Construct a required field.
-    pub fn required(id: i32, name: impl ToString, field_type: Type) -> Self {
+    pub fn required(id: i32, name: impl ToString, field_type: Type) -> Result<Self> {
         Self::new(id, name, field_type, true)
     }
 
     /// Construct an optional field.
-    pub fn optional(id: i32, name: impl ToString, field_type: Type) -> Self {
+    pub fn optional(id: i32, name: impl ToString, field_type: Type) -> Result<Self> {
         Self::new(id, name, field_type, false)
     }
 
     /// Construct list type's element field.
-    pub fn list_element(id: i32, field_type: Type, required: bool) -> Self {
+    pub fn list_element(id: i32, field_type: Type, required: bool) -> Result<Self> {
         Self::new(id, LIST_FIELD_NAME, field_type, required)
     }
 
     /// Construct map type's key field.
-    pub fn map_key_element(id: i32, field_type: Type) -> Self {
+    pub fn map_key_element(id: i32, field_type: Type) -> Result<Self> {
         Self::required(id, MAP_KEY_FIELD_NAME, field_type)
     }
 
     /// Construct map type's value field.
-    pub fn map_value_element(id: i32, field_type: Type, required: bool) -> Self {
+    pub fn map_value_element(id: i32, field_type: Type, required: bool) -> Result<Self> {
         Self::new(id, MAP_VALUE_FIELD_NAME, field_type, required)
     }
 
-    /// Set the field's doc.
-    pub fn with_doc(mut self, doc: impl ToString) -> Self {
-        self.doc = Some(doc.to_string());
-        self
+    pub(crate) fn rebuild(&self, id: i32, field_type: Type) -> Result<Self> {
+        Self::builder()
+            .id(id)
+            .name(self.name.clone())
+            .required(self.required)
+            .field_type(field_type)
+            .doc_opt(self.doc.clone())
+            .initial_default_opt(self.initial_default.clone())
+            .write_default_opt(self.write_default.clone())
+            .build()
     }
 
-    /// Set the field's initial default value.
-    pub fn with_initial_default(mut self, value: Literal) -> Self {
-        self.initial_default = Some(value);
-        self
-    }
+    fn validate(&self) -> Result<()> {
+        for (default_name, default_value) in [
+            ("initial-default", self.initial_default.as_ref()),
+            ("write-default", self.write_default.as_ref()),
+        ] {
+            if let Some(default_value) = default_value {
+                default_value
+                    .clone()
+                    .try_into_json(&self.field_type)
+                    .map_err(|error| {
+                        error
+                            .with_context("field", self.name.clone())
+                            .with_context("default", default_name)
+                    })?;
+            }
+        }
 
-    /// Set the field's initial default value.
-    pub fn with_write_default(mut self, value: Literal) -> Self {
-        self.write_default = Some(value);
-        self
+        Ok(())
     }
+}
 
-    /// Set the id of the field.
-    pub(crate) fn with_id(mut self, id: i32) -> Self {
-        self.id = id;
-        self
+impl From<NestedField> for Result<NestedField> {
+    fn from(field: NestedField) -> Self {
+        field.validate()?;
+        Ok(field)
     }
 }
 
@@ -738,6 +798,7 @@ pub(super) mod _serde {
 
     use serde_derive::{Deserialize, Serialize};
 
+    use crate::Result;
     use crate::spec::datatypes::Type::Map;
     use crate::spec::datatypes::{
         ListType, MapType, NestedField, NestedFieldRef, PrimitiveType, StructType, Type,
@@ -772,9 +833,11 @@ pub(super) mod _serde {
         Variant(VariantType),
     }
 
-    impl From<SerdeType<'_>> for Type {
-        fn from(value: SerdeType) -> Self {
-            match value {
+    impl TryFrom<SerdeType<'_>> for Type {
+        type Error = crate::Error;
+
+        fn try_from(value: SerdeType) -> Result<Self> {
+            Ok(match value {
                 SerdeType::List {
                     r#type: _,
                     element_id,
@@ -785,7 +848,7 @@ pub(super) mod _serde {
                         element_id,
                         element.into_owned(),
                         element_required,
-                    )
+                    )?
                     .into(),
                 }),
                 SerdeType::Map {
@@ -796,12 +859,12 @@ pub(super) mod _serde {
                     value_required,
                     value,
                 } => Map(MapType {
-                    key_field: NestedField::map_key_element(key_id, key.into_owned()).into(),
+                    key_field: NestedField::map_key_element(key_id, key.into_owned())?.into(),
                     value_field: NestedField::map_value_element(
                         value_id,
                         value.into_owned(),
                         value_required,
-                    )
+                    )?
                     .into(),
                 }),
                 SerdeType::Struct { r#type: _, fields } => {
@@ -809,7 +872,7 @@ pub(super) mod _serde {
                 }
                 SerdeType::Primitive(p) => Self::Primitive(p),
                 SerdeType::Variant(v) => Self::Variant(v),
-            }
+            })
         }
     }
 
@@ -863,19 +926,19 @@ impl MapType {
     }
 
     /// Construct an optional map type with the given key and value fields.
-    pub fn optional(key_id: i32, key_type: Type, value_id: i32, value_type: Type) -> Self {
-        Self {
-            key_field: NestedField::map_key_element(key_id, key_type).into(),
-            value_field: NestedField::map_value_element(value_id, value_type, false).into(),
-        }
+    pub fn optional(key_id: i32, key_type: Type, value_id: i32, value_type: Type) -> Result<Self> {
+        Ok(Self {
+            key_field: NestedField::map_key_element(key_id, key_type)?.into(),
+            value_field: NestedField::map_value_element(value_id, value_type, false)?.into(),
+        })
     }
 
     /// Construct a required map type with the given key and value fields.
-    pub fn required(key_id: i32, key_type: Type, value_id: i32, value_type: Type) -> Self {
-        Self {
-            key_field: NestedField::map_key_element(key_id, key_type).into(),
-            value_field: NestedField::map_value_element(value_id, value_type, true).into(),
-        }
+    pub fn required(key_id: i32, key_type: Type, value_id: i32, value_type: Type) -> Result<Self> {
+        Ok(Self {
+            key_field: NestedField::map_key_element(key_id, key_type)?.into(),
+            value_field: NestedField::map_value_element(value_id, value_type, true)?.into(),
+        })
     }
 }
 
@@ -921,7 +984,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::spec::values::PrimitiveLiteral;
+    use crate::ErrorKind;
+    use crate::spec::values::{Map, PrimitiveLiteral, Struct};
 
     fn check_type_serde(json: &str, expected_type: Type) {
         let desered_type: Type = serde_json::from_str(json).unwrap();
@@ -965,18 +1029,23 @@ mod tests {
             Type::Struct(StructType {
                 fields: vec![
                     NestedField::required(1, "bool_field", Type::Primitive(PrimitiveType::Boolean))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(2, "int_field", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(3, "long_field", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(4, "float_field", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(
                         5,
                         "double_field",
                         Type::Primitive(PrimitiveType::Double),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         6,
@@ -986,54 +1055,65 @@ mod tests {
                             scale: 2,
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(7, "date_field", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(8, "time_field", Type::Primitive(PrimitiveType::Time))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(
                         9,
                         "timestamp_field",
                         Type::Primitive(PrimitiveType::Timestamp),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         10,
                         "timestamptz_field",
                         Type::Primitive(PrimitiveType::Timestamptz),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         11,
                         "timestamp_ns_field",
                         Type::Primitive(PrimitiveType::TimestampNs),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         12,
                         "timestamptz_ns_field",
                         Type::Primitive(PrimitiveType::TimestamptzNs),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(13, "uuid_field", Type::Primitive(PrimitiveType::Uuid))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(
                         14,
                         "fixed_field",
                         Type::Primitive(PrimitiveType::Fixed(10)),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         15,
                         "binary_field",
                         Type::Primitive(PrimitiveType::Binary),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         16,
                         "string_field",
                         Type::Primitive(PrimitiveType::String),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ],
                 id_lookup: OnceLock::default(),
@@ -1069,19 +1149,27 @@ mod tests {
             record,
             Type::Struct(StructType {
                 fields: vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Uuid))
-                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::UInt128(
+                    NestedField::builder()
+                        .id(1)
+                        .name("id")
+                        .required(true)
+                        .field_type(Type::Primitive(PrimitiveType::Uuid))
+                        .initial_default(Literal::Primitive(PrimitiveLiteral::UInt128(
                             Uuid::parse_str("0db3e2a8-9d1d-42b9-aa7b-74ebe558dceb")
                                 .unwrap()
                                 .as_u128(),
                         )))
-                        .with_write_default(Literal::Primitive(PrimitiveLiteral::UInt128(
+                        .write_default(Literal::Primitive(PrimitiveLiteral::UInt128(
                             Uuid::parse_str("ec5911be-b0a7-458c-8438-c9a3e53cffae")
                                 .unwrap()
                                 .as_u128(),
                         )))
+                        .build()
+                        .unwrap()
                         .into(),
-                    NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ],
                 id_lookup: HashMap::from([(1, 0), (2, 1)]).into(),
                 name_lookup: HashMap::from([("id".to_string(), 0), ("data".to_string(), 1)]).into(),
@@ -1142,30 +1230,43 @@ mod tests {
 "#;
 
         let struct_type = Type::Struct(StructType::new(vec![
-            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Uuid))
-                .with_initial_default(Literal::Primitive(PrimitiveLiteral::UInt128(
+            NestedField::builder()
+                .id(1)
+                .name("id")
+                .required(true)
+                .field_type(Type::Primitive(PrimitiveType::Uuid))
+                .initial_default(Literal::Primitive(PrimitiveLiteral::UInt128(
                     Uuid::parse_str("0db3e2a8-9d1d-42b9-aa7b-74ebe558dceb")
                         .unwrap()
                         .as_u128(),
                 )))
-                .with_write_default(Literal::Primitive(PrimitiveLiteral::UInt128(
+                .write_default(Literal::Primitive(PrimitiveLiteral::UInt128(
                     Uuid::parse_str("ec5911be-b0a7-458c-8438-c9a3e53cffae")
                         .unwrap()
                         .as_u128(),
                 )))
+                .build()
+                .unwrap()
                 .into(),
-            NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
             NestedField::required(
                 3,
                 "address",
                 Type::Struct(StructType::new(vec![
                     NestedField::required(4, "street", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::optional(5, "province", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::required(6, "zip", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(6, "zip", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])),
             )
+            .expect("valid nested field")
             .into(),
         ]));
 
@@ -1191,6 +1292,7 @@ mod tests {
                     Type::Primitive(PrimitiveType::String),
                     true,
                 )
+                .expect("valid nested field")
                 .into(),
             }),
         );
@@ -1213,24 +1315,29 @@ mod tests {
             record,
             Type::Map(MapType {
                 key_field: NestedField::map_key_element(4, Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
                 value_field: NestedField::map_value_element(
                     5,
                     Type::Primitive(PrimitiveType::Double),
                     false,
                 )
+                .expect("valid nested field")
                 .into(),
             }),
         );
 
         check_type_serde(
             record,
-            Type::Map(MapType::optional(
-                4,
-                Type::Primitive(PrimitiveType::String),
-                5,
-                Type::Primitive(PrimitiveType::Double),
-            )),
+            Type::Map(
+                MapType::optional(
+                    4,
+                    Type::Primitive(PrimitiveType::String),
+                    5,
+                    Type::Primitive(PrimitiveType::Double),
+                )
+                .expect("valid nested field"),
+            ),
         );
     }
 
@@ -1251,24 +1358,29 @@ mod tests {
             record,
             Type::Map(MapType {
                 key_field: NestedField::map_key_element(4, Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
                 value_field: NestedField::map_value_element(
                     5,
                     Type::Primitive(PrimitiveType::String),
                     false,
                 )
+                .expect("valid nested field")
                 .into(),
             }),
         );
 
         check_type_serde(
             record,
-            Type::Map(MapType::optional(
-                4,
-                Type::Primitive(PrimitiveType::Int),
-                5,
-                Type::Primitive(PrimitiveType::String),
-            )),
+            Type::Map(
+                MapType::optional(
+                    4,
+                    Type::Primitive(PrimitiveType::Int),
+                    5,
+                    Type::Primitive(PrimitiveType::String),
+                )
+                .expect("valid nested field"),
+            ),
         );
     }
 
@@ -1287,12 +1399,15 @@ mod tests {
 
         check_type_serde(
             record,
-            Type::Map(MapType::required(
-                4,
-                Type::Primitive(PrimitiveType::Int),
-                5,
-                Type::Primitive(PrimitiveType::String),
-            )),
+            Type::Map(
+                MapType::required(
+                    4,
+                    Type::Primitive(PrimitiveType::Int),
+                    5,
+                    Type::Primitive(PrimitiveType::String),
+                )
+                .expect("valid nested field"),
+            ),
         );
     }
 
@@ -1381,6 +1496,91 @@ mod tests {
             let error = serde_json::from_str::<NestedField>(&json).unwrap_err();
             assert!(error.to_string().contains("must have the same length"));
         }
+    }
+
+    #[test]
+    fn nested_field_builder_sets_fields() {
+        let field = NestedField::builder()
+            .id(1)
+            .name("count")
+            .required(true)
+            .field_type(Type::Primitive(PrimitiveType::Int))
+            .doc("number of items")
+            .initial_default(Literal::int(1))
+            .write_default(Literal::int(2))
+            .build()
+            .unwrap();
+
+        assert_eq!(field.id(), 1);
+        assert_eq!(field.name(), "count");
+        assert!(field.is_required());
+        assert_eq!(field.field_type(), &Type::Primitive(PrimitiveType::Int));
+        assert_eq!(field.doc(), Some("number of items"));
+        assert_eq!(field.initial_default(), Some(&Literal::int(1)));
+        assert_eq!(field.write_default(), Some(&Literal::int(2)));
+    }
+
+    #[test]
+    fn nested_field_builder_rejects_incompatible_defaults() {
+        let struct_type = Type::Struct(StructType::new(vec![Arc::new(
+            NestedField::required(2, "value", Type::Primitive(PrimitiveType::String)).unwrap(),
+        )]));
+        let list_type = Type::List(ListType::new(
+            NestedField::list_element(3, Type::Primitive(PrimitiveType::Int), false)
+                .unwrap()
+                .into(),
+        ));
+        let map_type = Type::Map(
+            MapType::optional(
+                4,
+                Type::Primitive(PrimitiveType::String),
+                5,
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .unwrap(),
+        );
+
+        let cases = [
+            (Type::Primitive(PrimitiveType::String), Literal::int(1)),
+            (
+                Type::Primitive(PrimitiveType::Fixed(2)),
+                Literal::binary([1]),
+            ),
+            (
+                struct_type,
+                Literal::Struct(Struct::from_iter([Some(Literal::int(1))])),
+            ),
+            (list_type, Literal::List(vec![Some(Literal::string("one"))])),
+            (
+                map_type,
+                Literal::Map(Map::from([(Literal::int(1), Some(Literal::int(2)))])),
+            ),
+        ];
+
+        for (field_type, default) in cases {
+            let error = NestedField::builder()
+                .id(1)
+                .name("invalid")
+                .required(false)
+                .field_type(field_type)
+                .initial_default(default)
+                .build()
+                .unwrap_err();
+
+            assert_eq!(error.kind(), ErrorKind::DataInvalid);
+            assert!(error.to_string().contains("field: invalid"));
+            assert!(error.to_string().contains("default: initial-default"));
+        }
+
+        let error = NestedField::builder()
+            .id(1)
+            .name("invalid")
+            .required(false)
+            .field_type(Type::Primitive(PrimitiveType::String))
+            .write_default(Literal::int(1))
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("default: write-default"));
     }
 
     #[test]

--- a/crates/iceberg/src/spec/manifest/_serde.rs
+++ b/crates/iceberg/src/spec/manifest/_serde.rs
@@ -249,12 +249,12 @@ fn parse_bytes_entry(v: Vec<BytesEntry>, schema: &Schema) -> Result<HashMap<i32,
 
         if let Some(field) = field {
             let data_type = field
-                .field_type
+                .field_type()
                 .as_primitive_type()
                 .ok_or_else(|| {
                     Error::new(
                         ErrorKind::DataInvalid,
-                        format!("field {} is not a primitive type", field.name),
+                        format!("field {} is not a primitive type", field.name()),
                     )
                 })?
                 .clone();
@@ -346,21 +346,18 @@ mod tests {
         Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "v1",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v2",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "v3",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "v1", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v2", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(3, "v3", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/spec/manifest/entry.rs
+++ b/crates/iceberg/src/spec/manifest/entry.rs
@@ -182,330 +182,350 @@ use super::DataFileFormat;
 
 static STATUS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            0,
-            "status",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(0, "status", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static SNAPSHOT_ID_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            1,
-            "snapshot_id",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(1, "snapshot_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static SNAPSHOT_ID_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            1,
-            "snapshot_id",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(1, "snapshot_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static SEQUENCE_NUMBER: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            3,
-            "sequence_number",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(3, "sequence_number", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static FILE_SEQUENCE_NUMBER: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            4,
-            "file_sequence_number",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(
+                4,
+                "file_sequence_number",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static CONTENT: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
         Arc::new(
-            NestedField::required(134, "content", Type::Primitive(PrimitiveType::Int))
+            NestedField::builder()
+                .id(134)
+                .name("content")
+                .required(true)
+                .field_type(Type::Primitive(PrimitiveType::Int))
                 // 0 refers to DataContentType::DATA
-                .with_initial_default(Literal::Primitive(PrimitiveLiteral::Int(0))),
+                .initial_default(Literal::Primitive(PrimitiveLiteral::Int(0)))
+                .build()
+                .expect("valid content field"),
         )
     })
 };
 
 static FILE_PATH: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            100,
-            "file_path",
-            Type::Primitive(PrimitiveType::String),
-        ))
+        Arc::new(
+            NestedField::required(100, "file_path", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static FILE_FORMAT: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            101,
-            "file_format",
-            Type::Primitive(PrimitiveType::String),
-        ))
+        Arc::new(
+            NestedField::required(101, "file_format", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static RECORD_COUNT: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            103,
-            "record_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(103, "record_count", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static FILE_SIZE_IN_BYTES: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            104,
-            "file_size_in_bytes",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                104,
+                "file_size_in_bytes",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 // Deprecated. Always write a default in v1. Do not write in v2.
 static BLOCK_SIZE_IN_BYTES: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            105,
-            "block_size_in_bytes",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                105,
+                "block_size_in_bytes",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static COLUMN_SIZES: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            108,
-            "column_sizes",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    117,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    118,
-                    "value",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                108,
+                "column_sizes",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(117, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(118, "value", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static VALUE_COUNTS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            109,
-            "value_counts",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    119,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    120,
-                    "value",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                109,
+                "value_counts",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(119, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(120, "value", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static NULL_VALUE_COUNTS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            110,
-            "null_value_counts",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    121,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    122,
-                    "value",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                110,
+                "null_value_counts",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(121, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(122, "value", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static NAN_VALUE_COUNTS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            137,
-            "nan_value_counts",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    138,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    139,
-                    "value",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                137,
+                "nan_value_counts",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(138, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(139, "value", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static LOWER_BOUNDS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            125,
-            "lower_bounds",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    126,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    127,
-                    "value",
-                    Type::Primitive(PrimitiveType::Binary),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                125,
+                "lower_bounds",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(126, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(127, "value", Type::Primitive(PrimitiveType::Binary))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static UPPER_BOUNDS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            128,
-            "upper_bounds",
-            Type::Map(MapType {
-                key_field: Arc::new(NestedField::required(
-                    129,
-                    "key",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-                value_field: Arc::new(NestedField::required(
-                    130,
-                    "value",
-                    Type::Primitive(PrimitiveType::Binary),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                128,
+                "upper_bounds",
+                Type::Map(MapType {
+                    key_field: Arc::new(
+                        NestedField::required(129, "key", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    value_field: Arc::new(
+                        NestedField::required(130, "value", Type::Primitive(PrimitiveType::Binary))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static KEY_METADATA: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            131,
-            "key_metadata",
-            Type::Primitive(PrimitiveType::Binary),
-        ))
+        Arc::new(
+            NestedField::optional(131, "key_metadata", Type::Primitive(PrimitiveType::Binary))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static SPLIT_OFFSETS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            132,
-            "split_offsets",
-            Type::List(ListType {
-                element_field: Arc::new(NestedField::required(
-                    133,
-                    "element",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                132,
+                "split_offsets",
+                Type::List(ListType {
+                    element_field: Arc::new(
+                        NestedField::required(133, "element", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static EQUALITY_IDS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            135,
-            "equality_ids",
-            Type::List(ListType {
-                element_field: Arc::new(NestedField::required(
-                    136,
-                    "element",
-                    Type::Primitive(PrimitiveType::Int),
-                )),
-            }),
-        ))
+        Arc::new(
+            NestedField::optional(
+                135,
+                "equality_ids",
+                Type::List(ListType {
+                    element_field: Arc::new(
+                        NestedField::required(136, "element", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                }),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static SORT_ORDER_ID: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            140,
-            "sort_order_id",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::optional(140, "sort_order_id", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static FIRST_ROW_ID: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            142,
-            "first_row_id",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(142, "first_row_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static REFERENCE_DATA_FILE: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            143,
-            "referenced_data_file",
-            Type::Primitive(PrimitiveType::String),
-        ))
+        Arc::new(
+            NestedField::optional(
+                143,
+                "referenced_data_file",
+                Type::Primitive(PrimitiveType::String),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
 static CONTENT_OFFSET: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            144,
-            "content_offset",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(144, "content_offset", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 
 static CONTENT_SIZE_IN_BYTES: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            145,
-            "content_size_in_bytes",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(
+                145,
+                "content_size_in_bytes",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 
@@ -514,11 +534,10 @@ fn data_file_fields_v3(partition_type: &StructType) -> Vec<NestedFieldRef> {
         CONTENT.clone(),
         FILE_PATH.clone(),
         FILE_FORMAT.clone(),
-        Arc::new(NestedField::required(
-            102,
-            "partition",
-            Type::Struct(partition_type.clone()),
-        )),
+        Arc::new(
+            NestedField::required(102, "partition", Type::Struct(partition_type.clone()))
+                .expect("valid nested field"),
+        ),
         RECORD_COUNT.clone(),
         FILE_SIZE_IN_BYTES.clone(),
         COLUMN_SIZES.clone(),
@@ -550,11 +569,10 @@ fn data_file_fields_v2(partition_type: &StructType) -> Vec<NestedFieldRef> {
         CONTENT.clone(),
         FILE_PATH.clone(),
         FILE_FORMAT.clone(),
-        Arc::new(NestedField::required(
-            102,
-            "partition",
-            Type::Struct(partition_type.clone()),
-        )),
+        Arc::new(
+            NestedField::required(102, "partition", Type::Struct(partition_type.clone()))
+                .expect("valid nested field"),
+        ),
         RECORD_COUNT.clone(),
         FILE_SIZE_IN_BYTES.clone(),
         COLUMN_SIZES.clone(),
@@ -589,11 +607,14 @@ pub(super) fn manifest_schema_v2(partition_type: &StructType) -> Result<AvroSche
         SNAPSHOT_ID_V2.clone(),
         SEQUENCE_NUMBER.clone(),
         FILE_SEQUENCE_NUMBER.clone(),
-        Arc::new(NestedField::required(
-            2,
-            "data_file",
-            Type::Struct(StructType::new(data_file_fields_v2(partition_type))),
-        )),
+        Arc::new(
+            NestedField::required(
+                2,
+                "data_file",
+                Type::Struct(StructType::new(data_file_fields_v2(partition_type))),
+            )
+            .expect("valid nested field"),
+        ),
     ];
     let schema = Schema::builder().with_fields(fields).build()?;
     schema_to_avro_schema("manifest_entry", &schema)
@@ -603,11 +624,10 @@ fn data_file_fields_v1(partition_type: &StructType) -> Vec<NestedFieldRef> {
     vec![
         FILE_PATH.clone(),
         FILE_FORMAT.clone(),
-        Arc::new(NestedField::required(
-            102,
-            "partition",
-            Type::Struct(partition_type.clone()),
-        )),
+        Arc::new(
+            NestedField::required(102, "partition", Type::Struct(partition_type.clone()))
+                .expect("valid nested field"),
+        ),
         RECORD_COUNT.clone(),
         FILE_SIZE_IN_BYTES.clone(),
         BLOCK_SIZE_IN_BYTES.clone(),
@@ -634,11 +654,14 @@ pub(super) fn manifest_schema_v1(partition_type: &StructType) -> Result<AvroSche
     let fields = vec![
         STATUS.clone(),
         SNAPSHOT_ID_V1.clone(),
-        Arc::new(NestedField::required(
-            2,
-            "data_file",
-            Type::Struct(StructType::new(data_file_fields_v1(partition_type))),
-        )),
+        Arc::new(
+            NestedField::required(
+                2,
+                "data_file",
+                Type::Struct(StructType::new(data_file_fields_v1(partition_type))),
+            )
+            .expect("valid nested field"),
+        ),
     ];
     let schema = Schema::builder().with_fields(fields).build()?;
     schema_to_avro_schema("manifest_entry", &schema)

--- a/crates/iceberg/src/spec/manifest/mod.rs
+++ b/crates/iceberg/src/spec/manifest/mod.rs
@@ -183,69 +183,81 @@ mod tests {
             Schema::builder()
                 .with_fields(vec![
                     // id v_int v_long v_float v_double v_varchar v_bool v_date v_timestamp v_decimal v_ts_ntz
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v_int",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "v_long",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        4,
-                        "v_float",
-                        Type::Primitive(PrimitiveType::Float),
-                    )),
-                    Arc::new(NestedField::optional(
-                        5,
-                        "v_double",
-                        Type::Primitive(PrimitiveType::Double),
-                    )),
-                    Arc::new(NestedField::optional(
-                        6,
-                        "v_varchar",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::optional(
-                        7,
-                        "v_bool",
-                        Type::Primitive(PrimitiveType::Boolean),
-                    )),
-                    Arc::new(NestedField::optional(
-                        8,
-                        "v_date",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::optional(
-                        9,
-                        "v_timestamp",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::optional(
-                        10,
-                        "v_decimal",
-                        Type::Primitive(PrimitiveType::Decimal {
-                            precision: 36,
-                            scale: 10,
-                        }),
-                    )),
-                    Arc::new(NestedField::optional(
-                        11,
-                        "v_ts_ntz",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::optional(
-                        12,
-                        "v_ts_ns_ntz",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v_int", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(3, "v_long", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(4, "v_float", Type::Primitive(PrimitiveType::Float))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            5,
+                            "v_double",
+                            Type::Primitive(PrimitiveType::Double),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            6,
+                            "v_varchar",
+                            Type::Primitive(PrimitiveType::String),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(7, "v_bool", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(8, "v_date", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            9,
+                            "v_timestamp",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            10,
+                            "v_decimal",
+                            Type::Primitive(PrimitiveType::Decimal {
+                                precision: 36,
+                                scale: 10,
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            11,
+                            "v_ts_ntz",
+                            Type::Primitive(PrimitiveType::Timestamp),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            12,
+                            "v_ts_ns_ntz",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -300,11 +312,10 @@ mod tests {
     fn test_parse_snappy_manifest_v2() {
         let schema = Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::optional(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Long),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         );
@@ -422,69 +433,81 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v_int",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "v_long",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        4,
-                        "v_float",
-                        Type::Primitive(PrimitiveType::Float),
-                    )),
-                    Arc::new(NestedField::optional(
-                        5,
-                        "v_double",
-                        Type::Primitive(PrimitiveType::Double),
-                    )),
-                    Arc::new(NestedField::optional(
-                        6,
-                        "v_varchar",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::optional(
-                        7,
-                        "v_bool",
-                        Type::Primitive(PrimitiveType::Boolean),
-                    )),
-                    Arc::new(NestedField::optional(
-                        8,
-                        "v_date",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::optional(
-                        9,
-                        "v_timestamp",
-                        Type::Primitive(PrimitiveType::Timestamptz),
-                    )),
-                    Arc::new(NestedField::optional(
-                        10,
-                        "v_decimal",
-                        Type::Primitive(PrimitiveType::Decimal {
-                            precision: 36,
-                            scale: 10,
-                        }),
-                    )),
-                    Arc::new(NestedField::optional(
-                        11,
-                        "v_ts_ntz",
-                        Type::Primitive(PrimitiveType::Timestamp),
-                    )),
-                    Arc::new(NestedField::optional(
-                        12,
-                        "v_ts_ns_ntz",
-                        Type::Primitive(PrimitiveType::TimestampNs),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v_int", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(3, "v_long", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(4, "v_float", Type::Primitive(PrimitiveType::Float))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            5,
+                            "v_double",
+                            Type::Primitive(PrimitiveType::Double),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            6,
+                            "v_varchar",
+                            Type::Primitive(PrimitiveType::String),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(7, "v_bool", Type::Primitive(PrimitiveType::Boolean))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(8, "v_date", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            9,
+                            "v_timestamp",
+                            Type::Primitive(PrimitiveType::Timestamptz),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            10,
+                            "v_decimal",
+                            Type::Primitive(PrimitiveType::Decimal {
+                                precision: 36,
+                                scale: 10,
+                            }),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            11,
+                            "v_ts_ntz",
+                            Type::Primitive(PrimitiveType::Timestamp),
+                        )
+                        .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            12,
+                            "v_ts_ns_ntz",
+                            Type::Primitive(PrimitiveType::TimestampNs),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -612,21 +635,18 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "data",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "comment",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(3, "comment", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -702,21 +722,22 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "data",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "category",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            3,
+                            "category",
+                            Type::Primitive(PrimitiveType::String),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -820,16 +841,14 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v_int",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v_int", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -914,16 +933,14 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v_int",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v_int", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -985,21 +1002,22 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "time",
-                        Type::Primitive(PrimitiveType::Date),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "v_float",
-                        Type::Primitive(PrimitiveType::Float),
-                    )),
-                    Arc::new(NestedField::optional(
-                        3,
-                        "v_double",
-                        Type::Primitive(PrimitiveType::Double),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "time", Type::Primitive(PrimitiveType::Date))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "v_float", Type::Primitive(PrimitiveType::Float))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(
+                            3,
+                            "v_double",
+                            Type::Primitive(PrimitiveType::Double),
+                        )
+                        .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -1225,8 +1243,12 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![1])
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/manifest/reader.rs
+++ b/crates/iceberg/src/spec/manifest/reader.rs
@@ -237,11 +237,10 @@ mod tests {
     fn test_schema() -> Arc<Schema> {
         Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::optional(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Long),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         )

--- a/crates/iceberg/src/spec/manifest/writer.rs
+++ b/crates/iceberg/src/spec/manifest/writer.rs
@@ -253,7 +253,7 @@ impl ManifestWriter {
         let mut field_stats: Vec<_> = partition_type
             .fields()
             .iter()
-            .map(|f| PartitionFieldStats::new(f.field_type.as_primitive_type().unwrap().clone()))
+            .map(|f| PartitionFieldStats::new(f.field_type().as_primitive_type().unwrap().clone()))
             .collect();
         for partition in self.manifest_entries.iter().map(|e| &e.data_file.partition) {
             for (literal, stat) in partition.iter().zip_eq(field_stats.iter_mut()) {
@@ -615,16 +615,14 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Int),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "name",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),
@@ -764,16 +762,14 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    Arc::new(NestedField::optional(
-                        1,
-                        "id",
-                        Type::Primitive(PrimitiveType::Long),
-                    )),
-                    Arc::new(NestedField::optional(
-                        2,
-                        "data",
-                        Type::Primitive(PrimitiveType::String),
-                    )),
+                    Arc::new(
+                        NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field"),
+                    ),
+                    Arc::new(
+                        NestedField::optional(2, "data", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field"),
+                    ),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/spec/manifest_list/_const_schema.rs
+++ b/crates/iceberg/src/spec/manifest_list/_const_schema.rs
@@ -26,228 +26,265 @@ use crate::spec::{ListType, NestedField, NestedFieldRef, PrimitiveType, Schema, 
 
 static MANIFEST_PATH: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            500,
-            "manifest_path",
-            Type::Primitive(PrimitiveType::String),
-        ))
+        Arc::new(
+            NestedField::required(500, "manifest_path", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
+        )
     })
 };
 static MANIFEST_LENGTH: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            501,
-            "manifest_length",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(501, "manifest_length", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 static PARTITION_SPEC_ID: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            502,
-            "partition_spec_id",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(
+                502,
+                "partition_spec_id",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static CONTENT: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            517,
-            "content",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(517, "content", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field"),
+        )
     })
 };
 static SEQUENCE_NUMBER: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            515,
-            "sequence_number",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(515, "sequence_number", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 static MIN_SEQUENCE_NUMBER: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            516,
-            "min_sequence_number",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                516,
+                "min_sequence_number",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static ADDED_SNAPSHOT_ID: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            503,
-            "added_snapshot_id",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                503,
+                "added_snapshot_id",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static ADDED_FILES_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            504,
-            "added_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(
+                504,
+                "added_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static ADDED_FILES_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            504,
-            "added_data_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::optional(
+                504,
+                "added_data_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static EXISTING_FILES_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            505,
-            "existing_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(
+                505,
+                "existing_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static EXISTING_FILES_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            505,
-            "existing_data_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::optional(
+                505,
+                "existing_data_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static DELETED_FILES_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            506,
-            "deleted_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::required(
+                506,
+                "deleted_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static DELETED_FILES_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            506,
-            "deleted_data_files_count",
-            Type::Primitive(PrimitiveType::Int),
-        ))
+        Arc::new(
+            NestedField::optional(
+                506,
+                "deleted_data_files_count",
+                Type::Primitive(PrimitiveType::Int),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static ADDED_ROWS_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            512,
-            "added_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                512,
+                "added_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static ADDED_ROWS_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            512,
-            "added_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(
+                512,
+                "added_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static EXISTING_ROWS_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            513,
-            "existing_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                513,
+                "existing_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static EXISTING_ROWS_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            513,
-            "existing_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(
+                513,
+                "existing_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static DELETED_ROWS_COUNT_V2: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::required(
-            514,
-            "deleted_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::required(
+                514,
+                "deleted_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static DELETED_ROWS_COUNT_V1: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            514,
-            "deleted_rows_count",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(
+                514,
+                "deleted_rows_count",
+                Type::Primitive(PrimitiveType::Long),
+            )
+            .expect("valid nested field"),
+        )
     })
 };
 static PARTITIONS: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
         // element type
         let fields = vec![
-            Arc::new(NestedField::required(
-                509,
-                "contains_null",
-                Type::Primitive(PrimitiveType::Boolean),
-            )),
-            Arc::new(NestedField::optional(
-                518,
-                "contains_nan",
-                Type::Primitive(PrimitiveType::Boolean),
-            )),
-            Arc::new(NestedField::optional(
-                510,
-                "lower_bound",
-                Type::Primitive(PrimitiveType::Binary),
-            )),
-            Arc::new(NestedField::optional(
-                511,
-                "upper_bound",
-                Type::Primitive(PrimitiveType::Binary),
-            )),
+            Arc::new(
+                NestedField::required(
+                    509,
+                    "contains_null",
+                    Type::Primitive(PrimitiveType::Boolean),
+                )
+                .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(518, "contains_nan", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(510, "lower_bound", Type::Primitive(PrimitiveType::Binary))
+                    .expect("valid nested field"),
+            ),
+            Arc::new(
+                NestedField::optional(511, "upper_bound", Type::Primitive(PrimitiveType::Binary))
+                    .expect("valid nested field"),
+            ),
         ];
-        let element_field = Arc::new(NestedField::required(
-            508,
-            "r_508",
-            Type::Struct(StructType::new(fields)),
-        ));
-        Arc::new(NestedField::optional(
-            507,
-            "partitions",
-            Type::List(ListType { element_field }),
-        ))
+        let element_field = Arc::new(
+            NestedField::required(508, "r_508", Type::Struct(StructType::new(fields)))
+                .expect("valid nested field"),
+        );
+        Arc::new(
+            NestedField::optional(507, "partitions", Type::List(ListType { element_field }))
+                .expect("valid nested field"),
+        )
     })
 };
 static KEY_METADATA: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            519,
-            "key_metadata",
-            Type::Primitive(PrimitiveType::Binary),
-        ))
+        Arc::new(
+            NestedField::optional(519, "key_metadata", Type::Primitive(PrimitiveType::Binary))
+                .expect("valid nested field"),
+        )
     })
 };
 static FIRST_ROW_ID: Lazy<NestedFieldRef> = {
     Lazy::new(|| {
-        Arc::new(NestedField::optional(
-            520,
-            "first_row_id",
-            Type::Primitive(PrimitiveType::Long),
-        ))
+        Arc::new(
+            NestedField::optional(520, "first_row_id", Type::Primitive(PrimitiveType::Long))
+                .expect("valid nested field"),
+        )
     })
 };
 

--- a/crates/iceberg/src/spec/manifest_list/manifest_file.rs
+++ b/crates/iceberg/src/spec/manifest_list/manifest_file.rs
@@ -223,11 +223,10 @@ mod test {
     fn test_schema() -> SchemaRef {
         Arc::new(
             Schema::builder()
-                .with_fields(vec![Arc::new(NestedField::optional(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Long),
-                ))])
+                .with_fields(vec![Arc::new(
+                    NestedField::optional(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                )])
                 .build()
                 .unwrap(),
         )

--- a/crates/iceberg/src/spec/partition.rs
+++ b/crates/iceberg/src/spec/partition.rs
@@ -171,7 +171,7 @@ impl PartitionSpec {
                         &field.name,
                         &field
                             .transform
-                            .to_human_string(&field_types[i].field_type, value),
+                            .to_human_string(field_types[i].field_type(), value),
                     )
                     .finish()
             })
@@ -471,7 +471,7 @@ impl PartitionSpecBuilder {
                     ),
                 )
             })?
-            .id;
+            .id();
         let field = UnboundPartitionField {
             source_id,
             field_id: None,
@@ -583,9 +583,10 @@ impl PartitionSpecBuilder {
                         ),
                     )
                 })?;
-            let res_type = partition_field.transform.result_type(&field.field_type)?;
+            let res_type = partition_field.transform.result_type(field.field_type())?;
             let field =
                 NestedField::optional(partition_field.field_id, &partition_field.name, res_type)
+                    .expect("valid nested field")
                     .into();
             struct_fields.push(field);
         }
@@ -603,14 +604,16 @@ impl PartitionSpecBuilder {
         match schema.field_by_name(field.name.as_str()) {
             Some(schema_collision) => {
                 if field.transform == Transform::Identity {
-                    if schema_collision.id == field.source_id {
+                    if schema_collision.id() == field.source_id {
                         Ok(())
                     } else {
                         Err(Error::new(
                             ErrorKind::DataInvalid,
                             format!(
                                 "Cannot create identity partition sourced from different field in schema. Field name '{}' has id `{}` in schema but partition source id is `{}`",
-                                field.name, schema_collision.id, field.source_id
+                                field.name,
+                                schema_collision.id(),
+                                field.source_id
                             ),
                         ))
                     }
@@ -642,26 +645,26 @@ impl PartitionSpecBuilder {
         })?;
 
         if field.transform != Transform::Void {
-            if !schema_field.field_type.is_primitive() {
+            if !schema_field.field_type().is_primitive() {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Cannot partition by non-primitive source field: '{}'.",
-                        schema_field.field_type
+                        schema_field.field_type()
                     ),
                 ));
             }
 
             if field
                 .transform
-                .result_type(&schema_field.field_type)
+                .result_type(schema_field.field_type())
                 .is_err()
             {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Invalid source type: '{}' for transform: '{}'.",
-                        schema_field.field_type,
+                        schema_field.field_type(),
                         field.transform.dedup_name()
                     ),
                 ));
@@ -790,8 +793,12 @@ mod tests {
     fn test_is_unpartitioned() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -945,8 +952,12 @@ mod tests {
     fn test_new_unpartition() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -988,13 +999,24 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
-                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1008,6 +1030,7 @@ mod tests {
                 &partition_spec.fields[0].name,
                 Type::Primitive(PrimitiveType::Date)
             )
+            .expect("valid nested field")
         );
         assert_eq!(
             *partition_type.fields()[1],
@@ -1016,6 +1039,7 @@ mod tests {
                 &partition_spec.fields[1].name,
                 Type::Primitive(PrimitiveType::Int)
             )
+            .expect("valid nested field")
         );
         assert_eq!(
             *partition_type.fields()[2],
@@ -1024,6 +1048,7 @@ mod tests {
                 &partition_spec.fields[2].name,
                 Type::Primitive(PrimitiveType::String)
             )
+            .expect("valid nested field")
         );
     }
 
@@ -1039,13 +1064,24 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
-                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "ts_day", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(5, "id_bucket", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(6, "id_truncate", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1081,8 +1117,12 @@ mod tests {
         let partition_spec: PartitionSpec = serde_json::from_str(spec).unwrap();
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1103,8 +1143,12 @@ mod tests {
     fn test_builder_disallow_duplicate_field_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1129,9 +1173,15 @@ mod tests {
     fn test_builder_auto_assign_field_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1171,8 +1221,12 @@ mod tests {
     fn test_builder_valid_schema() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1202,6 +1256,7 @@ mod tests {
             spec.partition_type(&schema).unwrap(),
             StructType::new(vec![
                 NestedField::optional(1000, "id_bucket[16]", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into()
             ])
         )
@@ -1211,7 +1266,9 @@ mod tests {
     fn test_collision_with_schema_name() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1237,8 +1294,12 @@ mod tests {
     fn test_builder_collision_is_ok_for_identity_transforms() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "number", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "number", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1276,9 +1337,15 @@ mod tests {
     fn test_builder_all_source_ids_must_exist() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1328,8 +1395,12 @@ mod tests {
     fn test_builder_disallows_variant_source() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "v", Type::Variant(crate::spec::VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1369,7 +1440,9 @@ mod tests {
     fn test_builder_incompatible_transforms_disallowed() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1413,8 +1486,12 @@ mod tests {
     fn test_is_compatible_with() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1450,7 +1527,9 @@ mod tests {
     fn test_not_compatible_with_transform_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1486,8 +1565,12 @@ mod tests {
     fn test_not_compatible_with_source_id_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1523,8 +1606,12 @@ mod tests {
     fn test_not_compatible_with_order_different() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1584,8 +1671,12 @@ mod tests {
     fn test_highest_field_id() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1616,8 +1707,12 @@ mod tests {
     fn test_has_sequential_ids() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1650,8 +1745,12 @@ mod tests {
     fn test_sequential_ids_must_start_at_1000() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1684,8 +1783,12 @@ mod tests {
     fn test_sequential_ids_must_have_no_gaps() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1718,11 +1821,18 @@ mod tests {
     fn test_partition_to_path() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "timestamp", Type::Primitive(PrimitiveType::Timestamp))
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(4, "empty", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "timestamp", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "empty", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1757,8 +1867,11 @@ mod tests {
         let schema = Schema::builder()
             .with_fields(vec![
                 NestedField::required(1, "\"esc\"#1", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1785,8 +1898,11 @@ mod tests {
         let schema = Schema::builder()
             .with_fields(vec![
                 NestedField::required(1, "\"esc\"#1", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/schema/_serde.rs
+++ b/crates/iceberg/src/spec/schema/_serde.rs
@@ -188,17 +188,17 @@ mod tests {
         let result: SchemaV2 = serde_json::from_str(record).unwrap();
         assert_eq!(1, result.schema_id);
         assert_eq!(
-            Box::new(Type::Primitive(PrimitiveType::Uuid)),
-            result.fields[0].field_type
+            &Type::Primitive(PrimitiveType::Uuid),
+            result.fields[0].field_type()
         );
-        assert_eq!(1, result.fields[0].id);
-        assert!(result.fields[0].required);
+        assert_eq!(1, result.fields[0].id());
+        assert!(result.fields[0].is_required());
 
         assert_eq!(
-            Box::new(Type::Primitive(PrimitiveType::Int)),
-            result.fields[1].field_type
+            &Type::Primitive(PrimitiveType::Int),
+            result.fields[1].field_type()
         );
-        assert_eq!(2, result.fields[1].id);
-        assert!(!result.fields[1].required);
+        assert_eq!(2, result.fields[1].id());
+        assert!(!result.fields[1].is_required());
     }
 }

--- a/crates/iceberg/src/spec/schema/id_reassigner.rs
+++ b/crates/iceberg/src/spec/schema/id_reassigner.rs
@@ -41,8 +41,9 @@ impl ReassignFieldIds {
         let outer_fields = fields
             .into_iter()
             .map(|field| {
-                try_insert_field(&mut self.old_to_new_id, field.id, self.next_field_id)?;
-                let new_field = Arc::unwrap_or_clone(field).with_id(self.next_field_id);
+                try_insert_field(&mut self.old_to_new_id, field.id(), self.next_field_id)?;
+                let field = Arc::unwrap_or_clone(field);
+                let new_field = field.rebuild(self.next_field_id, field.field_type().clone())?;
                 self.increase_next_field_id()?;
                 Ok(Arc::new(new_field))
             })
@@ -52,12 +53,12 @@ impl ReassignFieldIds {
         outer_fields
             .into_iter()
             .map(|field| {
-                if field.field_type.is_primitive() {
+                if field.field_type().is_primitive() {
                     Ok(field)
                 } else {
-                    let mut new_field = Arc::unwrap_or_clone(field);
-                    *new_field.field_type = self.reassign_ids_visit_type(*new_field.field_type)?;
-                    Ok(Arc::new(new_field))
+                    let field = Arc::unwrap_or_clone(field);
+                    let field_type = self.reassign_ids_visit_type(field.field_type().clone())?;
+                    Ok(Arc::new(field.rebuild(field.id(), field_type)?))
                 }
             })
             .collect()
@@ -72,34 +73,34 @@ impl ReassignFieldIds {
             }
             Type::List(l) => {
                 self.old_to_new_id
-                    .insert(l.element_field.id, self.next_field_id);
-                let mut element_field = Arc::unwrap_or_clone(l.element_field);
-                element_field.id = self.next_field_id;
+                    .insert(l.element_field.id(), self.next_field_id);
+                let element_field = Arc::unwrap_or_clone(l.element_field);
+                let new_id = self.next_field_id;
                 self.increase_next_field_id()?;
-                *element_field.field_type =
-                    self.reassign_ids_visit_type(*element_field.field_type)?;
+                let field_type =
+                    self.reassign_ids_visit_type(element_field.field_type().clone())?;
                 Ok(Type::List(ListType {
-                    element_field: Arc::new(element_field),
+                    element_field: Arc::new(element_field.rebuild(new_id, field_type)?),
                 }))
             }
             Type::Map(m) => {
                 self.old_to_new_id
-                    .insert(m.key_field.id, self.next_field_id);
-                let mut key_field = Arc::unwrap_or_clone(m.key_field);
-                key_field.id = self.next_field_id;
+                    .insert(m.key_field.id(), self.next_field_id);
+                let key_field = Arc::unwrap_or_clone(m.key_field);
+                let new_key_id = self.next_field_id;
                 self.increase_next_field_id()?;
-                *key_field.field_type = self.reassign_ids_visit_type(*key_field.field_type)?;
+                let key_type = self.reassign_ids_visit_type(key_field.field_type().clone())?;
 
                 self.old_to_new_id
-                    .insert(m.value_field.id, self.next_field_id);
-                let mut value_field = Arc::unwrap_or_clone(m.value_field);
-                value_field.id = self.next_field_id;
+                    .insert(m.value_field.id(), self.next_field_id);
+                let value_field = Arc::unwrap_or_clone(m.value_field);
+                let new_value_id = self.next_field_id;
                 self.increase_next_field_id()?;
-                *value_field.field_type = self.reassign_ids_visit_type(*value_field.field_type)?;
+                let value_type = self.reassign_ids_visit_type(value_field.field_type().clone())?;
 
                 Ok(Type::Map(MapType {
-                    key_field: Arc::new(key_field),
-                    value_field: Arc::new(value_field),
+                    key_field: Arc::new(key_field.rebuild(new_key_id, key_type)?),
+                    value_field: Arc::new(value_field.rebuild(new_value_id, value_type)?),
                 }))
             }
             Type::Variant(v) => Ok(Type::Variant(v)),
@@ -164,9 +165,15 @@ mod tests {
             .with_identifier_field_ids(vec![3])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 3)]))
             .with_fields(vec![
-                NestedField::optional(5, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(4, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(5, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(4, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -182,9 +189,15 @@ mod tests {
             .with_identifier_field_ids(vec![1])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 1)]))
             .with_fields(vec![
-                NestedField::optional(0, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(0, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -199,8 +212,12 @@ mod tests {
 
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(5, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "data", Type::Variant(VariantType)).into(),
+                NestedField::required(5, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "data", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -215,8 +232,12 @@ mod tests {
         // top-level field ids shift (id → 0, data → 1).
         let expected = Schema::builder()
             .with_fields(vec![
-                NestedField::required(0, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(1, "data", Type::Variant(VariantType)).into(),
+                NestedField::required(0, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(1, "data", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -239,9 +260,15 @@ mod tests {
             .with_identifier_field_ids(vec![1])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 1)]))
             .with_fields(vec![
-                NestedField::optional(0, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(0, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(1, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "qux",
@@ -251,9 +278,11 @@ mod tests {
                             Type::Primitive(PrimitiveType::String),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     4,
@@ -263,6 +292,7 @@ mod tests {
                             8,
                             Type::Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::map_value_element(
                             9,
@@ -271,19 +301,23 @@ mod tests {
                                     10,
                                     Type::Primitive(PrimitiveType::String),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 value_field: NestedField::map_value_element(
                                     11,
                                     Type::Primitive(PrimitiveType::Int),
                                     true,
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             }),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     5,
@@ -297,30 +331,37 @@ mod tests {
                                     "latitude",
                                     Type::Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 NestedField::optional(
                                     14,
                                     "longitude",
                                     Type::Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     6,
                     "person",
                     Type::Struct(StructType::new(vec![
                         NestedField::optional(15, "name", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::required(16, "age", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -328,8 +369,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(expected, reassigned_schema);
         assert_eq!(reassigned_schema.highest_field_id(), 16);
-        assert_eq!(reassigned_schema.field_by_id(6).unwrap().name, "person");
-        assert_eq!(reassigned_schema.field_by_id(16).unwrap().name, "age");
+        assert_eq!(reassigned_schema.field_by_id(6).unwrap().name(), "person");
+        assert_eq!(reassigned_schema.field_by_id(16).unwrap().name(), "age");
     }
 
     #[test]
@@ -339,9 +380,15 @@ mod tests {
             .with_identifier_field_ids(vec![5])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 3)]))
             .with_fields(vec![
-                NestedField::required(5, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(3, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::required(5, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .with_reassigned_field_ids(0)
             .build()

--- a/crates/iceberg/src/spec/schema/index.rs
+++ b/crates/iceberg/src/spec/schema/index.rs
@@ -31,7 +31,7 @@ pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>
         }
 
         fn field(&mut self, field: &NestedFieldRef, _value: ()) -> Result<()> {
-            try_insert_field(&mut self.0, field.id, field.clone())
+            try_insert_field(&mut self.0, field.id(), field.clone())
         }
 
         fn r#struct(&mut self, _struct: &StructType, _results: Vec<Self::T>) -> Result<Self::T> {
@@ -41,14 +41,14 @@ pub fn index_by_id(r#struct: &StructType) -> Result<HashMap<i32, NestedFieldRef>
         fn list(&mut self, list: &ListType, _value: Self::T) -> Result<Self::T> {
             try_insert_field(
                 &mut self.0,
-                list.element_field.id,
+                list.element_field.id(),
                 list.element_field.clone(),
             )
         }
 
         fn map(&mut self, map: &MapType, _key_value: Self::T, _value: Self::T) -> Result<Self::T> {
-            try_insert_field(&mut self.0, map.key_field.id, map.key_field.clone())?;
-            try_insert_field(&mut self.0, map.value_field.id, map.value_field.clone())
+            try_insert_field(&mut self.0, map.key_field.id(), map.key_field.clone())?;
+            try_insert_field(&mut self.0, map.value_field.id(), map.value_field.clone())
         }
 
         fn primitive(&mut self, _: &PrimitiveType) -> Result<Self::T> {
@@ -77,9 +77,9 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
 
         fn before_struct_field(&mut self, field: &NestedFieldRef) -> Result<()> {
             if let Some(parent) = self.parents.last().copied() {
-                self.result.insert(field.id, parent);
+                self.result.insert(field.id(), parent);
             }
-            self.parents.push(field.id);
+            self.parents.push(field.id());
             Ok(())
         }
 
@@ -90,9 +90,9 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
 
         fn before_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
             if let Some(parent) = self.parents.last().copied() {
-                self.result.insert(field.id, parent);
+                self.result.insert(field.id(), parent);
             }
-            self.parents.push(field.id);
+            self.parents.push(field.id());
             Ok(())
         }
 
@@ -103,9 +103,9 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
 
         fn before_map_key(&mut self, field: &NestedFieldRef) -> Result<()> {
             if let Some(parent) = self.parents.last().copied() {
-                self.result.insert(field.id, parent);
+                self.result.insert(field.id(), parent);
             }
-            self.parents.push(field.id);
+            self.parents.push(field.id());
             Ok(())
         }
 
@@ -116,9 +116,9 @@ pub fn index_parents(r#struct: &StructType) -> Result<HashMap<i32, i32>> {
 
         fn before_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
             if let Some(parent) = self.parents.last().copied() {
-                self.result.insert(field.id, parent);
+                self.result.insert(field.id(), parent);
             }
-            self.parents.push(field.id);
+            self.parents.push(field.id());
             Ok(())
         }
 
@@ -224,8 +224,8 @@ impl SchemaVisitor for IndexByName {
     type T = ();
 
     fn before_struct_field(&mut self, field: &NestedFieldRef) -> Result<()> {
-        self.field_names.push(field.name.to_string());
-        self.short_field_names.push(field.name.to_string());
+        self.field_names.push(field.name().to_string());
+        self.short_field_names.push(field.name().to_string());
         Ok(())
     }
 
@@ -236,9 +236,9 @@ impl SchemaVisitor for IndexByName {
     }
 
     fn before_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
-        self.field_names.push(field.name.clone());
-        if !field.field_type.is_struct() {
-            self.short_field_names.push(field.name.to_string());
+        self.field_names.push(field.name().to_string());
+        if !field.field_type().is_struct() {
+            self.short_field_names.push(field.name().to_string());
         }
 
         Ok(())
@@ -246,7 +246,7 @@ impl SchemaVisitor for IndexByName {
 
     fn after_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
         self.field_names.pop();
-        if !field.field_type.is_struct() {
+        if !field.field_type().is_struct() {
             self.short_field_names.pop();
         }
 
@@ -262,16 +262,16 @@ impl SchemaVisitor for IndexByName {
     }
 
     fn before_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
-        self.field_names.push(field.name.to_string());
-        if !field.field_type.is_struct() {
-            self.short_field_names.push(field.name.to_string());
+        self.field_names.push(field.name().to_string());
+        if !field.field_type().is_struct() {
+            self.short_field_names.push(field.name().to_string());
         }
         Ok(())
     }
 
     fn after_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
         self.field_names.pop();
-        if !field.field_type.is_struct() {
+        if !field.field_type().is_struct() {
             self.short_field_names.pop();
         }
 
@@ -283,7 +283,7 @@ impl SchemaVisitor for IndexByName {
     }
 
     fn field(&mut self, field: &NestedFieldRef, _value: Self::T) -> Result<Self::T> {
-        self.add_field(field.name.as_str(), field.id)
+        self.add_field(field.name(), field.id())
     }
 
     fn r#struct(&mut self, _struct: &StructType, _results: Vec<Self::T>) -> Result<Self::T> {
@@ -291,12 +291,12 @@ impl SchemaVisitor for IndexByName {
     }
 
     fn list(&mut self, list: &ListType, _value: Self::T) -> Result<Self::T> {
-        self.add_field(LIST_FIELD_NAME, list.element_field.id)
+        self.add_field(LIST_FIELD_NAME, list.element_field.id())
     }
 
     fn map(&mut self, map: &MapType, _key_value: Self::T, _value: Self::T) -> Result<Self::T> {
-        self.add_field(MAP_KEY_FIELD_NAME, map.key_field.id)?;
-        self.add_field(MAP_VALUE_FIELD_NAME, map.value_field.id)
+        self.add_field(MAP_KEY_FIELD_NAME, map.key_field.id())?;
+        self.add_field(MAP_VALUE_FIELD_NAME, map.value_field.id())
     }
 
     fn primitive(&mut self, _p: &PrimitiveType) -> Result<Self::T> {
@@ -335,23 +335,30 @@ mod tests {
         // top level and nested inside a struct. Mirrors Java's TestTypeUtil index-by-id /
         // index-name-by-id coverage for variant.
         let s = StructType::new(vec![
-            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(2, "v", Type::Variant(VariantType))
+                .expect("valid nested field")
+                .into(),
             NestedField::required(
                 3,
                 "nested",
                 Type::Struct(StructType::new(vec![
-                    NestedField::optional(4, "inner_v", Type::Variant(VariantType)).into(),
+                    NestedField::optional(4, "inner_v", Type::Variant(VariantType))
+                        .expect("valid nested field")
+                        .into(),
                 ])),
             )
+            .expect("valid nested field")
             .into(),
         ]);
 
         let by_id = index_by_id(&s).unwrap();
         // All four fields (id, v, nested, nested.inner_v) are indexed exactly once.
         assert_eq!(by_id.len(), 4);
-        assert!(by_id[&2].field_type.is_variant());
-        assert!(by_id[&4].field_type.is_variant());
+        assert!(by_id[&2].field_type().is_variant());
+        assert!(by_id[&4].field_type().is_variant());
 
         let (name_to_id, id_to_name) = {
             let mut index = IndexByName::default();

--- a/crates/iceberg/src/spec/schema/mod.rs
+++ b/crates/iceberg/src/spec/schema/mod.rs
@@ -194,11 +194,11 @@ impl SchemaBuilder {
         let mut map = HashMap::new();
 
         for (pos, field) in self.fields.iter().enumerate() {
-            match field.field_type.as_ref() {
+            match field.field_type() {
                 Type::Primitive(prim_type) => {
                     // add an accessor for this field
                     let accessor = Arc::new(StructAccessor::new(pos, prim_type.clone()));
-                    map.insert(field.id, accessor.clone());
+                    map.insert(field.id(), accessor.clone());
                 }
 
                 Type::Struct(nested) => {
@@ -220,10 +220,10 @@ impl SchemaBuilder {
     fn build_accessors_nested(fields: &[NestedFieldRef]) -> Vec<(i32, Box<StructAccessor>)> {
         let mut results = vec![];
         for (pos, field) in fields.iter().enumerate() {
-            match field.field_type.as_ref() {
+            match field.field_type() {
                 Type::Primitive(prim_type) => {
                     let accessor = Box::new(StructAccessor::new(pos, prim_type.clone()));
-                    results.push((field.id, accessor));
+                    results.push((field.id(), accessor));
                 }
                 Type::Struct(nested) => {
                     let nested_accessors = Self::build_accessors_nested(nested.fields());
@@ -266,22 +266,22 @@ impl SchemaBuilder {
                 )
             })?;
             ensure_data_valid!(
-                field.required,
+                field.is_required(),
                 "Cannot add identifier field: {} is an optional field",
-                field.name
+                field.name()
             );
-            if let Type::Primitive(p) = field.field_type.as_ref() {
+            if let Type::Primitive(p) = field.field_type() {
                 ensure_data_valid!(
                     !matches!(p, PrimitiveType::Double | PrimitiveType::Float),
                     "Cannot add identifier field {}: cannot be a float or double type",
-                    field.name
+                    field.name()
                 );
             } else {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Cannot add field {} as an identifier field: not a primitive type field",
-                        field.name
+                        field.name()
                     ),
                 ));
             }
@@ -292,15 +292,15 @@ impl SchemaBuilder {
                     .get(parent)
                     .expect("Field id should not disappear.");
                 ensure_data_valid!(
-                    parent_field.field_type.is_struct(),
+                    parent_field.field_type().is_struct(),
                     "Cannot add field {} as an identifier field: must not be nested in {:?}",
-                    field.name,
+                    field.name(),
                     parent_field
                 );
                 ensure_data_valid!(
-                    parent_field.required,
+                    parent_field.is_required(),
                     "Cannot add field {} as an identifier field: must not be nested in an optional field {}",
-                    field.name,
+                    field.name(),
                     parent_field
                 );
                 cur_field_id = *parent;
@@ -435,7 +435,7 @@ impl Schema {
         // `id_to_field` is flattened, so the max over all fields covers nested ones too.
         self.id_to_field
             .values()
-            .map(|f| f.field_type.min_format_version())
+            .map(|f| f.field_type().min_format_version())
             .max()
             .unwrap_or(FormatVersion::V1)
     }
@@ -455,39 +455,39 @@ impl Schema {
         // `id_to_field` is flattened, so checking each field by its own type keeps the
         // blame on the offending leaf, not its container (mirrors Java's `lazyIdToField`).
         for field in self.id_to_field.values() {
-            let min_version = field.field_type.min_format_version();
+            let min_version = field.field_type().min_format_version();
             if format_version < min_version {
                 // Every id in `id_to_field` is also indexed in `id_to_name`; a miss means
                 // the schema's indexes are inconsistent (a bug), so surface it rather than
                 // guessing an unqualified name.
-                let name = self.name_by_field_id(field.id).ok_or_else(|| {
+                let name = self.name_by_field_id(field.id()).ok_or_else(|| {
                     Error::new(
                         ErrorKind::Unexpected,
                         format!(
                             "Field id {} is missing from the schema's name index",
-                            field.id
+                            field.id()
                         ),
                     )
                 })?;
-                problems.push((field.id, format!(
+                problems.push((field.id(), format!(
                     "Invalid type for {name}: {} is not supported until {min_version} but format version is {format_version}.",
-                    field.field_type,
+                    field.field_type(),
                 )));
             }
 
-            if let Some(default) = &field.initial_default
+            if let Some(default) = &field.initial_default()
                 && format_version < DEFAULT_VALUES_MIN_FORMAT_VERSION
             {
-                let name = self.name_by_field_id(field.id).ok_or_else(|| {
+                let name = self.name_by_field_id(field.id()).ok_or_else(|| {
                     Error::new(
                         ErrorKind::Unexpected,
                         format!(
                             "Field id {} is missing from the schema's name index",
-                            field.id
+                            field.id()
                         ),
                     )
                 })?;
-                problems.push((field.id, format!(
+                problems.push((field.id(), format!(
                     "Invalid initial default for {name}: non-null default ({default:?}) is not supported until {DEFAULT_VALUES_MIN_FORMAT_VERSION} but format version is {format_version}."
                 )));
             }
@@ -545,7 +545,9 @@ mod tests {
 
         // Variant type requires v3.
         let variant = schema_with(vec![
-            NestedField::optional(1, "v", Variant(VariantType)).into(),
+            NestedField::optional(1, "v", Variant(VariantType))
+                .expect("valid nested field")
+                .into(),
         ]);
         assert!(
             variant
@@ -560,8 +562,14 @@ mod tests {
 
         // A non-null initial default requires v3, even for a v1-compatible type.
         let with_default = schema_with(vec![
-            NestedField::optional(1, "a", Primitive(PrimitiveType::Int))
-                .with_initial_default(Literal::Primitive(PrimitiveLiteral::Int(1)))
+            NestedField::builder()
+                .id(1)
+                .name("a")
+                .required(false)
+                .field_type(Primitive(PrimitiveType::Int))
+                .initial_default(Literal::Primitive(PrimitiveLiteral::Int(1)))
+                .build()
+                .unwrap()
                 .into(),
         ]);
         let err = with_default
@@ -579,7 +587,9 @@ mod tests {
 
         // No default is fine at any version (an absent/null default never trips).
         let no_default = schema_with(vec![
-            NestedField::optional(1, "a", Primitive(PrimitiveType::Int)).into(),
+            NestedField::optional(1, "a", Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
         ]);
         assert!(
             no_default
@@ -593,11 +603,18 @@ mod tests {
                 1,
                 "s",
                 Struct(StructType::new(vec![
-                    NestedField::optional(2, "inner", Primitive(PrimitiveType::Long))
-                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(7)))
+                    NestedField::builder()
+                        .id(2)
+                        .name("inner")
+                        .required(false)
+                        .field_type(Primitive(PrimitiveType::Long))
+                        .initial_default(Literal::Primitive(PrimitiveLiteral::Long(7)))
+                        .build()
+                        .unwrap()
                         .into(),
                 ])),
             )
+            .expect("valid nested field")
             .into(),
         ]);
         let err = nested
@@ -611,9 +628,12 @@ mod tests {
                 1,
                 "container",
                 Struct(StructType::new(vec![
-                    NestedField::optional(2, "v", Variant(VariantType)).into(),
+                    NestedField::optional(2, "v", Variant(VariantType))
+                        .expect("valid nested field")
+                        .into(),
                 ])),
             )
+            .expect("valid nested field")
             .into(),
         ]);
         let err = nested_variant
@@ -636,14 +656,20 @@ mod tests {
 
         // All v1-compatible types → V1.
         let v1 = schema_with(vec![
-            NestedField::required(1, "a", Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "b", Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "a", Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(2, "b", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ]);
         assert_eq!(v1.calc_min_compatible_format(), FormatVersion::V1);
 
         // A top-level variant → V3.
         let variant = schema_with(vec![
-            NestedField::optional(1, "v", Variant(VariantType)).into(),
+            NestedField::optional(1, "v", Variant(VariantType))
+                .expect("valid nested field")
+                .into(),
         ]);
         assert_eq!(variant.calc_min_compatible_format(), FormatVersion::V3);
 
@@ -662,12 +688,15 @@ mod tests {
                                 "element",
                                 Primitive(PrimitiveType::TimestampNs),
                             )
+                            .expect("valid nested field")
                             .into(),
                         )),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])),
             )
+            .expect("valid nested field")
             .into(),
         ]);
         assert_eq!(nested.calc_min_compatible_format(), FormatVersion::V3);
@@ -682,11 +711,21 @@ mod tests {
         // with the type problem before the initial-default problem for field 2.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(3, "c", Variant(VariantType)).into(),
-                NestedField::optional(2, "b", Primitive(PrimitiveType::TimestampNs))
-                    .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(0)))
+                NestedField::optional(3, "c", Variant(VariantType))
+                    .expect("valid nested field")
                     .into(),
-                NestedField::required(1, "a", Primitive(PrimitiveType::Int)).into(),
+                NestedField::builder()
+                    .id(2)
+                    .name("b")
+                    .required(false)
+                    .field_type(Primitive(PrimitiveType::TimestampNs))
+                    .initial_default(Literal::Primitive(PrimitiveLiteral::Long(0)))
+                    .build()
+                    .unwrap()
+                    .into(),
+                NestedField::required(1, "a", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -712,9 +751,12 @@ mod tests {
     #[test]
     fn test_construct_schema() {
         let field1: NestedFieldRef =
-            NestedField::required(1, "f1", Primitive(PrimitiveType::Boolean)).into();
-        let field2: NestedFieldRef =
-            NestedField::optional(2, "f2", Primitive(PrimitiveType::Int)).into();
+            NestedField::required(1, "f1", Primitive(PrimitiveType::Boolean))
+                .expect("valid nested field")
+                .into();
+        let field2: NestedFieldRef = NestedField::optional(2, "f2", Primitive(PrimitiveType::Int))
+            .expect("valid nested field")
+            .into();
 
         let schema = Schema::builder()
             .with_fields(vec![field1.clone()])
@@ -735,9 +777,15 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -774,9 +822,15 @@ mod tests {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![2])
             .with_fields(vec![
-                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     4,
                     "qux",
@@ -786,9 +840,11 @@ mod tests {
                             Primitive(PrimitiveType::String),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     6,
@@ -798,6 +854,7 @@ mod tests {
                             7,
                             Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::map_value_element(
                             8,
@@ -806,19 +863,23 @@ mod tests {
                                     9,
                                     Primitive(PrimitiveType::String),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 value_field: NestedField::map_value_element(
                                     10,
                                     Primitive(PrimitiveType::Int),
                                     true,
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             }),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     11,
@@ -832,28 +893,37 @@ mod tests {
                                     "latitude",
                                     Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 NestedField::optional(
                                     14,
                                     "longitude",
                                     Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     15,
                     "person",
                     Struct(StructType::new(vec![
-                        NestedField::optional(16, "name", Primitive(PrimitiveType::String)).into(),
-                        NestedField::required(17, "age", Primitive(PrimitiveType::Int)).into(),
+                        NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
+                            .into(),
+                        NestedField::required(17, "age", Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -879,10 +949,18 @@ table {
             .with_schema_id(1)
             .with_identifier_field_ids(vec![1])
             .with_fields(vec![
-                NestedField::required(1, "foo", Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
-                NestedField::optional(4, "baz", Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::required(1, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(4, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build();
 
@@ -964,7 +1042,7 @@ table {
         for (name, id) in expected_name_to_id {
             assert_eq!(
                 Some(id),
-                schema.field_by_name_case_insensitive(&name).map(|f| f.id)
+                schema.field_by_name_case_insensitive(&name).map(|f| f.id())
             );
         }
     }
@@ -1046,15 +1124,18 @@ table {
         let expected_id_to_field: HashMap<i32, NestedField> = HashMap::from([
             (
                 1,
-                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
             ),
             (
                 2,
-                NestedField::required(2, "bar", Primitive(PrimitiveType::Int)),
+                NestedField::required(2, "bar", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
             ),
             (
                 3,
-                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field"),
             ),
             (
                 4,
@@ -1067,13 +1148,16 @@ table {
                             Primitive(PrimitiveType::String),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 5,
-                NestedField::required(5, "element", Primitive(PrimitiveType::String)),
+                NestedField::required(5, "element", Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
             ),
             (
                 6,
@@ -1085,6 +1169,7 @@ table {
                             7,
                             Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::map_value_element(
                             8,
@@ -1093,23 +1178,28 @@ table {
                                     9,
                                     Primitive(PrimitiveType::String),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 value_field: NestedField::map_value_element(
                                     10,
                                     Primitive(PrimitiveType::Int),
                                     true,
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             }),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 7,
-                NestedField::required(7, "key", Primitive(PrimitiveType::String)),
+                NestedField::required(7, "key", Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
             ),
             (
                 8,
@@ -1121,23 +1211,28 @@ table {
                             9,
                             Primitive(PrimitiveType::String),
                         )
+                        .expect("valid nested field")
                         .into(),
                         value_field: NestedField::map_value_element(
                             10,
                             Primitive(PrimitiveType::Int),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 9,
-                NestedField::required(9, "key", Primitive(PrimitiveType::String)),
+                NestedField::required(9, "key", Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
             ),
             (
                 10,
-                NestedField::required(10, "value", Primitive(PrimitiveType::Int)),
+                NestedField::required(10, "value", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
             ),
             (
                 11,
@@ -1153,19 +1248,23 @@ table {
                                     "latitude",
                                     Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                                 NestedField::optional(
                                     14,
                                     "longitude",
                                     Primitive(PrimitiveType::Float),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 12,
@@ -1173,20 +1272,25 @@ table {
                     12,
                     Struct(StructType::new(vec![
                         NestedField::optional(13, "latitude", Primitive(PrimitiveType::Float))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::optional(14, "longitude", Primitive(PrimitiveType::Float))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                     true,
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 13,
-                NestedField::optional(13, "latitude", Primitive(PrimitiveType::Float)),
+                NestedField::optional(13, "latitude", Primitive(PrimitiveType::Float))
+                    .expect("valid nested field"),
             ),
             (
                 14,
-                NestedField::optional(14, "longitude", Primitive(PrimitiveType::Float)),
+                NestedField::optional(14, "longitude", Primitive(PrimitiveType::Float))
+                    .expect("valid nested field"),
             ),
             (
                 15,
@@ -1194,18 +1298,25 @@ table {
                     15,
                     "person",
                     Struct(StructType::new(vec![
-                        NestedField::optional(16, "name", Primitive(PrimitiveType::String)).into(),
-                        NestedField::required(17, "age", Primitive(PrimitiveType::Int)).into(),
+                        NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
+                            .into(),
+                        NestedField::required(17, "age", Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
-                ),
+                )
+                .expect("valid nested field"),
             ),
             (
                 16,
-                NestedField::optional(16, "name", Primitive(PrimitiveType::String)),
+                NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                    .expect("valid nested field"),
             ),
             (
                 17,
-                NestedField::required(17, "age", Primitive(PrimitiveType::Int)),
+                NestedField::required(17, "age", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field"),
             ),
         ]);
 
@@ -1314,9 +1425,15 @@ table {
             .with_identifier_field_ids(vec![5])
             .with_alias(BiHashMap::from_iter(vec![("bar_alias".to_string(), 3)]))
             .with_fields(vec![
-                NestedField::required(5, "foo", Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(3, "bar", Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean)).into(),
+                NestedField::required(5, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "bar", Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "baz", Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap_err();
@@ -1351,15 +1468,18 @@ table {
                         "Map",
                         Map(MapType::new(
                             NestedField::map_key_element(2, Primitive(PrimitiveType::String))
+                                .expect("valid nested field")
                                 .into(),
                             NestedField::map_value_element(
                                 3,
                                 Primitive(PrimitiveType::Boolean),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         )),
                     )
+                    .expect("valid nested field")
                     .into()
                 ])
                 .build()
@@ -1375,15 +1495,18 @@ table {
                         "Map",
                         Map(MapType::new(
                             NestedField::map_key_element(2, Primitive(PrimitiveType::String))
+                                .expect("valid nested field")
                                 .into(),
                             NestedField::map_value_element(
                                 3,
                                 Primitive(PrimitiveType::Boolean),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         )),
                     )
+                    .expect("valid nested field")
                     .into()
                 ])
                 .build()
@@ -1401,9 +1524,11 @@ table {
                         "List",
                         List(ListType::new(
                             NestedField::list_element(2, Primitive(PrimitiveType::String), true)
+                                .expect("valid nested field")
                                 .into(),
                         )),
                     )
+                    .expect("valid nested field")
                     .into()
                 ])
                 .build()
@@ -1421,10 +1546,14 @@ table {
                         "Struct",
                         Struct(StructType::new(vec![
                             NestedField::required(2, "name", Primitive(PrimitiveType::String))
+                                .expect("valid nested field")
                                 .into(),
-                            NestedField::optional(3, "age", Primitive(PrimitiveType::Int)).into(),
+                            NestedField::optional(3, "age", Primitive(PrimitiveType::Int))
+                                .expect("valid nested field")
+                                .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into()
                 ])
                 .build()
@@ -1437,7 +1566,9 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Float", Primitive(PrimitiveType::Float),).into()
+                    NestedField::required(1, "Float", Primitive(PrimitiveType::Float),)
+                        .expect("valid nested field")
+                        .into()
                 ])
                 .build()
                 .is_err()
@@ -1447,7 +1578,9 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Double", Primitive(PrimitiveType::Double),).into()
+                    NestedField::required(1, "Double", Primitive(PrimitiveType::Double),)
+                        .expect("valid nested field")
+                        .into()
                 ])
                 .build()
                 .is_err()
@@ -1459,7 +1592,9 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::required(1, "Required", Primitive(PrimitiveType::String),).into()
+                    NestedField::required(1, "Required", Primitive(PrimitiveType::String),)
+                        .expect("valid nested field")
+                        .into()
                 ])
                 .build()
                 .is_ok()
@@ -1469,7 +1604,9 @@ table {
                 .with_schema_id(1)
                 .with_identifier_field_ids(vec![1])
                 .with_fields(vec![
-                    NestedField::optional(1, "Optional", Primitive(PrimitiveType::String),).into()
+                    NestedField::optional(1, "Optional", Primitive(PrimitiveType::String),)
+                        .expect("valid nested field")
+                        .into()
                 ])
                 .build()
                 .is_err()

--- a/crates/iceberg/src/spec/schema/prune_columns.rs
+++ b/crates/iceberg/src/spec/schema/prune_columns.rs
@@ -65,36 +65,26 @@ impl PruneColumn {
         }
     }
     fn project_list(list: &ListType, element_result: Type) -> Result<ListType> {
-        if *list.element_field.field_type == element_result {
+        if *list.element_field.field_type() == element_result {
             return Ok(list.clone());
         }
         Ok(ListType {
-            element_field: Arc::new(NestedField {
-                id: list.element_field.id,
-                name: list.element_field.name.clone(),
-                required: list.element_field.required,
-                field_type: Box::new(element_result),
-                doc: list.element_field.doc.clone(),
-                initial_default: list.element_field.initial_default.clone(),
-                write_default: list.element_field.write_default.clone(),
-            }),
+            element_field: Arc::new(
+                list.element_field
+                    .rebuild(list.element_field.id(), element_result)?,
+            ),
         })
     }
     fn project_map(map: &MapType, value_result: Type) -> Result<MapType> {
-        if *map.value_field.field_type == value_result {
+        if *map.value_field.field_type() == value_result {
             return Ok(map.clone());
         }
         Ok(MapType {
             key_field: map.key_field.clone(),
-            value_field: Arc::new(NestedField {
-                id: map.value_field.id,
-                name: map.value_field.name.clone(),
-                required: map.value_field.required,
-                field_type: Box::new(value_result),
-                doc: map.value_field.doc.clone(),
-                initial_default: map.value_field.initial_default.clone(),
-                write_default: map.value_field.write_default.clone(),
-            }),
+            value_field: Arc::new(
+                map.value_field
+                    .rebuild(map.value_field.id(), value_result)?,
+            ),
         })
     }
 }
@@ -107,23 +97,23 @@ impl SchemaVisitor for PruneColumn {
     }
 
     fn field(&mut self, field: &NestedFieldRef, value: Option<Type>) -> Result<Option<Type>> {
-        if self.selected.contains(&field.id) {
+        if self.selected.contains(&field.id()) {
             if self.select_full_types {
-                Ok(Some(*field.field_type.clone()))
-            } else if field.field_type.is_struct() {
+                Ok(Some(field.field_type().clone()))
+            } else if field.field_type().is_struct() {
                 Ok(Some(Type::Struct(PruneColumn::project_selected_struct(
                     value,
                 )?)))
-            } else if !field.field_type.is_nested() {
-                Ok(Some(*field.field_type.clone()))
+            } else if !field.field_type().is_nested() {
+                Ok(Some(field.field_type().clone()))
             } else {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Can't project list or map field directly when not selecting full type."
                         .to_string(),
                 )
-                .with_context("field_id", field.id.to_string())
-                .with_context("field_type", field.field_type.to_string()))
+                .with_context("field_id", field.id().to_string())
+                .with_context("field_type", field.field_type().to_string()))
             }
         } else {
             Ok(value)
@@ -141,19 +131,11 @@ impl SchemaVisitor for PruneColumn {
 
         for (field, projected_type) in zip_eq(fields.iter(), results.iter()) {
             if let Some(projected_type) = projected_type {
-                if *field.field_type == *projected_type {
+                if *field.field_type() == *projected_type {
                     selected_field.push(field.clone());
                 } else {
                     same_type = false;
-                    let new_field = NestedField {
-                        id: field.id,
-                        name: field.name.clone(),
-                        required: field.required,
-                        field_type: Box::new(projected_type.clone()),
-                        doc: field.doc.clone(),
-                        initial_default: field.initial_default.clone(),
-                        write_default: field.write_default.clone(),
-                    };
+                    let new_field = field.rebuild(field.id(), projected_type.clone())?;
                     selected_field.push(Arc::new(new_field));
                 }
             }
@@ -170,23 +152,24 @@ impl SchemaVisitor for PruneColumn {
     }
 
     fn list(&mut self, list: &ListType, value: Option<Type>) -> Result<Option<Type>> {
-        if self.selected.contains(&list.element_field.id) {
+        if self.selected.contains(&list.element_field.id()) {
             if self.select_full_types {
                 Ok(Some(Type::List(list.clone())))
-            } else if list.element_field.field_type.is_struct() {
+            } else if list.element_field.field_type().is_struct() {
                 let projected_struct = PruneColumn::project_selected_struct(value).unwrap();
                 Ok(Some(Type::List(PruneColumn::project_list(
                     list,
                     Type::Struct(projected_struct),
                 )?)))
-            } else if list.element_field.field_type.is_primitive() {
+            } else if list.element_field.field_type().is_primitive() {
                 Ok(Some(Type::List(list.clone())))
             } else {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Cannot explicitly project List or Map types, List element {} of type {} was selected",
-                        list.element_field.id, list.element_field.field_type
+                        list.element_field.id(),
+                        list.element_field.field_type()
                     ),
                 ))
             }
@@ -203,24 +186,25 @@ impl SchemaVisitor for PruneColumn {
         _key_value: Option<Type>,
         value: Option<Type>,
     ) -> Result<Option<Type>> {
-        if self.selected.contains(&map.value_field.id) {
+        if self.selected.contains(&map.value_field.id()) {
             if self.select_full_types {
                 Ok(Some(Type::Map(map.clone())))
-            } else if map.value_field.field_type.is_struct() {
+            } else if map.value_field.field_type().is_struct() {
                 let projected_struct =
                     PruneColumn::project_selected_struct(Some(value.unwrap())).unwrap();
                 Ok(Some(Type::Map(PruneColumn::project_map(
                     map,
                     Type::Struct(projected_struct),
                 )?)))
-            } else if map.value_field.field_type.is_primitive() {
+            } else if map.value_field.field_type().is_primitive() {
                 Ok(Some(Type::Map(map.clone())))
             } else {
                 Err(Error::new(
                     ErrorKind::DataInvalid,
                     format!(
                         "Cannot explicitly project List or Map types, Map value {} of type {} was selected",
-                        map.value_field.id, map.value_field.field_type
+                        map.value_field.id(),
+                        map.value_field.field_type()
                     ),
                 ))
             }
@@ -229,7 +213,7 @@ impl SchemaVisitor for PruneColumn {
                 map,
                 value_result,
             )?)))
-        } else if self.selected.contains(&map.key_field.id) {
+        } else if self.selected.contains(&map.key_field.id()) {
             Ok(Some(Type::Map(map.clone())))
         } else {
             Ok(None)
@@ -257,7 +241,9 @@ mod tests {
         let expected_type = Type::from(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap()
@@ -276,7 +262,9 @@ mod tests {
         let expected_type = Type::from(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
+                    NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap()
@@ -304,9 +292,11 @@ mod tests {
                                 Primitive(PrimitiveType::String),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -343,9 +333,11 @@ mod tests {
                                 Primitive(PrimitiveType::String),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -373,6 +365,7 @@ mod tests {
                                 7,
                                 Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::map_value_element(
                                 8,
@@ -381,19 +374,23 @@ mod tests {
                                         9,
                                         Primitive(PrimitiveType::String),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
                                         Primitive(PrimitiveType::Int),
                                         true,
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                 }),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -429,6 +426,7 @@ mod tests {
                                 7,
                                 Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::map_value_element(
                                 8,
@@ -437,19 +435,23 @@ mod tests {
                                         9,
                                         Primitive(PrimitiveType::String),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
                                         Primitive(PrimitiveType::Int),
                                         true,
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                 }),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -477,6 +479,7 @@ mod tests {
                                 7,
                                 Primitive(PrimitiveType::String),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::map_value_element(
                                 8,
@@ -485,19 +488,23 @@ mod tests {
                                         9,
                                         Primitive(PrimitiveType::String),
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                     value_field: NestedField::map_value_element(
                                         10,
                                         Primitive(PrimitiveType::Int),
                                         true,
                                     )
+                                    .expect("valid nested field")
                                     .into(),
                                 }),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -522,9 +529,11 @@ mod tests {
                         "person",
                         Type::Struct(StructType::new(vec![
                             NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                                .expect("valid nested field")
                                 .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -549,9 +558,11 @@ mod tests {
                         "person",
                         Type::Struct(StructType::new(vec![
                             NestedField::optional(16, "name", Primitive(PrimitiveType::String))
+                                .expect("valid nested field")
                                 .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -570,7 +581,9 @@ mod tests {
     fn test_prune_columns_empty_struct() {
         let schema_with_empty_struct_field = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(15, "person", Type::Struct(StructType::new(vec![]))).into(),
+                NestedField::optional(15, "person", Type::Struct(StructType::new(vec![])))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -578,6 +591,7 @@ mod tests {
             Schema::builder()
                 .with_fields(vec![
                     NestedField::optional(15, "person", Type::Struct(StructType::new(vec![])))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -595,7 +609,9 @@ mod tests {
     fn test_prune_columns_empty_struct_full() {
         let schema_with_empty_struct_field = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(15, "person", Type::Struct(StructType::new(vec![]))).into(),
+                NestedField::optional(15, "person", Type::Struct(StructType::new(vec![])))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -603,6 +619,7 @@ mod tests {
             Schema::builder()
                 .with_fields(vec![
                     NestedField::optional(15, "person", Type::Struct(StructType::new(vec![])))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -626,20 +643,25 @@ mod tests {
                     "id_to_person",
                     Type::Map(MapType {
                         key_field: NestedField::map_key_element(7, Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                         value_field: NestedField::map_value_element(
                             8,
                             Type::Struct(StructType::new(vec![
                                 NestedField::optional(10, "name", Primitive(PrimitiveType::String))
+                                    .expect("valid nested field")
                                     .into(),
                                 NestedField::required(11, "age", Primitive(PrimitiveType::Int))
+                                    .expect("valid nested field")
                                     .into(),
                             ])),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -655,18 +677,22 @@ mod tests {
                                 7,
                                 Primitive(PrimitiveType::Int),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::map_value_element(
                                 8,
                                 Type::Struct(StructType::new(vec![
                                     NestedField::required(11, "age", Primitive(PrimitiveType::Int))
+                                        .expect("valid nested field")
                                         .into(),
                                 ])),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -689,20 +715,25 @@ mod tests {
                     "id_to_person",
                     Type::Map(MapType {
                         key_field: NestedField::map_key_element(7, Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                         value_field: NestedField::map_value_element(
                             8,
                             Type::Struct(StructType::new(vec![
                                 NestedField::optional(10, "name", Primitive(PrimitiveType::String))
+                                    .expect("valid nested field")
                                     .into(),
                                 NestedField::required(11, "age", Primitive(PrimitiveType::Int))
+                                    .expect("valid nested field")
                                     .into(),
                             ])),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -718,18 +749,22 @@ mod tests {
                                 7,
                                 Primitive(PrimitiveType::Int),
                             )
+                            .expect("valid nested field")
                             .into(),
                             value_field: NestedField::map_value_element(
                                 8,
                                 Type::Struct(StructType::new(vec![
                                     NestedField::required(11, "age", Primitive(PrimitiveType::Int))
+                                        .expect("valid nested field")
                                         .into(),
                                 ])),
                                 true,
                             )
+                            .expect("valid nested field")
                             .into(),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -757,8 +792,12 @@ mod tests {
         // foo (String, id=1) + v (Variant, id=2).
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -766,7 +805,9 @@ mod tests {
         // A variant is a leaf (like a primitive): selecting it keeps it, the same way
         // for select_full_types true and false.
         let only_variant = Type::Struct(StructType::new(vec![
-            NestedField::optional(2, "v", Type::Variant(VariantType)).into(),
+            NestedField::optional(2, "v", Type::Variant(VariantType))
+                .expect("valid nested field")
+                .into(),
         ]));
         for full in [false, true] {
             let result = prune_columns(&schema, HashSet::from([2]), full).unwrap();
@@ -775,7 +816,9 @@ mod tests {
 
         // Selecting a sibling prunes the variant out.
         let only_foo = Type::Struct(StructType::new(vec![
-            NestedField::optional(1, "foo", Primitive(PrimitiveType::String)).into(),
+            NestedField::optional(1, "foo", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ]));
         let result = prune_columns(&schema, HashSet::from([1]), false).unwrap();
         assert_eq!(result, only_foo);

--- a/crates/iceberg/src/spec/schema/visitor.rs
+++ b/crates/iceberg/src/spec/schema/visitor.rs
@@ -81,21 +81,21 @@ pub(crate) fn visit_type<V: SchemaVisitor>(r#type: &Type, visitor: &mut V) -> Re
         Type::Primitive(p) => visitor.primitive(p),
         Type::List(list) => {
             visitor.before_list_element(&list.element_field)?;
-            let value = visit_type(&list.element_field.field_type, visitor)?;
+            let value = visit_type(list.element_field.field_type(), visitor)?;
             visitor.after_list_element(&list.element_field)?;
             visitor.list(list, value)
         }
         Type::Map(map) => {
             let key_result = {
                 visitor.before_map_key(&map.key_field)?;
-                let ret = visit_type(&map.key_field.field_type, visitor)?;
+                let ret = visit_type(map.key_field.field_type(), visitor)?;
                 visitor.after_map_key(&map.key_field)?;
                 ret
             };
 
             let value_result = {
                 visitor.before_map_value(&map.value_field)?;
-                let ret = visit_type(&map.value_field.field_type, visitor)?;
+                let ret = visit_type(map.value_field.field_type(), visitor)?;
                 visitor.after_map_value(&map.value_field)?;
                 ret
             };
@@ -112,7 +112,7 @@ pub fn visit_struct<V: SchemaVisitor>(s: &StructType, visitor: &mut V) -> Result
     let mut results = Vec::with_capacity(s.fields().len());
     for field in s.fields() {
         visitor.before_struct_field(field)?;
-        let result = visit_type(&field.field_type, visitor)?;
+        let result = visit_type(field.field_type(), visitor)?;
         visitor.after_struct_field(field)?;
         let result = visitor.field(field, result)?;
         results.push(result);
@@ -221,7 +221,7 @@ pub(crate) fn visit_type_with_partner<P, V: SchemaWithPartnerVisitor<P>, A: Part
             let list_element_partner = accessor.list_element_partner(partner)?;
             visitor.before_list_element(&list.element_field, list_element_partner)?;
             let element_results = visit_type_with_partner(
-                &list.element_field.field_type,
+                list.element_field.field_type(),
                 list_element_partner,
                 visitor,
                 accessor,
@@ -232,14 +232,18 @@ pub(crate) fn visit_type_with_partner<P, V: SchemaWithPartnerVisitor<P>, A: Part
         Type::Map(map) => {
             let key_partner = accessor.map_key_partner(partner)?;
             visitor.before_map_key(&map.key_field, key_partner)?;
-            let key_result =
-                visit_type_with_partner(&map.key_field.field_type, key_partner, visitor, accessor)?;
+            let key_result = visit_type_with_partner(
+                map.key_field.field_type(),
+                key_partner,
+                visitor,
+                accessor,
+            )?;
             visitor.after_map_key(&map.key_field, key_partner)?;
 
             let value_partner = accessor.map_value_partner(partner)?;
             visitor.before_map_value(&map.value_field, value_partner)?;
             let value_result = visit_type_with_partner(
-                &map.value_field.field_type,
+                map.value_field.field_type(),
                 value_partner,
                 visitor,
                 accessor,
@@ -264,7 +268,7 @@ pub fn visit_struct_with_partner<P, V: SchemaWithPartnerVisitor<P>, A: PartnerAc
     for field in s.fields() {
         let field_partner = accessor.field_partner(partner, field)?;
         visitor.before_struct_field(field, field_partner)?;
-        let result = visit_type_with_partner(&field.field_type, field_partner, visitor, accessor)?;
+        let result = visit_type_with_partner(field.field_type(), field_partner, visitor, accessor)?;
         visitor.after_struct_field(field, field_partner)?;
         let result = visitor.field(field, field_partner, result)?;
         results.push(result);

--- a/crates/iceberg/src/spec/snapshot_summary.rs
+++ b/crates/iceberg/src/spec/snapshot_summary.rs
@@ -819,8 +819,12 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -969,8 +973,12 @@ mod tests {
         let schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/spec/sort.rs
+++ b/crates/iceberg/src/spec/sort.rs
@@ -185,7 +185,7 @@ impl SortOrderBuilder {
                     ));
                 }
                 Some(source_field) => {
-                    let source_type = source_field.field_type.as_ref();
+                    let source_type = source_field.field_type();
 
                     if !source_type.is_primitive() {
                         return Err(Error::new(
@@ -387,7 +387,9 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -425,9 +427,11 @@ mod tests {
                             Type::Primitive(PrimitiveType::String),
                             true,
                         )
+                        .expect("valid nested field")
                         .into(),
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -457,7 +461,9 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(crate::spec::VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(crate::spec::VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -486,7 +492,9 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -515,8 +523,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "foo", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -1672,6 +1672,17 @@ mod tests {
         serde_json::from_str(&metadata).unwrap()
     }
 
+    fn field_with_doc(id: i32, name: &str, field_type: Type, doc: &str) -> NestedField {
+        NestedField::builder()
+            .id(id)
+            .name(name)
+            .required(true)
+            .field_type(field_type)
+            .doc(doc)
+            .build()
+            .unwrap()
+    }
+
     /// Loads a test table metadata and relocates it to `location`, so that derived
     /// metadata paths point at a writable (e.g. temp) directory.
     fn get_test_table_metadata_at(file_name: &str, location: &str) -> TableMetadata {
@@ -1751,16 +1762,18 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "struct_name",
-                    Type::Primitive(PrimitiveType::Fixed(1)),
-                )),
-                Arc::new(NestedField::required(
-                    4,
-                    "ts",
-                    Type::Primitive(PrimitiveType::Timestamp),
-                )),
+                Arc::new(
+                    NestedField::required(
+                        1,
+                        "struct_name",
+                        Type::Primitive(PrimitiveType::Fixed(1)),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(4, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -1905,11 +1918,10 @@ mod tests {
 
         let schema = Schema::builder()
             .with_schema_id(1)
-            .with_fields(vec![Arc::new(NestedField::required(
-                4,
-                "ts",
-                Type::Primitive(PrimitiveType::Timestamp),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(4, "ts", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
 
@@ -2082,31 +2094,34 @@ mod tests {
 
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::optional(
-                    1,
-                    "vendor_id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::optional(
-                    2,
-                    "trip_id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::optional(
-                    3,
-                    "trip_distance",
-                    Type::Primitive(PrimitiveType::Float),
-                )),
-                Arc::new(NestedField::optional(
-                    4,
-                    "fare_amount",
-                    Type::Primitive(PrimitiveType::Double),
-                )),
-                Arc::new(NestedField::optional(
-                    5,
-                    "store_and_fwd_flag",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::optional(1, "vendor_id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(2, "trip_id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        3,
+                        "trip_distance",
+                        Type::Primitive(PrimitiveType::Float),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(4, "fare_amount", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::optional(
+                        5,
+                        "store_and_fwd_flag",
+                        Type::Primitive(PrimitiveType::String),
+                    )
+                    .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -2219,11 +2234,10 @@ mod tests {
 
         let schema = Schema::builder()
             .with_schema_id(1)
-            .with_fields(vec![Arc::new(NestedField::required(
-                1,
-                "struct_name",
-                Type::Primitive(PrimitiveType::Fixed(1)),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(1, "struct_name", Type::Primitive(PrimitiveType::Fixed(1)))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
 
@@ -2727,11 +2741,10 @@ mod tests {
 
         let schema = Schema::builder()
             .with_schema_id(0)
-            .with_fields(vec![Arc::new(NestedField::required(
-                1,
-                "x",
-                Type::Primitive(PrimitiveType::Long),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
         let partition_spec = PartitionSpec::builder(schema.clone())
@@ -2869,11 +2882,10 @@ mod tests {
 
         let schema = Schema::builder()
             .with_schema_id(0)
-            .with_fields(vec![Arc::new(NestedField::required(
-                1,
-                "x",
-                Type::Primitive(PrimitiveType::Long),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
         let partition_spec = PartitionSpec::builder(schema.clone())
@@ -2972,19 +2984,26 @@ mod tests {
             .with_schema_id(0)
             .with_fields(vec![
                 Arc::new(
-                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
-                        .with_initial_default(Literal::Primitive(PrimitiveLiteral::Long(1)))
-                        .with_write_default(Literal::Primitive(PrimitiveLiteral::Long(1))),
+                    NestedField::builder()
+                        .id(1)
+                        .name("x")
+                        .required(true)
+                        .field_type(Type::Primitive(PrimitiveType::Long))
+                        .initial_default(Literal::Primitive(PrimitiveLiteral::Long(1)))
+                        .write_default(Literal::Primitive(PrimitiveLiteral::Long(1)))
+                        .build()
+                        .unwrap(),
                 ),
-                Arc::new(
-                    NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
-                        .with_doc("comment"),
-                ),
-                Arc::new(NestedField::required(
-                    3,
-                    "z",
+                Arc::new(field_with_doc(
+                    2,
+                    "y",
                     Type::Primitive(PrimitiveType::Long),
+                    "comment",
                 )),
+                Arc::new(
+                    NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -3056,31 +3075,30 @@ mod tests {
 
         let schema1 = Schema::builder()
             .with_schema_id(0)
-            .with_fields(vec![Arc::new(NestedField::required(
-                1,
-                "x",
-                Type::Primitive(PrimitiveType::Long),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
 
         let schema2 = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "x",
+                Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(field_with_doc(
+                    2,
+                    "y",
                     Type::Primitive(PrimitiveType::Long),
+                    "comment",
                 )),
                 Arc::new(
-                    NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
-                        .with_doc("comment"),
+                    NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
                 ),
-                Arc::new(NestedField::required(
-                    3,
-                    "z",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
             ])
             .with_identifier_field_ids(vec![1, 2])
             .build()
@@ -3197,20 +3215,20 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "x",
+                Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(field_with_doc(
+                    2,
+                    "y",
                     Type::Primitive(PrimitiveType::Long),
+                    "comment",
                 )),
                 Arc::new(
-                    NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
-                        .with_doc("comment"),
+                    NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
                 ),
-                Arc::new(NestedField::required(
-                    3,
-                    "z",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
             ])
             .build()
             .unwrap();
@@ -3283,20 +3301,20 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "x",
+                Arc::new(
+                    NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(field_with_doc(
+                    2,
+                    "y",
                     Type::Primitive(PrimitiveType::Long),
+                    "comment",
                 )),
                 Arc::new(
-                    NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
-                        .with_doc("comment"),
+                    NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
                 ),
-                Arc::new(NestedField::required(
-                    3,
-                    "z",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
             ])
             .build()
             .unwrap();
@@ -3401,9 +3419,9 @@ mod tests {
         // Get the schema and verify it has the expected fields
         let schema = desered_type.current_schema();
         assert_eq!(schema.as_struct().fields().len(), 3);
-        assert_eq!(schema.as_struct().fields()[0].name, "x");
-        assert_eq!(schema.as_struct().fields()[1].name, "y");
-        assert_eq!(schema.as_struct().fields()[2].name, "z");
+        assert_eq!(schema.as_struct().fields()[0].name(), "x");
+        assert_eq!(schema.as_struct().fields()[1].name(), "y");
+        assert_eq!(schema.as_struct().fields()[2].name(), "z");
     }
 
     #[test]
@@ -3767,8 +3785,11 @@ mod tests {
     fn test_partition_name_exists() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "partition_col", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3817,7 +3838,9 @@ mod tests {
         // Create metadata with no partition specs (unpartitioned table)
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -3845,8 +3868,12 @@ mod tests {
         let schema1 = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "field1", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "field2", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "field1", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "field2", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -3854,8 +3881,12 @@ mod tests {
         let schema2 = Schema::builder()
             .with_schema_id(2)
             .with_fields(vec![
-                NestedField::required(1, "field1", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(3, "field3", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "field1", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "field3", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -3909,13 +3940,18 @@ mod tests {
         // Test a realistic multi-version scenario
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "deprecated_field",
                     Type::Primitive(PrimitiveType::String),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -3933,15 +3969,21 @@ mod tests {
 
         let evolved_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "deprecated_field",
                     Type::Primitive(PrimitiveType::String),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(4, "new_field", Type::Primitive(PrimitiveType::Double))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3950,11 +3992,17 @@ mod tests {
         // Then add a third schema that removes the deprecated field
         let _final_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(4, "new_field", Type::Primitive(PrimitiveType::Double))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::required(5, "latest_field", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -4035,7 +4083,9 @@ mod tests {
 
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4071,7 +4121,9 @@ mod tests {
 
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4167,7 +4219,9 @@ mod tests {
     fn test_table_properties_with_invalid_value() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4214,7 +4268,9 @@ mod tests {
         // Create a v2 table metadata
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4314,7 +4370,9 @@ mod tests {
         // Create a v3 table metadata
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4452,9 +4510,15 @@ mod tests {
     fn test_unified_partition_type_spans_all_specs() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -4491,11 +4555,7 @@ mod tests {
         assert_eq!(metadata.default_partition_type().fields().len(), 1);
 
         let unified = metadata.unified_partition_type(&schema).unwrap();
-        let names: Vec<&str> = unified
-            .fields()
-            .iter()
-            .map(|field| field.name.as_str())
-            .collect();
+        let names: Vec<&str> = unified.fields().iter().map(|field| field.name()).collect();
         assert_eq!(names, vec!["y", "z"]);
     }
 }

--- a/crates/iceberg/src/spec/table_metadata_builder.rs
+++ b/crates/iceberg/src/spec/table_metadata_builder.rs
@@ -791,7 +791,7 @@ impl TableMetadataBuilder {
             if let Some(schema_field) = current_schema.field_by_name(&partition_field.name) {
                 let is_identity_transform =
                     partition_field.transform == crate::spec::Transform::Identity;
-                let has_matching_source_id = schema_field.id == partition_field.source_id;
+                let has_matching_source_id = schema_field.id() == partition_field.source_id;
 
                 if !is_identity_transform {
                     return Err(Error::new(
@@ -809,7 +809,9 @@ impl TableMetadataBuilder {
                         format!(
                             "Cannot create identity partition sourced from different field in schema. \
                              Field name '{}' has id `{}` in schema but partition source id is `{}`",
-                            partition_field.name, schema_field.id, partition_field.source_id
+                            partition_field.name,
+                            schema_field.id(),
+                            partition_field.source_id
                         ),
                     ));
                 }
@@ -1323,7 +1325,7 @@ impl TableMetadataBuilder {
                                    "Cannot find source column with name {source_field_name} for sort column in re-assigned schema."
                                ),
                            )
-                       })?.id;
+                       })?.id();
             field.source_id = new_field_id;
             fresh_order.with_sort_field(field);
         }
@@ -1481,9 +1483,15 @@ mod tests {
     fn schema() -> Schema {
         Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap()
@@ -1613,18 +1621,26 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(10)
             .with_fields(vec![
-                NestedField::required(11, "a", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(12, "b", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(11, "a", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(12, "b", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     13,
                     "struct",
                     Type::Struct(StructType::new(vec![
                         NestedField::required(14, "nested", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
-                NestedField::required(15, "c", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(15, "c", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1652,18 +1668,26 @@ mod tests {
 
         let expected_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "a", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "b", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "a", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "b", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "struct",
                     Type::Struct(StructType::new(vec![
                         NestedField::required(5, "nested", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
-                NestedField::required(4, "c", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(4, "c", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2021,10 +2045,18 @@ mod tests {
         let added_schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(4, "a", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "a", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2056,10 +2088,18 @@ mod tests {
         let added_schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(4, "a", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "y", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(3, "z", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "a", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2804,7 +2844,9 @@ mod tests {
     fn test_schema_evolution_now_correctly_validates_partition_field_name_conflicts() {
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2838,9 +2880,13 @@ mod tests {
 
         let evolved_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 // Adding a schema field with the same name as an existing partition field
-                NestedField::required(2, "bucket_data", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "bucket_data", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2863,7 +2909,9 @@ mod tests {
     fn test_schema_evolution_should_validate_on_schema_add_not_metadata_build() {
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2889,8 +2937,12 @@ mod tests {
 
         let non_conflicting_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::required(2, "new_field", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "new_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -2910,8 +2962,11 @@ mod tests {
     fn test_partition_spec_evolution_validates_schema_field_name_conflicts() {
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "existing_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -2963,8 +3018,11 @@ mod tests {
         // Create a table with an initial schema that has a field "existing_field"
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "existing_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -2992,8 +3050,11 @@ mod tests {
         // Add a second schema that removes the existing_field but keeps the data field
         let second_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(3, "new_field", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3012,10 +3073,14 @@ mod tests {
         // even though there's a partition field named "bucket_data"
         let third_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(3, "new_field", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::required(4, "existing_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3033,12 +3098,17 @@ mod tests {
         // and doesn't exist in any historical schema should fail
         let conflicting_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(3, "new_field", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::required(4, "existing_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::required(5, "bucket_data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(), // conflicts with partition field
             ])
             .build()
@@ -3059,8 +3129,11 @@ mod tests {
         // Create initial schema with a field
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "partition_data", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3088,10 +3161,14 @@ mod tests {
         // Add a new schema that still contains the partition_data field
         let evolved_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "partition_data", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::required(3, "new_field", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3110,7 +3187,9 @@ mod tests {
         // Create initial schema WITHOUT the conflicting field
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -3137,9 +3216,13 @@ mod tests {
         // Try to add a schema with a field that conflicts with partition field name
         let conflicting_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 // This field name conflicts with the partition field "bucket_data"
-                NestedField::required(2, "bucket_data", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(2, "bucket_data", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -3158,8 +3241,11 @@ mod tests {
     fn test_partition_spec_evolution_allows_non_conflicting_names() {
         let initial_schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(2, "existing_field", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()
@@ -3582,9 +3668,14 @@ mod tests {
     fn test_partition_field_id_reuse_across_specs() {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(3, "timestamp", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
                     .into(),
             ])
             .build()

--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -485,7 +485,7 @@ impl Transform {
                 BoundPredicate::Unary(expr) => Self::project_unary(expr.op(), name),
                 BoundPredicate::Binary(expr) => {
                     if matches!(
-                        expr.term().field().field_type.as_primitive_type(),
+                        expr.term().field().field_type().as_primitive_type(),
                         Some(&PrimitiveType::Int)
                             | Some(&PrimitiveType::Long)
                             | Some(&PrimitiveType::Decimal { .. })

--- a/crates/iceberg/src/spec/values/literal.rs
+++ b/crates/iceberg/src/spec/values/literal.rs
@@ -557,8 +557,8 @@ impl Literal {
                 if let JsonValue::Object(mut object) = value {
                     Ok(Some(Literal::Struct(Struct::from_iter(
                         schema.fields().iter().map(|field| {
-                            object.remove(&field.id.to_string()).and_then(|value| {
-                                Literal::try_from_json(value, &field.field_type)
+                            object.remove(&field.id().to_string()).and_then(|value| {
+                                Literal::try_from_json(value, field.field_type())
                                     .and_then(|value| {
                                         value.ok_or(Error::new(
                                             ErrorKind::DataInvalid,
@@ -582,7 +582,7 @@ impl Literal {
                         array
                             .into_iter()
                             .map(|value| {
-                                Literal::try_from_json(value, &list.element_field.field_type)
+                                Literal::try_from_json(value, list.element_field.field_type())
                             })
                             .collect::<Result<Vec<_>>>()?,
                     )))
@@ -614,14 +614,17 @@ impl Literal {
                                 .zip(values)
                                 .map(|(key, value)| {
                                     Ok((
-                                        Literal::try_from_json(key, &map.key_field.field_type)
+                                        Literal::try_from_json(key, map.key_field.field_type())
                                             .and_then(|value| {
                                                 value.ok_or(Error::new(
                                                     ErrorKind::DataInvalid,
                                                     "Key of map cannot be null",
                                                 ))
                                             })?,
-                                        Literal::try_from_json(value, &map.value_field.field_type)?,
+                                        Literal::try_from_json(
+                                            value,
+                                            map.value_field.field_type(),
+                                        )?,
                                     ))
                                 })
                                 .collect::<Result<Vec<_>>>()?,
@@ -736,17 +739,19 @@ impl Literal {
                 let mut id_and_value = Vec::with_capacity(struct_type.fields().len());
                 for (value, field) in s.into_iter().zip(struct_type.fields()) {
                     let json = match value {
-                        Some(val) => val.try_into_json(&field.field_type)?,
+                        Some(val) => val.try_into_json(field.field_type())?,
                         None => JsonValue::Null,
                     };
-                    id_and_value.push((field.id.to_string(), json));
+                    id_and_value.push((field.id().to_string(), json));
                 }
                 Ok(JsonValue::Object(JsonMap::from_iter(id_and_value)))
             }
             (Literal::List(list), Type::List(list_type)) => Ok(JsonValue::Array(
                 list.into_iter()
                     .map(|opt| match opt {
-                        Some(literal) => literal.try_into_json(&list_type.element_field.field_type),
+                        Some(literal) => {
+                            literal.try_into_json(list_type.element_field.field_type())
+                        }
                         None => Ok(JsonValue::Null),
                     })
                     .collect::<Result<Vec<JsonValue>>>()?,
@@ -756,9 +761,11 @@ impl Literal {
                 let mut json_keys = Vec::with_capacity(map.len());
                 let mut json_values = Vec::with_capacity(map.len());
                 for (key, value) in map.into_iter() {
-                    json_keys.push(key.try_into_json(&map_type.key_field.field_type)?);
+                    json_keys.push(key.try_into_json(map_type.key_field.field_type())?);
                     json_values.push(match value {
-                        Some(literal) => literal.try_into_json(&map_type.value_field.field_type)?,
+                        Some(literal) => {
+                            literal.try_into_json(map_type.value_field.field_type())?
+                        }
                         None => JsonValue::Null,
                     });
                 }

--- a/crates/iceberg/src/spec/values/serde.rs
+++ b/crates/iceberg/src/spec/values/serde.rs
@@ -256,11 +256,11 @@ pub(crate) mod _serde {
                     let mut optional = Vec::new();
                     if let Type::Struct(struct_ty) = ty {
                         for (value, field) in r#struct.into_iter().zip(struct_ty.fields()) {
-                            if field.required {
+                            if field.is_required() {
                                 if let Some(value) = value {
                                     required.push((
-                                        field.name.clone(),
-                                        RawLiteralEnum::try_from(value, &field.field_type)?,
+                                        field.name().to_string(),
+                                        RawLiteralEnum::try_from(value, field.field_type())?,
                                     ));
                                 } else {
                                     return Err(Error::new(
@@ -270,11 +270,11 @@ pub(crate) mod _serde {
                                 }
                             } else if let Some(value) = value {
                                 optional.push((
-                                    field.name.clone(),
-                                    Some(RawLiteralEnum::try_from(value, &field.field_type)?),
+                                    field.name().to_string(),
+                                    Some(RawLiteralEnum::try_from(value, field.field_type())?),
                                 ));
                             } else {
-                                optional.push((field.name.clone(), None));
+                                optional.push((field.name().to_string(), None));
                             }
                         }
                     } else {
@@ -291,14 +291,14 @@ pub(crate) mod _serde {
                             .into_iter()
                             .map(|v| {
                                 v.map(|v| {
-                                    RawLiteralEnum::try_from(v, &list_ty.element_field.field_type)
+                                    RawLiteralEnum::try_from(v, list_ty.element_field.field_type())
                                 })
                                 .transpose()
                             })
                             .collect::<Result<_, Error>>()?;
                         RawLiteralEnum::List(List {
                             list,
-                            required: list_ty.element_field.required,
+                            required: list_ty.element_field.is_required(),
                         })
                     } else {
                         return Err(Error::new(
@@ -309,7 +309,8 @@ pub(crate) mod _serde {
                 }
                 Literal::Map(map) => {
                     if let Type::Map(map_ty) = ty {
-                        if let Type::Primitive(PrimitiveType::String) = *map_ty.key_field.field_type
+                        if let Type::Primitive(PrimitiveType::String) =
+                            *map_ty.key_field.field_type()
                         {
                             let mut raw = Vec::with_capacity(map.len());
                             for (k, v) in map {
@@ -319,7 +320,7 @@ pub(crate) mod _serde {
                                         v.map(|v| {
                                             RawLiteralEnum::try_from(
                                                 v,
-                                                &map_ty.value_field.field_type,
+                                                map_ty.value_field.field_type(),
                                             )
                                         })
                                         .transpose()?,
@@ -333,18 +334,18 @@ pub(crate) mod _serde {
                             }
                             RawLiteralEnum::StringMap(StringMap {
                                 raw,
-                                required: map_ty.value_field.required,
+                                required: map_ty.value_field.is_required(),
                             })
                         } else {
                             let list = map.into_iter().map(|(k,v)| {
                                 let raw_k =
-                                    RawLiteralEnum::try_from(k, &map_ty.key_field.field_type)?;
+                                    RawLiteralEnum::try_from(k, map_ty.key_field.field_type())?;
                                 let raw_v = v
                                     .map(|v| {
-                                        RawLiteralEnum::try_from(v, &map_ty.value_field.field_type)
+                                        RawLiteralEnum::try_from(v, map_ty.value_field.field_type())
                                     })
                                     .transpose()?;
-                                if map_ty.value_field.required {
+                                if map_ty.value_field.is_required() {
                                     Ok(Some(RawLiteralEnum::Record(Record {
                                         required: vec![
                                             (MAP_KEY_FIELD_NAME.to_string(), raw_k),
@@ -523,7 +524,7 @@ pub(crate) mod _serde {
                             .into_iter()
                             .map(|v| {
                                 if let Some(v) = v {
-                                    v.try_into(&ty.element_field.field_type)
+                                    v.try_into(ty.element_field.field_type())
                                 } else {
                                     Ok(None)
                                 }
@@ -531,8 +532,8 @@ pub(crate) mod _serde {
                             .collect::<Result<_, Error>>()?,
                     ))),
                     Type::Map(map_ty) => {
-                        let key_ty = map_ty.key_field.field_type.as_ref();
-                        let value_ty = map_ty.value_field.field_type.as_ref();
+                        let key_ty = map_ty.key_field.field_type();
+                        let value_ty = map_ty.value_field.field_type();
                         let mut map = Map::new();
                         for k_v in v.list {
                             let k_v = k_v.ok_or_else(|| invalid_err_with_reason("list","In deserialize, None will be represented as Some(RawLiteral::Null), all element in list must be valid"))?;
@@ -565,7 +566,7 @@ pub(crate) mod _serde {
                                             )
                                         })?;
                                         let value = v.try_into(value_ty)?;
-                                        if map_ty.value_field.required && value.is_none() {
+                                        if map_ty.value_field.is_required() && value.is_none() {
                                             return Err(invalid_err_with_reason(
                                                 "list",
                                                 "Value element is required in this Map",
@@ -690,14 +691,15 @@ pub(crate) mod _serde {
                                             &format!("field {} is not exist", field_name),
                                         )
                                     })?;
-                                let value = value.try_into(&field.field_type)?;
+                                let value = value.try_into(field.field_type())?;
                                 Ok(value)
                             })
                             .collect::<Result<_, Error>>()?;
                         Ok(Some(Literal::Struct(Struct::from_iter(iters))))
                     }
                     Type::Map(map_ty) => {
-                        if *map_ty.key_field.field_type != Type::Primitive(PrimitiveType::String) {
+                        if *map_ty.key_field.field_type() != Type::Primitive(PrimitiveType::String)
+                        {
                             return Err(invalid_err_with_reason(
                                 "record",
                                 "Map key must be string",
@@ -705,8 +707,8 @@ pub(crate) mod _serde {
                         }
                         let mut map = Map::new();
                         for (k, v) in required {
-                            let value = v.try_into(&map_ty.value_field.field_type)?;
-                            if map_ty.value_field.required && value.is_none() {
+                            let value = v.try_into(map_ty.value_field.field_type())?;
+                            if map_ty.value_field.is_required() && value.is_none() {
                                 return Err(invalid_err_with_reason(
                                     "record",
                                     "Value element is required in this Map",

--- a/crates/iceberg/src/spec/values/tests.rs
+++ b/crates/iceberg/src/spec/values/tests.rs
@@ -77,7 +77,11 @@ fn check_avro_bytes_serde(input: Vec<u8>, expected_datum: Datum, expected_type: 
 }
 
 fn check_convert_with_avro(expected_literal: Literal, expected_type: &Type) {
-    let fields = vec![NestedField::required(1, "col", expected_type.clone()).into()];
+    let fields = vec![
+        NestedField::required(1, "col", expected_type.clone())
+            .expect("valid nested field")
+            .into(),
+    ];
     let schema = Schema::builder()
         .with_fields(fields.clone())
         .build()
@@ -102,7 +106,11 @@ fn check_convert_with_avro(expected_literal: Literal, expected_type: &Type) {
 fn check_serialize_avro(literal: Literal, ty: &Type, expect_value: Value) {
     let expect_value = Value::Record(vec![("col".to_string(), expect_value)]);
 
-    let fields = vec![NestedField::required(1, "col", ty.clone()).into()];
+    let fields = vec![
+        NestedField::required(1, "col", ty.clone())
+            .expect("valid nested field")
+            .into(),
+    ];
     let schema = Schema::builder()
         .with_fields(fields.clone())
         .build()
@@ -396,9 +404,15 @@ fn json_struct() {
             None,
         ])),
         &Type::Struct(StructType::new(vec![
-            NestedField::required(1, "id", Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "name", Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(3, "address", Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "id", Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(2, "name", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "address", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])),
     );
 }
@@ -416,7 +430,9 @@ fn json_list() {
             None,
         ]),
         &Type::List(ListType {
-            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true).into(),
+            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true)
+                .expect("valid nested field")
+                .into(),
         }),
     );
 }
@@ -442,8 +458,11 @@ fn json_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(0, Primitive(PrimitiveType::String)).into(),
+            key_field: NestedField::map_key_element(0, Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(1, Primitive(PrimitiveType::Int), true)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -452,8 +471,12 @@ fn json_map() {
 #[test]
 fn json_map_rejects_mismatched_key_value_lengths() {
     let map_type = Type::Map(MapType {
-        key_field: NestedField::map_key_element(0, Primitive(PrimitiveType::String)).into(),
-        value_field: NestedField::map_value_element(1, Primitive(PrimitiveType::Int), true).into(),
+        key_field: NestedField::map_key_element(0, Primitive(PrimitiveType::String))
+            .expect("valid nested field")
+            .into(),
+        value_field: NestedField::map_value_element(1, Primitive(PrimitiveType::Int), true)
+            .expect("valid nested field")
+            .into(),
     });
 
     for record in [
@@ -881,6 +904,7 @@ fn avro_convert_test_list() {
         ]),
         &Type::List(ListType {
             element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), false)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -892,13 +916,19 @@ fn avro_convert_test_list() {
             Some(Literal::Primitive(PrimitiveLiteral::Int(3))),
         ]),
         &Type::List(ListType {
-            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true).into(),
+            element_field: NestedField::list_element(0, Primitive(PrimitiveType::Int), true)
+                .expect("valid nested field")
+                .into(),
         }),
     );
 }
 
 fn check_convert_with_avro_map(expected_literal: Literal, expected_type: &Type) {
-    let fields = vec![NestedField::required(1, "col", expected_type.clone()).into()];
+    let fields = vec![
+        NestedField::required(1, "col", expected_type.clone())
+            .expect("valid nested field")
+            .into(),
+    ];
     let schema = Schema::builder()
         .with_fields(fields.clone())
         .build()
@@ -949,8 +979,11 @@ fn avro_convert_test_map() {
             (Literal::Primitive(PrimitiveLiteral::Int(3)), None),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int)).into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Long), false)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -971,8 +1004,11 @@ fn avro_convert_test_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int)).into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Long), true)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -996,8 +1032,11 @@ fn avro_convert_test_string_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String)).into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Int), false)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -1018,8 +1057,11 @@ fn avro_convert_test_string_map() {
             ),
         ])),
         &Type::Map(MapType {
-            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String)).into(),
+            key_field: NestedField::map_key_element(2, Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
             value_field: NestedField::map_value_element(3, Primitive(PrimitiveType::Int), true)
+                .expect("valid nested field")
                 .into(),
         }),
     );
@@ -1036,9 +1078,15 @@ fn avro_convert_test_record() {
             None,
         ])),
         &Type::Struct(StructType::new(vec![
-            NestedField::required(2, "id", Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(3, "name", Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(4, "address", Primitive(PrimitiveType::String)).into(),
+            NestedField::required(2, "id", Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "name", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(4, "address", Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])),
     );
 }

--- a/crates/iceberg/src/spec/view_metadata.rs
+++ b/crates/iceberg/src/spec/view_metadata.rs
@@ -480,8 +480,14 @@ pub(crate) mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![Arc::new(
-                NestedField::optional(1, "event_count", Type::Primitive(PrimitiveType::Int))
-                    .with_doc("Count of events"),
+                NestedField::builder()
+                    .id(1)
+                    .name("event_count")
+                    .required(false)
+                    .field_type(Type::Primitive(PrimitiveType::Int))
+                    .doc("Count of events")
+                    .build()
+                    .unwrap(),
             )])
             .build()
             .unwrap();
@@ -580,14 +586,19 @@ pub(crate) mod tests {
             .with_schema_id(1)
             .with_fields(vec![
                 Arc::new(
-                    NestedField::optional(1, "event_count", Type::Primitive(PrimitiveType::Int))
-                        .with_doc("Count of events"),
+                    NestedField::builder()
+                        .id(1)
+                        .name("event_count")
+                        .required(false)
+                        .field_type(Type::Primitive(PrimitiveType::Int))
+                        .doc("Count of events")
+                        .build()
+                        .unwrap(),
                 ),
-                Arc::new(NestedField::optional(
-                    2,
-                    "event_date",
-                    Type::Primitive(PrimitiveType::Date),
-                )),
+                Arc::new(
+                    NestedField::optional(2, "event_date", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/spec/view_metadata_builder.rs
+++ b/crates/iceberg/src/spec/view_metadata_builder.rs
@@ -1133,21 +1133,27 @@ mod test {
         let schema_one = Schema::builder()
             .with_schema_id(5)
             .with_fields(vec![
-                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "x", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
         let schema_two = Schema::builder()
             .with_schema_id(7)
             .with_fields(vec![
-                NestedField::required(1, "y", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "y", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
         let schema_three = Schema::builder()
             .with_schema_id(9)
             .with_fields(vec![
-                NestedField::required(1, "z", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(1, "z", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -288,7 +288,7 @@ impl<'a> SnapshotProducer<'a> {
         }
 
         for (value, field) in partition_value.fields().iter().zip(partition_type.fields()) {
-            let field = field.field_type.as_primitive_type().ok_or_else(|| {
+            let field = field.field_type().as_primitive_type().ok_or_else(|| {
                 Error::new(
                     ErrorKind::Unexpected,
                     "Partition field should only be primitive type.",

--- a/crates/iceberg/src/transaction/update_schema.rs
+++ b/crates/iceberg/src/transaction/update_schema.rs
@@ -75,18 +75,18 @@ impl AddColumn {
             .build()
     }
 
-    fn to_nested_field(&self) -> NestedFieldRef {
-        let mut field = NestedField::new(
-            DEFAULT_FIELD_ID,
-            self.name.clone(),
-            self.field_type.clone(),
-            self.required,
-        );
-
-        field.doc = self.doc.clone();
-        field.initial_default = self.initial_default.clone();
-        field.write_default = self.write_default.clone();
-        Arc::new(field)
+    fn to_nested_field(&self) -> Result<NestedFieldRef> {
+        Ok(Arc::new(
+            NestedField::builder()
+                .id(DEFAULT_FIELD_ID)
+                .name(self.name.clone())
+                .field_type(self.field_type.clone())
+                .required(self.required)
+                .doc_opt(self.doc.clone())
+                .initial_default_opt(self.initial_default.clone())
+                .write_default_opt(self.write_default.clone())
+                .build()?,
+        ))
     }
 }
 
@@ -160,52 +160,44 @@ impl UpdateSchemaAction {
 /// IDs rather than reassigning an existing schema. `ReassignFieldIds` cannot be used
 /// directly here because it rejects duplicate old IDs (all new fields share placeholder
 /// ID `DEFAULT_FIELD_ID`).
-fn assign_fresh_ids(field: &NestedField, next_id: &mut i32) -> NestedFieldRef {
+fn assign_fresh_ids(field: &NestedField, next_id: &mut i32) -> Result<NestedFieldRef> {
     *next_id += 1;
     let new_id = *next_id;
-    let new_type = assign_fresh_ids_to_type(&field.field_type, next_id);
+    let new_type = assign_fresh_ids_to_type(field.field_type(), next_id)?;
 
-    Arc::new(NestedField {
-        id: new_id,
-        name: field.name.clone(),
-        required: field.required,
-        field_type: Box::new(new_type),
-        doc: field.doc.clone(),
-        initial_default: field.initial_default.clone(),
-        write_default: field.write_default.clone(),
-    })
+    Ok(Arc::new(field.rebuild(new_id, new_type)?))
 }
 
 /// Recursively assign fresh field IDs to all nested fields within a `Type`.
-fn assign_fresh_ids_to_type(field_type: &Type, next_id: &mut i32) -> Type {
-    match field_type {
+fn assign_fresh_ids_to_type(field_type: &Type, next_id: &mut i32) -> Result<Type> {
+    Ok(match field_type {
         Type::Primitive(_) => field_type.clone(),
         // Variant carries no nested fields, so there is nothing to reassign
         // (matches id_reassigner.rs).
         Type::Variant(v) => Type::Variant(*v),
         Type::Struct(struct_type) => {
-            let new_fields: Vec<NestedFieldRef> = struct_type
+            let new_fields = struct_type
                 .fields()
                 .iter()
                 .map(|f| assign_fresh_ids(f, next_id))
-                .collect();
+                .collect::<Result<Vec<_>>>()?;
             Type::Struct(StructType::new(new_fields))
         }
         Type::List(list_type) => {
-            let new_element = assign_fresh_ids(&list_type.element_field, next_id);
+            let new_element = assign_fresh_ids(&list_type.element_field, next_id)?;
             Type::List(ListType {
                 element_field: new_element,
             })
         }
         Type::Map(map_type) => {
-            let new_key = assign_fresh_ids(&map_type.key_field, next_id);
-            let new_value = assign_fresh_ids(&map_type.value_field, next_id);
+            let new_key = assign_fresh_ids(&map_type.key_field, next_id)?;
+            let new_value = assign_fresh_ids(&map_type.value_field, next_id)?;
             Type::Map(MapType {
                 key_field: new_key,
                 value_field: new_value,
             })
         }
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -229,17 +221,17 @@ fn resolve_parent_target<'a>(
                 format!("Cannot add column: parent '{parent}' not found"),
             )
         })
-        .and_then(|parent_field| match parent_field.field_type.as_ref() {
-            Type::Struct(s) => Ok((parent_field.id, s)),
-            Type::Map(m) => match m.value_field.field_type.as_ref() {
-                Type::Struct(s) => Ok((m.value_field.id, s)),
+        .and_then(|parent_field| match parent_field.field_type() {
+            Type::Struct(s) => Ok((parent_field.id(), s)),
+            Type::Map(m) => match m.value_field.field_type() {
+                Type::Struct(s) => Ok((m.value_field.id(), s)),
                 _ => Err(Error::new(
                     ErrorKind::PreconditionFailed,
                     format!("Cannot add column: map value of '{parent}' is not a struct"),
                 )),
             },
-            Type::List(l) => match l.element_field.field_type.as_ref() {
-                Type::Struct(s) => Ok((l.element_field.id, s)),
+            Type::List(l) => match l.element_field.field_type() {
+                Type::Struct(s) => Ok((l.element_field.id(), s)),
                 _ => Err(Error::new(
                     ErrorKind::PreconditionFailed,
                     format!("Cannot add column: list element of '{parent}' is not a struct"),
@@ -263,13 +255,14 @@ fn rebuild_fields(
     adds: &HashMap<Option<i32>, Vec<NestedFieldRef>>,
     delete_ids: &HashSet<i32>,
     parent_id: Option<i32>,
-) -> Vec<NestedFieldRef> {
-    fields
+) -> Result<Vec<NestedFieldRef>> {
+    let mut rebuilt = fields
         .iter()
-        .filter(|f| !delete_ids.contains(&f.id))
+        .filter(|f| !delete_ids.contains(&f.id()))
         .map(|f| rebuild_field(f, adds, delete_ids))
-        .chain(adds.get(&parent_id).into_iter().flatten().cloned())
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    rebuilt.extend(adds.get(&parent_id).into_iter().flatten().cloned());
+    Ok(rebuilt)
 }
 
 /// Recursively rebuild a single field. If the field (or any descendant) is a struct
@@ -279,52 +272,34 @@ fn rebuild_field(
     field: &NestedFieldRef,
     adds: &HashMap<Option<i32>, Vec<NestedFieldRef>>,
     delete_ids: &HashSet<i32>,
-) -> NestedFieldRef {
-    match field.field_type.as_ref() {
+) -> Result<NestedFieldRef> {
+    Ok(match field.field_type() {
         Type::Primitive(_) | Type::Variant(_) => field.clone(),
         Type::Struct(s) => {
-            let new_fields = rebuild_fields(s.fields(), adds, delete_ids, Some(field.id));
-            Arc::new(NestedField {
-                id: field.id,
-                name: field.name.clone(),
-                required: field.required,
-                field_type: Box::new(Type::Struct(StructType::new(new_fields))),
-                doc: field.doc.clone(),
-                initial_default: field.initial_default.clone(),
-                write_default: field.write_default.clone(),
-            })
+            let new_fields = rebuild_fields(s.fields(), adds, delete_ids, Some(field.id()))?;
+            Arc::new(field.rebuild(field.id(), Type::Struct(StructType::new(new_fields)))?)
         }
         Type::List(l) => {
-            let new_element = rebuild_field(&l.element_field, adds, delete_ids);
-            Arc::new(NestedField {
-                id: field.id,
-                name: field.name.clone(),
-                required: field.required,
-                field_type: Box::new(Type::List(ListType {
+            let new_element = rebuild_field(&l.element_field, adds, delete_ids)?;
+            Arc::new(field.rebuild(
+                field.id(),
+                Type::List(ListType {
                     element_field: new_element,
-                })),
-                doc: field.doc.clone(),
-                initial_default: field.initial_default.clone(),
-                write_default: field.write_default.clone(),
-            })
+                }),
+            )?)
         }
         Type::Map(m) => {
-            let new_key = rebuild_field(&m.key_field, adds, delete_ids);
-            let new_value = rebuild_field(&m.value_field, adds, delete_ids);
-            Arc::new(NestedField {
-                id: field.id,
-                name: field.name.clone(),
-                required: field.required,
-                field_type: Box::new(Type::Map(MapType {
+            let new_key = rebuild_field(&m.key_field, adds, delete_ids)?;
+            let new_value = rebuild_field(&m.value_field, adds, delete_ids)?;
+            Arc::new(field.rebuild(
+                field.id(),
+                Type::Map(MapType {
                     key_field: new_key,
                     value_field: new_value,
-                })),
-                doc: field.doc.clone(),
-                initial_default: field.initial_default.clone(),
-                write_default: field.write_default.clone(),
-            })
+                }),
+            )?)
         }
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -353,13 +328,13 @@ impl TransactionAction for UpdateSchemaAction {
                     .and_then(|field| {
                         match base_schema
                             .identifier_field_ids()
-                            .find(|id| *id == field.id)
+                            .find(|id| *id == field.id())
                         {
                             Some(_) => Err(Error::new(
                                 ErrorKind::PreconditionFailed,
                                 format!("Cannot delete identifier field: {name}"),
                             )),
-                            None => Ok(field.id),
+                            None => Ok(field.id()),
                         }
                     })
             })
@@ -371,26 +346,26 @@ impl TransactionAction for UpdateSchemaAction {
         let mut additions_by_parent: HashMap<Option<i32>, Vec<NestedFieldRef>> = HashMap::new();
 
         for add in &self.additions {
-            let pending_field = add.to_nested_field();
+            let pending_field = add.to_nested_field()?;
 
             // Check that name does not contain `SCHEMA_NAME_DELIMITER`.
-            if pending_field.name.contains(SCHEMA_NAME_DELIMITER) {
+            if pending_field.name().contains(SCHEMA_NAME_DELIMITER) {
                 return Err(Error::new(
                     ErrorKind::PreconditionFailed,
                     format!(
                         "Cannot add column with ambiguous name: {}. Use `AddColumn::with_parent` to add a column to a nested struct.",
-                        pending_field.name
+                        pending_field.name()
                     ),
                 ));
             }
 
             // Required columns without an initial default need allow_incompatible_changes.
-            if pending_field.required && pending_field.initial_default.is_none() {
+            if pending_field.is_required() && pending_field.initial_default().is_none() {
                 return Err(Error::new(
                     ErrorKind::PreconditionFailed,
                     format!(
                         "Incompatible change: cannot add required column without an initial default: {}",
-                        pending_field.name
+                        pending_field.name()
                     ),
                 ));
             }
@@ -398,14 +373,14 @@ impl TransactionAction for UpdateSchemaAction {
             let parent_id = match &add.parent {
                 None => {
                     // Root-level: check name conflict against root-level fields.
-                    if let Some(existing) = base_schema.field_by_name(&pending_field.name)
-                        && !delete_ids.contains(&existing.id)
+                    if let Some(existing) = base_schema.field_by_name(pending_field.name())
+                        && !delete_ids.contains(&existing.id())
                     {
                         return Err(Error::new(
                             ErrorKind::PreconditionFailed,
                             format!(
                                 "Cannot add column, name already exists: {}",
-                                pending_field.name
+                                pending_field.name()
                             ),
                         ));
                     }
@@ -417,15 +392,16 @@ impl TransactionAction for UpdateSchemaAction {
                         resolve_parent_target(base_schema, parent_path)?;
 
                     if parent_struct.fields().iter().any(|f| {
-                        f.name == pending_field.name
-                            && !delete_ids.contains(&f.id)
+                        f.name() == pending_field.name()
+                            && !delete_ids.contains(&f.id())
                             && !delete_ids.contains(&resolved_parent_id)
                     }) {
                         return Err(Error::new(
                             ErrorKind::PreconditionFailed,
                             format!(
                                 "Cannot add column, name already exists in '{}': {}",
-                                parent_path, pending_field.name
+                                parent_path,
+                                pending_field.name()
                             ),
                         ));
                     }
@@ -435,7 +411,7 @@ impl TransactionAction for UpdateSchemaAction {
             };
 
             // Assign fresh IDs immediately, preserving insertion order.
-            let field = assign_fresh_ids(&pending_field, &mut last_column_id);
+            let field = assign_fresh_ids(&pending_field, &mut last_column_id)?;
 
             additions_by_parent
                 .entry(parent_id)
@@ -449,7 +425,7 @@ impl TransactionAction for UpdateSchemaAction {
             &additions_by_parent,
             &delete_ids,
             None,
-        );
+        )?;
 
         // --- 5. Build the new schema ---
         let schema = Schema::builder()
@@ -600,11 +576,12 @@ mod tests {
         // Variant carries no sub-fields, so fresh-id assignment only renames the field
         // itself and leaves the type untouched.
         let mut next_id = 10;
-        let field = NestedField::optional(1, "data", Type::Variant(VariantType));
-        let assigned = super::assign_fresh_ids(&field, &mut next_id);
+        let field = NestedField::optional(1, "data", Type::Variant(VariantType))
+            .expect("valid nested field");
+        let assigned = super::assign_fresh_ids(&field, &mut next_id).unwrap();
 
-        assert_eq!(assigned.id, 11);
-        assert_eq!(*assigned.field_type, Type::Variant(VariantType));
+        assert_eq!(assigned.id(), 11);
+        assert_eq!(assigned.field_type(), &Type::Variant(VariantType));
         assert_eq!(next_id, 11);
     }
 
@@ -638,7 +615,9 @@ mod tests {
             .into_builder()
             .with_schema_id(DEFAULT_SCHEMA_ID)
             .with_fields([
-                NestedField::optional(4, "new_col", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(4, "new_col", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -677,9 +656,9 @@ mod tests {
         let field = new_schema
             .field_by_name("documented_col")
             .expect("documented_col should exist");
-        assert_eq!(field.id, 4);
-        assert!(!field.required);
-        assert_eq!(field.doc.as_deref(), Some("A documented column"));
+        assert_eq!(field.id(), 4);
+        assert!(!field.is_required());
+        assert_eq!(field.doc(), Some("A documented column"));
     }
 
     #[tokio::test]
@@ -704,10 +683,10 @@ mod tests {
         let field = new_schema
             .field_by_name("req_col")
             .expect("req_col should exist");
-        assert_eq!(field.id, 4);
-        assert!(field.required);
-        assert_eq!(field.initial_default, Some(Literal::int(0)));
-        assert_eq!(field.write_default, Some(Literal::int(0)));
+        assert_eq!(field.id(), 4);
+        assert!(field.is_required());
+        assert_eq!(field.initial_default(), Some(&Literal::int(0)));
+        assert_eq!(field.write_default(), Some(&Literal::int(0)));
     }
 
     #[tokio::test]
@@ -805,8 +784,8 @@ mod tests {
             "z should be deleted"
         );
         let w = new_schema.field_by_name("w").expect("w should exist");
-        assert_eq!(w.id, 4);
-        assert!(!w.required);
+        assert_eq!(w.id(), 4);
+        assert!(!w.is_required());
     }
 
     #[tokio::test]
@@ -834,8 +813,8 @@ mod tests {
         let z = new_schema
             .field_by_name("z")
             .expect("z should exist with new type");
-        assert_eq!(z.id, 4); // new ID, not the old 3
-        assert_eq!(*z.field_type, Type::Primitive(PrimitiveType::Boolean));
+        assert_eq!(z.id(), 4); // new ID, not the old 3
+        assert_eq!(*z.field_type(), Type::Primitive(PrimitiveType::Boolean));
     }
 
     #[test]
@@ -888,9 +867,9 @@ mod tests {
         let email = new_schema
             .field_by_name("person.email")
             .expect("person.email should exist");
-        assert_eq!(email.id, 15);
-        assert!(!email.required);
-        assert_eq!(*email.field_type, Type::Primitive(PrimitiveType::String));
+        assert_eq!(email.id(), 15);
+        assert!(!email.is_required());
+        assert_eq!(*email.field_type(), Type::Primitive(PrimitiveType::String));
 
         // Original nested fields should still be there.
         assert!(new_schema.field_by_name("person.name").is_some());
@@ -922,8 +901,8 @@ mod tests {
         let phone = new_schema
             .field_by_name("person.phone")
             .expect("person.phone should exist");
-        assert_eq!(phone.id, 15);
-        assert_eq!(phone.doc.as_deref(), Some("Phone number"));
+        assert_eq!(phone.id(), 15);
+        assert_eq!(phone.doc(), Some("Phone number"));
     }
 
     #[tokio::test]
@@ -953,8 +932,8 @@ mod tests {
         let score = new_schema
             .field_by_name("tags.element.score")
             .expect("tags.element.score should exist");
-        assert_eq!(score.id, 15);
-        assert!(!score.required);
+        assert_eq!(score.id(), 15);
+        assert!(!score.is_required());
 
         // Existing fields preserved.
         assert!(new_schema.field_by_name("tags.element.key").is_some());
@@ -987,7 +966,7 @@ mod tests {
         let version = new_schema
             .field_by_name("props.value.version")
             .expect("props.value.version should exist");
-        assert_eq!(version.id, 15);
+        assert_eq!(version.id(), 15);
 
         // Existing map value fields preserved.
         assert!(new_schema.field_by_name("props.value.data").is_some());
@@ -1102,13 +1081,13 @@ mod tests {
         let root_col = new_schema
             .field_by_name("root_col")
             .expect("root_col should exist");
-        assert_eq!(root_col.id, 15);
+        assert_eq!(root_col.id(), 15);
 
         // Nested column gets the next ID.
         let email = new_schema
             .field_by_name("person.email")
             .expect("person.email should exist");
-        assert_eq!(email.id, 16);
+        assert_eq!(email.id(), 16);
     }
 
     #[tokio::test]
@@ -1126,12 +1105,14 @@ mod tests {
                     "street",
                     Type::Primitive(PrimitiveType::String),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     DEFAULT_FIELD_ID,
                     "city",
                     Type::Primitive(PrimitiveType::String),
                 )
+                .expect("valid nested field")
                 .into(),
             ])),
         ));
@@ -1148,17 +1129,17 @@ mod tests {
         let address = new_schema
             .field_by_name("address")
             .expect("address should exist");
-        assert_eq!(address.id, 4);
+        assert_eq!(address.id(), 4);
 
         // Sub-fields get IDs 5 and 6.
         let street = new_schema
             .field_by_name("address.street")
             .expect("address.street should exist");
-        assert_eq!(street.id, 5);
+        assert_eq!(street.id(), 5);
 
         let city = new_schema
             .field_by_name("address.city")
             .expect("address.city should exist");
-        assert_eq!(city.id, 6);
+        assert_eq!(city.id(), 6);
     }
 }

--- a/crates/iceberg/src/transform/bucket.rs
+++ b/crates/iceberg/src/transform/bucket.rs
@@ -343,7 +343,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -361,7 +363,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Primitive(Uuid)),
+            NestedField::required(1, "value", Primitive(Uuid)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -421,7 +423,8 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Primitive(Fixed(value.len() as u64))),
+            NestedField::required(1, "value", Primitive(Fixed(value.len() as u64)))
+                .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -484,7 +487,8 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -552,7 +556,8 @@ mod test {
                     precision: 9,
                     scale: 2,
                 }),
-            ),
+            )
+            .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -620,7 +625,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Primitive(Long)),
+            NestedField::required(1, "value", Primitive(Long)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -680,7 +685,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Bucket(10),
             "name",
-            NestedField::required(1, "value", Primitive(Int)),
+            NestedField::required(1, "value", Primitive(Int)).expect("valid nested field"),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/transform/identity.rs
+++ b/crates/iceberg/src/transform/identity.rs
@@ -85,7 +85,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(TimestamptzNs))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),

--- a/crates/iceberg/src/transform/temporal.rs
+++ b/crates/iceberg/src/transform/temporal.rs
@@ -451,7 +451,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -500,7 +502,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -549,7 +553,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(Date))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -598,7 +604,9 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(Int))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -618,7 +626,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Hour,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -692,7 +700,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Hour,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -764,7 +772,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -836,7 +844,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -908,7 +916,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -980,7 +988,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1051,7 +1059,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1123,7 +1131,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1197,7 +1205,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1271,7 +1279,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1345,7 +1353,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1419,7 +1427,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1493,7 +1501,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Timestamp)),
+            NestedField::required(1, "value", Primitive(Timestamp)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1567,7 +1575,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1635,7 +1643,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Day,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1703,7 +1711,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1771,7 +1779,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1839,7 +1847,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1907,7 +1915,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -1975,7 +1983,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Month,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -2042,7 +2050,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -2110,7 +2118,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -2178,7 +2186,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -2246,7 +2254,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Year,
             "name",
-            NestedField::required(1, "value", Primitive(Date)),
+            NestedField::required(1, "value", Primitive(Date)).expect("valid nested field"),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/transform/truncate.rs
+++ b/crates/iceberg/src/transform/truncate.rs
@@ -245,7 +245,9 @@ mod test {
                 (Primitive(TimestamptzNs), None),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     None,
                 ),
@@ -262,7 +264,8 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(5),
             "name",
-            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -296,7 +299,8 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(5),
             "name",
-            NestedField::required(1, "value", Primitive(PrimitiveType::String)),
+            NestedField::required(1, "value", Primitive(PrimitiveType::String))
+                .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -359,7 +363,8 @@ mod test {
                     precision: 9,
                     scale: 2,
                 }),
-            ),
+            )
+            .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -429,7 +434,8 @@ mod test {
                     precision: 9,
                     scale: 2,
                 }),
-            ),
+            )
+            .expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -490,7 +496,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Primitive(Long)),
+            NestedField::required(1, "value", Primitive(Long)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -545,7 +551,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Primitive(Long)),
+            NestedField::required(1, "value", Primitive(Long)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -600,7 +606,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Primitive(Int)),
+            NestedField::required(1, "value", Primitive(Int)).expect("valid nested field"),
         );
 
         fixture.assert_projection(
@@ -655,7 +661,7 @@ mod test {
         let fixture = TestProjectionFixture::new(
             Transform::Truncate(10),
             "name",
-            NestedField::required(1, "value", Primitive(Int)),
+            NestedField::required(1, "value", Primitive(Int)).expect("valid nested field"),
         );
 
         fixture.assert_projection(

--- a/crates/iceberg/src/transform/void.rs
+++ b/crates/iceberg/src/transform/void.rs
@@ -85,10 +85,14 @@ mod test {
                 (Primitive(TimestamptzNs), Some(Primitive(TimestamptzNs))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     Some(Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ]))),
                 ),
             ],
@@ -135,7 +139,9 @@ mod test {
                 (Primitive(Timestamptz), Some(Primitive(StringType))),
                 (
                     Struct(StructType::new(vec![
-                        NestedField::optional(1, "a", Primitive(Timestamp)).into(),
+                        NestedField::optional(1, "a", Primitive(Timestamp))
+                            .expect("valid nested field")
+                            .into(),
                     ])),
                     Some(Primitive(StringType)),
                 ),

--- a/crates/iceberg/src/writer/base_writer/data_file_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/data_file_writer.rs
@@ -173,8 +173,12 @@ mod test {
         let schema = Schema::builder()
             .with_schema_id(3)
             .with_fields(vec![
-                NestedField::required(3, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(4, "bar", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(3, "foo", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(4, "bar", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 
@@ -250,8 +254,12 @@ mod test {
         let schema = Schema::builder()
             .with_schema_id(5)
             .with_fields(vec![
-                NestedField::required(5, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(6, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(5, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(6, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
         let schema_ref = Arc::new(schema);

--- a/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
+++ b/crates/iceberg/src/writer/base_writer/equality_delete_writer.rs
@@ -360,25 +360,33 @@ mod test {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     1,
                     "col1",
                     Type::Struct(StructType::new(vec![
                         NestedField::required(5, "sub_col", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
-                NestedField::required(2, "col2", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "col2", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "col3",
                     Type::List(ListType::new(
                         NestedField::required(6, "element", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     4,
@@ -393,12 +401,15 @@ mod test {
                                     "sub_sub_col",
                                     Type::Primitive(PrimitiveType::Int),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                         )
+                        .expect("valid nested field")
                         .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -504,8 +515,12 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -559,9 +574,15 @@ mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Float)).into(),
-                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Double)).into(),
-                    NestedField::optional(2, "col2", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Float))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Double))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::optional(2, "col2", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(
                         3,
                         "col3",
@@ -571,9 +592,11 @@ mod test {
                                 "sub_col",
                                 Type::Primitive(PrimitiveType::Int),
                             )
+                            .expect("valid nested field")
                             .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::optional(
                         5,
@@ -584,36 +607,49 @@ mod test {
                                 "sub_col2",
                                 Type::Primitive(PrimitiveType::Int),
                             )
+                            .expect("valid nested field")
                             .into(),
                         ])),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         7,
                         "col5",
                         Type::Map(MapType::new(
-                            Arc::new(NestedField::required(
-                                8,
-                                "key",
-                                Type::Primitive(PrimitiveType::String),
-                            )),
-                            Arc::new(NestedField::required(
-                                9,
-                                "value",
-                                Type::Primitive(PrimitiveType::Int),
-                            )),
+                            Arc::new(
+                                NestedField::required(
+                                    8,
+                                    "key",
+                                    Type::Primitive(PrimitiveType::String),
+                                )
+                                .expect("valid nested field"),
+                            ),
+                            Arc::new(
+                                NestedField::required(
+                                    9,
+                                    "value",
+                                    Type::Primitive(PrimitiveType::Int),
+                                )
+                                .expect("valid nested field"),
+                            ),
                         )),
                     )
+                    .expect("valid nested field")
                     .into(),
                     NestedField::required(
                         10,
                         "col6",
-                        Type::List(ListType::new(Arc::new(NestedField::required(
-                            11,
-                            "element",
-                            Type::Primitive(PrimitiveType::Int),
-                        )))),
+                        Type::List(ListType::new(Arc::new(
+                            NestedField::required(
+                                11,
+                                "element",
+                                Type::Primitive(PrimitiveType::Int),
+                            )
+                            .expect("valid nested field"),
+                        ))),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -652,9 +688,14 @@ mod test {
                 .with_schema_id(1)
                 .with_fields(vec![
                     NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Boolean))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::required(1, "col1", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "col2", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(
                         3,
                         "col3",
@@ -663,23 +704,37 @@ mod test {
                             scale: 5,
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
-                    NestedField::required(4, "col4", Type::Primitive(PrimitiveType::Date)).into(),
-                    NestedField::required(5, "col5", Type::Primitive(PrimitiveType::Time)).into(),
+                    NestedField::required(4, "col4", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(5, "col5", Type::Primitive(PrimitiveType::Time))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(6, "col6", Type::Primitive(PrimitiveType::Timestamp))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(7, "col7", Type::Primitive(PrimitiveType::Timestamptz))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(8, "col8", Type::Primitive(PrimitiveType::TimestampNs))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(9, "col9", Type::Primitive(PrimitiveType::TimestamptzNs))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(10, "col10", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
-                    NestedField::required(11, "col11", Type::Primitive(PrimitiveType::Uuid)).into(),
+                    NestedField::required(11, "col11", Type::Primitive(PrimitiveType::Uuid))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(12, "col12", Type::Primitive(PrimitiveType::Fixed(10)))
+                        .expect("valid nested field")
                         .into(),
                     NestedField::required(13, "col13", Type::Primitive(PrimitiveType::Binary))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -802,15 +857,19 @@ mod test {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(0, "col0", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(0, "col0", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::optional(
                     1,
                     "col1",
                     Type::Struct(StructType::new(vec![
                         NestedField::optional(2, "sub_col", Type::Primitive(PrimitiveType::Int))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     3,
@@ -825,12 +884,15 @@ mod test {
                                     "sub_sub_col",
                                     Type::Primitive(PrimitiveType::Int),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                         )
+                        .expect("valid nested field")
                         .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()

--- a/crates/iceberg/src/writer/file_writer/location_generator.rs
+++ b/crates/iceberg/src/writer/file_writer/location_generator.rs
@@ -361,8 +361,12 @@ pub(crate) mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -407,7 +411,9 @@ pub(crate) mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "data#1", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "data#1", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -456,8 +462,12 @@ pub(crate) mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "a", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "a", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -495,7 +505,9 @@ pub(crate) mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "data#1", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "data#1", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -534,7 +546,9 @@ pub(crate) mod test {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/iceberg/src/writer/file_writer/parquet_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/parquet_writer.rs
@@ -219,8 +219,8 @@ impl SchemaVisitor for IndexByParquetPathName {
     type T = ();
 
     fn before_struct_field(&mut self, field: &NestedFieldRef) -> Result<()> {
-        self.field_names.push(field.name.to_string());
-        self.field_id = field.id;
+        self.field_names.push(field.name().to_string());
+        self.field_id = field.id();
         Ok(())
     }
 
@@ -230,8 +230,8 @@ impl SchemaVisitor for IndexByParquetPathName {
     }
 
     fn before_list_element(&mut self, field: &NestedFieldRef) -> Result<()> {
-        self.field_names.push(format!("list.{}", field.name));
-        self.field_id = field.id;
+        self.field_names.push(format!("list.{}", field.name()));
+        self.field_id = field.id();
         Ok(())
     }
 
@@ -243,7 +243,7 @@ impl SchemaVisitor for IndexByParquetPathName {
     fn before_map_key(&mut self, field: &NestedFieldRef) -> Result<()> {
         self.field_names
             .push(format!("{DEFAULT_MAP_FIELD_NAME}.key"));
-        self.field_id = field.id;
+        self.field_id = field.id();
         Ok(())
     }
 
@@ -255,7 +255,7 @@ impl SchemaVisitor for IndexByParquetPathName {
     fn before_map_value(&mut self, field: &NestedFieldRef) -> Result<()> {
         self.field_names
             .push(format!("{DEFAULT_MAP_FIELD_NAME}.value"));
-        self.field_id = field.id;
+        self.field_id = field.id();
         Ok(())
     }
 
@@ -361,11 +361,7 @@ impl MinMaxColAggregator {
 
     /// Update statistics
     fn update(&mut self, field_id: i32, value: &Statistics) -> Result<()> {
-        let Some(ty) = self
-            .schema
-            .field_by_id(field_id)
-            .map(|f| f.field_type.as_ref())
-        else {
+        let Some(ty) = self.schema.field_by_id(field_id).map(|f| f.field_type()) else {
             // Following java implementation: https://github.com/apache/iceberg/blob/29a2c456353a6120b8c882ed2ab544975b168d7b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java#L163
             // Ignore the field if it is not in schema.
             return Ok(());
@@ -791,34 +787,56 @@ mod tests {
         Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::optional(0, "boolean", Type::Primitive(PrimitiveType::Boolean)).into(),
-                NestedField::optional(1, "int", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "long", Type::Primitive(PrimitiveType::Long)).into(),
-                NestedField::optional(3, "float", Type::Primitive(PrimitiveType::Float)).into(),
-                NestedField::optional(4, "double", Type::Primitive(PrimitiveType::Double)).into(),
-                NestedField::optional(5, "string", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(6, "binary", Type::Primitive(PrimitiveType::Binary)).into(),
-                NestedField::optional(7, "date", Type::Primitive(PrimitiveType::Date)).into(),
-                NestedField::optional(8, "time", Type::Primitive(PrimitiveType::Time)).into(),
+                NestedField::optional(0, "boolean", Type::Primitive(PrimitiveType::Boolean))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(1, "int", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "long", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "float", Type::Primitive(PrimitiveType::Float))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(4, "double", Type::Primitive(PrimitiveType::Double))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(5, "string", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(6, "binary", Type::Primitive(PrimitiveType::Binary))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(7, "date", Type::Primitive(PrimitiveType::Date))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(8, "time", Type::Primitive(PrimitiveType::Time))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::optional(9, "timestamp", Type::Primitive(PrimitiveType::Timestamp))
+                    .expect("valid nested field")
                     .into(),
                 NestedField::optional(
                     10,
                     "timestamptz",
                     Type::Primitive(PrimitiveType::Timestamptz),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     11,
                     "timestamp_ns",
                     Type::Primitive(PrimitiveType::TimestampNs),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     12,
                     "timestamptz_ns",
                     Type::Primitive(PrimitiveType::TimestamptzNs),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::optional(
                     13,
@@ -828,9 +846,13 @@ mod tests {
                         scale: 5,
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
-                NestedField::optional(14, "uuid", Type::Primitive(PrimitiveType::Uuid)).into(),
+                NestedField::optional(14, "uuid", Type::Primitive(PrimitiveType::Uuid))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::optional(15, "fixed", Type::Primitive(PrimitiveType::Fixed(10)))
+                    .expect("valid nested field")
                     .into(),
                 // Parquet Statistics will use different representation for Decimal with precision 38 and scale 5,
                 // so we need to add a new field for it.
@@ -842,6 +864,7 @@ mod tests {
                         scale: 5,
                     }),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -853,27 +876,36 @@ mod tests {
         Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Long)).into(),
+                NestedField::required(0, "col0", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     1,
                     "col1",
                     Type::Struct(StructType::new(vec![
                         NestedField::required(5, "col_1_5", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::required(6, "col_1_6", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field")
                             .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
-                NestedField::required(2, "col2", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "col2", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
                 NestedField::required(
                     3,
                     "col3",
                     Type::List(ListType::new(
                         NestedField::required(7, "element", Type::Primitive(PrimitiveType::Long))
+                            .expect("valid nested field")
                             .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     4,
@@ -888,18 +920,22 @@ mod tests {
                                     "col_4_8_9",
                                     Type::Primitive(PrimitiveType::Long),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             ])),
                         )
+                        .expect("valid nested field")
                         .into(),
                     ])),
                 )
+                .expect("valid nested field")
                 .into(),
                 NestedField::required(
                     10,
                     "col5",
                     Type::Map(MapType::new(
                         NestedField::required(11, "key", Type::Primitive(PrimitiveType::String))
+                            .expect("valid nested field")
                             .into(),
                         NestedField::required(
                             12,
@@ -910,12 +946,15 @@ mod tests {
                                     "item",
                                     Type::Primitive(PrimitiveType::Long),
                                 )
+                                .expect("valid nested field")
                                 .into(),
                             )),
                         )
+                        .expect("valid nested field")
                         .into(),
                     )),
                 )
+                .expect("valid nested field")
                 .into(),
             ])
             .build()
@@ -945,7 +984,9 @@ mod tests {
         // contains one must error rather than silently miss-map columns.
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::optional(1, "v", Type::Variant(VariantType)).into(),
+                NestedField::optional(1, "v", Type::Variant(VariantType))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -1604,6 +1645,7 @@ mod tests {
                             scale: 10,
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -1656,6 +1698,7 @@ mod tests {
                             scale: 10,
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -1714,6 +1757,7 @@ mod tests {
                             scale: decimal_scale(&decimal_max),
                         }),
                     )
+                    .expect("valid nested field")
                     .into(),
                 ])
                 .build()
@@ -1767,7 +1811,7 @@ mod tests {
         //                 precision: 38,
         //                 scale: 0,
         //             }),
-        //         )
+        //         ).expect("valid nested field")
         //         .into()])
         //         .build()
         //         .unwrap(),
@@ -2488,7 +2532,7 @@ mod tests {
                     .with_schema_id(1)
                     .with_fields(vec![
                         NestedField::required(0, "col", Type::Primitive(PrimitiveType::Long))
-                            .with_id(0)
+                            .expect("valid nested field")
                             .into(),
                     ])
                     .build()
@@ -2513,7 +2557,7 @@ mod tests {
                 .with_schema_id(1)
                 .with_fields(vec![
                     NestedField::required(0, "col", Type::Primitive(PrimitiveType::Int))
-                        .with_id(0)
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()
@@ -2546,8 +2590,11 @@ mod tests {
             Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(2, "payload", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()

--- a/crates/iceberg/src/writer/file_writer/rolling_writer.rs
+++ b/crates/iceberg/src/writer/file_writer/rolling_writer.rs
@@ -285,8 +285,12 @@ mod tests {
         Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
     }

--- a/crates/iceberg/src/writer/partitioning/clustered_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/clustered_writer.rs
@@ -176,9 +176,14 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,
@@ -272,9 +277,14 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,
@@ -410,9 +420,14 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,

--- a/crates/iceberg/src/writer/partitioning/fanout_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/fanout_writer.rs
@@ -153,9 +153,14 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,
@@ -249,9 +254,14 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,

--- a/crates/iceberg/src/writer/partitioning/unpartitioned_writer.rs
+++ b/crates/iceberg/src/writer/partitioning/unpartitioned_writer.rs
@@ -133,8 +133,12 @@ mod tests {
             crate::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()?,
         );

--- a/crates/integration_tests/tests/common/mod.rs
+++ b/crates/integration_tests/tests/common/mod.rs
@@ -55,9 +55,15 @@ pub fn test_schema() -> Schema {
         .with_schema_id(1)
         .with_identifier_field_ids(vec![2])
         .with_fields(vec![
-            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean)).into(),
+            NestedField::optional(1, "foo", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "bar", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "baz", Type::Primitive(PrimitiveType::Boolean))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()
         .unwrap()

--- a/crates/integrations/datafusion/src/physical_plan/commit.rs
+++ b/crates/integrations/datafusion/src/physical_plan/commit.rs
@@ -415,8 +415,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 
@@ -557,7 +561,9 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 
@@ -634,8 +640,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(1)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 

--- a/crates/integrations/datafusion/src/physical_plan/project.rs
+++ b/crates/integrations/datafusion/src/physical_plan/project.rs
@@ -199,8 +199,12 @@ mod tests {
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -215,7 +219,10 @@ mod tests {
 
         // Verify partition type
         assert_eq!(calculator.partition_type().fields().len(), 1);
-        assert_eq!(calculator.partition_type().fields()[0].name, "id_partition");
+        assert_eq!(
+            calculator.partition_type().fields()[0].name(),
+            "id_partition"
+        );
     }
 
     #[test]
@@ -223,8 +230,12 @@ mod tests {
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -270,8 +281,12 @@ mod tests {
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -324,15 +339,23 @@ mod tests {
     #[test]
     fn test_nested_partition() {
         let address_struct = StructType::new(vec![
-            NestedField::required(3, "street", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::required(4, "city", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(3, "street", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(4, "city", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ]);
 
         let table_schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "address", Type::Struct(address_struct)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "address", Type::Struct(address_struct))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -403,8 +426,12 @@ mod tests {
         let table_schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -462,8 +489,12 @@ mod tests {
         let table_schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),
@@ -532,8 +563,12 @@ mod tests {
         let table_schema = Arc::new(
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                 ])
                 .build()
                 .unwrap(),

--- a/crates/integrations/datafusion/src/physical_plan/repartition.rs
+++ b/crates/integrations/datafusion/src/physical_plan/repartition.rs
@@ -189,16 +189,14 @@ mod tests {
     fn create_test_table() -> Table {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "data",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "data", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -330,16 +328,14 @@ mod tests {
     async fn test_bucket_aware_partitioning() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "category",
-                    Type::Primitive(PrimitiveType::String),
-                )),
+                Arc::new(
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "category", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -404,21 +400,18 @@ mod tests {
     async fn test_combined_partition_and_bucket_strategy() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "date",
-                    Type::Primitive(PrimitiveType::Date),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "user_id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::required(
-                    3,
-                    "amount",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(1, "date", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "user_id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(3, "amount", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -504,11 +497,10 @@ mod tests {
     #[tokio::test]
     async fn test_none_distribution_mode_fallback() {
         let schema = Schema::builder()
-            .with_fields(vec![Arc::new(NestedField::required(
-                1,
-                "id",
-                Type::Primitive(PrimitiveType::Long),
-            ))])
+            .with_fields(vec![Arc::new(
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long))
+                    .expect("valid nested field"),
+            )])
             .build()
             .unwrap();
 
@@ -568,16 +560,14 @@ mod tests {
     async fn test_range_only_partitions_use_round_robin() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "date",
-                    Type::Primitive(PrimitiveType::Date),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "amount",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(1, "date", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "amount", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -633,21 +623,18 @@ mod tests {
     async fn test_mixed_transforms_use_hash_partitioning() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "date",
-                    Type::Primitive(PrimitiveType::Date),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "user_id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::required(
-                    3,
-                    "amount",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(1, "date", Type::Primitive(PrimitiveType::Date))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "user_id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(3, "amount", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -719,16 +706,18 @@ mod tests {
     async fn test_partition_column_with_temporal_transforms_uses_round_robin() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "event_time",
-                    Type::Primitive(PrimitiveType::Timestamp),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "amount",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(
+                        1,
+                        "event_time",
+                        Type::Primitive(PrimitiveType::Timestamp),
+                    )
+                    .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "amount", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();
@@ -789,16 +778,14 @@ mod tests {
     async fn test_partition_column_with_identity_transforms_uses_hash() {
         let schema = Schema::builder()
             .with_fields(vec![
-                Arc::new(NestedField::required(
-                    1,
-                    "user_id",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
-                Arc::new(NestedField::required(
-                    2,
-                    "amount",
-                    Type::Primitive(PrimitiveType::Long),
-                )),
+                Arc::new(
+                    NestedField::required(1, "user_id", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
+                Arc::new(
+                    NestedField::required(2, "amount", Type::Primitive(PrimitiveType::Long))
+                        .expect("valid nested field"),
+                ),
             ])
             .build()
             .unwrap();

--- a/crates/integrations/datafusion/src/physical_plan/write.rs
+++ b/crates/integrations/datafusion/src/physical_plan/write.rs
@@ -447,8 +447,12 @@ mod tests {
         Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
     }

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -395,8 +395,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();
@@ -648,8 +652,12 @@ mod tests {
         let schema = Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "category", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "category", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()
             .unwrap();

--- a/crates/integrations/datafusion/src/task_writer.rs
+++ b/crates/integrations/datafusion/src/task_writer.rs
@@ -286,9 +286,14 @@ mod tests {
             iceberg::spec::Schema::builder()
                 .with_schema_id(1)
                 .with_fields(vec![
-                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                        .expect("valid nested field")
+                        .into(),
+                    NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
+                        .into(),
                     NestedField::required(3, "region", Type::Primitive(PrimitiveType::String))
+                        .expect("valid nested field")
                         .into(),
                 ])
                 .build()?,

--- a/crates/integrations/datafusion/tests/integration_datafusion_test.rs
+++ b/crates/integrations/datafusion/tests/integration_datafusion_test.rs
@@ -56,8 +56,12 @@ async fn get_iceberg_catalog() -> MemoryCatalog {
 
 fn get_struct_type() -> StructType {
     StructType::new(vec![
-        NestedField::required(4, "s_foo1", Type::Primitive(PrimitiveType::Int)).into(),
-        NestedField::required(5, "s_foo2", Type::Primitive(PrimitiveType::String)).into(),
+        NestedField::required(4, "s_foo1", Type::Primitive(PrimitiveType::Int))
+            .expect("valid nested field")
+            .into(),
+        NestedField::required(5, "s_foo2", Type::Primitive(PrimitiveType::String))
+            .expect("valid nested field")
+            .into(),
     ])
 }
 
@@ -78,8 +82,12 @@ fn get_table_creation(
         None => Schema::builder()
             .with_schema_id(0)
             .with_fields(vec![
-                NestedField::required(1, "foo1", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "foo2", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "foo1", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "foo2", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?,
         Some(schema) => schema,
@@ -215,9 +223,15 @@ async fn test_table_projection() -> Result<()> {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "foo1", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::required(2, "foo2", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(3, "foo3", Type::Struct(get_struct_type())).into(),
+            NestedField::required(1, "foo1", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "foo2", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "foo3", Type::Struct(get_struct_type()))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()?;
     let creation = get_table_creation(temp_path(), "t1", Some(schema))?;
@@ -283,8 +297,12 @@ async fn test_table_predict_pushdown() -> Result<()> {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "bar", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(2, "bar", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()?;
     let creation = get_table_creation(temp_path(), "t1", Some(schema))?;
@@ -328,8 +346,12 @@ async fn test_metadata_table() -> Result<()> {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::optional(2, "bar", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "foo", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(2, "bar", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()?;
     let creation = get_table_creation(temp_path(), "t1", Some(schema))?;
@@ -536,20 +558,32 @@ fn get_nested_struct_type() -> StructType {
             10,
             "address",
             Type::Struct(StructType::new(vec![
-                NestedField::optional(11, "street", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(12, "city", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(13, "zip", Type::Primitive(PrimitiveType::Int)).into(),
+                NestedField::optional(11, "street", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(12, "city", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(13, "zip", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
             ])),
         )
+        .expect("valid nested field")
         .into(),
         NestedField::optional(
             20,
             "contact",
             Type::Struct(StructType::new(vec![
-                NestedField::optional(21, "email", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(22, "phone", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::optional(21, "email", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(22, "phone", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])),
         )
+        .expect("valid nested field")
         .into(),
     ])
 }
@@ -565,9 +599,15 @@ async fn test_insert_into_nested() -> Result<()> {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::required(2, "name", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::optional(3, "profile", Type::Struct(get_nested_struct_type())).into(),
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "name", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::optional(3, "profile", Type::Struct(get_nested_struct_type()))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()?;
 
@@ -820,9 +860,15 @@ async fn test_insert_into_partitioned() -> Result<()> {
     let schema = Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![
-            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-            NestedField::required(2, "category", Type::Primitive(PrimitiveType::String)).into(),
-            NestedField::required(3, "value", Type::Primitive(PrimitiveType::String)).into(),
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(2, "category", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
+            NestedField::required(3, "value", Type::Primitive(PrimitiveType::String))
+                .expect("valid nested field")
+                .into(),
         ])
         .build()?;
 

--- a/crates/sqllogictest/src/engine/datafusion.rs
+++ b/crates/sqllogictest/src/engine/datafusion.rs
@@ -121,9 +121,15 @@ impl DataFusionEngine {
     ) -> anyhow::Result<()> {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::required(2, "category", Type::Primitive(PrimitiveType::String)).into(),
-                NestedField::optional(3, "value", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::required(2, "category", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(3, "value", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 
@@ -155,8 +161,12 @@ impl DataFusionEngine {
     ) -> anyhow::Result<()> {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Binary)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "data", Type::Primitive(PrimitiveType::Binary))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 
@@ -179,8 +189,12 @@ impl DataFusionEngine {
     ) -> anyhow::Result<()> {
         let schema = Schema::builder()
             .with_fields(vec![
-                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
-                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int))
+                    .expect("valid nested field")
+                    .into(),
+                NestedField::optional(2, "name", Type::Primitive(PrimitiveType::String))
+                    .expect("valid nested field")
+                    .into(),
             ])
             .build()?;
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3182.

## What changes are included in this PR?

- Makes NestedField fields private and exposes read-only accessors.
- Adds a typed NestedField builder whose build method returns Result and validates initial and write defaults against the field type.
- Routes NestedField constructors, serde conversion, and internal schema rebuilds through the builder.
- Removes the consuming NestedField with methods and makes NestedField and MapType convenience constructors fallible.
- Migrates workspace consumers and updates the public API snapshot.

## Are these changes tested?

- Added unit coverage for builder field access and validation of primitive, fixed, struct, list, and map defaults.
- cargo test -p iceberg --lib: 1,676 passed.
- cargo test -p iceberg --doc --all-features: 83 passed, 13 ignored.
- cargo clippy --workspace --all-targets --all-features -- -D warnings: passed.
- make check-public-api: passed.
- cargo fmt --all -- --check: passed.

## AI Disclosure

This PR was implemented with assistance from OpenAI Codex for code migration, test scaffolding, and verification. The implementation and generated changes were reviewed, and the full core test suite, workspace clippy checks, formatting checks, doctests, and public API checks were run locally. There are no known unresolved uncertainties.