### PR TITLE
 fix: break dev-dependency cycle that blocks publishing iceberg-property-macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,12 @@ jobs:
             cargo check -p "$pkg" --all-targets || exit 1
           done
 
+      # Dry-runs the publish without compiling, which catches dependency cycles between
+      # workspace crates, versions that do not resolve on crates.io, and missing metadata.
+      # publish.yml runs the full dry-run with compilation on release candidate tags.
+      - name: Check each crate can be published
+        run: cargo publish --workspace --all-features --dry-run --no-verify
+
   # Verifies the core iceberg crate compiles without default features, ensuring
   # optional functionality is properly gated behind feature flags.
   build_with_no_default_features:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,13 @@ jobs:
         with:
           rust-version: ${{ steps.get-msrv.outputs.msrv }}
 
+      # Packages and builds every crate as it would be published, without uploading,
+      # so publish failures are caught during the release candidate process.
+      - name: Dry-run publish for release candidates
+        if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') }}
+        run: cargo publish --workspace --all-features --dry-run
+        shell: bash
+
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 

--- a/crates/property-macro/Cargo.toml
+++ b/crates/property-macro/Cargo.toml
@@ -28,7 +28,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 categories = ["database"]
-description = "Property derive macro for Apache Iceberg Rust"
+description = "Apache Iceberg Rust property macros, internal to the iceberg crate"
 keywords = ["iceberg"]
 
 [lib]
@@ -40,7 +40,9 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-iceberg = { workspace = true }
+# Path-only so cargo strips it when packaging; a versioned dev-dependency would
+# create a publish cycle, since `iceberg` depends on this crate.
+iceberg = { path = "../iceberg" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 trybuild = { workspace = true }

--- a/crates/property-macro/README.md
+++ b/crates/property-macro/README.md
@@ -19,6 +19,11 @@
 
 # Iceberg property macros
 
+This crate contains the property macros used internally by
+[`iceberg`](https://crates.io/crates/iceberg). It is published only because
+`iceberg` depends on it and has no API stability guarantees, so depend on
+`iceberg` rather than on this crate.
+
 ## `Properties` derive macro
 
 `#[derive(Properties)]` parses an owned typed struct from a flat

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -42,7 +42,7 @@ Common options:
 dev/release/create_rc.sh 0.9.1 2 --release_ref <commit-ish>
 dev/release/create_rc.sh 0.9.1 2 --create_rc_tag 0 --sign 0
 dev/release/create_rc.sh 0.9.1 2 --upload_svn 1
-dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0
+dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0 --check_publish 0
 ```
 
 Defaults:
@@ -52,6 +52,7 @@ Defaults:
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.
 - `--check_deps 1`: run dependency license checks before artifact creation.
+- `--check_publish 1`: dry-run publishing every crate to crates.io before artifact creation.
 - `--sign 1`: create and verify the detached GPG signature.
 - `--upload_svn 0`: upload RC artifacts to the ASF dev dist SVN repository.
 - `--svn_dist_url https://dist.apache.org/repos/dist/dev/iceberg`: SVN directory URL where the RC artifact directory will be uploaded.
@@ -63,6 +64,9 @@ Defaults:
 ```shell
 cargo install --locked cargo-deny
 ```
+
+`--check_publish 1` runs `cargo publish --workspace --dry-run`, which packages and compiles every crate and needs network access to crates.io.
+Pass `--check_publish 0` to skip it when offline or when iterating on the script.
 
 ## Verify an RC
 

--- a/dev/release/create_rc.sh
+++ b/dev/release/create_rc.sh
@@ -69,6 +69,10 @@ Options:
       Whether to run the dependency license check before creating artifacts.
       Default: 1
 
+  --check_publish <0|1>
+      Whether to dry-run publishing every crate to crates.io before creating artifacts.
+      Default: 1
+
   --sign <0|1>
       Whether to create and verify the detached GPG signature for the source archive.
       Default: 1
@@ -227,6 +231,12 @@ parse_args() {
         CHECK_DEPS="$2"
         shift 2
         ;;
+      --check_publish | --check-publish)
+        require_option_value "$1" "${2:-}"
+        validate_bool_option "$1" "$2"
+        CHECK_PUBLISH="$2"
+        shift 2
+        ;;
       --sign)
         require_option_value "$1" "${2:-}"
         validate_bool_option "$1" "$2"
@@ -313,6 +323,13 @@ check_dependency_licenses() {
     cd "${REPO_ROOT}"
     cargo deny check license
   )
+}
+
+# Packages and builds every crate as `cargo publish` would, without uploading,
+# so crates that cannot be published fail RC creation.
+check_crates_publishable() {
+  require_command cargo
+  cargo publish --workspace --all-features --dry-run --manifest-path "${REPO_ROOT}/Cargo.toml"
 }
 
 prepare_output_directory() {
@@ -500,6 +517,7 @@ RELEASE_DIST_DIR="dist"
 CREATE_RC_TAG="1"
 CHECK_HEADERS="1"
 CHECK_DEPS="1"
+CHECK_PUBLISH="1"
 SIGN_ARCHIVE="1"
 UPLOAD_SVN="0"
 SVN_DIST_URL="https://dist.apache.org/repos/dist/dev/iceberg"
@@ -521,6 +539,12 @@ if enabled "${CHECK_DEPS}"; then
   run_step "Check dependency licenses" check_dependency_licenses
 else
   skip_step "Check dependency licenses"
+fi
+
+if enabled "${CHECK_PUBLISH}"; then
+  run_step "Check crates can be published" check_crates_publishable
+else
+  skip_step "Check crates can be published"
 fi
 
 run_step "Prepare output directory ${RC_DIR}" prepare_output_directory

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -202,6 +202,7 @@ Useful options include:
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.
 - `--check_deps 1`: run dependency license checks before artifact creation.
+- `--check_publish 1`: dry-run publishing every crate to crates.io before artifact creation.
 - `--sign 1`: create and verify the detached GPG signature.
 - `--upload_svn 0`: upload RC artifacts to the ASF dev dist SVN repository.
 - `--svn_dist_url https://dist.apache.org/repos/dist/dev/iceberg`: SVN directory URL where the RC artifact directory will be uploaded.
@@ -214,7 +215,10 @@ This script creates:
 - SHA-512 checksum: `apache-iceberg-rust-${iceberg_version}.tar.gz.sha512`
 - Signed annotated RC tag: `v${iceberg_version}-rc.${rc}`
 
-The script checks license headers against the generated source archive, not the live Git worktree. If enabled, SVN upload runs after local artifact verification and before RC tag creation. The script creates the signed RC tag as the final release step, then prints a draft VOTE email for `dev@iceberg.apache.org`.
+The script runs a number of verifications.
+It performs a dry-run packaging step and builds every crate as the final release would, so a crate that cannot be published fails RC creation.
+It also checks license headers against the generated source archive.
+If enabled, SVN upload runs after local artifact verification and before RC tag creation. The script creates the signed RC tag as the final release step, then prints a draft VOTE email for `dev@iceberg.apache.org`.
 
 To upload artifacts to ASF dev dist as part of RC creation, pass:
 


### PR DESCRIPTION
## Which issue does this PR close?

Backport 0aeccb8c8d4e81e6e2e916427e183607049cd4a5 as part of 0.11.0 release to unlock RC2.

Related: #3034

## What changes are included in this PR?

Backport of 0aeccb8c8d4e81e6e2e916427e183607049cd4a5.

The dev dependency of iceberg-property-macro on iceberg is changed to a path dependency, to avoid a cycle between them when publishing.

## Are these changes tested?

N/A

## AI Disclosure

LLM was used to create the backport commit. Reviewed by me.
