### PR TITLE
ci: pull MinIO images from Quay

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
   # MinIO - S3-compatible storage (shared by all tests)
   # =============================================================================
   minio:
-    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    image: quay.io/minio/minio:RELEASE.2025-05-24T17-08-30Z
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
@@ -56,7 +56,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    image: quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password


### PR DESCRIPTION
Related:

- https://github.com/apache/iggy/pull/4148
- https://github.com/apache/doris/pull/67897
- https://github.com/apache/iceberg/pull/18071

Docker Hub is no longer serving `minio/minio` (https://hub.docker.com/r/minio/minio) or `minio/mc` (https://hub.docker.com/r/minio/mc), stopping the [integration test containers](https://github.com/apache/iceberg-rust/actions/runs/34654325185) from starting on `main` and affecting open PRs.

This PR switches to the corresponding Quay images, as the related PRs above do - those other projects are encountering the same issue as us.

**We should track moving away from MinIO as a follow-up, like [PyIceberg did](https://github.com/apache/iceberg-python/pull/3928) - but that's a larger discussion; this fix is temporary to unblock CI, PRs, etc.**

AI Disclosure: Assisted by Codex (GPT-6).
