### PR TITLE
fix(release): warn when bash 3.2 will not report the failed step

### DIFF
--- a/dev/release/create_rc.sh
+++ b/dev/release/create_rc.sh
@@ -19,6 +19,12 @@
 
 set -Eeuo pipefail
 
+# bash 3.2 (macOS default) does not run the ERR trap for a failing subshell:
+# the script still exits on failure but does not report which step failed.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "Warning: bash ${BASH_VERSION} will not print which step failed. Use bash 4 or newer to see it." >&2
+fi
+
 CURRENT_STEP=""
 
 on_error() {

--- a/dev/release/dependencies.sh
+++ b/dev/release/dependencies.sh
@@ -19,6 +19,12 @@
 
 set -Eeuo pipefail
 
+# bash 3.2 (macOS default) does not run the ERR trap for a failing subshell:
+# the script still exits on failure but does not report which step failed.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "Warning: bash ${BASH_VERSION} will not print which step failed. Use bash 4 or newer to see it." >&2
+fi
+
 # Keep this in sync with CARGO_DENY_VERSION in .github/workflows/dependencies.yml.
 # The generated DEPENDENCIES.rust.tsv files are version-sensitive, so the local
 # cargo-deny must match the version CI uses to avoid spurious diffs.

--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -19,6 +19,12 @@
 
 set -Eeuo pipefail
 
+# bash 3.2 (macOS default) does not run the ERR trap for a failing subshell:
+# the script still exits on failure but does not report which step failed.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "Warning: bash ${BASH_VERSION} will not print which step failed. Use bash 4 or newer to see it." >&2
+fi
+
 CURRENT_STEP=""
 
 on_error() {

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -19,6 +19,12 @@
 
 set -Eeuo pipefail
 
+# bash 3.2 (macOS default) does not run the ERR trap for a failing subshell:
+# the script still exits on failure but does not report which step failed.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "Warning: bash ${BASH_VERSION} will not print which step failed. Use bash 4 or newer to see it." >&2
+fi
+
 CURRENT_STEP=""
 VERIFY_SUCCESS="no"
 VERIFY_OWNS_TMPDIR="0"


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## What changes are included in this PR?

A small nit PR. 

Hit this running `create_rc.sh` on macOS. The release scripts run each step in a `( trap - ERR; ... )` subshell. bash 3.2 (macOS default) does not run the parent's ERR trap for a failing subshell, so the script still exits on failure but does not report which step failed. bash 4.0+ does, verified against 3.2 through 5.1.

Since the script still fails correctly, print a warning at startup on bash older than 4 in the four scripts that install the trap.

## Are these changes tested?

Under `/bin/bash` 3.2 each script prints the warning and continues; a forced failure exits with the tool's status and the warning explains why no step is reported. Under bash 5 there is no warning and the failed step is reported.

## AI Disclosure

Written with Claude Code, reviewed by me.
