### PR TITLE
fix(ci): keep .github/actions in the source archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,20 @@
 # Paths left out of the source archive built by dev/release/create_rc.sh.
 # Files needed to build, test, and verify from source (dev/, .licenserc.yaml,
 # lint configs) must stay in.
+#
+# .github is listed entry by entry rather than wholesale: GitHub resolves the
+# `uses: $/...` self-repository action references in our workflows by fetching a
+# repository archive, which honours export-ignore. Excluding .github as a whole
+# therefore hides .github/actions from that fetch and every workflow using a
+# local composite action fails with "Can't find 'action.yml'".
 website export-ignore
 .asf.yaml export-ignore
 .devcontainer export-ignore
 .gitattributes export-ignore
-.github export-ignore
+.github/ISSUE_TEMPLATE export-ignore
+.github/PULL_REQUEST_TEMPLATE.md export-ignore
+.github/copilot-instructions.md export-ignore
+.github/dependabot.yml export-ignore
+.github/workflows export-ignore
 .gitignore export-ignore
 .idea export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,19 +2,11 @@
 # Files needed to build, test, and verify from source (dev/, .licenserc.yaml,
 # lint configs) must stay in.
 #
-# .github is listed entry by entry rather than wholesale: GitHub resolves the
-# `uses: $/...` self-repository action references in our workflows by fetching a
-# repository archive, which honours export-ignore. Excluding .github as a whole
-# therefore hides .github/actions from that fetch and every workflow using a
-# local composite action fails with "Can't find 'action.yml'".
+# .github must stay in too: `uses: $/...` action references are resolved from
+# the repository archive, which honors export-ignore.
 website export-ignore
 .asf.yaml export-ignore
 .devcontainer export-ignore
 .gitattributes export-ignore
-.github/ISSUE_TEMPLATE export-ignore
-.github/PULL_REQUEST_TEMPLATE.md export-ignore
-.github/copilot-instructions.md export-ignore
-.github/dependabot.yml export-ignore
-.github/workflows export-ignore
 .gitignore export-ignore
 .idea export-ignore


### PR DESCRIPTION
## Which issue does this PR close?

- None. Fixes a CI regression on `main` introduced by the interaction of #3161 and #3189.

## What changes are included in this PR?

CI is currently red on `main` and on every open PR. Jobs fail at action-resolution time, before anything is built:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action
'apache/iceberg-rust/.github/actions/setup-builder@<sha>'
```

### Cause

Two changes that are each fine in isolation:

- #3161 migrated 22 local action references from `./...` to GitHub self-repository `$/...` references, to resolve a zizmor 1.30 audit. CI passed on that commit and for three days afterwards.
- #3189 added `.github export-ignore` to `.gitattributes`, to trim repo-only files from the release source archive.

GitHub resolves a `uses: $/...` reference by fetching a repository archive, and those archives honour `export-ignore`. Excluding `.github` wholesale therefore hides `.github/actions` from that fetch, so every workflow using a local composite action (`setup-builder`, `get-msrv`, `overwrite-package-version`) fails to resolve it. `./...` references read the checked-out worktree and were unaffected, which is why this only surfaced once both changes were on `main`.

Timeline on `main` (workflow `CI`):

| commit | result |
|---|---|
| `1deceb138` #3161 — `$/` migration, 09-07 | success |
| `28ede505e` … `4d83bc77d`, 09-07 → 09-09 | success |
| `d6c2eb440` #3189 — `.github export-ignore`, 09-10 | **failure** |

### Fix

List the `.github` entries individually rather than excluding the directory, so the repo-only files #3189 targeted stay out of the tarball while `.github/actions` remains resolvable.

A `-export-ignore` negation on the subdirectory does not work — git does not descend into an export-ignored directory, so the child attribute is never consulted. Verified below.

This keeps both earlier changes intact: no `$/` reference is reverted, and no zizmor suppression is added.

## Are these changes tested?

The archive half is verified locally with `git archive --worktree-attributes HEAD | tar t`, comparing attribute sets:

| `.gitattributes` | `.github/actions` | `.github/workflows` | other `.github` |
|---|---|---|---|
| `main` today | 0 | 0 | 0 |
| `.github export-ignore` + `.github/actions -export-ignore` | 0 | 0 | 0 |
| this PR | **7** | 0 | 0 |

Everything else #3189 excluded (`website`, `.asf.yaml`, `.devcontainer`, `.gitattributes`, `.gitignore`, `.idea`) remains excluded — verified as 0 entries each.

**The action-resolution half cannot be verified by this PR's own checks.** `ci.yml`, `bindings_python_ci.yml` and `public-api.yml` all carry `- '!.gitattributes'` in their `pull_request` path filters, so a `.gitattributes`-only change does not trigger them. The checks that do run here (`asf-allowlist-check`, `Analyze Actions`, `CodeQL`, `zizmor`) contain no `uses: $/...` reference, so their passing says nothing about the fix.

Those workflows trigger unconditionally on `push` to `main`, so the fix validates on merge. If you would rather confirm before merging, re-running the failed `CI` job on any open PR with this branch merged in will exercise it — or I am happy to push a throwaway one-character change to a `crates/**` file here to force the full suite to run, if that is preferred over merging on the strength of the archive evidence.