### PR TITLE
chore(release): Remove --release_ref from create_rc.sh, always release HEAD

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -36,10 +36,11 @@ This creates:
 
 The license header check runs against the generated source archive, not the live Git worktree. The optional SVN upload runs after local artifact verification and before RC tag creation. The signed RC tag is created as the final release step, then the script prints a draft VOTE email for `dev@iceberg.apache.org`. The script logs every step before it runs and after it succeeds. If a step fails, it prints the failed step and stops.
 
+The script always archives and tags `HEAD`, so check out the exact commit to release before running it.
+
 Common options:
 
 ```shell
-dev/release/create_rc.sh 0.9.1 2 --release_ref <commit-ish>
 dev/release/create_rc.sh 0.9.1 2 --create_rc_tag 0 --sign 0
 dev/release/create_rc.sh 0.9.1 2 --upload_svn 1
 dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0 --check_publish 0
@@ -47,7 +48,6 @@ dev/release/create_rc.sh 0.9.1 2 --check_headers 0 --check_deps 0 --check_publis
 
 Defaults:
 
-- `--release_ref HEAD`: git commit-ish to archive and tag.
 - `--dist_dir dist`: artifact output root.
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.

--- a/dev/release/create_rc.sh
+++ b/dev/release/create_rc.sh
@@ -47,11 +47,10 @@ Arguments:
       Numeric release candidate round.
       Example: 2 creates tag v0.9.1-rc.2 and dist dir apache-iceberg-rust-0.9.1-rc2.
 
-Options:
-  --release_ref <ref>
-      Git commit-ish to archive and tag.
-      Default: HEAD
+The script always archives and tags HEAD, so check out the exact commit to
+release before running it.
 
+Options:
   --dist_dir <dir>
       Directory where RC artifacts are written.
       Relative paths are resolved from the repository root.
@@ -92,7 +91,7 @@ Examples:
   $0 0.9.1 2
   $0 0.9.1 2 --create_rc_tag 0 --sign 0
   $0 0.9.1 2 --upload_svn 1
-  $0 0.9.1 2 --release_ref abc123 --dist_dir /tmp/iceberg-rust-dist
+  $0 0.9.1 2 --dist_dir /tmp/iceberg-rust-dist
 USAGE
 }
 
@@ -203,11 +202,6 @@ parse_args() {
         usage
         exit 0
         ;;
-      --release_ref | --release-ref)
-        require_option_value "$1" "${2:-}"
-        RELEASE_REF="$2"
-        shift 2
-        ;;
       --dist_dir | --dist-dir)
         require_option_value "$1" "${2:-}"
         RELEASE_DIST_DIR="$2"
@@ -305,7 +299,7 @@ derive_release_names() {
 
 check_release_ref() {
   require_command git
-  git -C "${REPO_ROOT}" rev-parse --verify "${RELEASE_REF}^{commit}" >/dev/null
+  git -C "${REPO_ROOT}" rev-parse --verify "HEAD^{commit}" >/dev/null
 }
 
 check_rc_tag_available() {
@@ -343,7 +337,7 @@ create_source_archive() {
     --format=tar.gz \
     --output="${RC_DIR}/${ARCHIVE_FILE_NAME}" \
     --prefix="${ARCHIVE_BASE_NAME}/" \
-    "${RELEASE_REF}"
+    HEAD
 }
 
 check_license_headers() {
@@ -434,7 +428,7 @@ upload_to_svn() {
 create_rc_tag() {
   require_command git
   require_gpg_secret_key
-  git -C "${REPO_ROOT}" tag -s "${RC_TAG}" "${RELEASE_REF}" -m "Apache Iceberg Rust ${VERSION} RC${RC}"
+  git -C "${REPO_ROOT}" tag -s "${RC_TAG}" HEAD -m "Apache Iceberg Rust ${VERSION} RC${RC}"
 }
 
 print_summary() {
@@ -512,7 +506,6 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 VERSION=""
 RC=""
-RELEASE_REF="HEAD"
 RELEASE_DIST_DIR="dist"
 CREATE_RC_TAG="1"
 CHECK_HEADERS="1"
@@ -527,7 +520,7 @@ run_step "Parse command arguments" parse_args "$@"
 run_step "Validate release arguments" validate_args
 derive_release_names
 
-run_step "Check release reference ${RELEASE_REF}" check_release_ref
+run_step "Check release reference HEAD" check_release_ref
 
 if enabled "${CREATE_RC_TAG}"; then
   run_step "Check RC tag ${RC_TAG} is available" check_rc_tag_available

--- a/website/src/release.md
+++ b/website/src/release.md
@@ -195,9 +195,10 @@ For example:
 dev/release/create_rc.sh 0.9.1 2
 ```
 
+The script always archives and tags `HEAD`, so make sure the exact commit to release is checked out before running it.
+
 Useful options include:
 
-- `--release_ref HEAD`: git commit-ish to archive and tag.
 - `--dist_dir dist`: artifact output root.
 - `--create_rc_tag 1`: create the signed annotated RC tag as the final release step.
 - `--check_headers 1`: check Apache license headers against the source archive.


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3198.

## What changes are included in this PR?

Removes the `--release_ref` option from `dev/release/create_rc.sh` so the script always archives and tags `HEAD`.

Checks like `check_dependency_licenses` (and the newly added publishability check) always run against `HEAD`, so allowing a different `--release_ref` could produce an archive/tag that was never actually validated. The script now requires the release manager to check out the exact commit to release before running it, and the usage text calls this out.

Also updates `dev/release/README.md` and `website/src/release.md` to drop the `--release_ref` mentions and document the HEAD-only behavior.

## Are these changes tested?

Yes, manually:

- `bash -n dev/release/create_rc.sh` passes and `--help` renders the updated usage.
- Full dry run (`create_rc.sh 0.9.1 2 --dist_dir <tmp> --create_rc_tag 0 --sign 0 --check_headers 0 --check_deps 0`) creates and verifies the source archive an- Full dry run (`create_rc.sss- Full dry run (`create_rc.shjected - Full drnown opt- Full dry run (`create_rc.sh 0.9.1 2 - authored with AI assistance (Kiro) and reviewed by me.
