### PR TITLE
ci: avoid redundant post-merge runs

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -26,9 +26,6 @@ name: "ASF Allowlist Check"
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/bindings_python_ci.yml
+++ b/.github/workflows/bindings_python_ci.yml
@@ -18,9 +18,6 @@
 name: Bindings Python CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -18,9 +18,6 @@
 name: Public API
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,8 +20,6 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A. Follow-up to #3195 and mirrors apache/iceberg-python#3933.

## What changes are included in this PR?

Remove `main` push triggers from required workflows. The merge queue already runs the same checks against the final combined change.

## Are these changes tested?

Checked with actionlint.

## AI Disclosure

Written with GitHub Copilot, reviewed by me.