### PR TITLE
ci: enable GitHub merge queue with required CI gates

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,15 +36,51 @@ github:
   protected_branches:
     main:
       required_status_checks:
-        # strict means "Require branches to be up to date before merging".
-        strict: true
+        # Check context names (job names, not workflow files) that Merge Queue
+        # waits for. Every producer workflow must run on both `pull_request`
+        # and `merge_group`, without path filters, so each context always
+        # reports. `strict` is omitted: Merge Queue validates every entry
+        # against an up-to-date main, and ASF defaults it to false.
+        contexts:
+          # Repository policy and security checks.
+          - Analyze Actions
+          - Run zizmor 🌈
+          - asf-allowlist-check
+
+          # Rust workflow gates.
+          - ci-required
+          - check-public-api
+
+          # Python bindings workflow gates.
+          - bindings-python-ci-required
 
       required_pull_request_reviews:
         required_approving_review_count: 1
         dismiss_stale_reviews: false
 
       required_linear_history: true
+  rulesets:
+    - name: Merge Queue
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - "~DEFAULT_BRANCH"
+          exclude: []
+      rules:
+        - type: merge_queue
+          parameters:
+            check_response_timeout_minutes: 90
+            grouping_strategy: ALLGREEN
+            max_entries_to_build: 1
+            max_entries_to_merge: 1
+            merge_method: SQUASH
+            min_entries_to_merge: 1
+            min_entries_to_merge_wait_minutes: 0
   pull_requests:
+    # allow pull requests to merge automatically once all requirements are met
+    allow_auto_merge: true
     # auto-delete head branches after being merged
     del_branch_on_merge: true
   features:

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -25,6 +25,7 @@ name: "ASF Allowlist Check"
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -22,19 +22,7 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - '**'                                       # Include all files and directories in the repository by default.
-      - '!.github/ISSUE_TEMPLATE/**'               # Exclude files and directories that don't impact tests or code like templates, metadata, and documentation.
-      - '!dev/release/**'
-      - '!website/**'
-      - '!.asf.yml'
-      - '!.gitattributes'
-      - '!.gitignore'
-      - '!CONTRIBUTING.md'
-      - '!CHANGELOG.md'
-      - '!LICENSE'
-      - '!NOTICE'
-      - '!README.md'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -121,3 +109,17 @@ jobs:
           HF_DATASET: ${{ secrets.HF_DATASET }}
         run: |
           make test
+
+  bindings-python-ci-required:
+    if: ${{ always() }}
+    needs: [check-python, test]
+    runs-on: ubuntu-slim
+    steps:
+      - name: Verify Bindings Python CI jobs succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          read -ra results <<< "$RESULTS"
+          for result in "${results[@]}"; do
+            test "$result" = "success"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,7 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      # Artifacts that must be included in releases, such as LICENSE and NOTICE, are deliberately not excluded so we can verify they will be bundled.
-      # Include all files and directories, then filter out files and directories that don't impact code, tests, or release artifacts.
-      - '**'
-      - '!.github/ISSUE_TEMPLATE/**'
-      - '!dev/release/**'
-      - '!website/**'
-      - '!.asf.yml'
-      - '!.gitattributes'
-      - '!.gitignore'
-      - '!CONTRIBUTING.md'
-      - '!CHANGELOG.md'
-      - '!README.md'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -258,3 +246,17 @@ jobs:
         uses: $/.github/actions/setup-builder
       - name: Check MSRV
         run: make check-msrv
+
+  ci-required:
+    if: ${{ always() }}
+    needs: [lint, clippy, build, check_standalone, build_with_no_default_features, tests, msrv]
+    runs-on: ubuntu-slim
+    steps:
+      - name: Verify CI jobs succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          read -ra results <<< "$RESULTS"
+          for result in "${results[@]}"; do
+            test "$result" = "success"
+          done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -22,8 +22,7 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'crates/**'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,7 +23,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["**"]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3140.

## What changes are included in this PR?

Enable GitHub merge queue, same setup as pyiceberg: apache/iceberg-python#3815 (auto-merge) and apache/iceberg-python#3832 (merge queue + required checks).

- `.asf.yaml`: required check contexts, `Merge Queue` ruleset (squash, one at a time), `allow_auto_merge`. Dropped `strict` since the queue already tests against latest `main`.
- Required workflows now run on `merge_group`.
- Removed `pull_request` path/branch filters from required workflows. A skipped workflow never reports its check, which blocks the PR and the queue entry.
- `ci-required` and `bindings-python-ci-required` aggregate jobs so we don't have to list matrix job names in `.asf.yaml`.

Not required: `audit` and `website`.

After this lands, open PRs need a push or close/reopen to pick up the new checks.

## Are these changes tested?

Checked that every required context maps to a job that runs on both `pull_request` and `merge_group`, and that the aggregate `needs` lists cover every job. actionlint and zizmor are clean. The ruleset only takes effect once this is on `main`.

## AI Disclosure

Written with Claude Code, reviewed by me.
