### PR TITLE
chore: exclude repo-only files from the source archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
+# Paths left out of the source archive built by dev/release/create_rc.sh.
+# Files needed to build, test, and verify from source (dev/, .licenserc.yaml,
+# lint configs) must stay in.
 website export-ignore
+.asf.yaml export-ignore
+.devcontainer export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+.idea export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 # Paths left out of the source archive built by dev/release/create_rc.sh.
 # Files needed to build, test, and verify from source (dev/, .licenserc.yaml,
 # lint configs) must stay in.
+#
+# .github must stay in too: `uses: ./...` action references are resolved from
+# the repository archive, which honors export-ignore.
 website export-ignore
 .asf.yaml export-ignore
 .devcontainer export-ignore
 .gitattributes export-ignore
-.github export-ignore
 .gitignore export-ignore
 .idea export-ignore


### PR DESCRIPTION
## Which issue does this PR close?

Backports two changes from `main` (#3189, #3193) to remove unecessary files from `git archive`, used in the release process.

Related: #3034

## What changes are included in this PR?

This change adds new entries to the `.gitattributes` file to exclude them when `git archive` is run.

## Are these changes tested?

N/A

## AI Disclosure

LLM was used to help draft the backport commit for 0.11.x branch.
